### PR TITLE
fix(web): correct pending question attachment message

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -4182,7 +4182,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (pendingUserInputs.length > 0) {
       toastManager.add({
         type: "error",
-        title: "Attach files after answering plan questions.",
+        title: "Attach files after answering pending questions.",
       });
       return;
     }
@@ -4337,7 +4337,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
-    // Claimable pastes go through even when plan questions are pending or the
+    // Claimable pastes go through even when agent questions are pending or the
     // composer is at its attachment limit: `addComposerAttachments` surfaces
     // those as a toast and a thread error. An early return here would swallow
     // the paste with no feedback.


### PR DESCRIPTION
## What Changed

Changed the attachment toast to say "Attach files after answering pending questions." Updated the nearby comment to use the same mode-independent terminology.

## Why

Attaching a file while an agent question awaits an answer showed "Attach files after answering plan questions," even outside plan mode. The guard checks for pending questions, so the message now describes that condition. Attachment behavior is unchanged.

## Validation

- `git diff --check` passed after rebasing onto upstream `main`.
- Targeted lint could not run because this checkout is missing `vite-plus`.
- Copy-only change; no browser verification or screenshots captured.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix attachment toast message in ChatComposer to say "pending questions"
> Updates the attachment rejection toast and inline paste comments in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/10599/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a). Changes the wording from "plan questions" to "pending questions" or "agent questions" without changing any routing or validation logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca1f763.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated wording in the attachment notification to refer to pending questions.
  - Clarified related terminology for agent questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->