### PR TITLE
fix(server): close stdin for noninteractive process runs

### DIFF
--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -11,6 +11,7 @@ import { TestClock } from "effect/testing";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { SpawnExecutableResolution } from "@t3tools/shared/shell";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 
 import * as ProcessRunner from "./processRunner.ts";
 
@@ -80,6 +81,28 @@ const runWith =
     );
 
 describe("runProcess", () => {
+  for (const stdin of [undefined, "", "hello\n世界\n"]) {
+    it.effect(
+      `delivers EOF to a real child with ${stdin === undefined ? "omitted" : stdin === "" ? "empty" : "provided"} stdin`,
+      () =>
+        Effect.gen(function* () {
+          const runner = yield* ProcessRunner.ProcessRunner;
+          const result = yield* runner.run({
+            command: process.execPath,
+            args: [
+              "-e",
+              "process.stdin.setEncoding('utf8'); let input = ''; process.stdin.on('data', chunk => { input += chunk }); process.stdin.on('end', () => { process.stdout.write('EOF:' + input) });",
+            ],
+            ...(stdin !== undefined ? { stdin } : {}),
+          });
+          expect(result.code).toBe(0);
+          expect(result.stdout).toBe(`EOF:${stdin ?? ""}`);
+          expect(result.timedOut).toBe(false);
+        }).pipe(Effect.provide(ProcessRunner.layer.pipe(Layer.provide(NodeServices.layer)))),
+      10_000,
+    );
+  }
+
   it.effect("collects stdout through an injected ChildProcessSpawner", () =>
     Effect.gen(function* () {
       const spawner = makeSpawner((command) =>

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -311,6 +311,9 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
             }
           : {}),
         shell: spawnCommand.shell,
+        // This runner has no interactive input channel. An unused pipe would
+        // leave commands waiting for stdin until the process timeout.
+        stdin: input.stdin === undefined ? "ignore" : "pipe",
       }),
     )
     .pipe(


### PR DESCRIPTION
## What Changed

The noninteractive process runner uses ignored stdin when no input was supplied. Explicit empty or nonempty input still uses a pipe and is delivered before EOF.

## Why

The default piped stdin was left open when `stdin` was omitted. A child that reads until EOF could wait indefinitely even though this runner has no interactive input channel.

## Testing

- A real child waiting for EOF hangs on upstream with omitted input and completes with the fix.
- All 30 focused ProcessRunner and VcsProcess tests pass, including omitted, empty, and Unicode stdin.
- Server typecheck, scoped lint, and formatting pass.
- No frontend changes or browser verification.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close stdin for noninteractive process runs in `runProcessCore`
> Sets the child-process spawn `stdio` option so stdin is `ignore` when the caller omits stdin and a `pipe` when stdin is supplied. Previously an unused pipe was left open, causing noninteractive processes to hang waiting for EOF.
>
> Adds integration tests in [processRunner.test.ts](https://github.com/pingdotgg/t3code/pull/10583/files#diff-541892f3e4bc556fab62a53bfd21c3d2ac4c8e55a17d11cf89b3c7d904890cf8) that spawn the current Node executable and verify EOF, expected input, exit code, and timeout behavior across omitted, empty, and non-empty Unicode stdin cases.
> - Risk: child processes that previously relied on an open (but empty) stdin pipe will now receive immediate EOF instead of a blocked read; any process expecting to read from stdin even when none is supplied will exit differently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a9847.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed command execution hanging until timeout when no standard input was provided.
  - Processes now complete normally when they do not require input, while commands receiving input continue to handle it correctly.
  - Improved handling for empty and Unicode input, including reliable end-of-input detection and echoed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->