### PR TITLE
fix(shared): bound readiness response body reads

### DIFF
--- a/packages/shared/src/httpReadiness.test.ts
+++ b/packages/shared/src/httpReadiness.test.ts
@@ -1,0 +1,107 @@
+import { it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Result from "effect/Result";
+import * as TestClock from "effect/testing/TestClock";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { describe, expect } from "vite-plus/test";
+
+import { waitForHttpReady } from "./httpReadiness.ts";
+
+const options = {
+  baseUrl: "http://localhost:3773/",
+  timeoutMs: 1_000,
+  probeTimeoutMs: 250,
+  intervalMs: 100,
+  makeError: ({ cause }: { readonly cause: unknown }) => new Error("Readiness failed", { cause }),
+};
+
+describe("waitForHttpReady", () => {
+  it.effect.each(["headers", "body"] as const)(
+    "retries after stalled %s and interrupts the stalled probe",
+    (phase) =>
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>();
+        const interrupted = yield* Deferred.make<void>();
+        const stalled = Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined)),
+        );
+        let attempts = 0;
+        const signals: AbortSignal[] = [];
+        const client = HttpClient.make((request, _url, signal) =>
+          Effect.suspend(() => {
+            attempts += 1;
+            signals.push(signal);
+            const response = HttpClientResponse.fromWeb(request, new Response("ready"));
+            if (attempts !== 1) return Effect.succeed(response);
+            if (phase === "headers") return stalled;
+            Object.defineProperty(response, "text", { value: stalled });
+            return Effect.succeed(response);
+          }),
+        );
+        const fiber = yield* waitForHttpReady(options).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.result,
+          Effect.forkChild,
+        );
+
+        yield* Deferred.await(started);
+        yield* TestClock.adjust("1 second");
+        const result = yield* Fiber.join(fiber);
+
+        expect(Result.isSuccess(result)).toBe(true);
+        expect(attempts).toBe(2);
+        expect(yield* Deferred.isDone(interrupted)).toBe(true);
+        expect(signals[0]?.aborted).toBe(true);
+        expect(signals[1]?.aborted).toBe(false);
+      }),
+  );
+
+  it.effect("reports the last body timeout when no probe completes", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      let attempts = 0;
+      const failures: unknown[] = [];
+      const client = HttpClient.make((request) =>
+        Effect.sync(() => {
+          attempts += 1;
+          const response = HttpClientResponse.fromWeb(request, new Response(""));
+          Object.defineProperty(response, "text", {
+            value: Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+          });
+          return response;
+        }),
+      );
+      const fiber = yield* waitForHttpReady({
+        ...options,
+        makeError: (info) => {
+          failures.push(info.cause);
+          return options.makeError(info);
+        },
+      }).pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+        Effect.result,
+        Effect.forkChild,
+      );
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("1 second");
+      const result = yield* Fiber.join(fiber);
+
+      expect(attempts).toBe(3);
+      expect(failures.slice(0, 3)).toEqual(
+        [1, 2, 3].map((attempt) => ({ kind: "probe-timeout", attempt, probeTimeoutMs: 250 })),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure.cause).toMatchObject({
+          kind: "overall-timeout",
+          lastFailure: {
+            attempt: 3,
+          },
+        });
+      }
+    }),
+  );
+});

--- a/packages/shared/src/httpReadiness.ts
+++ b/packages/shared/src/httpReadiness.ts
@@ -99,6 +99,8 @@ export const waitForHttpReady = Effect.fn("shared.httpReadiness.waitForHttpReady
 
   const readinessClient = client.pipe(
     HttpClient.filterStatusOk,
+    // Include body consumption in the probe deadline, not just the response headers.
+    HttpClient.tap((response) => response.text.pipe(Effect.ignore)),
     HttpClient.transform((effect) =>
       Effect.gen(function* () {
         attempt += 1;
@@ -127,7 +129,6 @@ export const waitForHttpReady = Effect.fn("shared.httpReadiness.waitForHttpReady
         ),
       ),
     ),
-    HttpClient.tap((response) => response.text.pipe(Effect.ignore)),
     HttpClient.retry(retryPolicy),
   );
 


### PR DESCRIPTION
## What Changed

Put response-body consumption inside the existing per-probe HTTP readiness deadline so a stalled body is interrupted and retried.

## Why

A backend or proxy can send successful headers and then stop sending its body. SSH tunnel and desktop backend startup currently spend the entire overall deadline on that one response, even if the next probe would succeed.

Checked open PR file lists and relevant patches before implementing. The two open branches touching this helper, #9376 and #10051, only change an export and do not address body deadlines.

## Testing

- Reproduced on upstream `02443335b`: both stalled-body regressions fail before the fix.
- 44 focused tests pass across shared HTTP readiness, SSH tunnel, and desktop backend manager suites.
- Regression coverage checks recovery, request abortion, repeated body stalls, and the overall deadline using TestClock.
- Targeted lint and shared-package typecheck pass.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound response body reads under per-probe timeout in `waitForHttpReady`
> - Moves response-body consumption into the `HttpClient` pipeline before the per-probe timeout transform in [httpReadiness.ts](https://github.com/pingdotgg/t3code/pull/10603/files#diff-1b4f9bb074cb3c80336afae701f31df286c6b701d3e1b08a6920524d8e6a7637), so a stalled body now hits the probe deadline instead of hanging outside it.
> - Adds an Effect-based test suite in [httpReadiness.test.ts](https://github.com/pingdotgg/t3code/pull/10603/files#diff-9b0efa638b8363b709147c2734615cc2216ffdb83b188137d4e03b24971cb8b8) using `TestClock` to verify probe interruption, retry on stalled headers/body, and overall-timeout reporting for never-completing bodies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db0916b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP readiness checks now include response-body consumption within each probe’s timeout window.
  * Stalled readiness probes are retried correctly, with timed-out attempts canceled before the next attempt begins.

* **Tests**
  * Added coverage for retries, probe cancellation, abort signals, per-probe timeouts, and overall timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->