### PR TITLE
fix(server): dismiss orphaned provider questions

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -27,6 +27,7 @@ import { serializeAssistantCitation } from "@t3tools/shared/assistantCitations";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Option from "effect/Option";
@@ -46,7 +47,10 @@ import {
 } from "../../provider/Errors.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
-import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import {
+  makeSqlitePersistenceLive,
+  SqlitePersistenceMemory,
+} from "../../persistence/Layers/Sqlite.ts";
 import {
   ProviderService,
   type ProviderServiceShape,
@@ -167,6 +171,7 @@ describe("ProviderCommandReactor", () => {
 
   async function createHarness(input?: {
     readonly baseDir?: string;
+    readonly databasePath?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
     readonly requiresNewThreadForModelChange?: boolean;
@@ -184,6 +189,9 @@ describe("ProviderCommandReactor", () => {
     readonly tryHandlePromptCommandEffect?: ProviderAuthService["Service"]["tryHandlePromptCommand"];
   }) {
     const now = "2026-01-01T00:00:00.000Z";
+    const persistence = input?.databasePath
+      ? makeSqlitePersistenceLive(input.databasePath)
+      : SqlitePersistenceMemory;
     const baseDir =
       input?.baseDir ?? NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-reactor-"));
     createdBaseDirs.add(baseDir);
@@ -404,13 +412,13 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(OrchestrationEventStoreLive),
       Layer.provide(OrchestrationCommandReceiptRepositoryLive),
       Layer.provide(RepositoryIdentityResolver.layer),
-      Layer.provide(SqlitePersistenceMemory),
+      Layer.provide(persistence),
     );
     const projectionSnapshotLayer = OrchestrationProjectionSnapshotQueryLive.pipe(
       Layer.provide(ThreadBackgroundLiveness.layer),
       Layer.provide(ThreadPlanProgress.layer),
       Layer.provide(RepositoryIdentityResolver.layer),
-      Layer.provide(SqlitePersistenceMemory),
+      Layer.provide(persistence),
     );
     let titleRegenerationCompletionDispatchAttempts = 0;
     const reactorOrchestrationLayer = Layer.effect(
@@ -476,7 +484,7 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
       Layer.provideMerge(ServerSettingsService.layerTest()),
-      Layer.provideMerge(SqlitePersistenceMemory),
+      Layer.provideMerge(persistence),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -3826,6 +3834,117 @@ describe("ProviderCommandReactor", () => {
     );
     expect(resolvedActivity).toBeUndefined();
   });
+
+  for (const status of ["missing", "stopped", "running"] as const) {
+    effectIt.effect(
+      `only dismisses an orphaned native question when the session is ${status}`,
+      () =>
+        Effect.gen(function* () {
+          const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-orphan-question-"));
+          const databasePath = NodePath.join(baseDir, "questions.sqlite");
+          let harness = yield* Effect.promise(() =>
+            createHarness({ baseDir, databasePath, unreadableHistory: true }),
+          );
+          const threadId = ThreadId.make("thread-1");
+          const requestId = asApprovalRequestId("orphaned-question");
+          const createdAt = "2026-01-01T00:00:01.000Z";
+          if (status !== "missing") {
+            yield* harness.engine.dispatch({
+              type: "thread.session.set",
+              commandId: CommandId.make("orphan-session"),
+              threadId,
+              createdAt,
+              session: {
+                threadId,
+                status,
+                providerName: "codex",
+                runtimeMode: "approval-required",
+                activeTurnId: null,
+                lastError: null,
+                updatedAt: createdAt,
+              },
+            });
+          }
+          yield* harness.engine.dispatch({
+            type: "thread.activity.append",
+            commandId: CommandId.make("orphan-request"),
+            threadId,
+            createdAt,
+            activity: {
+              id: EventId.make("orphan-request"),
+              kind: "user-input.requested",
+              summary: "User input requested",
+              tone: "info",
+              turnId: asTurnId("old-turn"),
+              createdAt,
+              payload: { requestId, questions: [] },
+            },
+          });
+          // Restart from the persisted projection, whose command snapshot omits
+          // activities entirely, so recovery must query this request directly.
+          if (status === "stopped") {
+            yield* Scope.close(scope!, Exit.void);
+            scope = null;
+            yield* Effect.promise(() => runtime!.dispose());
+            runtime = null;
+            harness = yield* Effect.promise(() => createHarness({ baseDir, databasePath }));
+          }
+          harness.respondToUserInput.mockImplementation(() =>
+            Effect.fail(
+              new ProviderAdapterRequestError({
+                provider: "codex",
+                method: "item/tool/respondToUserInput",
+                detail: "Temporary transport failure",
+              }),
+            ),
+          );
+          for (const suffix of ["first", "retry"]) {
+            const domainEvents = yield* harness.engine.subscribeDomainEvents;
+            const responseProcessed = yield* domainEvents.pipe(
+              Stream.filter(
+                (event) =>
+                  event.type === "thread.activity-appended" &&
+                  event.payload.threadId === threadId &&
+                  event.payload.activity.kind === "provider.user-input.respond.failed",
+              ),
+              Stream.runHead,
+              Effect.forkChild,
+            );
+            yield* harness.engine.dispatch({
+              type: "thread.user-input.respond",
+              commandId: CommandId.make(`orphan-response-${suffix}`),
+              threadId,
+              requestId,
+              answers: { choice: "yes" },
+              createdAt: "2026-01-01T00:00:02.000Z",
+            });
+            yield* Fiber.join(responseProcessed);
+            yield* Effect.promise(() => harness.drain());
+            if (status === "stopped" && suffix === "first") {
+              expect(
+                Option.getOrThrow(
+                  yield* harness.snapshotQuery.getUserInputActivity({ threadId, requestId }),
+                ).kind,
+              ).toBe("user-input.resolved");
+              yield* Scope.close(scope!, Exit.void);
+              scope = null;
+              yield* Effect.promise(() => runtime!.dispose());
+              runtime = null;
+              harness = yield* Effect.promise(() => createHarness({ baseDir, databasePath }));
+            }
+          }
+          const latest = yield* harness.snapshotQuery.getUserInputActivity({ threadId, requestId });
+          expect(Option.getOrThrow(latest)).toMatchObject({
+            kind: status === "running" ? "user-input.requested" : "user-input.resolved",
+            turnId: "old-turn",
+            payload: { requestId },
+          });
+          const shell = yield* harness.snapshotQuery.getThreadShellById(threadId);
+          expect(Option.getOrThrow(shell).hasPendingUserInput).toBe(status === "running");
+          expect(harness.respondToUserInput).toHaveBeenCalledTimes(status === "running" ? 2 : 0);
+        }),
+    );
+  }
 
   it("surfaces non-resumable provider user-input callbacks as stale failures", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -3847,7 +3847,7 @@ describe("ProviderCommandReactor", () => {
           );
           const threadId = ThreadId.make("thread-1");
           const requestId = asApprovalRequestId("orphaned-question");
-          const createdAt = "2026-01-01T00:00:01.000Z";
+          const createdAt = "2099-01-01T00:00:01.000Z";
           if (status !== "missing") {
             yield* harness.engine.dispatch({
               type: "thread.session.set",
@@ -3939,6 +3939,16 @@ describe("ProviderCommandReactor", () => {
             turnId: "old-turn",
             payload: { requestId },
           });
+          if (status !== "running") {
+            expect(Option.getOrThrow(latest).createdAt > createdAt).toBe(true);
+          }
+          const events = yield* harness.engine.readEvents(0).pipe(Stream.runCollect);
+          const resolutions = events.filter(
+            (event) =>
+              event.type === "thread.activity-appended" &&
+              event.payload.activity.kind === "user-input.resolved",
+          );
+          expect(resolutions).toHaveLength(status === "running" ? 0 : 1);
           const shell = yield* harness.snapshotQuery.getThreadShellById(threadId);
           expect(Option.getOrThrow(shell).hasPendingUserInput).toBe(status === "running");
           expect(harness.respondToUserInput).toHaveBeenCalledTimes(status === "running" ? 2 : 0);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1593,7 +1593,7 @@ const make = Effect.gen(function* () {
       }
       const hasSession = thread.session && thread.session.status !== "stopped";
       if (!hasSession) {
-        return yield* appendProviderFailureActivity({
+        yield* appendProviderFailureActivity({
           threadId: event.payload.threadId,
           kind: "provider.user-input.respond.failed",
           summary: "Provider user input response failed",
@@ -1602,6 +1602,37 @@ const make = Effect.gen(function* () {
           createdAt: event.payload.createdAt,
           requestId: event.payload.requestId,
         });
+        // Requests can survive a server restart or predate session-exit cleanup.
+        // Read the durable request, not the capped command snapshot, and record
+        // dismissal separately from the failed answer so every client can settle.
+        const request = yield* projectionSnapshotQuery.getUserInputActivity(event.payload);
+        if (
+          Option.isSome(request) &&
+          request.value.kind === "user-input.requested" &&
+          !(
+            typeof request.value.payload === "object" &&
+            request.value.payload !== null &&
+            "responseMode" in request.value.payload &&
+            request.value.payload.responseMode === "message"
+          )
+        ) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.activity.append",
+            commandId: yield* serverCommandId("orphaned-user-input-resolved"),
+            threadId: thread.id,
+            activity: {
+              id: yield* serverEventId(),
+              tone: "info",
+              kind: "user-input.resolved",
+              summary: "User input dismissed because the provider session ended",
+              payload: { requestId: event.payload.requestId },
+              turnId: request.value.turnId,
+              createdAt: event.payload.createdAt,
+            },
+            createdAt: event.payload.createdAt,
+          });
+        }
+        return;
       }
 
       yield* providerService

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1616,6 +1616,16 @@ const make = Effect.gen(function* () {
             request.value.payload.responseMode === "message"
           )
         ) {
+          // Legacy activities have no sequence, so their durable lookup orders
+          // by timestamp even when the client or server clock has moved back.
+          const resolvedAt = DateTime.formatIso(
+            DateTime.makeUnsafe(
+              Math.max(
+                DateTime.toEpochMillis(yield* DateTime.now),
+                DateTime.toEpochMillis(DateTime.makeUnsafe(request.value.createdAt)) + 1,
+              ),
+            ),
+          );
           yield* orchestrationEngine.dispatch({
             type: "thread.activity.append",
             commandId: yield* serverCommandId("orphaned-user-input-resolved"),
@@ -1627,9 +1637,9 @@ const make = Effect.gen(function* () {
               summary: "User input dismissed because the provider session ended",
               payload: { requestId: event.payload.requestId },
               turnId: request.value.turnId,
-              createdAt: event.payload.createdAt,
+              createdAt: resolvedAt,
             },
-            createdAt: event.payload.createdAt,
+            createdAt: resolvedAt,
           });
         }
         return;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2629,6 +2629,74 @@ describe("ProviderRuntimeIngestion", () => {
     ).toMatchObject([{ payload: { requestId: request.requestId } }]);
   });
 
+  it("resolves every native callback when the session exits without a terminal turn", async () => {
+    const harness = await createHarness();
+    const parent = userInputEvent("parent-turn", "parent-question");
+    const child = userInputEvent("child-turn", "child-question");
+    const turnless = { ...userInputEvent("unused", "turnless-question"), turnId: undefined };
+    const answered = userInputEvent("parent-turn", "answered-question");
+    const asynchronous = userInputEvent("parent-turn", "async-question", "message");
+    await harness.emitAndDrain([
+      parent,
+      child,
+      turnless,
+      answered,
+      asynchronous,
+      {
+        type: "user-input.resolved",
+        eventId: asEventId("answered-before-exit"),
+        provider: parent.provider,
+        threadId: parent.threadId,
+        requestId: answered.requestId,
+        createdAt: "2026-01-01T00:00:02.000Z",
+        payload: { answers: { first: "yes", second: "yes" } },
+      },
+    ]);
+    const exited: ProviderRuntimeEvent = {
+      type: "session.exited",
+      eventId: asEventId("question-session-exited"),
+      provider: parent.provider,
+      threadId: parent.threadId,
+      createdAt: "2026-01-01T00:00:03.000Z",
+      payload: { reason: "Provider process exited." },
+    };
+    await harness.emitAndDrain([exited]);
+    const resolutions = (await harness.readModel()).threads[0]!.activities.filter(
+      (activity) => activity.kind === "user-input.resolved",
+    );
+    expect(resolutions).toHaveLength(4);
+    expect(resolutions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          turnId: parent.turnId,
+          payload: { requestId: parent.requestId },
+        }),
+        expect.objectContaining({ turnId: child.turnId, payload: { requestId: child.requestId } }),
+        expect.objectContaining({ turnId: null, payload: { requestId: turnless.requestId } }),
+      ]),
+    );
+    expect((await harness.readThreadShell()).hasPendingUserInput).toBe(true);
+
+    await harness.emitAndDrain([exited]);
+    expect(
+      (await harness.readModel()).threads[0]!.activities.filter(
+        (activity) => activity.kind === "user-input.resolved",
+      ),
+    ).toEqual(resolutions);
+    await harness.emitAndDrain([
+      {
+        type: "user-input.resolved",
+        eventId: asEventId("async-answer-after-exit"),
+        provider: parent.provider,
+        threadId: parent.threadId,
+        requestId: asynchronous.requestId,
+        createdAt: "2026-01-01T00:00:04.000Z",
+        payload: { answers: { first: "yes", second: "yes" } },
+      },
+    ]);
+    expect((await harness.readThreadShell()).hasPendingUserInput).toBe(false);
+  });
+
   it("preserves answered questions and leaves newer, child and async questions pending", async () => {
     const harness = await createHarness();
     const answered = userInputEvent("old-turn", "answered-question");

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1833,14 +1833,14 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (isTerminalTurn) {
+      if (isTerminalTurn || event.type === "session.exited") {
         const turnId = toTurnId(event.turnId);
-        if (turnId) {
+        if (turnId || event.type === "session.exited") {
           const userInputActivities =
             yield* projectionThreadActivityRepository.listUserInputLifecycleByThreadId({
               threadId: thread.id,
             });
-          const pendingRequestIds = new Set<string>();
+          const pendingRequests = new Map<string, TurnId | null>();
           for (const activity of userInputActivities) {
             const payload =
               typeof activity.payload === "object" && activity.payload !== null
@@ -1850,17 +1850,17 @@ const make = Effect.gen(function* () {
             if (typeof requestId !== "string") continue;
             if (
               activity.kind === "user-input.requested" &&
-              activity.turnId === turnId &&
+              (event.type === "session.exited" || activity.turnId === turnId) &&
               payload?.responseMode !== "message"
             ) {
-              pendingRequestIds.add(requestId);
+              pendingRequests.set(requestId, activity.turnId);
             } else if (activity.kind === "user-input.resolved") {
-              pendingRequestIds.delete(requestId);
+              pendingRequests.delete(requestId);
             }
           }
-          // A terminal turn cannot accept native callback answers. Message-mode
-          // questions may outlive that turn and still accept a later user message.
-          for (const requestId of pendingRequestIds) {
+          // Session exit abandons every native callback, including child and
+          // turnless requests. Message-mode questions can still resume later.
+          for (const [requestId, requestTurnId] of pendingRequests) {
             yield* orchestrationEngine.dispatch({
               type: "thread.activity.append",
               commandId: yield* providerCommandId(event, "terminal-user-input-resolved"),
@@ -1872,11 +1872,16 @@ const make = Effect.gen(function* () {
                 kind: "user-input.resolved",
                 summary: "User input dismissed",
                 payload: { requestId },
-                turnId,
+                turnId: requestTurnId,
               },
               createdAt: now,
             });
           }
+        }
+      }
+      if (isTerminalTurn) {
+        const turnId = toTurnId(event.turnId);
+        if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);
           yield* Effect.forEach(
             assistantMessageIds,


### PR DESCRIPTION
Native provider questions can outlive their session and leave clients offering answers that the provider can no longer accept. Session exit now dismisses native questions, including turnless questions. Answering a legacy question against a missing or stopped session also records a durable dismissal while retaining the failed-answer activity.

Dismissals use server time strictly after the stored request timestamp, so clock rollback or an older client timestamp cannot leave pending input set after restart. Repeated answers do not append duplicate resolutions. Asynchronous message-mode questions and transient failures from live sessions retain their existing behavior.

Validation: 131 focused ProviderCommandReactor and ProviderRuntimeIngestion tests pass. Missing/stopped-session timestamp regressions fail before the fix and pass afterward, including restart, durable pending state, and duplicate-resolution coverage. Scoped lint and server typecheck pass with existing warnings/suggestions. Rebased onto main.

Fixes #5454.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Native user-input requests are now resolved when their provider session ends or is stopped.
  - Requests remain pending while the provider session is still running, including after a restart.
  - Resolution applies consistently across turns, including requests without an associated turn.
  - Repeated session-exit events no longer create duplicate resolutions.
  - Responses received after session exit correctly clear pending input indicators.
  - Requests tied to message-based responses are not incorrectly marked as resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->