### PR TITLE
fix(web): keep legacy thread routes stable during reconnect

### DIFF
--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -4,7 +4,11 @@ import { useEffect } from "react";
 import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
-import { resolveThreadRouteRef, resolveThreadRouteRenderState } from "../threadRoutes";
+import {
+  isThreadRouteSnapshotAuthoritative,
+  resolveThreadRouteRef,
+  resolveThreadRouteRenderState,
+} from "../threadRoutes";
 import { resolveThreadSyncPhase } from "../threadSync";
 import { useSidebarPendingFileDropStore } from "../sidebarPendingFileDropStore";
 import { SidebarInset } from "~/components/ui/sidebar";
@@ -29,7 +33,7 @@ function ChatThreadRouteView() {
   const serverThreadDetail = useThreadDetail(threadRef);
   const serverThreadStatus = useThreadStatus(threadRef);
   const environmentThreadRefs = useEnvironmentThreadRefs(threadRef?.environmentId ?? null);
-  const bootstrapComplete = shell.data?.snapshot._tag === "Some";
+  const bootstrapComplete = isThreadRouteSnapshotAuthoritative(shell.data?.status);
   const environmentHasServerThreads = environmentThreadRefs.length > 0;
   const draftThreadExists = useComposerDraftStore((store) =>
     threadRef ? store.getDraftThreadByRef(threadRef) !== null : false,

--- a/apps/web/src/threadRoutes.test.ts
+++ b/apps/web/src/threadRoutes.test.ts
@@ -6,6 +6,7 @@ import { DraftId } from "./composerDraftStore";
 import {
   buildDraftThreadRouteParams,
   buildThreadRouteParams,
+  isThreadRouteSnapshotAuthoritative,
   resolveActiveThreadRouteRef,
   resolveThreadRouteRenderState,
   resolveThreadRouteRef,
@@ -13,6 +14,13 @@ import {
 } from "./threadRoutes";
 
 describe("threadRoutes", () => {
+  it("does not treat cached thread lists as authoritative for deep links", () => {
+    expect(isThreadRouteSnapshotAuthoritative("empty")).toBe(false);
+    expect(isThreadRouteSnapshotAuthoritative("cached")).toBe(false);
+    expect(isThreadRouteSnapshotAuthoritative("synchronizing")).toBe(false);
+    expect(isThreadRouteSnapshotAuthoritative("live")).toBe(true);
+  });
+
   it("builds canonical thread route params from a scoped ref", () => {
     const ref = scopeThreadRef("env-1" as never, ThreadId.make("thread-1"));
 

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -20,6 +20,12 @@ type DraftThreadRouteState = {
 
 export type ThreadRouteRenderState = "loading" | "ready" | "missing";
 
+export function isThreadRouteSnapshotAuthoritative(
+  status: "empty" | "cached" | "synchronizing" | "live" | undefined,
+): boolean {
+  return status === "live";
+}
+
 export function resolveThreadRouteRenderState(input: {
   bootstrapComplete: boolean;
   serverThreadShellExists: boolean;

--- a/apps/web/src/threadRoutes.ts
+++ b/apps/web/src/threadRoutes.ts
@@ -1,4 +1,5 @@
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import type { DraftId } from "./composerDraftStore";
 
@@ -21,7 +22,7 @@ type DraftThreadRouteState = {
 export type ThreadRouteRenderState = "loading" | "ready" | "missing";
 
 export function isThreadRouteSnapshotAuthoritative(
-  status: "empty" | "cached" | "synchronizing" | "live" | undefined,
+  status: EnvironmentShellStatus | undefined,
 ): boolean {
   return status === "live";
 }

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -457,7 +457,7 @@ describe("environment shell synchronization", () => {
     }),
   );
 
-  it.effect("refreshes the shell before resuming against servers without completion markers", () =>
+  it.effect("keeps a legacy HTTP refresh non-authoritative until a socket snapshot arrives", () =>
     Effect.gen(function* () {
       const events = yield* Queue.unbounded<OrchestrationShellStreamItem>();
       const wakeups = yield* Queue.unbounded<ConnectionWakeups.ConnectionWakeup>();
@@ -514,15 +514,31 @@ describe("environment shell synchronization", () => {
         ),
       );
 
-      expect(yield* Queue.take(subscribeInputs)).toEqual({ afterSequence: 10 });
-      expect((yield* SubscriptionRef.get(shellState)).status).toBe("live");
+      expect(yield* Queue.take(subscribeInputs)).toEqual({});
+      const initial = yield* SubscriptionRef.get(shellState);
+      expect(initial.status).toBe("synchronizing");
+      expect(Option.getOrThrow(initial.snapshot).snapshotSequence).toBe(10);
 
-      yield* Queue.offer(wakeups, "application-active");
-      expect(yield* Queue.take(subscribeInputs)).toEqual({ afterSequence: 20 });
-      const resumed = yield* SubscriptionRef.get(shellState);
-      expect(resumed.status).toBe("live");
-      expect(Option.getOrThrow(resumed.snapshot).snapshotSequence).toBe(20);
-      expect(yield* Ref.get(loaderCalls)).toBe(2);
+      yield* Queue.offer(events, {
+        kind: "snapshot",
+        snapshot: {
+          ...LIVE_SHELL_SNAPSHOT,
+          snapshotSequence: 11,
+          threads: [{ id: "created-after-http-snapshot" } as never],
+        },
+      });
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((yield* SubscriptionRef.get(shellState)).status === "live") break;
+        yield* Effect.yieldNow;
+      }
+      const live = yield* SubscriptionRef.get(shellState);
+      expect(yield* Queue.size(events)).toBe(0);
+      expect(Option.getOrThrow(live.snapshot).snapshotSequence).toBe(11);
+      expect(live.status).toBe("live");
+      expect(Option.getOrThrow(live.snapshot).threads).toEqual([
+        { id: "created-after-http-snapshot" },
+      ]);
+      expect(yield* Ref.get(loaderCalls)).toBe(1);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -48,10 +48,15 @@ const LIVE_SHELL_SNAPSHOT: OrchestrationShellSnapshot = {
   updatedAt: "2026-06-06T00:00:00.000Z",
 };
 
-function session(client: WsRpcProtocolClient): RpcSession.RpcSession {
+function session(
+  client: WsRpcProtocolClient,
+  options?: { readonly completionMarker?: boolean },
+): RpcSession.RpcSession {
   return {
     client,
-    initialConfig: Effect.succeed({ shellResumeCompletionMarker: true } as never),
+    initialConfig: Effect.succeed(
+      (options?.completionMarker === false ? {} : { shellResumeCompletionMarker: true }) as never,
+    ),
     subscribeServerConfig: (input) => client.subscribeServerConfig(input),
     ready: Effect.void,
     probe: Effect.void,
@@ -448,6 +453,75 @@ describe("environment shell synchronization", () => {
         yield* Effect.yieldNow;
       }
       expect(yield* Ref.get(capturedAfterSequences)).toEqual([10, 40, 40, 20]);
+      expect(yield* Ref.get(loaderCalls)).toBe(2);
+    }),
+  );
+
+  it.effect("refreshes the shell before resuming against servers without completion markers", () =>
+    Effect.gen(function* () {
+      const events = yield* Queue.unbounded<OrchestrationShellStreamItem>();
+      const wakeups = yield* Queue.unbounded<ConnectionWakeups.ConnectionWakeup>();
+      const subscribeInputs = yield* Queue.unbounded<{ readonly afterSequence?: number }>();
+      const loaderCalls = yield* Ref.make(0);
+      const client = {
+        [ORCHESTRATION_WS_METHODS.subscribeShell]: (input: { readonly afterSequence?: number }) =>
+          Stream.unwrap(
+            Queue.offer(subscribeInputs, input).pipe(Effect.as(Stream.fromQueue(events))),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const supervisorState = yield* SubscriptionRef.make(AVAILABLE_CONNECTION_STATE);
+      const activeSession = yield* SubscriptionRef.make(
+        Option.some(session(client, { completionMarker: false })),
+      );
+      const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+        target: TARGET,
+        state: supervisorState,
+        session: activeSession,
+        prepared: yield* SubscriptionRef.make(Option.some(PREPARED)),
+        connect: Effect.void,
+        disconnect: Effect.void,
+        retryNow: Effect.void,
+      } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+      const cache = Persistence.EnvironmentCacheStore.of({
+        loadShell: () => Effect.succeed(Option.none()),
+        saveShell: () => Effect.void,
+        loadThread: () => Effect.succeed(Option.none()),
+        saveThread: () => Effect.void,
+        removeThread: () => Effect.void,
+        loadServerConfig: () => Effect.succeed(Option.none()),
+        saveServerConfig: () => Effect.void,
+        loadVcsRefs: () => Effect.succeed(Option.none()),
+        saveVcsRefs: () => Effect.void,
+        removeVcsRefs: () => Effect.void,
+        clearVcsRefs: () => Effect.void,
+        clear: () => Effect.void,
+      });
+      const snapshotLoader = ShellSnapshotLoader.of({
+        load: () =>
+          Ref.updateAndGet(loaderCalls, (count) => count + 1).pipe(
+            Effect.map((count) =>
+              Option.some({ ...LIVE_SHELL_SNAPSHOT, snapshotSequence: count * 10 }),
+            ),
+          ),
+      });
+      const shellState = yield* makeEnvironmentShellState().pipe(
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.provideService(Persistence.EnvironmentCacheStore, cache),
+        Effect.provideService(ShellSnapshotLoader, snapshotLoader),
+        Effect.provideService(
+          ConnectionWakeups.ConnectionWakeups,
+          ConnectionWakeups.ConnectionWakeups.of({ changes: Stream.fromQueue(wakeups) }),
+        ),
+      );
+
+      expect(yield* Queue.take(subscribeInputs)).toEqual({ afterSequence: 10 });
+      expect((yield* SubscriptionRef.get(shellState)).status).toBe("live");
+
+      yield* Queue.offer(wakeups, "application-active");
+      expect(yield* Queue.take(subscribeInputs)).toEqual({ afterSequence: 20 });
+      const resumed = yield* SubscriptionRef.get(shellState);
+      expect(resumed.status).toBe("live");
+      expect(Option.getOrThrow(resumed.snapshot).snapshotSequence).toBe(20);
       expect(yield* Ref.get(loaderCalls)).toBe(2);
     }),
   );

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -527,11 +527,12 @@ describe("environment shell synchronization", () => {
           threads: [{ id: "created-after-http-snapshot" } as never],
         },
       });
-      for (let attempt = 0; attempt < 100; attempt += 1) {
-        if ((yield* SubscriptionRef.get(shellState)).status === "live") break;
-        yield* Effect.yieldNow;
-      }
-      const live = yield* SubscriptionRef.get(shellState);
+      const live = Option.getOrThrow(
+        yield* SubscriptionRef.changes(shellState).pipe(
+          Stream.filter((state) => state.status === "live"),
+          Stream.runHead,
+        ),
+      );
       expect(yield* Queue.size(events)).toBe(0);
       expect(Option.getOrThrow(live.snapshot).snapshotSequence).toBe(11);
       expect(live.status).toBe("live");

--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -540,6 +540,12 @@ describe("environment shell synchronization", () => {
         { id: "created-after-http-snapshot" },
       ]);
       expect(yield* Ref.get(loaderCalls)).toBe(1);
+
+      // A same-session resubscribe still requests a full socket snapshot but
+      // does not pay for another HTTP refresh first.
+      yield* Queue.offer(wakeups, "application-active");
+      expect(yield* Queue.take(subscribeInputs)).toEqual({});
+      expect(yield* Ref.get(loaderCalls)).toBe(1);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -205,9 +205,11 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
         yield* setSynchronizing;
 
         // Foreground resubscriptions on the same live session can resume from
-        // the in-memory cursor. A new session reloads the authoritative HTTP
-        // snapshot so a valid cursor cannot preserve incomplete cached data.
-        const hasAuthoritativeSnapshot = (yield* Ref.get(lastAuthoritativeSession)) === session;
+        // the in-memory cursor when the server marks replay completion. Older
+        // servers need another authoritative HTTP snapshot because they report
+        // the resumed subscription as live before its replay can arrive.
+        const hasAuthoritativeSnapshot =
+          supportsCompletionMarker && (yield* Ref.get(lastAuthoritativeSession)) === session;
         let canResume = hasAuthoritativeSnapshot;
         let current = yield* SubscriptionRef.get(state);
         if (!hasAuthoritativeSnapshot || Option.isNone(current.snapshot)) {

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -206,8 +206,8 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
 
         // Foreground resubscriptions on the same live session can resume from
         // the in-memory cursor when the server marks replay completion. Older
-        // servers need another authoritative HTTP snapshot because they report
-        // the resumed subscription as live before its replay can arrive.
+        // servers need a full socket snapshot because an HTTP snapshot cannot
+        // account for events committed before the socket subscription starts.
         const hasAuthoritativeSnapshot =
           supportsCompletionMarker && (yield* Ref.get(lastAuthoritativeSession)) === session;
         let canResume = hasAuthoritativeSnapshot;
@@ -229,7 +229,11 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
           );
           const httpSnapshot = yield* snapshotLoader.load(prepared);
           if (Option.isSome(httpSnapshot)) {
+            yield* Ref.set(awaitingCompletion, true);
             yield* applyItems([{ kind: "snapshot", snapshot: httpSnapshot.value }]);
+            if (!supportsCompletionMarker) {
+              yield* Ref.set(awaitingCompletion, false);
+            }
             canResume = true;
             current = yield* SubscriptionRef.get(state);
           }
@@ -241,17 +245,11 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
           return supportsCompletionMarker ? { requestCompletionMarker: true as const } : {};
         }
         if (!supportsCompletionMarker) {
-          // Without a completion marker there is no synchronized signal for a
-          // resumed subscription, so report live immediately, like threads.
-          yield* SubscriptionRef.update(state, (value) => ({
-            ...value,
-            status: "live" as const,
-            error: Option.none(),
-          }));
+          return {};
         }
         return {
           afterSequence: current.snapshot.value.snapshotSequence,
-          ...(supportsCompletionMarker ? { requestCompletionMarker: true as const } : {}),
+          requestCompletionMarker: true as const,
         };
       }),
       {

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -72,7 +72,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
     error: Option.none(),
   });
   const awaitingCompletion = yield* Ref.make(false);
-  const lastAuthoritativeSession = yield* Ref.make<RpcSession | null>(null);
+  const lastSnapshotSession = yield* Ref.make<RpcSession | null>(null);
   const activeSubscriptionSession = yield* Ref.make<RpcSession | null>(null);
   const persistence = yield* Queue.sliding<OrchestrationShellSnapshot>(1);
 
@@ -177,7 +177,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
     if (receivedSnapshot) {
       const session = yield* Ref.get(activeSubscriptionSession);
       if (session !== null) {
-        yield* Ref.set(lastAuthoritativeSession, session);
+        yield* Ref.set(lastSnapshotSession, session);
       }
     }
     if (next.snapshot !== initial.snapshot && Option.isSome(next.snapshot)) {
@@ -207,12 +207,13 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
         // Foreground resubscriptions on the same live session can resume from
         // the in-memory cursor when the server marks replay completion. Older
         // servers need a full socket snapshot because an HTTP snapshot cannot
-        // account for events committed before the socket subscription starts.
-        const hasAuthoritativeSnapshot =
-          supportsCompletionMarker && (yield* Ref.get(lastAuthoritativeSession)) === session;
+        // account for events committed before the socket subscription starts,
+        // but a session that already holds one skips the redundant HTTP reload.
+        const sessionHasSnapshot = (yield* Ref.get(lastSnapshotSession)) === session;
+        const hasAuthoritativeSnapshot = supportsCompletionMarker && sessionHasSnapshot;
         let canResume = hasAuthoritativeSnapshot;
         let current = yield* SubscriptionRef.get(state);
-        if (!hasAuthoritativeSnapshot || Option.isNone(current.snapshot)) {
+        if (!sessionHasSnapshot || Option.isNone(current.snapshot)) {
           const prepared = yield* SubscriptionRef.get(supervisor.prepared).pipe(
             Effect.flatMap(
               Option.match({


### PR DESCRIPTION
## What Changed

Opening a valid thread deep link while a legacy connection is still synchronizing now waits for the live shell snapshot and keeps the requested conversation. Previously, a cached or HTTP snapshot could be treated as authoritative too soon and redirect the client to an unrelated thread.

Legacy servers now receive a full socket snapshot request instead of cursor resumption without a completion signal. Marker-capable servers retain their completion-marker path.

## Proof

Same Linux Chromium web scenario at base `09e8de9c655ae85410bf6b00446f272a01da81c7` and candidate `a325b17ed3e398a88ce10de7744008c064debf7e`: an isolated fixture retains the HTTP shell response from before the target thread was created, omits the completion-marker capability, and holds live shell/target-detail delivery until the initial route is observed. Delivery then resumes. Both clients use the same exact-base backend; Chromium local-network permission is scoped to that isolated origin.

**Before:** the valid deep link redirects to an unrelated **New thread** and remains there after live delivery resumes.

![Before: base redirects the requested conversation to an unrelated New thread](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/base-navigation.gif)

[Full before recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/base-full.mp4) · [Full before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/base-full.png)

**After:** the requested **Reconnect target conversation** stays selected and opens after the live snapshot arrives.

![After: the candidate preserves and opens the requested conversation](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/candidate-navigation.gif)

[Full after recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/candidate-full.mp4) · [Full after screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/candidate-full.png)

The GIFs use the same sidebar crop and 12 fps sampling, with labels added above the captured frame. No temporal cuts or speed changes. Full recordings provide context. Files were anonymously downloaded again, hash-verified, decoded, and inspected by sampled frames; interactive browser playback was not inspected. [Raw recordings, receipts, and capture script](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/route-proof.zip) · [Media receipt](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/media-receipt.json).

## How

- `packages/client-runtime/src/state/shell.ts`: when the server lacks `shellResumeCompletionMarker`, an HTTP snapshot keeps the shell `synchronizing` and the socket subscribes without a cursor, so the server sends a full snapshot. That snapshot is what sets the shell `live`. Marker-capable servers keep cursor resumption, and a session that already holds a snapshot skips the HTTP reload on resubscribe either way.
- `apps/web/src/threadRoutes.ts`: the thread route treats the shell as authoritative only when its status is `live`, rather than whenever any snapshot exists. Until then a deep link shows loading instead of redirecting.

Mobile has no equivalent missing-thread redirect. The other web checks for snapshot presence (ChatView file surfaces, desktop activation) don't redirect, so they are unchanged.

## Verification

- Rebased onto `origin/main` at `b1e223e2b0` with no conflicts; none of the touched files changed upstream since the branch opened, and no merged or open PR covers this fix.
- `vp test run apps/web/src/threadRoutes.test.ts packages/client-runtime/src/state/shell-sync.test.ts`: 17/17 passed.
- Typecheck of `@t3tools/client-runtime` and `@t3tools/web` passed (only pre-existing Effect lint suggestions in untouched files).
- The new shell-sync test waits on `SubscriptionRef.changes` instead of a `yieldNow` polling loop.
- Cross-provider review (Codex GPT-5.6 Sol, high effort, read-only) found one P2: legacy resubscribes reloaded the shell over HTTP before every full socket snapshot, doubling transfer per wakeup/retry. Fixed in `4b9e7bbad2` by tracking "session already holds a snapshot" separately from cursor authority — same-session resubscribes skip the HTTP reload, and the extended test asserts `loaderCalls` stays at 1 across a wakeup.
- The before/after media above was captured at head `a325b17`; the rebased code plus the resubscribe fix preserve the demonstrated behavior (deep links still hold through reconnect on legacy servers).

Coordination trace: T3 thread 6ab946db-fa5f-4a69-8100-989898b3be01
Coordination trace: T3 thread 70aa05a0-1e96-4ca1-bad0-bd7968216764

Original fix implemented by GPT-5.6 Sol through the T3 Code Codex harness; comparison evidence prepared by GPT-6 through Codex. Rebased and refreshed by Claude Opus 5 through Claude Code in T3 Code. Rebase, review fix, and this refresh by SWE-2 High through Devin in T3 Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix legacy thread routes to require live shell snapshot during reconnect
> - Legacy sessions without the shell resume completion marker were incorrectly treated as bootstrapped after an HTTP refresh, because the route only checked for snapshot presence. Bootstrap completion now requires an authoritative (live) shell snapshot via `isThreadRouteSnapshotAuthoritative` in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/10604/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3), used by the `ChatThreadRouteView` component in [_chat.$environmentId.$threadId.tsx](https://github.com/pingdotgg/t3code/pull/10604/files#diff-5873401c664d8c70d7bd404a83ecb5f76631a08bc699d6e4841186b329a2cf63).
> - `makeSubscribeInput` in [shell.ts](https://github.com/pingdotgg/t3code/pull/10604/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83) now requires both same RPC session and completion-marker support for resume eligibility. Marker-capable sessions keep cursor-based resumption; legacy sessions return without a cursor so the socket must supply a full snapshot.
> - Behavioral Change: legacy sessions without the completion marker no longer report live after HTTP refresh — they remain synchronizing until a socket snapshot arrives. Check `EnvironmentShellState.makeSubscribeInput` in [shell.ts](https://github.com/pingdotgg/t3code/pull/10604/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83) and the route bootstrap predicate in [threadRoutes.ts](https://github.com/pingdotgg/t3code/pull/10604/files#diff-2786ca87c67654801c30d674118b89515b8a9e7fa2d9806b90b36f71c887a7b3) for regressions in reconnect flows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a325b17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat thread loading so initialization completes only after a confirmed live snapshot is available.
  * Added compatibility for older servers without snapshot completion support, preventing stale or incomplete session state from being treated as current.
  * Improved session recovery by retrieving complete snapshots when needed and maintaining accurate synchronization status during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
