### PR TITLE
fix(ssh): cancel environment setup during manager shutdown

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -566,7 +566,84 @@ describe("ssh tunnel scripts", () => {
     },
   );
 
-  it.effect("does not spawn SSH commands after the manager closes", () => {
+  it.effect.each(["successful stop", "failed stop"] as const)(
+    "preserves an in-flight disconnect through manager shutdown after a %s",
+    (mode) => {
+      let completed = false;
+      return Effect.gen(function* () {
+        const stopStarted = yield* Deferred.make<void>();
+        const finishStop = yield* Deferred.make<void>();
+        let stopCount = 0;
+        let killCount = 0;
+        let remoteRunning = true;
+        const spawner = ChildProcessSpawner.make((command) =>
+          Effect.sync(() => {
+            const args = commandArgs(command);
+            if (args.includes("-G")) return makeSuccessfulProcess("");
+            if (args.includes("-N"))
+              return makeRunningProcess(() => {
+                killCount += 1;
+              });
+            if (args.includes("--")) return makeSuccessfulProcess('{"remotePort":3773}\n');
+            stopCount += 1;
+            return {
+              ...makeSuccessfulProcess('{"stopped":true}\n'),
+              stderr:
+                mode === "failed stop"
+                  ? Stream.make(new TextEncoder().encode("Remote stop failed.\n"))
+                  : Stream.empty,
+              exitCode: Deferred.succeed(stopStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(finishStop)),
+                Effect.andThen(
+                  Effect.sync(() => {
+                    remoteRunning = mode === "failed stop";
+                    return ChildProcessSpawner.ExitCode(mode === "failed stop" ? 1 : 0);
+                  }),
+                ),
+              ),
+            };
+          }),
+        );
+        const services = Layer.mergeAll(
+          NodeServices.layer,
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Layer.succeed(HttpClient.HttpClient, testHttpClient),
+          Layer.succeed(NetService.NetService, testNetService),
+          SshPasswordPrompt.disabledLayer,
+        );
+        yield* Effect.gen(function* () {
+          const scope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+            Scope.close(scope, Exit.void),
+          );
+          const context = yield* Layer.buildWithScope(SshEnvironmentManager.layer(), scope);
+          const manager = yield* SshEnvironmentManager.pipe(Effect.provide(context));
+          const target = { alias: "devbox", hostname: "devbox", username: null, port: null };
+          yield* manager.ensureEnvironment(target);
+          const disconnect = yield* Effect.forkChild(
+            manager.disconnectEnvironment(target).pipe(Effect.result),
+          );
+          yield* Deferred.await(stopStarted);
+          yield* Scope.close(scope, Exit.void).pipe(Effect.uninterruptible);
+          yield* Deferred.succeed(finishStop, undefined);
+          const exit = yield* Fiber.await(disconnect);
+          assert.isTrue(Exit.isSuccess(exit));
+          if (Exit.isSuccess(exit)) {
+            assert.equal(Result.isFailure(exit.value), mode === "failed stop");
+            if (Result.isFailure(exit.value)) {
+              assert.instanceOf(exit.value.failure, SshCommandError);
+              assert.equal(exit.value.failure.message, "Remote stop failed.");
+            }
+          }
+          assert.equal(remoteRunning, mode === "failed stop");
+          assert.equal(stopCount, 1);
+          assert.equal(killCount, 1);
+          completed = true;
+        }).pipe(Effect.provide(services), Effect.scoped);
+      }).pipe(Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));
+    },
+  );
+
+  it.effect("does not start environment setup after the manager closes", () => {
     let completed = false;
     return Effect.gen(function* () {
       let spawnCount = 0;
@@ -590,12 +667,10 @@ describe("ssh tunnel scripts", () => {
         Layer.succeed(NetService.NetService, testNetService),
         SshPasswordPrompt.disabledLayer,
       );
-      const results = yield* Effect.all([
-        manager.ensureEnvironment(target).pipe(Effect.exit),
-        manager.disconnectEnvironment(target).pipe(Effect.exit),
-      ]).pipe(Effect.provide(services));
-      assert.isTrue(Exit.hasInterrupts(results[0]));
-      assert.isTrue(Exit.hasInterrupts(results[1]));
+      const result = yield* manager
+        .ensureEnvironment(target)
+        .pipe(Effect.exit, Effect.provide(services));
+      assert.isTrue(Exit.hasInterrupts(result));
       assert.equal(spawnCount, 0);
       completed = true;
     }).pipe(Effect.scoped, Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -4,9 +4,11 @@ import * as NetService from "@t3tools/shared/Net";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
+import * as Scope from "effect/Scope";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
@@ -484,6 +486,238 @@ describe("ssh tunnel scripts", () => {
       );
     },
   );
+
+  it.effect.each(["resolution", "readiness", "pairing"] as const)(
+    "cancels pending %s before the environment manager finishes shutdown",
+    (stage) => {
+      let completed = false;
+      return Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+        const pause = Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Deferred.await(release)),
+        );
+        let tunnelCount = 0;
+        let killCount = 0;
+        let stopCount = 0;
+        let pairingStarted = false;
+        const spawner = ChildProcessSpawner.make((command) =>
+          Effect.gen(function* () {
+            const args = commandArgs(command);
+            if (args.includes("-G")) {
+              if (stage === "resolution") yield* pause;
+              return makeSuccessfulProcess("");
+            }
+            if (args.includes("-N")) {
+              tunnelCount += 1;
+              return makeRunningProcess(() => {
+                killCount += 1;
+              });
+            }
+            if (args.includes("--")) {
+              return makeSuccessfulProcess('{"remotePort":3773}\n');
+            }
+            if (stage === "pairing" && !pairingStarted) {
+              pairingStarted = true;
+              yield* pause;
+              return makeSuccessfulProcess('{"credential":"LCL4R2TPHDKQ"}\n');
+            }
+            stopCount += 1;
+            return makeSuccessfulProcess('{"stopped":true}\n');
+          }),
+        );
+        const httpClient = HttpClient.make((request) =>
+          (stage === "readiness" ? pause : Effect.void).pipe(
+            Effect.as(HttpClientResponse.fromWeb(request, new Response("", { status: 200 }))),
+          ),
+        );
+        const services = Layer.mergeAll(
+          NodeServices.layer,
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Layer.succeed(HttpClient.HttpClient, httpClient),
+          Layer.succeed(NetService.NetService, testNetService),
+          SshPasswordPrompt.disabledLayer,
+        );
+        yield* Effect.gen(function* () {
+          const scope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+            Scope.close(scope, Exit.void),
+          );
+          const context = yield* Layer.buildWithScope(SshEnvironmentManager.layer(), scope);
+          const manager = yield* SshEnvironmentManager.pipe(Effect.provide(context));
+          const request = yield* Effect.forkChild(
+            manager.ensureEnvironment(
+              { alias: "devbox", hostname: "devbox", username: null, port: null },
+              { issuePairingToken: stage === "pairing" },
+            ),
+            { startImmediately: true },
+          );
+          yield* Deferred.await(started);
+          yield* Scope.close(scope, Exit.void).pipe(Effect.uninterruptible);
+          const killsAtShutdown = killCount;
+          yield* Deferred.succeed(release, undefined);
+          const exit = yield* Fiber.await(request);
+          assert.isTrue(Exit.hasInterrupts(exit));
+          assert.equal(tunnelCount, stage === "resolution" ? 0 : 1);
+          assert.equal(killsAtShutdown, stage === "resolution" ? 0 : 1);
+          assert.equal(stopCount, stage === "pairing" ? 1 : 0);
+          completed = true;
+        }).pipe(Effect.provide(services), Effect.scoped);
+      }).pipe(Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));
+    },
+  );
+
+  it.effect("does not spawn SSH commands after the manager closes", () => {
+    let completed = false;
+    return Effect.gen(function* () {
+      let spawnCount = 0;
+      const spawner = ChildProcessSpawner.make(() =>
+        Effect.sync(() => {
+          spawnCount += 1;
+          return makeSuccessfulProcess("");
+        }),
+      );
+      const scope = yield* Effect.acquireRelease(Scope.make(), (scope) =>
+        Scope.close(scope, Exit.void),
+      );
+      const context = yield* Layer.buildWithScope(SshEnvironmentManager.layer(), scope);
+      const manager = yield* SshEnvironmentManager.pipe(Effect.provide(context));
+      yield* Scope.close(scope, Exit.void);
+      const target = { alias: "devbox", hostname: "devbox", username: null, port: null };
+      const services = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, testHttpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+      );
+      const results = yield* Effect.all([
+        manager.ensureEnvironment(target).pipe(Effect.exit),
+        manager.disconnectEnvironment(target).pipe(Effect.exit),
+      ]).pipe(Effect.provide(services));
+      assert.isTrue(Exit.hasInterrupts(results[0]));
+      assert.isTrue(Exit.hasInterrupts(results[1]));
+      assert.equal(spawnCount, 0);
+      completed = true;
+    }).pipe(Effect.scoped, Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));
+  });
+
+  it.effect(
+    "cancels an abandoned setup and shares the next tunnel between concurrent callers",
+    () => {
+      let completed = false;
+      return Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        let probeCount = 0;
+        let tunnelCount = 0;
+        let killCount = 0;
+        const spawner = ChildProcessSpawner.make((command) =>
+          Effect.sync(() => {
+            const args = commandArgs(command);
+            if (args.includes("-N")) {
+              tunnelCount += 1;
+              return makeRunningProcess(() => {
+                killCount += 1;
+              });
+            }
+            return makeSuccessfulProcess(args.includes("--") ? '{"remotePort":3773}\n' : "");
+          }),
+        );
+        const httpClient = HttpClient.make((request) =>
+          Effect.gen(function* () {
+            if (++probeCount === 1) {
+              yield* Deferred.succeed(started, undefined);
+              return yield* Effect.never;
+            }
+            return HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
+          }),
+        );
+        const layer = Layer.mergeAll(
+          NodeServices.layer,
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Layer.succeed(HttpClient.HttpClient, httpClient),
+          Layer.succeed(NetService.NetService, testNetService),
+          SshPasswordPrompt.disabledLayer,
+          SshEnvironmentManager.layer(),
+        );
+        yield* Effect.gen(function* () {
+          const manager = yield* SshEnvironmentManager;
+          const target = { alias: "devbox", hostname: "devbox", username: null, port: null };
+          const first = yield* Effect.forkChild(manager.ensureEnvironment(target));
+          yield* Deferred.await(started);
+          yield* Fiber.interrupt(first);
+          assert.equal(killCount, 1);
+          const [second, third] = yield* Effect.all(
+            [manager.ensureEnvironment(target), manager.ensureEnvironment(target)],
+            { concurrency: "unbounded" },
+          );
+          assert.equal(second.httpBaseUrl, third.httpBaseUrl);
+          assert.equal(tunnelCount, 2);
+          assert.equal(killCount, 1);
+        }).pipe(Effect.provide(layer), Effect.scoped);
+        assert.equal(killCount, 2);
+        completed = true;
+      }).pipe(Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));
+    },
+  );
+
+  it.effect("waits for pending setup before disconnecting its tunnel", () => {
+    let completed = false;
+    return Effect.gen(function* () {
+      const readyStarted = yield* Deferred.make<void>();
+      const finishReady = yield* Deferred.make<void>();
+      const disconnectStarted = yield* Deferred.make<void>();
+      let resolutions = 0;
+      let stopCount = 0;
+      let killCount = 0;
+      const spawner = ChildProcessSpawner.make((command) =>
+        Effect.gen(function* () {
+          const args = commandArgs(command);
+          if (args.includes("-G")) {
+            if (++resolutions === 2) yield* Deferred.succeed(disconnectStarted, undefined);
+            return makeSuccessfulProcess("");
+          }
+          if (args.includes("-N"))
+            return makeRunningProcess(() => {
+              killCount += 1;
+            });
+          if (args.includes("--")) return makeSuccessfulProcess('{"remotePort":3773}\n');
+          stopCount += 1;
+          return makeSuccessfulProcess('{"stopped":true}\n');
+        }),
+      );
+      const httpClient = HttpClient.make((request) =>
+        Deferred.succeed(readyStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(finishReady)),
+          Effect.as(HttpClientResponse.fromWeb(request, new Response("", { status: 200 }))),
+        ),
+      );
+      const layer = Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Layer.succeed(HttpClient.HttpClient, httpClient),
+        Layer.succeed(NetService.NetService, testNetService),
+        SshPasswordPrompt.disabledLayer,
+        SshEnvironmentManager.layer(),
+      );
+      yield* Effect.gen(function* () {
+        const manager = yield* SshEnvironmentManager;
+        const target = { alias: "devbox", hostname: "devbox", username: null, port: null };
+        const setup = yield* Effect.forkChild(manager.ensureEnvironment(target));
+        yield* Deferred.await(readyStarted);
+        const disconnect = yield* Effect.forkChild(manager.disconnectEnvironment(target));
+        yield* Deferred.await(disconnectStarted);
+        assert.equal(stopCount, 0);
+        yield* Deferred.succeed(finishReady, undefined);
+        yield* Fiber.join(setup);
+        yield* Fiber.join(disconnect);
+        assert.equal(stopCount, 1);
+        assert.equal(killCount, 1);
+      }).pipe(Effect.provide(layer), Effect.scoped);
+      assert.equal(stopCount, 1);
+      assert.equal(killCount, 1);
+      completed = true;
+    }).pipe(Effect.ensuring(Effect.sync(() => assert.isTrue(completed))));
+  });
 
   it.effect.each(["local tunnel", "remote server"] as const)(
     "waits for %s shutdown before reconnecting the same target",

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -1175,7 +1175,7 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const targetLocks = new Map<string, Semaphore.Semaphore>();
   const authSecrets = new Map<string, string>();
 
-  // Operations belong to both the caller and the manager: either can cancel setup.
+  // Setup belongs to both the caller and the manager: either can cancel it.
   // Propagate the exit after releasing the fiber to avoid reentrant interruption during shutdown.
   const runInManagerScope = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     Effect.acquireUseRelease(
@@ -1620,7 +1620,8 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   return SshEnvironmentManager.of({
     ensureEnvironment: (target, requestOptions) =>
       runInManagerScope(ensureEnvironment(target, requestOptions)),
-    disconnectEnvironment: (target) => runInManagerScope(disconnectEnvironment(target)),
+    // Disconnect owns remote cleanup after removing the tunnel from the manager.
+    disconnectEnvironment,
   });
 });
 

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -12,6 +12,7 @@ import { satisfiesSemverRange } from "@t3tools/shared/semver";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
@@ -1174,6 +1175,15 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
   const targetLocks = new Map<string, Semaphore.Semaphore>();
   const authSecrets = new Map<string, string>();
 
