### PR TITLE
fix(usage): make unavailable account limits more visible

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -213,7 +213,9 @@ export function UsageLimitsSection({
           {notices.map((notice) => (
             <View
               key={notice}
+              accessible
               accessibilityRole="alert"
+              accessibilityLiveRegion="polite"
               className="flex-row items-start gap-2 rounded-xl border border-warning-border bg-warning px-3.5 py-3"
             >
               <SymbolView
@@ -233,7 +235,7 @@ export function UsageLimitsSection({
           {failedLabels.join(", ")} could not refresh limits. Showing the last known values.
         </Text>
       ) : null}
-      {pools.length === 0 && notices.length === 0 ? (
+      {pools.length === 0 && notices.length === 0 && failedLabels.length === 0 ? (
         <Text className="py-12 text-center text-base text-foreground-muted">
           {selected.size === 0
             ? "Select an environment to see limits."

--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -208,12 +208,32 @@ export function UsageLimitsSection({
   const colors = useProviderColors();
   return (
     <View className="gap-6">
+      {notices.length > 0 ? (
+        <View className="gap-2">
+          {notices.map((notice) => (
+            <View
+              key={notice}
+              accessibilityRole="alert"
+              className="flex-row items-start gap-2 rounded-xl border border-warning-border bg-warning px-3.5 py-3"
+            >
+              <SymbolView
+                name="exclamationmark.triangle"
+                size={16}
+                tintColorClassName="accent-warning-foreground"
+              />
+              <Text className="min-w-0 flex-1 text-sm font-t3-medium text-warning-foreground">
+                {notice}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
       {failedLabels.length ? (
         <Text className="text-sm text-foreground-muted">
           {failedLabels.join(", ")} could not refresh limits. Showing the last known values.
         </Text>
       ) : null}
-      {pools.length === 0 ? (
+      {pools.length === 0 && notices.length === 0 ? (
         <Text className="py-12 text-center text-base text-foreground-muted">
           {selected.size === 0
             ? "Select an environment to see limits."
@@ -238,11 +258,6 @@ export function UsageLimitsSection({
             />
           ))}
         </View>
-      ))}
-      {notices.map((notice) => (
-        <Text key={notice} className="text-sm text-foreground-muted">
-          {notice}
-        </Text>
       ))}
     </View>
   );

--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -234,7 +234,7 @@ export function UsageLimitsSection({
           ))}
         </View>
       ))}
-      {notices.length > 0 ? (
+      {notices.length > 0 || failedLabels.length > 0 ? (
         <View
           accessible
           accessibilityRole="alert"
@@ -252,13 +252,13 @@ export function UsageLimitsSection({
                 {notice}
               </Text>
             ))}
+            {failedLabels.length > 0 ? (
+              <Text className="text-sm font-t3-medium text-warning-foreground">
+                {failedLabels.join(", ")} could not refresh limits. Showing the last known values.
+              </Text>
+            ) : null}
           </View>
         </View>
-      ) : null}
-      {failedLabels.length ? (
-        <Text className="text-sm text-foreground-muted">
-          {failedLabels.join(", ")} could not refresh limits. Showing the last known values.
-        </Text>
       ) : null}
     </View>
   );

--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -208,6 +208,32 @@ export function UsageLimitsSection({
   const colors = useProviderColors();
   return (
     <View className="gap-6">
+      {pools.length === 0 && notices.length === 0 && failedLabels.length === 0 ? (
+        <Text className="py-12 text-center text-base text-foreground-muted">
+          {selected.size === 0
+            ? "Select an environment to see limits."
+            : "No provider on the selected environments reports subscription limits."}
+        </Text>
+      ) : null}
+      {pools.map((pool) => (
+        <View key={pool.driver} className="gap-3">
+          <View className="flex-row items-center gap-2 px-1">
+            <ProviderIcon provider={pool.driver} size={18} />
+            <Text className="text-base font-t3-medium text-foreground">
+              {DRIVER_LABEL[pool.driver] ?? pool.driver}
+            </Text>
+          </View>
+          {pool.windows.map((window) => (
+            <PoolWindowCard
+              key={`${window.kind}:${window.id}`}
+              pool={window}
+              color={pool.driver === "claudeAgent" ? colors.claude : colors.codex}
+              now={now}
+              environmentIds={selectedEnvironmentIds === null ? null : [...selectedEnvironmentIds]}
+            />
+          ))}
+        </View>
+      ))}
       {notices.length > 0 ? (
         <View className="gap-2">
           {notices.map((notice) => (
@@ -235,32 +261,6 @@ export function UsageLimitsSection({
           {failedLabels.join(", ")} could not refresh limits. Showing the last known values.
         </Text>
       ) : null}
-      {pools.length === 0 && notices.length === 0 && failedLabels.length === 0 ? (
-        <Text className="py-12 text-center text-base text-foreground-muted">
-          {selected.size === 0
-            ? "Select an environment to see limits."
-            : "No provider on the selected environments reports subscription limits."}
-        </Text>
-      ) : null}
-      {pools.map((pool) => (
-        <View key={pool.driver} className="gap-3">
-          <View className="flex-row items-center gap-2 px-1">
-            <ProviderIcon provider={pool.driver} size={18} />
-            <Text className="text-base font-t3-medium text-foreground">
-              {DRIVER_LABEL[pool.driver] ?? pool.driver}
-            </Text>
-          </View>
-          {pool.windows.map((window) => (
-            <PoolWindowCard
-              key={`${window.kind}:${window.id}`}
-              pool={window}
-              color={pool.driver === "claudeAgent" ? colors.claude : colors.codex}
-              now={now}
-              environmentIds={selectedEnvironmentIds === null ? null : [...selectedEnvironmentIds]}
-            />
-          ))}
-        </View>
-      ))}
     </View>
   );
 }

--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -235,25 +235,24 @@ export function UsageLimitsSection({
         </View>
       ))}
       {notices.length > 0 ? (
-        <View className="gap-2">
-          {notices.map((notice) => (
-            <View
-              key={notice}
-              accessible
-              accessibilityRole="alert"
-              accessibilityLiveRegion="polite"
-              className="flex-row items-start gap-2 rounded-xl border border-warning-border bg-warning px-3.5 py-3"
-            >
-              <SymbolView
-                name="exclamationmark.triangle"
-                size={16}
-                tintColorClassName="accent-warning-foreground"
-              />
-              <Text className="min-w-0 flex-1 text-sm font-t3-medium text-warning-foreground">
+        <View
+          accessible
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+          className="flex-row items-start gap-2 rounded-xl border border-warning-border bg-warning px-3.5 py-3"
+        >
+          <SymbolView
+            name="exclamationmark.triangle"
+            size={16}
+            tintColorClassName="accent-warning-foreground"
+          />
+          <View className="min-w-0 flex-1 gap-0.5">
+            {notices.map((notice) => (
+              <Text key={notice} className="text-sm font-t3-medium text-warning-foreground">
                 {notice}
               </Text>
-            </View>
-          ))}
+            ))}
+          </View>
         </View>
       ) : null}
       {failedLabels.length ? (

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -562,13 +562,13 @@ export function UsageLimitsPooled({
 function LimitNotices({ notices }: { readonly notices: readonly string[] }) {
   if (notices.length === 0) return null;
   return (
-    <div className="flex flex-col gap-2">
+    <Alert variant="warning" controlAlignment="first-line">
+      <AlertTriangleIcon />
       {notices.map((notice) => (
-        <Alert key={notice} variant="warning" controlAlignment="first-line">
-          <AlertTriangleIcon />
-          <AlertTitle className="break-words">{notice}</AlertTitle>
-        </Alert>
+        <AlertTitle key={notice} className="break-words">
+          {notice}
+        </AlertTitle>
       ))}
-    </div>
+    </Alert>
   );
 }

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -545,7 +545,6 @@ export function UsageLimitsPooled({
   const notices = collectLimitNotices(presentations);
   return (
     <div className="flex flex-col gap-8">
-      <LimitNotices notices={notices} />
       {pools.length === 0 && notices.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No provider on the selected environments reports subscription limits.
@@ -554,6 +553,7 @@ export function UsageLimitsPooled({
       {pools.map((pool) => (
         <PoolSection key={pool.driver} pool={pool} now={now} />
       ))}
+      <LimitNotices notices={notices} />
     </div>
   );
 }

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -10,7 +10,7 @@ import {
   type LimitPoolWindow,
   remainingPercent,
 } from "@t3tools/shared/usageLimits";
-import { TicketIcon } from "lucide-react";
+import { AlertTriangleIcon, TicketIcon } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
 import { usePrimarySettings } from "../../hooks/useSettings";
@@ -20,6 +20,7 @@ import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
 import { getDriverOption } from "../settings/providerDriverMeta";
 import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
 import { Button } from "../ui/button";
+import { Alert, AlertTitle } from "../ui/alert";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import {
   PaceIcon,
@@ -544,7 +545,8 @@ export function UsageLimitsPooled({
   const notices = collectLimitNotices(presentations);
   return (
     <div className="flex flex-col gap-8">
-      {pools.length === 0 ? (
+      <LimitNotices notices={notices} />
+      {pools.length === 0 && notices.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No provider on the selected environments reports subscription limits.
         </p>
@@ -552,7 +554,6 @@ export function UsageLimitsPooled({
       {pools.map((pool) => (
         <PoolSection key={pool.driver} pool={pool} now={now} />
       ))}
-      <LimitNotices notices={notices} />
     </div>
   );
 }
@@ -561,10 +562,13 @@ export function UsageLimitsPooled({
 function LimitNotices({ notices }: { readonly notices: readonly string[] }) {
   if (notices.length === 0) return null;
   return (
-    <ul className="flex flex-col gap-1 text-xs text-muted-foreground">
+    <div className="flex flex-col gap-2">
       {notices.map((notice) => (
-        <li key={notice}>{notice}</li>
+        <Alert key={notice} variant="warning" controlAlignment="first-line">
+          <AlertTriangleIcon />
+          <AlertTitle className="break-words">{notice}</AlertTitle>
+        </Alert>
       ))}
-    </ul>
+    </div>
   );
 }


### PR DESCRIPTION
Failed usage-limit reads were easy to miss as small, muted text below the charts. Group affected accounts and sources in one warning box, with a single warning icon and one line per account or source. Keep the warning box below the charts so errors arriving from a slower environment do not push existing charts down. Applies to web, desktop, and mobile.

When failures leave no charts to show, omit the misleading message that no providers report subscription limits. The mobile warning box includes refresh failures, is accessible, and announces updates politely.

| Before | After |
| --- | --- |
| ![Small muted failure notice](https://github.com/dominic-r/t3code/releases/download/evidence-usage-limit-notices-825b2b85a/before.png) | ![Actual Usage Limits page with the Codex 2 warning below the charts](https://github.com/dominic-r/t3code/releases/download/evidence-usage-limit-notices-825b2b85a/after-real-usage.png) |

Validation:

- Web and mobile typechecks, targeted lint, formatting, and diff checks pass.
- The after screenshot is the normal Usage → Limits page with actual account data.
- Controlled browser test uses the real web component with two mocked environment snapshots. The existing chart stays at y=166 when one warning arrives, four warnings arrive, the same failures refresh, and the failures clear. Four failures render as four lines inside one alert. Scroll position stays at zero throughout.
- [Browser recording](https://github.com/dominic-r/t3code/releases/download/evidence-usage-limit-notices-825b2b85a/limits-combined-proof.mp4) and [measurements](https://github.com/dominic-r/t3code/releases/download/evidence-usage-limit-notices-825b2b85a/measurements-combined.json). Mobile was not simulator-tested.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Usage limit notices now appear below pooled usage sections.
  * Notices display in warning alerts with icons, warning styling, and wrapped titles.
  * Empty-state messaging appears only when neither pooled usage data nor notices are available.
  * Failed-refresh messages now appear within the warning alert and indicate that the last known values are being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->