### PR TITLE
fix(opencode): stop cancelled text generation sessions

### DIFF
--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -1,8 +1,11 @@
 import { OpenCodeSettings, ProviderInstanceId, TextGenerationError } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
@@ -23,6 +26,10 @@ const runtimeMock = {
     authHeaders: [] as Array<string | null>,
     closeCalls: [] as string[],
     sessionCreateCalls: 0,
+    abortCalls: [] as string[],
+    onSessionCreate: undefined as ((signal?: AbortSignal) => Promise<never>) | undefined,
+    onPrompt: undefined as ((signal?: AbortSignal) => Promise<never>) | undefined,
+    onAbort: undefined as ((signal?: AbortSignal) => Promise<never>) | undefined,
     connectionError: undefined as Error | undefined,
     sessionCreateError: undefined as unknown,
     sessionResult: undefined as { data?: { id: string } } | undefined,
@@ -38,6 +45,10 @@ const runtimeMock = {
     this.state.authHeaders.length = 0;
     this.state.closeCalls.length = 0;
     this.state.sessionCreateCalls = 0;
+    this.state.abortCalls.length = 0;
+    this.state.onSessionCreate = undefined;
+    this.state.onPrompt = undefined;
+    this.state.onAbort = undefined;
     this.state.connectionError = undefined;
     this.state.sessionCreateError = undefined;
     this.state.sessionResult = undefined;
@@ -94,19 +105,34 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
   createOpenCodeSdkClient: ({ baseUrl, serverPassword }) =>
     ({
       session: {
-        create: async () => {
+        create: async (_input: unknown, options?: { readonly signal?: AbortSignal }) => {
           runtimeMock.state.sessionCreateCalls += 1;
+          if (runtimeMock.state.onSessionCreate) {
+            return runtimeMock.state.onSessionCreate(options?.signal);
+          }
           if (runtimeMock.state.sessionCreateError !== undefined) {
             throw runtimeMock.state.sessionCreateError;
           }
           return runtimeMock.state.sessionResult ?? { data: { id: `${baseUrl}/session` } };
         },
-        prompt: async (input: { readonly parts: ReadonlyArray<unknown> }) => {
+        abort: async (
+          input: { readonly sessionID: string },
+          options?: { readonly signal?: AbortSignal },
+        ) => {
+          runtimeMock.state.abortCalls.push(input.sessionID);
+          if (runtimeMock.state.onAbort) return runtimeMock.state.onAbort(options?.signal);
+          return { data: true };
+        },
+        prompt: async (
+          input: { readonly parts: ReadonlyArray<unknown> },
+          options?: { readonly signal?: AbortSignal },
+        ) => {
           runtimeMock.state.promptUrls.push(baseUrl);
           runtimeMock.state.promptParts.push(input.parts);
           runtimeMock.state.authHeaders.push(
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
+          if (runtimeMock.state.onPrompt) return runtimeMock.state.onPrompt(options?.signal);
           if (runtimeMock.state.promptRequestError !== undefined) {
             throw runtimeMock.state.promptRequestError;
           }
@@ -235,6 +261,101 @@ const advanceIdleClock = Effect.gen(function* () {
 });
 
 it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
+  it.effect.each(["local", "external"] as const)(
+    "cancels an in-flight session creation on the %s server",
+    (server) =>
+      withOpenCodeTextGeneration(
+        server === "local" ? DEFAULT_OPENCODE_SETTINGS : EXISTING_SERVER_OPENCODE_SETTINGS,
+        (textGeneration) =>
+          Effect.gen(function* () {
+            const started = Promise.withResolvers<AbortSignal | undefined>();
+            runtimeMock.state.onSessionCreate = (signal) => {
+              started.resolve(signal);
+              return new Promise<never>(() => {});
+            };
+            const fiber = yield* textGeneration
+              .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+              .pipe(Effect.forkChild);
+            const signal = yield* Effect.promise(() => started.promise);
+            yield* Fiber.interrupt(fiber);
+
+            expect(signal?.aborted).toBe(true);
+            expect(runtimeMock.state.promptUrls).toEqual([]);
+            expect(runtimeMock.state.abortCalls).toEqual([]);
+          }),
+      ),
+  );
+
+  it.effect.each(["local", "external"] as const)(
+    "cancels the prompt and stops only its session on the %s server",
+    (server) =>
+      withOpenCodeTextGeneration(
+        server === "local" ? DEFAULT_OPENCODE_SETTINGS : EXISTING_SERVER_OPENCODE_SETTINGS,
+        (textGeneration) =>
+          Effect.gen(function* () {
+            const started = Promise.withResolvers<AbortSignal | undefined>();
+            runtimeMock.state.onPrompt = (signal) => {
+              started.resolve(signal);
+              return new Promise<never>(() => {});
+            };
+            const fiber = yield* textGeneration
+              .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+              .pipe(Effect.forkChild);
+            const signal = yield* Effect.promise(() => started.promise);
+            yield* Fiber.interrupt(fiber);
+
+            expect(signal?.aborted).toBe(true);
+            expect(runtimeMock.state.abortCalls).toEqual([
+              `${runtimeMock.state.promptUrls[0]}/session`,
+            ]);
+            expect(runtimeMock.state.closeCalls).toEqual([]);
+
+            runtimeMock.state.onPrompt = undefined;
+            const result = yield* textGeneration.generateCommitMessage(
+              DEFAULT_COMMIT_MESSAGE_INPUT,
+            );
+            expect(result.subject).toBe("Improve OpenCode reuse");
+            expect(runtimeMock.state.abortCalls).toHaveLength(1);
+          }),
+      ),
+  );
+
+  it.effect.each(["failure", "timeout"] as const)(
+    "preserves cancellation when the session abort ends in %s",
+    (outcome) =>
+      withOpenCodeTextGeneration(EXISTING_SERVER_OPENCODE_SETTINGS, (textGeneration) =>
+        Effect.gen(function* () {
+          const promptStarted = Promise.withResolvers<void>();
+          const abortStarted = Promise.withResolvers<AbortSignal | undefined>();
+          runtimeMock.state.onPrompt = () => {
+            promptStarted.resolve();
+            return new Promise<never>(() => {});
+          };
+          runtimeMock.state.onAbort = (signal) => {
+            abortStarted.resolve(signal);
+            return outcome === "failure"
+              ? Promise.reject(new Error("Server disconnected"))
+              : new Promise<never>(() => {});
+          };
+          const fiber = yield* textGeneration
+            .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+            .pipe(Effect.forkChild);
+          yield* Effect.promise(() => promptStarted.promise);
+          const cancellation = yield* Fiber.interrupt(fiber).pipe(Effect.forkChild);
+          const abortSignal = yield* Effect.promise(() => abortStarted.promise);
+          if (outcome === "timeout") {
+            yield* TestClock.adjust("10 seconds");
+          }
+          yield* Fiber.join(cancellation);
+
+          const exit = yield* Fiber.await(fiber);
+          expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+          expect(runtimeMock.state.abortCalls).toEqual(["http://127.0.0.1:9999/session"]);
+          if (outcome === "timeout") expect(abortSignal?.aborted).toBe(true);
+        }),
+      ),
+  );
+
   it.effect("excludes generic files from thread title generation", () =>
     withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
       Effect.gen(function* () {

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -212,11 +212,14 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
           ...(server.serverPassword !== undefined ? { serverPassword: server.serverPassword } : {}),
         });
         const session = yield* Effect.tryPromise({
-          try: () =>
-            client.session.create({
-              title: `T3 Code ${input.operation}`,
-              permission: [{ permission: "*", pattern: "*", action: "deny" }],
-            }),
+          try: (signal) =>
+            client.session.create(
+              {
+                title: `T3 Code ${input.operation}`,
+                permission: [{ permission: "*", pattern: "*", action: "deny" }],
+              },
+              { signal },
+            ),
           catch: (cause) =>
             new OpenCodeTextGenerationSessionRequestError({
               operation: input.operation,
@@ -241,20 +244,40 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
         };
 
         const result = yield* Effect.tryPromise({
-          try: () =>
-            client.session.prompt({
-              sessionID: session.data.id,
-              model: parsedModel,
-              ...(selectedAgent ? { agent: selectedAgent } : {}),
-              ...(selectedVariant ? { variant: selectedVariant } : {}),
-              parts: [{ type: "text", text: input.prompt }, ...fileParts],
-            }),
+          try: (signal) =>
+            client.session.prompt(
+              {
+                sessionID: session.data.id,
+                model: parsedModel,
+                ...(selectedAgent ? { agent: selectedAgent } : {}),
+                ...(selectedVariant ? { variant: selectedVariant } : {}),
+                parts: [{ type: "text", text: input.prompt }, ...fileParts],
+              },
+              { signal },
+            ),
           catch: (cause) =>
             new OpenCodeTextGenerationPromptRequestError({
               ...promptContext,
               cause,
             }),
-        });
+        }).pipe(
+          // Disconnecting the HTTP request does not stop work in a shared or external server.
+          Effect.onInterrupt(() =>
+            OpenCodeRuntime.runOpenCodeSdk("session.abort", (signal) =>
+              client.session.abort({ sessionID: session.data.id }, { signal }),
+            ).pipe(
+              Effect.interruptible,
+              Effect.timeout("10 seconds"),
+              Effect.catch((cause) =>
+                Effect.logWarning("Failed to stop cancelled OpenCode text generation.", {
+                  ...promptContext,
+                  cause,
+                }),
+              ),
+              Effect.asVoid,
+            ),
+          ),
+        );
         const promptFailure = getOpenCodePromptFailure(result.data?.info?.error);
         if (promptFailure) {
           return yield* new OpenCodeTextGenerationPromptResponseError({


### PR DESCRIPTION
## What Changed

Forward cancellation signals to OpenCode text-generation session creation and prompt requests. When a prompt is interrupted, abort that generation session without shutting down the shared server. Bound the abort request to ten seconds and preserve the original cancellation if cleanup fails.

## Why

Cancelling a commit-message, PR-content, branch-name, or title generation currently stops waiting in T3 but leaves its SDK request running. Shared and external OpenCode servers can continue generating after the caller has gone away.

The fix follows the main adapter's session-specific abort approach. It does not delete session history or change successful generation.

Checked open PR file lists, actual patches touching this implementation, and merged work before implementing. Existing OpenCode PRs in this file cover model IDs, terminal escaping, configuration, handover generation, or remote directories, not cancellation of text generation.

## Testing

- Reproduced on upstream main: four cancellation regressions fail before the fix, covering session creation and prompts on local and external servers.
- 27 focused tests pass across OpenCode text generation and shared server ownership.
- Covered session-specific abort, successful generation after cancellation, abort failure, and stalled abort cleanup using TestClock.
- Targeted lint and server-package typecheck pass; the typecheck reports existing suggestions outside the changed files.

Model: GPT-6 Astra
Harness: T3 code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop OpenCode sessions on cancelled text generation
> - Passes the Effect-provided `AbortSignal` into session creation and prompt SDK requests so fiber interruption reaches the OpenCode SDK calls
> - Adds an interruption handler around prompting that calls the OpenCode session-abort endpoint for the active session, with a 10-second timeout; abort failures and timeouts are logged and suppressed so they do not replace the original cancellation outcome
> - Adds tests covering cancellation during session creation, during an active prompt, and when the session-abort request fails or times out
> - Risk: the session-abort call in `runOpenCodeJson.runAgainstServer` is best-effort and interruptible; a slow or hanging abort endpoint could leave the OpenCode session active server-side despite client-side cancellation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f2bada.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling for AI text generation requests.
  - In-progress session creation and prompts can now be cancelled reliably.
  - Cancelling a prompt stops only the associated session.
  - Added safeguards for cases where session cancellation fails or times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->