+  // Operations belong to both the caller and the manager: either can cancel setup.
+  // Propagate the exit after releasing the fiber to avoid reentrant interruption during shutdown.
+  const runInManagerScope = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.acquireUseRelease(
+      Effect.forkIn(effect, managerScope),
+      Fiber.await,
+      Fiber.interrupt,
+    ).pipe(Effect.flatMap((exit) => exit));
+
   // Keep one lock per target so reconnect cannot reuse a server while stop is pending.
   const withTargetLock = Effect.fn("ssh/tunnel.withTargetLock")(function* <A, E, R>(
     key: string,
@@ -1358,85 +1368,92 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
       localPort,
       remotePort,
     });
-    const entryScope = yield* Scope.make("sequential");
-    const tunnelEntry = yield* runWithSshAuth({
-      key: input.key,
-      target: input.resolvedTarget,
-      operation: (authOptions) =>
-        startSshTunnel({
-          key: input.key,
-          resolvedTarget: input.resolvedTarget,
-          remotePort,
-          localPort,
-          httpBaseUrl,
-          wsBaseUrl,
-          authOptions,
-          remoteServerKind: remoteLaunch.remoteServerKind,
-        }).pipe(Effect.provideService(Scope.Scope, entryScope)),
-    }).pipe(
-      Effect.onExit((exit) =>
-        Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, Exit.void).pipe(Effect.ignore),
-      ),
+    return yield* Effect.acquireUseRelease(
+      Scope.make("sequential"),
+      (entryScope) =>
+        Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const tunnelEntry = yield* restore(
+              runWithSshAuth({
+                key: input.key,
+                target: input.resolvedTarget,
+                operation: (authOptions) =>
+                  startSshTunnel({
+                    key: input.key,
+                    resolvedTarget: input.resolvedTarget,
+                    remotePort,
+                    localPort,
+                    httpBaseUrl,
+                    wsBaseUrl,
+                    authOptions,
+                    remoteServerKind: remoteLaunch.remoteServerKind,
+                  }).pipe(Effect.provideService(Scope.Scope, entryScope)),
+              }),
+            );
+            tunnels.set(input.key, tunnelEntry);
+            const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
+            const fileSystemService = yield* FileSystem.FileSystem;
+            const pathService = yield* Path.Path;
+            yield* Scope.addFinalizer(
+              entryScope,
+              Effect.gen(function* () {
+                const stopRemote = tunnels.get(tunnelEntry.key) === tunnelEntry;
+                if (stopRemote) {
+                  tunnels.delete(tunnelEntry.key);
+                }
+                yield* tunnelEntry.process
+                  .kill({
+                    killSignal: "SIGTERM",
+                    forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
+                  })
+                  .pipe(Effect.ignore);
+                if (!stopRemote) {
+                  return;
+                }
+                yield* Effect.logDebug("ssh.environment.tunnel.finalizer.start", {
+                  ...sshTargetLogFields(tunnelEntry.target),
+                  key: tunnelEntry.key,
+                  localPort: tunnelEntry.localPort,
+                  remotePort: tunnelEntry.remotePort,
+                });
+                const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
+                yield* stopRemoteServer(
+                  tunnelEntry.target,
+                  authSecret === null
+                    ? {
+                        batchMode: "yes",
+                        interactiveAuth: false,
+                      }
+                    : {
+                        authSecret,
+                        batchMode: "no",
+                        interactiveAuth: true,
+                      },
+                ).pipe(
+                  Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
+                  Effect.provideService(FileSystem.FileSystem, fileSystemService),
+                  Effect.provideService(Path.Path, pathService),
+                );
+                yield* Effect.logDebug("ssh.environment.tunnel.finalizer.succeeded", {
+                  ...sshTargetLogFields(tunnelEntry.target),
+                  key: tunnelEntry.key,
+                  localPort: tunnelEntry.localPort,
+                  remotePort: tunnelEntry.remotePort,
+                });
+              }).pipe(Effect.ignore),
+            );
+            yield* Effect.logDebug("ssh.environment.tunnel.create.succeeded", {
+              ...sshTargetLogFields(input.resolvedTarget),
+              key: input.key,
+              localPort,
+              remotePort,
+            });
+            return tunnelEntry;
+          }),
+        ),
+      (entryScope, exit) =>
+        Exit.isSuccess(exit) ? Effect.void : Scope.close(entryScope, exit).pipe(Effect.ignore),
     );
