### PR TITLE
test(web): derive the snooze weekday assertion from the machine locale

### DIFF
--- a/apps/web/src/components/Sidebar.snooze.test.ts
+++ b/apps/web/src/components/Sidebar.snooze.test.ts
@@ -7,6 +7,13 @@ function localDate(year: number, month: number, day: number, hour: number, minut
   return new Date(year, month - 1, day, hour, minute, 0, 0);
 }
 
+// Weekday names come out of Intl, so they follow the machine's locale: "Mon"
+// on en-US, "Mo" on de-DE, "lun." on fr-FR. Asking Intl for the same day is
+// what keeps the assertion about *which* weekday, not about English.
+function shortWeekday(date: Date): string {
+  return date.toLocaleDateString(undefined, { weekday: "short" });
+}
+
 describe("resolveSnoozePresets", () => {
   it("offers one hour, three hours, evening, tomorrow, and next week in the morning", () => {
     // Wednesday 2026-04-08 10:00 local.
@@ -42,7 +49,7 @@ describe("resolveSnoozePresets", () => {
     const tomorrow = presets.find((preset) => preset.id === "tomorrow");
     expect(tomorrow!.whenLabel).toMatch(/9/);
     const nextWeek = presets.find((preset) => preset.id === "next-week");
-    expect(nextWeek!.whenLabel).toMatch(/Mon/);
+    expect(nextWeek!.whenLabel).toContain(shortWeekday(localDate(2026, 4, 13, 9)));
   });
 
   it("drops the evening preset once evening is near or past", () => {
@@ -80,8 +87,8 @@ describe("snoozeWakeDescription", () => {
     expect(snoozeWakeDescription(localDate(2026, 4, 9, 9).toISOString(), now, "locale")).toContain(
       "tomorrow",
     );
-    expect(snoozeWakeDescription(localDate(2026, 4, 13, 9).toISOString(), now, "locale")).toMatch(
-      /Mon/,
+    expect(snoozeWakeDescription(localDate(2026, 4, 13, 9).toISOString(), now, "locale")).toContain(
+      shortWeekday(localDate(2026, 4, 13, 9)),
     );
   });
 


### PR DESCRIPTION
## What Changed

`Sidebar.snooze.test.ts` asserted the next-week weekday with `/Mon/` in two places. Both expectations now derive the expected short weekday from `Intl` for the same date, via a small `shortWeekday` helper in the test file. Test-only change, ten lines added, three removed.

## Why

The code under test formats the weekday through `toLocaleDateString(undefined, { weekday: "short" })`, so the label follows the machine locale. The assertion hard-coded English, so the test failed on any non-English dev machine:

```
AssertionError: expected 'Mo 9:00' to match /Mon/
```

Reproduced on `main` with `LANG=de_DE.UTF-8`: 2 of 7 tests in this file fail. With the change, the file passes under `de_DE.UTF-8`, `en_US.UTF-8` and `C`.

Asking `Intl` for the same day keeps the assertion about *which* weekday is shown rather than about English, so CI stays untouched and the test also passes locally for contributors outside en-US.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — no UI changes
- [ ] I included a video for animation/interaction changes — not applicable

---

Claude Fable 5.1 via Claude Code inside T3 Code.

_Created with AI assistance (Claude), reviewed by Timo._


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive snooze weekday test assertions from the machine locale
> - Adds a `shortWeekday` helper to [Sidebar.snooze.test.ts](https://github.com/pingdotgg/t3code/pull/10590/files#diff-6ff53e96cf7b1a21b640764736e3fad6d660b6ca6076085266d8a0ca4eebdb8a) that formats a date's abbreviated weekday using the runtime locale.
> - Replaces hardcoded English weekday matches in the next-week preset and wake-description tests with the locale-derived weekday text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b28c2bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated snooze-related tests to support localized weekday names across different locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->