### PR TITLE
fix(server): bound native telemetry command writes

### DIFF
--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.transport.test.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.transport.test.ts
@@ -7,6 +7,7 @@ import {
   type ResourceMonitorCommand as MonitorCommand,
 } from "@t3tools/contracts";
 import * as Deferred from "effect/Deferred";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -167,7 +168,11 @@ describe("native telemetry transport deadlines", () => {
         });
         expect(yield* Fiber.join(blockedWrite)).toMatchObject({
           _tag: "Failure",
-          failure: { _tag: "NativeTelemetryCommandFailed", operation: "setExternalProcesses" },
+          failure: {
+            _tag: "NativeTelemetryCommandTimedOut",
+            operation: "setExternalProcesses",
+            timeoutMs: 5000,
+          },
         });
       }).pipe(Effect.provide(NodeServices.layer)),
     );
@@ -211,6 +216,85 @@ describe("native telemetry transport deadlines", () => {
       });
       expect(yield* client.health).toMatchObject({ sampleIntervalMs: 5000 });
     }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect.each([false, true])(
+    "corrects partial control with rollback stalled=%s",
+    (stallRollback) =>
+      Effect.gen(function* () {
+        const enabling = yield* Deferred.make<void>();
+        const commands: Array<MonitorCommand> = [];
+        let interval = 5000;
+        let streaming = false;
+        let rollbackStalled = false;
+        const { client, configured } = yield* makeClient((command) =>
+          Effect.gen(function* () {
+            if (command.type === "setSampleInterval") {
+              commands.push(command);
+              interval = command.sampleIntervalMs;
+            }
+            if (command.type === "setStreaming") {
+              commands.push(command);
+              streaming = command.enabled;
+              if (command.enabled) {
+                yield* Deferred.succeed(enabling, undefined);
+                return yield* Effect.never;
+              }
+              if (stallRollback && !rollbackStalled) {
+                rollbackStalled = true;
+                return yield* Effect.never;
+              }
+            }
+          }),
+        );
+        yield* Deferred.await(configured);
+        const subscription = yield* client.snapshots.pipe(
+          Stream.runDrain,
+          Effect.result,
+          Effect.forkChild,
+        );
+        yield* Deferred.await(enabling);
+        expect(interval).toBe(1000);
+        expect(streaming).toBe(true);
+        yield* TestClock.adjust("5 seconds");
+        if (stallRollback) yield* TestClock.adjust("5 seconds");
+        expect(subscription.pollUnsafe()).toBeDefined();
+        expect(yield* Fiber.join(subscription)).toMatchObject({
+          _tag: "Failure",
+          failure: { operation: "setStreaming" },
+        });
+        expect(commands).toEqual([
+          {
+            version: RESOURCE_MONITOR_PROTOCOL_VERSION,
+            type: "setSampleInterval",
+            sampleIntervalMs: 1000,
+          },
+          { version: RESOURCE_MONITOR_PROTOCOL_VERSION, type: "setStreaming", enabled: true },
+          {
+            version: RESOURCE_MONITOR_PROTOCOL_VERSION,
+            type: "setSampleInterval",
+            sampleIntervalMs: 5000,
+          },
+          { version: RESOURCE_MONITOR_PROTOCOL_VERSION, type: "setStreaming", enabled: false },
+        ]);
+        expect(interval).toBe(5000);
+        expect(streaming).toBe(false);
+        if (stallRollback) {
+          yield* client.setHostPowerState({
+            source: "unknown",
+            idle: "unknown",
+            idleSeconds: null,
+            locked: "unknown",
+            suspended: false,
+            onBattery: "unknown",
+            lowPowerMode: "unknown",
+            thermalState: "unknown",
+            stale: true,
+            updatedAt: yield* DateTime.now,
+          });
+          expect(commands.slice(4)).toEqual(commands.slice(2, 4));
+        }
+      }).pipe(Effect.provide(NodeServices.layer)),
   );
 
   it.effect("finishes scoped subscription release when disabling streaming stalls", () =>

--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.transport.test.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.transport.test.ts
@@ -1,0 +1,240 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import {
+  RESOURCE_MONITOR_PROTOCOL_VERSION,
+  ResourceMonitorCommand,
+  ResourceMonitorEvent,
+  type ResourceMonitorCommand as MonitorCommand,
+} from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Queue from "effect/Queue";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as ServerConfig from "../config.ts";
+import * as NativeTelemetryClient from "./NativeTelemetryClient.ts";
+import * as ResourceMonitorBinary from "./ResourceMonitorBinary.ts";
+
+const decodeCommand = Schema.decodeUnknownSync(Schema.fromJsonString(ResourceMonitorCommand));
+const encodeEvent = Schema.encodeSync(Schema.fromJsonString(ResourceMonitorEvent));
+
+const requestFor = (
+  client: NativeTelemetryClient.NativeTelemetryClient["Service"],
+  operation: "sampleNow" | "processTable" | "readHistory",
+) => {
+  switch (operation) {
+    case "sampleNow":
+      return client.sampleNow.pipe(Effect.asVoid);
+    case "processTable":
+      return client.processTable.pipe(Effect.asVoid);
+    case "readHistory":
+      return client.readHistory(1000).pipe(Effect.asVoid);
+  }
+};
+
+const makeClient = Effect.fn(function* (
+  onCommand: (
+    command: MonitorCommand,
+    send: (event: ResourceMonitorEvent) => Effect.Effect<boolean>,
+  ) => Effect.Effect<void>,
+) {
+  const output = yield* Queue.unbounded<Uint8Array>();
+  const send = (event: ResourceMonitorEvent) =>
+    Queue.offer(output, new TextEncoder().encode(`${encodeEvent(event)}\n`));
+  yield* send({
+    version: RESOURCE_MONITOR_PROTOCOL_VERSION,
+    type: "hello",
+    sidecarVersion: "test",
+    sidecarPid: 100,
+    platform: "linux",
+    arch: "x64",
+    capabilities: {
+      cumulativeCpuTime: true,
+      currentCpuPercent: true,
+      residentMemory: true,
+      virtualMemory: true,
+      ioBytes: true,
+      processStartTime: true,
+      processTree: true,
+    },
+  });
+  const configured = yield* Deferred.make<void>();
+  const killed = yield* Deferred.make<void>();
+  const handle = ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(100),
+    exitCode: Effect.never,
+    isRunning: Effect.succeed(true),
+    kill: () => Deferred.succeed(killed, undefined).pipe(Effect.asVoid),
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.forEach((bytes: Uint8Array) =>
+      Effect.gen(function* () {
+        const command = decodeCommand(new TextDecoder().decode(bytes));
+        yield* onCommand(command, send);
+        if (command.type === "setExternalProcesses") yield* Deferred.succeed(configured, undefined);
+      }),
+    ),
+    stdout: Stream.fromQueue(output),
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+  const config = yield* Layer.build(
+    ServerConfig.layerTest("/test", { prefix: "t3-telemetry-test-" }),
+  );
+  const client = yield* NativeTelemetryClient.make().pipe(
+    Effect.provide(config),
+    Effect.provideService(ResourceMonitorBinary.ResourceMonitorBinary, {
+      resolve: Effect.succeed("test-monitor"),
+    }),
+    Effect.provideService(
+      ChildProcessSpawner.ChildProcessSpawner,
+      ChildProcessSpawner.make(() => Effect.succeed(handle)),
+    ),
+  );
+  return { client, configured, killed, send };
+});
+
+describe("native telemetry transport deadlines", () => {
+  for (const operation of ["sampleNow", "processTable", "readHistory"] as const) {
+    it.effect(`bounds a stalled ${operation} write and releases the command permit`, () =>
+      Effect.gen(function* () {
+        const writing = yield* Deferred.make<void>();
+        let blocked = true;
+        const { client, configured } = yield* makeClient((command, send) =>
+          command.type === operation && blocked
+            ? Deferred.succeed(writing, undefined).pipe(Effect.andThen(Effect.never))
+            : command.type === "processTable"
+              ? send({
+                  version: RESOURCE_MONITOR_PROTOCOL_VERSION,
+                  type: "processTable",
+                  requestId: command.requestId,
+                  processes: [],
+                }).pipe(Effect.asVoid)
+              : Effect.void,
+        );
+        yield* Deferred.await(configured);
+        const request = yield* requestFor(client, operation).pipe(Effect.result, Effect.forkChild);
+        yield* Deferred.await(writing);
+        yield* TestClock.adjust("5 seconds");
+        expect(request.pollUnsafe()).toBeDefined();
+        expect(yield* Fiber.join(request)).toMatchObject({
+          _tag: "Failure",
+          failure: { operation },
+        });
+        blocked = false;
+        expect(yield* client.processTable).toEqual([]);
+      }).pipe(Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  for (const operation of ["sampleNow", "processTable", "readHistory"] as const) {
+    it.effect(`includes mutex wait time in the ${operation} response deadline`, () =>
+      Effect.gen(function* () {
+        const blocking = yield* Deferred.make<void>();
+        let blockExternal = false;
+        const { client, configured } = yield* makeClient((command) =>
+          blockExternal && command.type === "setExternalProcesses"
+            ? Deferred.succeed(blocking, undefined).pipe(Effect.andThen(Effect.never))
+            : Effect.void,
+        );
+        yield* Deferred.await(configured);
+        blockExternal = true;
+        const blockedWrite = yield* client
+          .setExternalProcesses([])
+          .pipe(Effect.result, Effect.forkChild);
+        yield* Deferred.await(blocking);
+        yield* TestClock.adjust("2 seconds");
+        const request = yield* requestFor(client, operation).pipe(
+          Effect.result,
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* TestClock.adjust(operation === "readHistory" ? "15 seconds" : "5 seconds");
+        expect(request.pollUnsafe()).toBeDefined();
+        expect(yield* Fiber.join(request)).toMatchObject({
+          _tag: "Failure",
+          failure: {
+            _tag: "NativeTelemetryRequestTimedOut",
+            operation,
+            timeoutMs: operation === "readHistory" ? 15000 : 5000,
+          },
+        });
+        expect(yield* Fiber.join(blockedWrite)).toMatchObject({
+          _tag: "Failure",
+          failure: { _tag: "NativeTelemetryCommandFailed", operation: "setExternalProcesses" },
+        });
+      }).pipe(Effect.provide(NodeServices.layer)),
+    );
+  }
+
+  it.effect("releases a sidecar when its startup configure write stalls", () =>
+    Effect.gen(function* () {
+      const writing = yield* Deferred.make<void>();
+      const { client, killed } = yield* makeClient((command) =>
+        command.type === "configure"
+          ? Deferred.succeed(writing, undefined).pipe(Effect.andThen(Effect.never))
+          : Effect.void,
+      );
+      yield* Deferred.await(writing);
+      yield* TestClock.adjust("5 seconds");
+      expect(yield* Deferred.isDone(killed)).toBe(true);
+      expect(yield* client.health).toMatchObject({ status: "degraded", restartCount: 1 });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("rolls back demand when acquiring a live subscription times out", () =>
+    Effect.gen(function* () {
+      const enabling = yield* Deferred.make<void>();
+      const { client, configured } = yield* makeClient((command) =>
+        command.type === "setSampleInterval" && command.sampleIntervalMs === 1000
+          ? Deferred.succeed(enabling, undefined).pipe(Effect.andThen(Effect.never))
+          : Effect.void,
+      );
+      yield* Deferred.await(configured);
+      const subscription = yield* client.snapshots.pipe(
+        Stream.runDrain,
+        Effect.result,
+        Effect.forkChild,
+      );
+      yield* Deferred.await(enabling);
+      yield* TestClock.adjust("5 seconds");
+      expect(subscription.pollUnsafe()).toBeDefined();
+      expect(yield* Fiber.join(subscription)).toMatchObject({
+        _tag: "Failure",
+        failure: { operation: "setSampleInterval" },
+      });
+      expect(yield* client.health).toMatchObject({ sampleIntervalMs: 5000 });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("finishes scoped subscription release when disabling streaming stalls", () =>
+    Effect.gen(function* () {
+      const enabled = yield* Deferred.make<void>();
+      const disabling = yield* Deferred.make<void>();
+      const { client, configured } = yield* makeClient((command) =>
+        command.type === "setStreaming"
+          ? command.enabled
+            ? Deferred.succeed(enabled, undefined).pipe(Effect.asVoid)
+            : Deferred.succeed(disabling, undefined).pipe(Effect.andThen(Effect.never))
+          : Effect.void,
+      );
+      yield* Deferred.await(configured);
+      const subscription = yield* client.snapshots.pipe(Stream.runDrain, Effect.forkChild);
+      yield* Deferred.await(enabled);
+      const closing = yield* Fiber.interrupt(subscription).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      );
+      yield* Deferred.await(disabling);
+      yield* TestClock.adjust("5 seconds");
+      expect(closing.pollUnsafe()).toBeDefined();
+      yield* Fiber.join(closing);
+      expect(yield* client.health).toMatchObject({ sampleIntervalMs: 5000 });
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
@@ -44,6 +44,7 @@ const UNKNOWN_BACKGROUND_SAMPLE_INTERVAL_MS = 5_000;
 const BATTERY_SAMPLE_INTERVAL_MS = 5_000;
 const CONSTRAINED_SAMPLE_INTERVAL_MS = 15_000;
 const HANDSHAKE_TIMEOUT = Duration.seconds(5);
+const COMMAND_WRITE_TIMEOUT = Duration.seconds(5);
 const SAMPLE_REQUEST_TIMEOUT = Duration.seconds(5);
 const PROCESS_TABLE_REQUEST_TIMEOUT = Duration.seconds(5);
 const HISTORY_REQUEST_TIMEOUT = Duration.seconds(15);
@@ -430,28 +431,41 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
     handle: ChildProcessSpawner.ChildProcessHandle,
     command: ResourceMonitorCommand,
   ): Effect.Effect<void, NativeTelemetryClientError> =>
-    commandMutex.withPermits(1)(
-      encodeMonitorCommand(command).pipe(
-        Effect.map((encoded) => `${encoded}\n`),
-        Effect.mapError(
-          (cause) =>
-            new NativeTelemetryCommandFailed({
-              operation: command.type,
-              cause,
-            }),
+    commandMutex
+      .withPermits(1)(
+        encodeMonitorCommand(command).pipe(
+          Effect.map((encoded) => `${encoded}\n`),
+          Effect.mapError(
+            (cause) =>
+              new NativeTelemetryCommandFailed({
+                operation: command.type,
+                cause,
+              }),
+          ),
+          Effect.flatMap((encoded) =>
+            Stream.run(Stream.encodeText(Stream.make(encoded)), handle.stdin),
+          ),
+          Effect.mapError(
+            (cause) =>
+              new NativeTelemetryCommandFailed({
+                operation: command.type,
+                cause,
+              }),
+          ),
         ),
-        Effect.flatMap((encoded) =>
-          Stream.run(Stream.encodeText(Stream.make(encoded)), handle.stdin),
-        ),
-        Effect.mapError(
-          (cause) =>
-            new NativeTelemetryCommandFailed({
-              operation: command.type,
-              cause,
-            }),
-        ),
-      ),
-    );
+      )
+      .pipe(
+        Effect.timeoutOrElse({
+          duration: COMMAND_WRITE_TIMEOUT,
+          orElse: () =>
+            Effect.fail(
+              new NativeTelemetryCommandFailed({
+                operation: command.type,
+                cause: `Resource monitor command write timed out after ${Duration.toMillis(COMMAND_WRITE_TIMEOUT)}ms.`,
+              }),
+            ),
+        }),
+      );
 
   const processEvent = (
     event: ResourceMonitorEvent,
@@ -832,8 +846,11 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
   const liveSnapshots = Stream.unwrap(
     Effect.gen(function* () {
       const subscription = yield* PubSub.subscribe(snapshots);
-      yield* Effect.acquireRelease(changeLiveSubscriberCount(1), () =>
-        changeLiveSubscriberCount(-1).pipe(Effect.ignore),
+      yield* Effect.acquireRelease(
+        changeLiveSubscriberCount(1).pipe(
+          Effect.onError(() => changeLiveSubscriberCount(-1).pipe(Effect.ignore)),
+        ),
+        () => changeLiveSubscriberCount(-1).pipe(Effect.ignore),
       );
       return Stream.fromSubscription(subscription);
     }),
@@ -885,22 +902,19 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
         requestId,
         windowMs: Math.max(0, Math.round(windowMs)),
       }).pipe(
-        Effect.andThen(
-          Deferred.await(deferred).pipe(
-            Effect.timeoutOption(HISTORY_REQUEST_TIMEOUT),
-            Effect.flatMap(
-              Option.match({
-                onNone: () =>
-                  Effect.fail(
-                    new NativeTelemetryRequestTimedOut({
-                      operation: "readHistory",
-                      timeoutMs: Duration.toMillis(HISTORY_REQUEST_TIMEOUT),
-                    }),
-                  ),
-                onSome: Effect.succeed,
-              }),
-            ),
-          ),
+        Effect.andThen(Deferred.await(deferred)),
+        Effect.timeoutOption(HISTORY_REQUEST_TIMEOUT),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new NativeTelemetryRequestTimedOut({
+                  operation: "readHistory",
+                  timeoutMs: Duration.toMillis(HISTORY_REQUEST_TIMEOUT),
+                }),
+              ),
+            onSome: Effect.succeed,
+          }),
         ),
         Effect.ensuring(
           Ref.update(pendingHistories, (pending) => {
@@ -940,22 +954,19 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
       type: "sampleNow",
       requestId,
     }).pipe(
-      Effect.andThen(
-        Deferred.await(deferred).pipe(
-          Effect.timeoutOption(SAMPLE_REQUEST_TIMEOUT),
-          Effect.flatMap(
-            Option.match({
-              onNone: () =>
-                Effect.fail(
-                  new NativeTelemetryRequestTimedOut({
-                    operation: "sampleNow",
-                    timeoutMs: Duration.toMillis(SAMPLE_REQUEST_TIMEOUT),
-                  }),
-                ),
-              onSome: Effect.succeed,
-            }),
-          ),
-        ),
+      Effect.andThen(Deferred.await(deferred)),
+      Effect.timeoutOption(SAMPLE_REQUEST_TIMEOUT),
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new NativeTelemetryRequestTimedOut({
+                operation: "sampleNow",
+                timeoutMs: Duration.toMillis(SAMPLE_REQUEST_TIMEOUT),
+              }),
+            ),
+          onSome: Effect.succeed,
+        }),
       ),
       Effect.ensuring(
         Ref.update(pendingSamples, (pending) => {
@@ -994,22 +1005,19 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
       type: "processTable",
       requestId,
     }).pipe(
-      Effect.andThen(
-        Deferred.await(deferred).pipe(
-          Effect.timeoutOption(PROCESS_TABLE_REQUEST_TIMEOUT),
-          Effect.flatMap(
-            Option.match({
-              onNone: () =>
-                Effect.fail(
-                  new NativeTelemetryRequestTimedOut({
-                    operation: "processTable",
-                    timeoutMs: Duration.toMillis(PROCESS_TABLE_REQUEST_TIMEOUT),
-                  }),
-                ),
-              onSome: Effect.succeed,
-            }),
-          ),
-        ),
+      Effect.andThen(Deferred.await(deferred)),
+      Effect.timeoutOption(PROCESS_TABLE_REQUEST_TIMEOUT),
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new NativeTelemetryRequestTimedOut({
+                operation: "processTable",
+                timeoutMs: Duration.toMillis(PROCESS_TABLE_REQUEST_TIMEOUT),
+              }),
+            ),
+          onSome: Effect.succeed,
+        }),
       ),
       Effect.ensuring(
         Ref.update(pendingProcessTables, (pending) => {

--- a/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
+++ b/apps/server/src/resourceTelemetry/NativeTelemetryClient.ts
@@ -123,6 +123,18 @@ export class NativeTelemetryCommandFailed extends Schema.TaggedErrorClass<Native
   }
 }
 
+export class NativeTelemetryCommandTimedOut extends Schema.TaggedErrorClass<NativeTelemetryCommandTimedOut>()(
+  "NativeTelemetryCommandTimedOut",
+  {
+    operation: Schema.String,
+    timeoutMs: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Resource monitor command '${this.operation}' timed out after ${this.timeoutMs}ms.`;
+  }
+}
+
 export class NativeTelemetryExited extends Schema.TaggedErrorClass<NativeTelemetryExited>()(
   "NativeTelemetryExited",
   {
@@ -162,6 +174,7 @@ export type NativeTelemetryClientError =
   | NativeTelemetryProtocolMismatch
   | NativeTelemetryDecodeFailed
   | NativeTelemetryCommandFailed
+  | NativeTelemetryCommandTimedOut
   | NativeTelemetryExited
   | NativeTelemetryStreamClosed
   | NativeTelemetryUnavailable;
@@ -385,6 +398,7 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
     sampleIntervalMs: UNKNOWN_BACKGROUND_SAMPLE_INTERVAL_MS,
   });
   const appliedCollectionControl = yield* Ref.make(yield* Ref.get(collectionControl));
+  const collectionControlNeedsSync = yield* Ref.make(false);
   const externalProcesses = yield* Ref.make<ReadonlyArray<ResourceMonitorExternalProcess>>([]);
   const pendingSamples = yield* Ref.make(
     new Map<string, Deferred.Deferred<NativeTelemetrySnapshot, NativeTelemetryClientError>>(),
@@ -459,9 +473,9 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
           duration: COMMAND_WRITE_TIMEOUT,
           orElse: () =>
             Effect.fail(
-              new NativeTelemetryCommandFailed({
+              new NativeTelemetryCommandTimedOut({
                 operation: command.type,
-                cause: `Resource monitor command write timed out after ${Duration.toMillis(COMMAND_WRITE_TIMEOUT)}ms.`,
+                timeoutMs: Duration.toMillis(COMMAND_WRITE_TIMEOUT),
               }),
             ),
         }),
@@ -684,7 +698,10 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
           ...current,
           status: "healthy" as const,
           hello: Option.some(hello),
-        })).pipe(Effect.andThen(publishHealth)),
+        })).pipe(
+          Effect.andThen(Ref.set(collectionControlNeedsSync, false)),
+          Effect.andThen(publishHealth),
+        ),
       );
 
       yield* writeCommand(handle, {
@@ -794,7 +811,11 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
     const current = yield* Ref.get(state);
     if (canCommandNativeTelemetrySidecar(current.status, Option.isSome(current.handle))) {
       const handle = Option.getOrThrow(current.handle);
-      if (previous.sampleIntervalMs !== next.sampleIntervalMs) {
+      const needsSync = yield* Ref.get(collectionControlNeedsSync);
+      // A failed write may already have reached the sidecar, so the next update
+      // must resend both settings even when the last confirmed values match.
+      yield* Ref.set(collectionControlNeedsSync, true);
+      if (needsSync || previous.sampleIntervalMs !== next.sampleIntervalMs) {
         yield* writeCommand(handle, {
           version: RESOURCE_MONITOR_PROTOCOL_VERSION,
           type: "setSampleInterval",
@@ -803,13 +824,14 @@ export const make = Effect.fn("resourceTelemetry.nativeTelemetryClient.make")(fu
       }
       const wasStreaming = previous.liveSubscriberCount > 0;
       const isStreaming = next.liveSubscriberCount > 0;
-      if (wasStreaming !== isStreaming) {
+      if (needsSync || wasStreaming !== isStreaming) {
         yield* writeCommand(handle, {
           version: RESOURCE_MONITOR_PROTOCOL_VERSION,
           type: "setStreaming",
           enabled: isStreaming,
         });
       }
+      yield* Ref.set(collectionControlNeedsSync, false);
     }
   });
 


### PR DESCRIPTION
## What Changed

Native telemetry command deadlines now include waiting for the command mutex and writing to the sidecar. Request deadlines cover the complete write-and-response operation, and failed live subscriptions roll back their demand count.

## Why

A sidecar that stopped reading stdin could hang telemetry requests before their response timeout started. The same unbounded write path could prevent startup cleanup or subscription release from finishing.

## Testing

- Seven transport regressions fail on upstream and pass with the fix, covering stalled sample, process-table, and history writes, queued request deadlines, and stalled startup configuration.
- Subscription tests cover failed-acquisition demand rollback and cleanup when disabling streaming stalls.
- All 16 focused telemetry tests, server typecheck, scoped lint, and formatting pass.
- Tests use a controlled sidecar transport and virtual clock; no browser, native monitor process, or live database used.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `NativeTelemetryClient` command writes with 5-second timeout and fix rollback state
> - Adds `COMMAND_WRITE_TIMEOUT` (5s) around command-mutex acquisition and stdin streaming in `writeCommand`; timeout produces `NativeTelemetryCommandTimedOut` and releases the command permit.
> - Adds a collection-control resynchronization marker so the next eligible update resends both sample interval and streaming state after a failed control write, clearing only on success or hello.
> - Fixes `liveSnapshots` to decrement subscriber count when acquisition fails instead of leaving demand incremented.
> - Moves request deadlines in `readHistory`, `sampleNow`, and `processTable` to wrap the combined command dispatch and response wait, not just the deferred response.
> - Adds a transport test suite with an in-memory child-process fixture covering write deadlines, rollback ordering, startup timeout, and scoped release.
> - Risk: request handlers in `NativeTelemetryClient.ts` now enforce their deadlines from before dispatch, so previously-tolerable slow command writes may surface as request-level timeouts earlier than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1b8e27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry command operations now have time limits, preventing stalled operations from hanging indefinitely.
  * Request deadlines now cover command execution and queue waits.
  * Improved cleanup and rollback when live telemetry subscriptions fail or are interrupted.
  * Timed-out subscriptions restore default sampling and streaming settings, including after partial updates.
  * Startup configuration failures now trigger recovery and report degraded health.

* **Tests**
  * Added coverage for command timeouts, recovery, subscription cleanup, partial updates, and deadline handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->