-    tunnels.set(input.key, tunnelEntry);
-    const spawnerService = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const fileSystemService = yield* FileSystem.FileSystem;
-    const pathService = yield* Path.Path;
-    yield* Scope.addFinalizer(
-      entryScope,
-      Effect.gen(function* () {
-        const stopRemote = tunnels.get(tunnelEntry.key) === tunnelEntry;
-        if (stopRemote) {
-          tunnels.delete(tunnelEntry.key);
-        }
-        yield* tunnelEntry.process
-          .kill({
-            killSignal: "SIGTERM",
-            forceKillAfter: TUNNEL_SHUTDOWN_TIMEOUT_MS,
-          })
-          .pipe(Effect.ignore);
-        if (!stopRemote) {
-          return;
-        }
-        yield* Effect.logDebug("ssh.environment.tunnel.finalizer.start", {
-          ...sshTargetLogFields(tunnelEntry.target),
-          key: tunnelEntry.key,
-          localPort: tunnelEntry.localPort,
-          remotePort: tunnelEntry.remotePort,
-        });
-        const authSecret = authSecrets.get(tunnelEntry.key) ?? null;
-        yield* stopRemoteServer(
-          tunnelEntry.target,
-          authSecret === null
-            ? {
-                batchMode: "yes",
-                interactiveAuth: false,
-              }
-            : {
-                authSecret,
-                batchMode: "no",
-                interactiveAuth: true,
-              },
-        ).pipe(
-          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawnerService),
-          Effect.provideService(FileSystem.FileSystem, fileSystemService),
-          Effect.provideService(Path.Path, pathService),
-        );
-        yield* Effect.logDebug("ssh.environment.tunnel.finalizer.succeeded", {
-          ...sshTargetLogFields(tunnelEntry.target),
-          key: tunnelEntry.key,
-          localPort: tunnelEntry.localPort,
-          remotePort: tunnelEntry.remotePort,
-        });
-      }).pipe(Effect.ignore),
-    );
-    yield* Effect.logDebug("ssh.environment.tunnel.create.succeeded", {
-      ...sshTargetLogFields(input.resolvedTarget),
-      key: input.key,
-      localPort,
-      remotePort,
-    });
-    return tunnelEntry;
   });
 
   const ensureTunnelEntry = Effect.fn("ssh/tunnel.ensureTunnelEntry")(function* (
@@ -1600,7 +1617,11 @@ const makeSshEnvironmentManager = Effect.fn("ssh/tunnel.SshEnvironmentManager.ma
     );
   });
 
