### PR TITLE
fix(desktop): survive pre-window close events

### DIFF
--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -255,7 +255,7 @@ describe("DesktopLifecycle", () => {
     }),
   );
 
-  it.effect("ignores window-all-closed until a main window has been created", () =>
+  it.effect("ignores a synthetic early close but quits after an owned window existed", () =>
     Effect.gen(function* () {
       const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
       let quitCount = 0;
@@ -289,11 +289,13 @@ describe("DesktopLifecycle", () => {
           appListeners.get("window-all-closed")?.();
           yield* Effect.yieldNow;
           assert.equal(quitCount, 0);
+          assert.isFalse(yield* Ref.get(state.quitting));
 
-          yield* Ref.set(state.mainWindowCreated, true);
+          yield* Ref.set(state.windowCreated, true);
           appListeners.get("window-all-closed")?.();
           yield* Effect.yieldNow;
           assert.equal(quitCount, 1);
+          assert.isTrue(yield* Ref.get(state.quitting));
         }),
       ).pipe(Effect.provide(layer));
     }),

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -254,4 +254,48 @@ describe("DesktopLifecycle", () => {
       ).pipe(Effect.provide(layer));
     }),
   );
+
+  it.effect("ignores window-all-closed until a main window has been created", () =>
+    Effect.gen(function* () {
+      const appListeners = new Map<string, (...args: readonly unknown[]) => void>();
+      let quitCount = 0;
+      const environmentLayer = Layer.succeed(DesktopEnvironment.DesktopEnvironment, {
+        platform: "linux",
+        isDevelopment: false,
+      } as DesktopEnvironment.DesktopEnvironment["Service"]);
+      const layer = DesktopLifecycle.layer.pipe(
+        Layer.provideMerge(
+          makeElectronAppLayer(
+            appListeners,
+            Effect.sync(() => {
+              quitCount += 1;
+            }),
+          ),
+        ),
+        Layer.provideMerge(electronThemeLayer),
+        Layer.provideMerge(makeElectronWindowLayer()),
+        Layer.provideMerge(makeDesktopWindowLayer()),
+        Layer.provideMerge(environmentLayer),
+        Layer.provideMerge(DesktopShutdown.layer),
+        Layer.provideMerge(DesktopState.layer),
+      );
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+          const state = yield* DesktopState.DesktopState;
+          yield* lifecycle.register;
+
+          appListeners.get("window-all-closed")?.();
+          yield* Effect.yieldNow;
+          assert.equal(quitCount, 0);
+
+          yield* Ref.set(state.mainWindowCreated, true);
+          appListeners.get("window-all-closed")?.();
+          yield* Effect.yieldNow;
+          assert.equal(quitCount, 1);
+        }),
+      ).pipe(Effect.provide(layer));
+    }),
+  );
 });

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -246,7 +246,11 @@ export const make = DesktopLifecycle.of({
         Effect.gen(function* () {
           const app = yield* ElectronApp.ElectronApp;
           const state = yield* DesktopState.DesktopState;
-          if (environment.platform !== "darwin" && !(yield* Ref.get(state.quitting))) {
+          if (
+            environment.platform !== "darwin" &&
+            (yield* Ref.get(state.mainWindowCreated)) &&
+            !(yield* Ref.get(state.quitting))
+          ) {
             yield* app.quit;
           }
         }).pipe(Effect.withSpan("desktop.lifecycle.windowAllClosed")),

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -248,9 +248,10 @@ export const make = DesktopLifecycle.of({
           const state = yield* DesktopState.DesktopState;
           if (
             environment.platform !== "darwin" &&
-            (yield* Ref.get(state.mainWindowCreated)) &&
+            (yield* Ref.get(state.windowCreated)) &&
             !(yield* Ref.get(state.quitting))
           ) {
+            yield* Ref.set(state.quitting, true);
             yield* app.quit;
           }
         }).pipe(Effect.withSpan("desktop.lifecycle.windowAllClosed")),

--- a/apps/desktop/src/app/DesktopState.ts
+++ b/apps/desktop/src/app/DesktopState.ts
@@ -7,14 +7,14 @@ export class DesktopState extends Context.Service<
   DesktopState,
   {
     readonly backendReady: Ref.Ref<boolean>;
-    readonly mainWindowCreated: Ref.Ref<boolean>;
+    readonly windowCreated: Ref.Ref<boolean>;
     readonly quitting: Ref.Ref<boolean>;
   }
 >()("@t3tools/desktop/app/DesktopState") {}
 
 const make = Effect.all({
   backendReady: Ref.make(false),
-  mainWindowCreated: Ref.make(false),
+  windowCreated: Ref.make(false),
   quitting: Ref.make(false),
 });
 

--- a/apps/desktop/src/app/DesktopState.ts
+++ b/apps/desktop/src/app/DesktopState.ts
@@ -7,12 +7,14 @@ export class DesktopState extends Context.Service<
   DesktopState,
   {
     readonly backendReady: Ref.Ref<boolean>;
+    readonly mainWindowCreated: Ref.Ref<boolean>;
     readonly quitting: Ref.Ref<boolean>;
   }
 >()("@t3tools/desktop/app/DesktopState") {}
 
 const make = Effect.all({
   backendReady: Ref.make(false),
+  mainWindowCreated: Ref.make(false),
   quitting: Ref.make(false),
 });
 

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -217,6 +217,8 @@ function makeTestLayer(input: {
   readonly beforeMainWindowBoundsUpdate?: (
     bounds: DesktopAppSettings.DesktopWindowBounds,
   ) => Effect.Effect<void>;
+  readonly setPreviewMainWindow?: (window: Electron.BrowserWindow) => Effect.Effect<void>;
+  readonly destroyAll?: Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly copiedTexts?: string[];
   readonly onPopupTemplate?: (input: ElectronMenu.ElectronMenuTemplateInput) => Effect.Effect<void>;
@@ -273,7 +275,7 @@ function makeTestLayer(input: {
     prepareReveal: () => Effect.succeed(false),
     reveal: (window) => Effect.sync(() => input.onReveal?.(window)),
     sendAll: () => Effect.void,
-    destroyAll: Effect.void,
+    destroyAll: input.destroyAll ?? Effect.void,
     syncAllAppearance: (sync) => sync(input.window),
   } satisfies ElectronWindow.ElectronWindow["Service"]);
   const desktopStateLayer = DesktopState.layer;
@@ -309,7 +311,7 @@ function makeTestLayer(input: {
         electronWindowLayer,
         Layer.mock(PreviewManager.PreviewManager)({
           getBrowserSession: () => Effect.succeed({} as Electron.Session),
-          setMainWindow: () => Effect.void,
+          setMainWindow: input.setPreviewMainWindow ?? (() => Effect.void),
           isBrowserPartition: (partition) => partition.startsWith("persist:t3code-preview-"),
           getBrowserPartition: () => Effect.succeed("persist:t3code-preview-test"),
           reapplyZoom: () =>
@@ -739,7 +741,84 @@ describe("DesktopWindow", () => {
         assert.equal(createdWindowOptions[0]?.height, 880);
         assert.equal(createdWindowOptions[0]?.x, 120);
         assert.equal(createdWindowOptions[0]?.y, 80);
-        assert.isTrue(yield* Ref.get(desktopState.mainWindowCreated));
+        assert.isTrue(yield* Ref.get(desktopState.windowCreated));
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("marks the connecting splash as an owned window", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({ window: fakeWindow.window, createCount, mainWindow });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
+
+        yield* desktopWindow.showConnectingSplash;
+
+        assert.isTrue(yield* Ref.get(desktopState.windowCreated));
+        assert.isTrue(Option.isNone(yield* Ref.get(mainWindow)));
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("does not register a main window whose setup finishes after shutdown starts", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const previewStarted = yield* Deferred.make<void>();
+      const releasePreview = yield* Deferred.make<void>();
+      const destroyCount = yield* Ref.make(0);
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        setPreviewMainWindow: () =>
+          Deferred.succeed(previewStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releasePreview)),
+            Effect.asVoid,
+          ),
+        destroyAll: Ref.update(destroyCount, (count) => count + 1),
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
+        const creation = yield* desktopWindow
+          .handleBackendReady(new URL("http://127.0.0.1:3773"))
+          .pipe(Effect.forkChild({ startImmediately: true }));
+
+        yield* Deferred.await(previewStarted);
+        yield* Ref.set(desktopState.quitting, true);
+        yield* Deferred.succeed(releasePreview, undefined);
+        yield* Fiber.join(creation);
+
+        assert.isTrue(Option.isNone(yield* Ref.get(mainWindow)));
+        assert.equal(yield* Ref.get(destroyCount), 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("does not start main window creation after shutdown starts", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({ window: fakeWindow.window, createCount, mainWindow });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
+
+        yield* Ref.set(desktopState.quitting, true);
+        yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
+
+        assert.equal(yield* Ref.get(createCount), 0);
+        assert.isTrue(Option.isNone(yield* Ref.get(mainWindow)));
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -219,6 +219,7 @@ function makeTestLayer(input: {
   ) => Effect.Effect<void>;
   readonly setPreviewMainWindow?: (window: Electron.BrowserWindow) => Effect.Effect<void>;
   readonly destroyAll?: Effect.Effect<void>;
+  readonly onWindowCreate?: Effect.Effect<void>;
   readonly openedExternalUrls?: unknown[];
   readonly copiedTexts?: string[];
   readonly onPopupTemplate?: (input: ElectronMenu.ElectronMenuTemplateInput) => Effect.Effect<void>;
@@ -265,6 +266,7 @@ function makeTestLayer(input: {
         input.createdWindowOptions?.push(options);
       }).pipe(
         Effect.andThen(Ref.update(input.createCount, (count) => count + 1)),
+        Effect.andThen(input.onWindowCreate ?? Effect.void),
         Effect.as(input.window),
       ),
     main: Ref.get(input.mainWindow),
@@ -761,6 +763,58 @@ describe("DesktopWindow", () => {
 
         assert.isTrue(yield* Ref.get(desktopState.windowCreated));
         assert.isTrue(Option.isNone(yield* Ref.get(mainWindow)));
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("does not create the connecting splash after shutdown starts", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const layer = makeTestLayer({ window: fakeWindow.window, createCount, mainWindow });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
+
+        yield* Ref.set(desktopState.quitting, true);
+        yield* desktopWindow.showConnectingSplash;
+
+        assert.equal(yield* Ref.get(createCount), 0);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("destroys a connecting splash whose creation finishes after shutdown starts", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const destroyCount = yield* Ref.make(0);
+      const desktopStateRef = yield* Ref.make<DesktopState.DesktopState["Service"] | null>(null);
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        destroyAll: Ref.update(destroyCount, (count) => count + 1),
+        onWindowCreate: Effect.gen(function* () {
+          const state = yield* Ref.get(desktopStateRef);
+          if (state !== null) {
+            yield* Ref.set(state.quitting, true);
+          }
+        }),
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
+        yield* Ref.set(desktopStateRef, desktopState);
+
+        yield* desktopWindow.showConnectingSplash;
+
+        assert.equal(yield* Ref.get(createCount), 1);
+        assert.equal(yield* Ref.get(destroyCount), 1);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -276,6 +276,7 @@ function makeTestLayer(input: {
     destroyAll: Effect.void,
     syncAllAppearance: (sync) => sync(input.window),
   } satisfies ElectronWindow.ElectronWindow["Service"]);
+  const desktopStateLayer = DesktopState.layer;
 
   return DesktopWindow.layer.pipe(
     Layer.provide(
@@ -285,7 +286,7 @@ function makeTestLayer(input: {
         desktopAppSettingsLayer,
         desktopClientSettingsLayer,
         desktopServerExposureLayer,
-        DesktopState.layer,
+        desktopStateLayer,
         electronAppLayer,
         Layer.succeed(ElectronMenu.ElectronMenu, {
           setApplicationMenu: () => Effect.void,
@@ -318,6 +319,7 @@ function makeTestLayer(input: {
         }),
       ),
     ),
+    Layer.merge(desktopStateLayer),
   );
 }
 
@@ -399,6 +401,7 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
           DesktopAppSettings.layerTest(),
           desktopClientSettingsLayer,
           desktopServerExposureLayer,
+          DesktopState.layer,
           electronAppLayer,
           electronMenuLayer,
           Layer.succeed(ElectronShell.ElectronShell, {
@@ -729,12 +732,14 @@ describe("DesktopWindow", () => {
 
       yield* Effect.gen(function* () {
         const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        const desktopState = yield* DesktopState.DesktopState;
         yield* desktopWindow.handleBackendReady(new URL("http://127.0.0.1:3773"));
 
         assert.equal(createdWindowOptions[0]?.width, 1320);
         assert.equal(createdWindowOptions[0]?.height, 880);
         assert.equal(createdWindowOptions[0]?.x, 120);
         assert.equal(createdWindowOptions[0]?.y, 80);
+        assert.isTrue(yield* Ref.get(desktopState.mainWindowCreated));
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -13,6 +13,7 @@ import { type DesktopSnapShotEvent, DEFAULT_CLIENT_SETTINGS } from "@t3tools/con
 import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import { makeComponentLogger } from "../app/DesktopObservability.ts";
+import * as DesktopState from "../app/DesktopState.ts";
 import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import { getDesktopUrl } from "../electron/ElectronProtocol.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
@@ -59,6 +60,7 @@ type WindowTitleBarOptions = Pick<
 
 type DesktopWindowRuntimeServices =
   | DesktopEnvironment.DesktopEnvironment
+  | DesktopState.DesktopState
   | DesktopAssets.DesktopAssets
   | DesktopAppSettings.DesktopAppSettings
   | DesktopClientSettings.DesktopClientSettings
@@ -293,6 +295,7 @@ function bindFirstRevealTrigger(
 /** @public Service construction is part of the canonical Effect module API. */
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const desktopState = yield* DesktopState.DesktopState;
   const assets = yield* DesktopAssets.DesktopAssets;
   const electronMenu = yield* ElectronMenu.ElectronMenu;
   const electronShell = yield* ElectronShell.ElectronShell;
@@ -820,6 +823,7 @@ export const make = Effect.gen(function* () {
   const createMain = Effect.gen(function* () {
     const window = yield* createWindow();
     yield* electronWindow.setMain(window);
+    yield* Ref.set(desktopState.mainWindowCreated, true);
     yield* logWindowInfo("main window created");
     return window;
   }).pipe(Effect.withSpan("desktop.window.createMain"));

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -856,6 +856,7 @@ export const make = Effect.gen(function* () {
   }).pipe(Effect.withSpan("desktop.window.createMainIfBackendReady"));
 
   const showConnectingSplash = Effect.gen(function* () {
+    if (yield* Ref.get(desktopState.quitting)) return;
     // Only when nothing is shown yet: no real window, no existing splash.
     const existingSplash = yield* Ref.get(splashWindowRef);
     if (Option.isSome(existingSplash)) return;
@@ -883,6 +884,12 @@ export const make = Effect.gen(function* () {
       },
     });
     yield* Ref.set(desktopState.windowCreated, true);
+    // Quit may have begun while the splash was being created; destroy it
+    // instead of registering a window that outlives shutdown's destroyAll.
+    if (yield* Ref.get(desktopState.quitting)) {
+      yield* electronWindow.destroyAll;
+      return;
+    }
     yield* Ref.set(splashWindowRef, Option.some(splash));
     splash.once("closed", () => {
       void runPromise(Ref.set(splashWindowRef, Option.none()));

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -402,6 +402,7 @@ export const make = Effect.gen(function* () {
         webviewTag: true,
       },
     });
+    yield* Ref.set(desktopState.windowCreated, true);
 
     if (environment.platform === "darwin") {
       window.setAutoHideCursor(false);
@@ -822,8 +823,11 @@ export const make = Effect.gen(function* () {
 
   const createMain = Effect.gen(function* () {
     const window = yield* createWindow();
+    if (yield* Ref.get(desktopState.quitting)) {
+      yield* electronWindow.destroyAll;
+      return window;
+    }
     yield* electronWindow.setMain(window);
-    yield* Ref.set(desktopState.mainWindowCreated, true);
     yield* logWindowInfo("main window created");
     return window;
   }).pipe(Effect.withSpan("desktop.window.createMain"));
@@ -843,6 +847,7 @@ export const make = Effect.gen(function* () {
   }).pipe(Effect.withSpan("desktop.window.revealOrCreateMain"));
 
   const createMainIfBackendReady = Effect.gen(function* () {
+    if (yield* Ref.get(desktopState.quitting)) return;
     const backendReady = yield* Ref.get(backendReadyRef);
     if (!backendReady) return;
     const existingWindow = yield* currentMainWindow;
@@ -877,6 +882,7 @@ export const make = Effect.gen(function* () {
         sandbox: true,
       },
     });
+    yield* Ref.set(desktopState.windowCreated, true);
     yield* Ref.set(splashWindowRef, Option.some(splash));
     splash.once("closed", () => {
       void runPromise(Ref.set(splashWindowRef, Option.none()));


### PR DESCRIPTION
## What Changed

Closing the last desktop window on Linux or Windows now starts shutdown even while startup is still in progress, while a spurious `window-all-closed` before the app creates any window remains ignored. Window ownership is tracked from creation: once an owned main window or WSL connecting splash exists, closing it marks the app as quitting. Any window whose creation finishes after shutdown begins — main window or connecting splash — is destroyed instead of being registered, and no new window is started once quitting begins.

## Why

Ignoring all close events until the main window was registered fixed an early startup exit but also ignored a real user closing the WSL splash or a window still being initialized. Track ownership from window creation, and reject both new and late window registration once quitting begins.

## Evidence

This automated Linux/Xvfb comparison uses the exact base `09e8de9c655ae85410bf6b00446f272a01da81c7` and head `e19e3e0ff44c1d81065f658b92a3224beeb823f1`, the same 1200×800 display, and repository-pinned Electron 43.4.1. A capture-only hook waits until the product installs its lifecycle listener, verifies that there are zero `BrowserWindow` instances, then emits the actual Electron `window-all-closed` event. Captions reflect the recorded event log; playback remains at real speed. The recorded startup path is unchanged by the later commits on this branch.

### Before: base exits before opening a window

![Base: the injected pre-window event quits the app without opening T3 Code](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-base-early-event.gif)

The base exits with code 0 and reaches `quit` at 1.317 s without creating a window.

### After: startup survives and opens the real T3 window

![Candidate: the same event is ignored during startup and the real T3 Code window opens](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-candidate-early-event.gif)

The candidate returns from the event, creates the real T3 window at 3.419 s, shows it at 3.552 s, and remains running until the recorder's owned cleanup.

[Base annotated recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-base-annotated.mp4) · [Candidate annotated recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-candidate-annotated.mp4) · [Capture and media receipt](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-media-receipt.json)

<details>
<summary>Raw recordings</summary>

[Base raw recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-base-raw.mp4) · [Candidate raw recording](https://github.com/saphid/t3code/releases/download/pr-evidence-core-regressions-20260908/desktop10605-candidate-raw.mp4)

</details>

## Verification

At head `e5fcc60596`, rebased onto `origin/main` `b1e223e2b0`:

- `vp test run apps/desktop/src/app/DesktopLifecycle.test.ts apps/desktop/src/window/DesktopWindow.test.ts`: **43/43 passed**, including new coverage that the connecting splash is neither created nor registered once shutdown starts.
- The held-creation regression failed before the fix: a late window was registered after quitting began.
- The exact-base/candidate Linux capture reproduced the pre-window exit and verified that the candidate opens a real T3 window after the same event.
- Scoped `vp fmt --check`, `vp lint`, `@t3tools/desktop` typecheck, and `git diff --check`: clean.
- Fresh independent GPT-5.6 Sol (Codex) review of the rebased diff returned one P2 — the connecting splash lacked the shutdown guard — fixed in `e5fcc60596` with regression tests. The main-window path already rechecks after construction and `destroyAll` enumerates every live window; `reveal` is `isDestroyed`-guarded.

The integrated recording covers Linux/Xvfb. Windows and the WSL splash path are covered by source inspection and the focused lifecycle tests; no OS-level Windows or WSL recording is claimed. macOS retains its existing last-window behavior. Final combined packaged verification remains a separate batch gate.

Coordination trace: T3 thread f04b996e-5605-45fe-8e94-29424b6798b4

Originally implemented by GPT-6 Codex through the T3 Code Codex harness; rebased and extended by SWE-2 High through the T3 Code Cursor harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop shutdown handling so the app no longer quits when a window-close event occurs before an application window is created.
  - Prevented new desktop windows or connection screens from opening after shutdown begins.
  - Improved shutdown reliability by recording the app's quitting state before exiting.
  - Kept window creation and shutdown behavior consistent across main-window and connection-screen scenarios.
  - Reduced the chance of orphaned windows during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
