### PR TITLE
fix(sqlite): retry failed statement preparations

### DIFF
--- a/packages/shared/src/nodeSqliteClient.test.ts
+++ b/packages/shared/src/nodeSqliteClient.test.ts
@@ -1,6 +1,10 @@
+import * as NodeSqlite from "node:sqlite";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as SqliteClient from "./nodeSqliteClient.ts";
@@ -8,6 +12,21 @@ import * as SqliteClient from "./nodeSqliteClient.ts";
 const layer = it.layer(SqliteClient.layerMemory());
 
 layer("NodeSqliteClient", (it) => {
+  it.effect("retries preparing a query after the missing schema becomes available", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const select = sql<{ name: string }>`SELECT name FROM created_after_prepare_failure`;
+      const error = yield* select.pipe(Effect.flip);
+      assert.equal(error._tag, "SqlError");
+      assert.equal(error.reason.operation, "prepare");
+
+      yield* sql`CREATE TABLE created_after_prepare_failure(name TEXT NOT NULL)`;
+      yield* sql`INSERT INTO created_after_prepare_failure VALUES ('recovered')`;
+      assert.deepEqual(yield* select, [{ name: "recovered" }]);
+      assert.deepEqual(yield* select.values, [["recovered"]]);
+    }),
+  );
+
   it.effect("runs prepared queries and returns positional values", () =>
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
@@ -53,4 +72,33 @@ it.effect("returns a typed failure when the database cannot be opened", () =>
     assert.equal(error._tag, "SqlError");
     assert.equal(error.reason.operation, "open");
   }),
+);
+
+it.effect(
+  "recovers a prepared query immediately after an exclusive database lock is released",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-sqlite-prepare-" });
+      const filename = path.join(directory, "state.sqlite");
+      const blocker = yield* Effect.acquireRelease(
+        Effect.sync(() => new NodeSqlite.DatabaseSync(filename)),
+        (database) => Effect.sync(() => database.close()),
+      );
+      yield* Effect.sync(() => {
+        blocker.exec("CREATE TABLE entries(value TEXT); INSERT INTO entries VALUES ('retained')");
+      });
+      yield* Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* Effect.sync(() => blocker.exec("BEGIN EXCLUSIVE"));
+        const select = sql`SELECT value FROM entries`;
+        const error = yield* select.values.pipe(Effect.flip);
+        assert.equal(error._tag, "SqlError");
+        assert.equal(error.reason.operation, "prepare");
+        yield* Effect.sync(() => blocker.exec("ROLLBACK"));
+        assert.deepEqual(yield* select.values, [["retained"]]);
+        assert.deepEqual(yield* select, [{ value: "retained" }]);
+      }).pipe(Effect.provide(SqliteClient.layer({ filename })));
+    }).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/packages/shared/src/nodeSqliteClient.ts
+++ b/packages/shared/src/nodeSqliteClient.ts
@@ -10,6 +10,7 @@ import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
@@ -151,10 +152,11 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
           }),
       });
 
-    const prepareCache = yield* Cache.make({
+    const prepareCache = yield* Cache.makeWith(prepare, {
       capacity: options.prepareCacheSize ?? 200,
-      timeToLive: options.prepareCacheTTL ?? Duration.minutes(10),
-      lookup: prepare,
+      // A transient prepare failure must not outlive the lock or missing schema.
+      timeToLive: (exit) =>
+        Exit.isSuccess(exit) ? (options.prepareCacheTTL ?? Duration.minutes(10)) : Duration.zero,
     });
 
     const runStatement = (


### PR DESCRIPTION
## What Changed

SQLite caches successfully prepared statements for the configured lifetime, but expires failed preparations immediately. A later query can retry after the database becomes available without recreating the client.

## Why

The prepare cache retained failures for ten minutes by default. A query that initially failed because a table was missing or another connection held an exclusive lock continued returning its cached error after the condition was resolved.

## Testing

- The missing-table regression fails on upstream even after creating and populating the table.
- A real temporary SQLite database verifies positional and object queries recover immediately after an exclusive lock is released.
- All 16 focused shared-client and server persistence tests pass across three suites.
- Shared-package typecheck, scoped lint, and formatting pass.
- No live database access, frontend changes, or browser verification.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix retry of failed statement preparations in 'nodeSqliteClient'
> - Failed statement preparations were previously cached for the configured TTL in [nodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/10584/files#diff-6fe85285a40e8985eab36d8c4e0a8bb9f8427b1f33b1ca54e8f1c09b86d8917b), preventing retries after the underlying issue resolved.
> - The `makeWithDatabase` client factory now passes the prepare function through `Cache.makeWith`. Successful preparations keep the configured TTL, while failed results use a zero TTL to allow retrying.
> - Added tests covering query reuse after a missing table is created and after an exclusive database lock is released.
> - Risk: Behavioral Change: failed `prepare` results in `nodeSqliteClient` no longer remain cached, so later query executions will re-attempt the `prepare` step rather than returning the cached error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c63948.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SQLite queries can now be retried successfully after a temporarily missing table is created.
  - Queries affected by an exclusive database lock can recover once the lock is released.
  - Failed query preparations no longer remain cached, preventing repeated failures after database conditions change.
  - Successfully prepared queries continue to benefit from caching for the configured duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->