-  return SshEnvironmentManager.of({ ensureEnvironment, disconnectEnvironment });
+  return SshEnvironmentManager.of({
+    ensureEnvironment: (target, requestOptions) =>
+      runInManagerScope(ensureEnvironment(target, requestOptions)),
+    disconnectEnvironment: (target) => runInManagerScope(disconnectEnvironment(target)),
+  });
 });
 
 /**


### PR DESCRIPTION
## What Changed

SSH environment setup and disconnect operations are owned by both their caller and the environment manager. Shutdown cancels pending operations before closing established tunnels, and a completed tunnel is handed over to the manager without an interruption gap.

## Why

Closing the manager only cleaned up tunnels already present in its map. Setup still resolving a target or waiting for readiness could finish afterward and leave a tunnel running beyond its owner's lifetime. A canceled caller could also abandon setup while another connection attempt waited on the same target.

## Testing

- Regression coverage shuts down during target resolution, HTTP readiness, and pairing, asserting cleanup before shutdown returns.
- Calls after manager shutdown must spawn no commands; canceled setup must release its tunnel and allow concurrent callers to share a successful retry.
- All 32 focused tunnel, command, and authentication tests, SSH package typecheck, scoped lint, and formatting pass.
- Tests use controlled process and HTTP services with completion assertions; no remote SSH hosts, browser, or live T3 environment used.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel pending `ensureEnvironment` setup during `SshEnvironmentManager` shutdown
> - Adds `runInManagerScope` helper in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/10588/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) that forks an operation into the manager scope, awaits its `Exit`, interrupts the child during release, and re-emits the child `Exit` so caller interruption propagates correctly.
> - `SshEnvironmentManager.ensureEnvironment` now runs through this helper, so pending setup is interrupted when the manager scope closes. `disconnectEnvironment` stays directly exposed so an in-flight disconnect is not canceled by the wrapper.
> - Reworks tunnel-entry creation to acquire a sequential entry scope and perform authentication, tunnel registration, and finalizer installation inside an uninterruptible critical section. Failed or interrupted creation now closes the entry scope with the original exit.
> - Adds tests in [tunnel.test.ts](https://github.com/pingdotgg/t3code/pull/10588/files#diff-76d3724ec8959625b119aff8272a5d733f73551706a487e303ddbd13e10a06ad) covering pending setup cancellation at each stage, in-flight disconnect after shutdown, closed-manager setup, abandoned setup cleanup with concurrent reuse, and disconnect ordering relative to pending setup.
> - Behavioral Change: tunnel-entry creation no longer leaves an orphaned entry scope when interrupted; the registration/finalizer handoff is atomic. `disconnectEnvironment` is intentionally not tied to manager-scope shutdown, so reviewers should confirm a disconnect running after `close` still completes and emits its `SshCommandError` if the remote stop fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba71dbd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH tunnel shutdown handling so setup and disconnection can be cancelled safely.
  * Prevented new SSH processes from starting after a tunnel has closed.
  * Ensured abandoned or failed tunnel setup is cleaned up reliably.
  * Improved coordination for concurrent setup requests and disconnect operations.
  * Preserved in-progress disconnections during manager shutdown and ensured cleanup completes consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->