### PR TITLE
fix(shared): release relay install locks on cancellation

### DIFF
--- a/packages/shared/src/relayClient.test.ts
+++ b/packages/shared/src/relayClient.test.ts
@@ -2,9 +2,11 @@ import { sha256 } from "@noble/hashes/sha2";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
@@ -70,6 +72,134 @@ const makeSpawnerLayer = (commands: Array<string>) =>
   );
 
 describe("RelayClient", () => {
+  it.effect("cancels a contended install without removing the other installer's lock", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cloudflared-test-" });
+      const directory = `${baseDir}/tools/cloudflared/${CLOUDFLARED_VERSION}/linux-x64`;
+      const lockPath = `${directory}/cloudflared.lock`;
+      yield* fileSystem.makeDirectory(directory, { recursive: true });
+      yield* fileSystem.writeFileString(lockPath, "other-installer");
+      const contended = yield* Deferred.make<void>();
+      const manager = yield* makeCloudflaredRelayClient({ baseDir }).pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fileSystem,
+          writeFileString: (path, contents, options) =>
+            fileSystem
+              .writeFileString(path, contents, options)
+              .pipe(
+                Effect.tapError(() =>
+                  path === lockPath ? Deferred.succeed(contended, undefined) : Effect.void,
+                ),
+              ),
+        }),
+      );
+      const installing = yield* manager.install.pipe(Effect.forkChild);
+      yield* Deferred.await(contended);
+      yield* Fiber.interrupt(installing);
+      expect(yield* fileSystem.readFileString(lockPath)).toBe("other-installer");
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        Layer.mergeAll(
+          NodeServices.layer,
+          makeHttpClientLayer(new Uint8Array()),
+          makeSpawnerLayer([]),
+          hostRuntimeLayer(),
+        ),
+      ),
+    ),
+  );
+
+  it.effect("releases the install lock when a download is cancelled", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cloudflared-test-" });
+      const lockPath = `${baseDir}/tools/cloudflared/${CLOUDFLARED_VERSION}/linux-x64/cloudflared.lock`;
+      const downloading = yield* Deferred.make<void>();
+      const manager = yield* makeCloudflaredRelayClient({ baseDir });
+      const installing = yield* manager
+        .installWithProgress((event) =>
+          event.type === "progress" && event.stage === "downloading"
+            ? Deferred.succeed(downloading, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.void,
+        )
+        .pipe(Effect.forkChild);
+      yield* Deferred.await(downloading);
+      expect(yield* fileSystem.exists(lockPath)).toBe(true);
+      yield* Fiber.interrupt(installing);
+      expect(yield* fileSystem.exists(lockPath)).toBe(false);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        Layer.mergeAll(
+          NodeServices.layer,
+          makeHttpClientLayer(new Uint8Array()),
+          makeSpawnerLayer([]),
+          hostRuntimeLayer(),
+        ),
+      ),
+    ),
+  );
+
+  it.effect.skipIf(windowsHost)("releases a lock acquired while installation is cancelled", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-cloudflared-test-" });
+      const lockPath = `${baseDir}/tools/cloudflared/${CLOUDFLARED_VERSION}/linux-x64/cloudflared.lock`;
+      const acquired = yield* Deferred.make<void>();
+      const completeWrite = yield* Deferred.make<void>();
+      let pauseWrite = true;
+      const manager = yield* makeCloudflaredRelayClient({
+        baseDir,
+        releaseAsset: {
+          url: "https://example.test/cloudflared",
+          sha256: Encoding.encodeHex(sha256(new TextEncoder().encode("test-binary"))),
+          archive: "binary",
+        },
+      }).pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fileSystem,
+          writeFileString: (path, contents, options) =>
+            fileSystem
+              .writeFileString(path, contents, options)
+              .pipe(
+                Effect.tap(() =>
+                  path === lockPath && pauseWrite
+                    ? Deferred.succeed(acquired, undefined).pipe(
+                        Effect.andThen(Deferred.await(completeWrite)),
+                      )
+                    : Effect.void,
+                ),
+              ),
+        }),
+      );
+
+      const installing = yield* manager.install.pipe(Effect.forkChild);
+      yield* Deferred.await(acquired);
+      const cancelling = yield* Fiber.interrupt(installing).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.succeed(completeWrite, undefined);
+      yield* Fiber.join(cancelling);
+      expect(yield* fileSystem.exists(lockPath)).toBe(false);
+
+      pauseWrite = false;
+      expect(yield* manager.install).toMatchObject({ status: "available" });
+      expect(yield* fileSystem.exists(lockPath)).toBe(false);
+    }).pipe(
+      Effect.scoped,
+      Effect.provide(
+        Layer.mergeAll(
+          NodeServices.layer,
+          makeHttpClientLayer(new TextEncoder().encode("test-binary")),
+          makeSpawnerLayer([]),
+          hostRuntimeLayer(),
+        ),
+      ),
+    ),
+  );
+
   it.effect.skipIf(windowsHost)(
     "resolves explicit overrides before managed and PATH executables",
     () =>
@@ -190,6 +320,11 @@ describe("RelayClient", () => {
       const error = yield* manager.install.pipe(Effect.flip);
       expect(error).toBeInstanceOf(RelayClientInstallError);
       expect(error.reason).toBe("invalid_checksum");
+      expect(
+        yield* fileSystem.exists(
+          `${baseDir}/tools/cloudflared/${CLOUDFLARED_VERSION}/linux-x64/cloudflared.lock`,
+        ),
+      ).toBe(false);
     }).pipe(
       Effect.scoped,
       Effect.provide(

--- a/packages/shared/src/relayClient.ts
+++ b/packages/shared/src/relayClient.ts
@@ -329,7 +329,10 @@ export const makeCloudflaredRelayClient = Effect.fn("cloudflared.make")(function
     lockPath: string,
   ) {
     for (let attempt = 0; attempt < INSTALL_LOCK_RETRY_COUNT; attempt += 1) {
-      const acquired = yield* fileSystem.writeFileString(lockPath, "", { flag: "wx" }).pipe(
+      const acquired = yield* Effect.acquireRelease(
+        fileSystem.writeFileString(lockPath, "", { flag: "wx" }),
+        () => fileSystem.remove(lockPath, { force: true }).pipe(Effect.ignore),
+      ).pipe(
         Effect.as(true),
         Effect.catch((error) =>
           isAlreadyExists(error) ? Effect.succeed(false) : Effect.fail(error),
@@ -444,7 +447,6 @@ export const makeCloudflaredRelayClient = Effect.fn("cloudflared.make")(function
       } satisfies AvailableRelayClient;
     }).pipe(
       Effect.scoped,
-      Effect.ensuring(fileSystem.remove(lockPath, { force: true }).pipe(Effect.ignore)),
       Effect.catch((cause) =>
         cause instanceof RelayClientInstallError
           ? Effect.fail(cause)
@@ -465,7 +467,7 @@ export const makeCloudflaredRelayClient = Effect.fn("cloudflared.make")(function
           type: "progress",
           stage,
         }),
-      ),
+      ).pipe(Effect.scoped),
     );
   const install = installWithProgress(() => Effect.void);
 


### PR DESCRIPTION
## What Changed

The relay client installer registers lock cleanup as part of each successful exclusive acquisition. The installation owns that cleanup through its scope, while contention waits remain interruptible.

## Why

Cancellation after the lock file was created but before the old cleanup handler was installed could strand the lock. A subsequent installation then failed as locked until stale-lock recovery became eligible.

## Testing

- The controlled acquisition-cancellation regression leaves a lock behind on upstream and removes it with the fix.
- Eight focused relay client tests pass, including cancellation during download, cancellation while another installer owns the lock, checksum failure cleanup, and an immediate successful retry.
- Shared-package typecheck, scoped lint, and formatting pass.
- No tunnel configuration, frontend changes, browser verification, or live network operations.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release relay install locks on cancellation in `cloudflared.installWithProgress`
> - Lock cleanup moves from an installer-level finalizer into an acquire-release resource inside `cloudflared.acquireInstallLock`, so the lock file is force-removed when the scope exits — including interruption or cancellation.
> - Failed acquisition attempts caused by an existing lock owned by another installer do not register cleanup, so that pre-existing lock is left untouched.
> - `cloudflared.installWithProgress` now wraps `installUnlocked` in an explicit scoped effect so the acquire-release lock resource is finalized for the public install operation.
> - Adds tests covering cancellation during a contended lock, during download, and racing with lock acquisition, plus an assertion that an invalid checksum leaves no lock behind.
> - Risk: `installUnlocked` no longer unconditionally removes the lock file from its own finalizer; any caller that invokes `installUnlocked` outside of a managed scope will not get automatic lock cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03235d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installation cancellation so interrupted downloads and installs properly release their locks.
  - Prevented a cancelled installation from removing a lock held by another active installation.
  - Ensured installations can proceed normally after a previous attempt is cancelled.
  - Cleaned up installation locks after checksum validation failures, preventing stale locks from blocking future installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->