### PR TITLE
fix(server): serialize checkpoint restores with pending turns

### DIFF
--- a/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
+++ b/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
@@ -276,12 +276,13 @@ it.effect(
         const restartedStoppedBindingThread = Option.getOrThrow(
           yield* query.getThreadDetailById(stoppedBindingThreadId),
         );
-        const pendingRows = yield* sql<{ readonly threadId: string }>`
-          SELECT thread_id AS "threadId"
+        const pendingRows = yield* sql<{ readonly messageId: string }>`
+          SELECT pending_message_id AS "messageId"
           FROM projection_turns
           WHERE thread_id IN (${threadId}, ${stoppedBindingThreadId})
             AND turn_id IS NULL
             AND state = 'pending'
+          ORDER BY pending_message_id ASC
         `;
         const settleExit = yield* Effect.exit(
           engine.dispatch({
@@ -323,7 +324,11 @@ it.effect(
           sessionStatus: restartedThread.session?.status,
           activeTurnId: restartedThread.session?.activeTurnId,
           latestTurn: restartedThread.latestTurn,
-          pendingTurnCount: pendingRows.length,
+          // This seam mocks OrchestrationReactor, so the provider reactor that
+          // emits correlated restart failures does not consume these requests.
+          // Session reconciliation must leave them intact instead of clearing
+          // unrelated pending work with an uncorrelated terminal status.
+          pendingTurnMessageIds: pendingRows.map((row) => row.messageId),
           settleSucceeded: Exit.isSuccess(settleExit),
           snoozeSucceeded: Exit.isSuccess(snoozeExit),
           newTurnSucceeded: Exit.isSuccess(newTurnExit),
@@ -341,7 +346,10 @@ it.effect(
         sessionStatus: "error",
         activeTurnId: null,
         latestTurn: null,
-        pendingTurnCount: 0,
+        pendingTurnMessageIds: [
+          "message-pending-before-restart",
+          "message-stopped-binding-pending-before-restart",
+        ],
         settleSucceeded: true,
         snoozeSucceeded: true,
         newTurnSucceeded: true,

--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -116,6 +116,116 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
     );
   });
 
+  it.effect("preserves unrelated files created after the checkpoint", () =>
+    Effect.gen(function* () {
+      const tmp = yield* makeTmpDir();
+      yield* initRepoWithCommit(tmp);
+      const store = yield* CheckpointStore.CheckpointStore;
+      const fs = yield* FileSystem.FileSystem;
+      const checkpointRef = checkpointRefForThreadTurn(ThreadId.make("unrelated-file"), 0);
+      yield* store.captureCheckpoint({ cwd: tmp, checkpointRef });
+      yield* writeTextFile(NodePath.join(tmp, "unrelated.txt"), "Human bytes\n");
+      expect(yield* store.restoreCheckpoint({ cwd: tmp, checkpointRef })).toBe(true);
+      expect(yield* fs.readFileString(NodePath.join(tmp, "unrelated.txt"))).toBe("Human bytes\n");
+    }),
+  );
+
+  it.effect("removes checkpoint additions without cleaning later unrelated files", () =>
+    Effect.gen(function* () {
+      const tmp = yield* makeTmpDir();
+      yield* initRepoWithCommit(tmp);
+      const store = yield* CheckpointStore.CheckpointStore;
+      const fs = yield* FileSystem.FileSystem;
+      const thread = ThreadId.make("checkpoint-additions");
+      const checkpointRef = checkpointRefForThreadTurn(thread, 0);
+      const fromCheckpointRef = checkpointRefForThreadTurn(thread, 1);
+      yield* store.captureCheckpoint({ cwd: tmp, checkpointRef });
+      yield* fs.makeDirectory(NodePath.join(tmp, "new directory"));
+      yield* writeTextFile(NodePath.join(tmp, "new directory/agent.txt"), "Agent bytes\n");
+      yield* writeTextFile(NodePath.join(tmp, "README.md"), "Agent edit\n");
+      yield* store.captureCheckpoint({ cwd: tmp, checkpointRef: fromCheckpointRef });
+      yield* writeTextFile(NodePath.join(tmp, "new directory/human.txt"), "Human bytes\n");
+      expect(yield* store.restoreCheckpoint({ cwd: tmp, checkpointRef, fromCheckpointRef })).toBe(
+        true,
+      );
+      expect(yield* fs.exists(NodePath.join(tmp, "new directory/agent.txt"))).toBe(false);
+      expect(yield* fs.readFileString(NodePath.join(tmp, "new directory/human.txt"))).toBe(
+        "Human bytes\n",
+      );
+      expect(yield* fs.readFileString(NodePath.join(tmp, "README.md"))).toBe("# test\n");
+    }),
+  );
+
+  it.effect("preserves post-checkpoint tracked edits outside the reverted turn diff", () =>
+    Effect.gen(function* () {
+      const tmp = yield* makeTmpDir();
+      yield* initRepoWithCommit(tmp);
+      const store = yield* CheckpointStore.CheckpointStore;
+      const fs = yield* FileSystem.FileSystem;
+      const thread = ThreadId.make("post-checkpoint-tracked-edits");
+      const checkpointRef = checkpointRefForThreadTurn(thread, 0);
+      const fromCheckpointRef = checkpointRefForThreadTurn(thread, 1);
+      const humanFile = NodePath.join(tmp, "human.txt");
+
+      yield* writeTextFile(humanFile, "Human baseline\n");
+      yield* git(tmp, ["add", "human.txt"]);
+      yield* git(tmp, ["commit", "-m", "add human file"]);
+      yield* store.captureCheckpoint({ cwd: tmp, checkpointRef });
+
+      yield* writeTextFile(NodePath.join(tmp, "README.md"), "Agent edit\n");
+      yield* store.captureCheckpoint({ cwd: tmp, checkpointRef: fromCheckpointRef });
+
+      yield* writeTextFile(humanFile, "Human staged\n");
+      yield* git(tmp, ["add", "human.txt"]);
+      yield* writeTextFile(humanFile, "Human unstaged\n");
+
+      expect(yield* store.restoreCheckpoint({ cwd: tmp, checkpointRef, fromCheckpointRef })).toBe(
+        true,
+      );
+      expect(yield* fs.readFileString(NodePath.join(tmp, "README.md"))).toBe("# test\n");
+      expect(yield* git(tmp, ["show", ":human.txt"])).toBe("Human staged");
+      expect(yield* fs.readFileString(humanFile)).toBe("Human unstaged\n");
+    }),
+  );
+
+  it.effect("preserves staged changes outside a nested project during restore", () =>
+    Effect.gen(function* () {
+      const tmp = yield* makeTmpDir();
+      yield* initRepoWithCommit(tmp);
+      const project = NodePath.join(tmp, "project");
+      const projectFile = NodePath.join(project, "app.ts");
+      const outsideFile = NodePath.join(tmp, "outside.txt");
+      const store = yield* CheckpointStore.CheckpointStore;
+      const fs = yield* FileSystem.FileSystem;
+      const thread = ThreadId.make("nested-project-index");
+      const checkpointRef = checkpointRefForThreadTurn(thread, 0);
+      const fromCheckpointRef = checkpointRefForThreadTurn(thread, 1);
+
+      yield* fs.makeDirectory(project);
+      yield* writeTextFile(projectFile, "baseline\n");
+      yield* writeTextFile(outsideFile, "outside baseline\n");
+      yield* git(tmp, ["add", "."]);
+      yield* git(tmp, ["commit", "-m", "add project"]);
+      yield* store.captureCheckpoint({ cwd: project, checkpointRef });
+
+      yield* writeTextFile(projectFile, "agent edit\n");
+      yield* writeTextFile(NodePath.join(project, "agent.txt"), "agent addition\n");
+      yield* store.captureCheckpoint({ cwd: project, checkpointRef: fromCheckpointRef });
+
+      yield* writeTextFile(outsideFile, "outside staged\n");
+      yield* git(tmp, ["add", "outside.txt"]);
+      yield* writeTextFile(outsideFile, "outside unstaged\n");
+
+      expect(
+        yield* store.restoreCheckpoint({ cwd: project, checkpointRef, fromCheckpointRef }),
+      ).toBe(true);
+      expect(yield* git(tmp, ["show", ":outside.txt"])).toBe("outside staged");
+      expect(yield* fs.readFileString(outsideFile)).toBe("outside unstaged\n");
+      expect(yield* fs.readFileString(projectFile)).toBe("baseline\n");
+      expect(yield* fs.exists(NodePath.join(project, "agent.txt"))).toBe(false);
+    }),
+  );
+
   describe("diffCheckpoints", () => {
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -30,6 +30,8 @@ export interface CaptureCheckpointInput {
 export interface RestoreCheckpointInput {
   readonly cwd: string;
   readonly checkpointRef: CheckpointRef;
+  /** Current checkpoint whose added files should be removed by the rollback. */
+  readonly fromCheckpointRef?: CheckpointRef;
   readonly fallbackToHead?: boolean;
 }
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -25,6 +25,7 @@ import * as Clock from "effect/Clock";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as PubSub from "effect/PubSub";
@@ -63,6 +64,7 @@ import {
 import { checkpointRefForThreadTurn } from "../../checkpointing/Utils.ts";
 import { ProviderValidationError } from "../../provider/Errors.ts";
 import { ServerConfig } from "../../config.ts";
+import { ServerActivation } from "../../serverActivation.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 import * as WorkspacePaths from "../../workspace/WorkspacePaths.ts";
 import { PullRequestService } from "../../pullRequest/PullRequestService.ts";
@@ -88,11 +90,12 @@ function createProviderServiceHarness(
   hasSession = true,
   sessionCwd = cwd,
   providerName: ProviderSession["provider"] = ProviderDriverKind.make("codex"),
+  rollbackConversationEffect: ProviderServiceShape["rollbackConversation"] = () => Effect.void,
 ) {
   const now = "2026-01-01T00:00:00.000Z";
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
-  const rollbackConversation = vi.fn(
-    (_input: { readonly threadId: ThreadId; readonly numTurns: number }) => Effect.void,
+  const rollbackConversation = vi.fn<ProviderServiceShape["rollbackConversation"]>(
+    rollbackConversationEffect,
   );
   const assertConversationRollbackSupported = vi.fn<
     ProviderServiceShape["assertConversationRollbackSupported"]
@@ -303,6 +306,8 @@ describe("CheckpointReactor", () => {
     readonly gitStatusRefreshCalls?: Array<string>;
     readonly pullRequestRefreshCalls?: Array<string>;
     readonly pullRequestRefresh?: Effect.Effect<void>;
+    readonly serverActivation?: Effect.Effect<void>;
+    readonly rollbackConversationEffect?: ProviderServiceShape["rollbackConversation"];
   }) {
     const cwd = createGitRepository();
     if (options?.initializeGit === false) {
@@ -314,6 +319,7 @@ describe("CheckpointReactor", () => {
       options?.hasSession ?? true,
       options?.providerSessionCwd ?? cwd,
       options?.providerName ?? ProviderDriverKind.make("codex"),
+      options?.rollbackConversationEffect,
     );
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionSnapshotQueryLive),
@@ -380,6 +386,7 @@ describe("CheckpointReactor", () => {
       Layer.provideMerge(VcsProcess.layer),
       Layer.provideMerge(ServerConfigLayer),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(SqlitePersistenceMemory),
     );
 
     runtime = ManagedRuntime.make(layer);
@@ -400,7 +407,12 @@ describe("CheckpointReactor", () => {
         yield* Stream.runForEach(receiptBus.streamEventsForTest, (receipt) =>
           Queue.offer(receipts, receipt),
         ).pipe(Effect.forkIn(testScope, { startImmediately: true }));
-        yield* reactor.start().pipe(Scope.provide(testScope));
+        yield* reactor
+          .start()
+          .pipe(
+            Scope.provide(testScope),
+            Effect.provideService(ServerActivation, options?.serverActivation),
+          );
         return receipts;
       }),
     );
@@ -488,6 +500,8 @@ describe("CheckpointReactor", () => {
 
     return {
       engine,
+      reactor,
+      checkpointStore,
       readModel: () => Effect.runPromise(snapshotQuery.getSnapshot()),
       provider,
       cwd,
@@ -496,6 +510,86 @@ describe("CheckpointReactor", () => {
       pullRequestRefreshes,
     };
   }
+
+  effectIt.effect("releases a domain sequence barrier only after checkpoint work reaches it", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ seedFilesystemCheckpoints: false }),
+      );
+      const targetSequence = (yield* harness.engine.latestSequence) + 2;
+      const waiter = yield* harness.reactor
+        .awaitDomainSequence(targetSequence)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Effect.yieldNow;
+      expect(waiter.pollUnsafe()).toBeUndefined();
+
+      const result = yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-checkpoint-sequence-barrier"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: MessageId.make("message-checkpoint-sequence-barrier"),
+          role: "user",
+          text: "Start after the checkpoint barrier",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      expect(result.sequence).toBe(targetSequence);
+      yield* Fiber.join(waiter);
+
+      expect(
+        yield* harness.checkpointStore.hasCheckpointRef({
+          cwd: harness.cwd,
+          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
+        }),
+      ).toBe(true);
+    }),
+  );
+
+  effectIt.effect("subscribes to domain events before waiting for server activation", () =>
+    Effect.gen(function* () {
+      const activation = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          seedFilesystemCheckpoints: false,
+          serverActivation: Deferred.await(activation),
+        }),
+      );
+      const targetSequence = (yield* harness.engine.latestSequence) + 2;
+      const waiter = yield* harness.reactor
+        .awaitDomainSequence(targetSequence)
+        .pipe(Effect.forkChild({ startImmediately: true }));
+
+      const result = yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-checkpoint-before-activation"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: MessageId.make("message-checkpoint-before-activation"),
+          role: "user",
+          text: "Start after activation",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      expect(result.sequence).toBe(targetSequence);
+      expect(waiter.pollUnsafe()).toBeUndefined();
+
+      yield* Deferred.succeed(activation, undefined);
+      yield* Fiber.join(waiter);
+      expect(
+        yield* harness.checkpointStore.hasCheckpointRef({
+          cwd: harness.cwd,
+          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 0),
+        }),
+      ).toBe(true);
+    }),
+  );
 
   effectIt.effect("captures baseline and large turn summaries before completion receipts", () =>
     Effect.gen(function* () {
@@ -1637,6 +1731,28 @@ describe("CheckpointReactor", () => {
           createdAt,
         });
         yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make(`cmd-unsupported-rewind-running-${turnCount}`),
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "antigravity",
+            runtimeMode: "approval-required",
+            activeTurnId: asTurnId(`turn-unsupported-rewind-${turnCount}`),
+            lastError: null,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        });
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start.acknowledge",
+          commandId: CommandId.make(`cmd-unsupported-rewind-ack-${turnCount}`),
+          threadId,
+          messageId: MessageId.make(`message-unsupported-rewind-${turnCount}`),
+          turnId: asTurnId(`turn-unsupported-rewind-${turnCount}`),
+        });
+        yield* harness.engine.dispatch({
           type: "thread.turn.diff.complete",
           commandId: CommandId.make(`cmd-unsupported-rewind-diff-${turnCount}`),
           threadId,
@@ -1646,6 +1762,21 @@ describe("CheckpointReactor", () => {
           status: "ready",
           files: [],
           checkpointTurnCount: turnCount,
+          createdAt,
+        });
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make(`cmd-unsupported-rewind-ready-${turnCount}`),
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "antigravity",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: createdAt,
+          },
           createdAt,
         });
       }
@@ -1810,83 +1941,25 @@ describe("CheckpointReactor", () => {
     },
   );
 
-  it("executes provider revert and emits thread.reverted for claude sessions", async () => {
-    const harness = await createHarness({ providerName: ProviderDriverKind.make("claudeAgent") });
-    const createdAt = "2026-01-01T00:00:00.000Z";
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.make("cmd-session-set-claude"),
-        threadId: ThreadId.make("thread-1"),
-        session: {
-          threadId: ThreadId.make("thread-1"),
-          status: "ready",
-          providerName: "claudeAgent",
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: createdAt,
-        },
-        createdAt,
-      }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-diff-claude-1"),
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-claude-1"),
-        completedAt: createdAt,
-        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
-        status: "ready",
-        files: [],
-        checkpointTurnCount: 1,
-        createdAt,
-      }),
-    );
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-diff-claude-2"),
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-claude-2"),
-        completedAt: createdAt,
-        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
-        status: "ready",
-        files: [],
-        checkpointTurnCount: 2,
-        createdAt,
-      }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.checkpoint.revert",
-        commandId: CommandId.make("cmd-revert-request-claude"),
-        threadId: ThreadId.make("thread-1"),
-        turnCount: 1,
-        createdAt,
-      }),
-    );
-
-    await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
-    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
-    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
-      threadId: ThreadId.make("thread-1"),
-      numTurns: 1,
+  it("executes provider revert and emits thread.reverted for checkpoint revert requests", async () => {
+    const rollbackStarted = await Effect.runPromise(Deferred.make<void>());
+    const continueRollback = await Effect.runPromise(Deferred.make<void>());
+    const harness = await createHarness({
+      rollbackConversationEffect: () =>
+        Deferred.succeed(rollbackStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(continueRollback)),
+        ),
     });
-  });
-
-  it("processes consecutive revert requests with deterministic rollback sequencing", async () => {
-    const harness = await createHarness();
     const createdAt = "2026-01-01T00:00:00.000Z";
+    const pendingMessageIds = [
+      MessageId.make("message-accepted-during-revert-with-skew-1"),
+      MessageId.make("message-accepted-during-revert-with-skew-2"),
+    ];
 
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.session.set",
-        commandId: CommandId.make("cmd-session-set-inline-revert"),
+        commandId: CommandId.make("cmd-session-set"),
         threadId: ThreadId.make("thread-1"),
         session: {
           threadId: ThreadId.make("thread-1"),
@@ -1904,7 +1977,7 @@ describe("CheckpointReactor", () => {
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-inline-revert-diff-1"),
+        commandId: CommandId.make("cmd-diff-1"),
         threadId: ThreadId.make("thread-1"),
         turnId: asTurnId("turn-1"),
         completedAt: createdAt,
@@ -1918,7 +1991,7 @@ describe("CheckpointReactor", () => {
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-inline-revert-diff-2"),
+        commandId: CommandId.make("cmd-diff-2"),
         threadId: ThreadId.make("thread-1"),
         turnId: asTurnId("turn-2"),
         completedAt: createdAt,
@@ -1933,46 +2006,391 @@ describe("CheckpointReactor", () => {
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.checkpoint.revert",
-        commandId: CommandId.make("cmd-sequenced-revert-request-1"),
+        commandId: CommandId.make("cmd-revert-request"),
         threadId: ThreadId.make("thread-1"),
         turnCount: 1,
         createdAt,
       }),
     );
-    await Effect.runPromise(
-      harness.engine.dispatch({
+
+    await Effect.runPromise(Deferred.await(rollbackStarted));
+    for (const [index, pendingMessageId] of pendingMessageIds.entries()) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-turn-start-during-revert-with-skew-${index + 1}`),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: pendingMessageId,
+            role: "user",
+            text: `Continue after revert ${index + 1}`,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: `2025-12-31T23:59:0${index}.000Z`,
+        }),
+      );
+    }
+    await Effect.runPromise(Deferred.succeed(continueRollback, undefined));
+
+    const events = await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
+    const thread = await waitForThread(
+      harness.readModel,
+      (entry) => entry.checkpoints.length === 1,
+    );
+
+    expect(thread.latestTurn?.turnId).toBe("turn-1");
+    expect(thread.checkpoints).toHaveLength(1);
+    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(
+      (await harness.readModel()).threads[0]?.messages
+        .filter((message) => pendingMessageIds.includes(message.id))
+        .map((message) => message.id),
+    ).toEqual(pendingMessageIds);
+    expect(events.find((event) => event.type === "thread.reverted")?.payload).toMatchObject({
+      preservedMessageIds: pendingMessageIds,
+    });
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+      threadId: ThreadId.make("thread-1"),
+      numTurns: 1,
+    });
+    expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
+    expect(
+      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
+    ).toBe(false);
+  });
+
+  effectIt.effect("restores a captured target when the newest checkpoint is missing", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const threadId = ThreadId.make("thread-1");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-missing-latest"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-ready-target-diff"),
+        threadId,
+        turnId: asTurnId("turn-ready-target"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-missing-latest-diff"),
+        threadId,
+        turnId: asTurnId("turn-missing-latest"),
+        completedAt: createdAt,
+        checkpointRef: CheckpointRef.make("provider-diff:missing-latest"),
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 2,
+        createdAt,
+      });
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+
+      yield* harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-revert-from-missing-latest"),
+        threadId,
+        turnCount: 1,
+        createdAt,
+      });
+      yield* Effect.promise(harness.drain);
+
+      expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+        threadId,
+        numTurns: 1,
+      });
+      expect((yield* Effect.promise(harness.readModel)).threads[0]?.checkpoints).toHaveLength(1);
+    }),
+  );
+
+  effectIt.effect("removes files captured by a failed turn when reverting", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ seedFilesystemCheckpoints: false }),
+      );
+      const threadId = ThreadId.make("thread-1");
+      const createdAt = "2026-01-01T00:00:00.000Z";
+      const failedFile = NodePath.join(harness.cwd, "failed-turn.txt");
+
+      yield* harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+      });
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "v2\n", "utf8");
+      yield* harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+      });
+      NodeFS.writeFileSync(failedFile, "created by failed turn\n", "utf8");
+      yield* harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 2),
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-failed-checkpoint"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+      for (const [turnCount, status] of [
+        [1, "ready"],
+        [2, "error"],
+      ] as const) {
+        yield* harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make(`cmd-failed-checkpoint-diff-${turnCount}`),
+          threadId,
+          turnId: asTurnId(`turn-failed-checkpoint-${turnCount}`),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, turnCount),
+          status,
+          files: [],
+          checkpointTurnCount: turnCount,
+          createdAt,
+        });
+      }
+
+      yield* harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-revert-failed-checkpoint"),
+        threadId,
+        turnCount: 1,
+        createdAt,
+      });
+      yield* Effect.promise(harness.drain);
+
+      expect(NodeFS.existsSync(failedFile)).toBe(false);
+      expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
+    }),
+  );
+
+  effectIt.effect("executes provider revert and emits thread.reverted for claude sessions", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ providerName: ProviderDriverKind.make("claudeAgent") }),
+      );
+      const createdAt = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-claude"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-diff-claude-1"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-claude-1"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-diff-claude-2"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-claude-2"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 2,
+        createdAt,
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-revert-request-claude"),
+        threadId: ThreadId.make("thread-1"),
+        turnCount: 1,
+        createdAt,
+      });
+
+      yield* Effect.promise(() =>
+        waitForEvent(harness.engine, (event) => event.type === "thread.reverted"),
+      );
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+        threadId: ThreadId.make("thread-1"),
+        numTurns: 1,
+      });
+    }),
+  );
+
+  effectIt.effect("preserves every queued start across consecutive revert requests", () =>
+    Effect.gen(function* () {
+      const firstRollbackStarted = yield* Deferred.make<void>();
+      const releaseFirstRollback = yield* Deferred.make<void>();
+      let rollbackCount = 0;
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          rollbackConversationEffect: () => {
+            rollbackCount += 1;
+            return rollbackCount === 1
+              ? Deferred.succeed(firstRollbackStarted, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseFirstRollback)),
+                )
+              : Effect.void;
+          },
+        }),
+      );
+      const createdAt = "2026-01-01T00:00:00.000Z";
+
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-session-set-inline-revert"),
+        threadId: ThreadId.make("thread-1"),
+        session: {
+          threadId: ThreadId.make("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-inline-revert-diff-1"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-1"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt,
+      });
+      yield* harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.make("cmd-inline-revert-diff-2"),
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-2"),
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
+        status: "ready",
+        files: [],
+        checkpointTurnCount: 2,
+        createdAt,
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.make("cmd-sequenced-revert-request-1"),
+        threadId: ThreadId.make("thread-1"),
+        turnCount: 1,
+        createdAt,
+      });
+      yield* Deferred.await(firstRollbackStarted);
+      yield* harness.engine.dispatch({
         type: "thread.checkpoint.revert",
         commandId: CommandId.make("cmd-sequenced-revert-request-0"),
         threadId: ThreadId.make("thread-1"),
         turnCount: 0,
         createdAt,
-      }),
-    );
-
-    await harness.drain();
-
-    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(2);
-    expect(harness.provider.rollbackConversation.mock.calls[0]?.[0]).toEqual({
-      threadId: ThreadId.make("thread-1"),
-      numTurns: 1,
-    });
-    expect(harness.provider.rollbackConversation.mock.calls[1]?.[0]).toEqual({
-      threadId: ThreadId.make("thread-1"),
-      numTurns: 1,
-    });
-  });
-
-  it.each([false, true])(
-    "reverts without an active session using project cwd fallback: %s",
-    async (useProjectCwd) => {
-      const harness = await createHarness({
-        hasSession: false,
-        ...(useProjectCwd ? { threadWorktreePath: null } : {}),
       });
-      const createdAt = "2026-01-01T00:00:00.000Z";
+      for (const [index, messageId] of ["queued-message-1", "queued-message-2"].entries()) {
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make(`cmd-queued-turn-${index + 1}`),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: MessageId.make(messageId),
+            role: "user",
+            text: `Queued work ${index + 1}`,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        });
+      }
 
-      await Effect.runPromise(
-        harness.engine.dispatch({
+      yield* Deferred.succeed(releaseFirstRollback, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(2);
+      expect(harness.provider.rollbackConversation.mock.calls[0]?.[0]).toEqual({
+        threadId: ThreadId.make("thread-1"),
+        numTurns: 1,
+      });
+      expect(harness.provider.rollbackConversation.mock.calls[1]?.[0]).toEqual({
+        threadId: ThreadId.make("thread-1"),
+        numTurns: 1,
+      });
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      expect(
+        readModel.threads[0]?.messages
+          .filter((message) => message.role === "user")
+          .map((message) => message.id),
+      ).toEqual(["queued-message-1", "queued-message-2"]);
+    }),
+  );
+
+  effectIt.effect.each([false, true])(
+    "reverts without an active session using project cwd fallback: %s",
+    (useProjectCwd) =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            hasSession: false,
+            ...(useProjectCwd ? { threadWorktreePath: null } : {}),
+          }),
+        );
+        const createdAt = "2026-01-01T00:00:00.000Z";
+
+        yield* harness.engine.dispatch({
           type: "thread.turn.diff.complete",
           commandId: CommandId.make("cmd-diff-before-session-recovery"),
           threadId: ThreadId.make("thread-1"),
@@ -1983,24 +2401,23 @@ describe("CheckpointReactor", () => {
           files: [],
           checkpointTurnCount: 1,
           createdAt,
-        }),
-      );
-      await Effect.runPromise(
-        harness.engine.dispatch({
+        });
+        yield* harness.engine.dispatch({
           type: "thread.checkpoint.revert",
           commandId: CommandId.make("cmd-revert-no-session"),
           threadId: ThreadId.make("thread-1"),
           turnCount: 0,
           createdAt,
-        }),
-      );
+        });
 
-      await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
-      expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
-        threadId: ThreadId.make("thread-1"),
-        numTurns: 1,
-      });
-      expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v1\n");
-    },
+        yield* Effect.promise(() =>
+          waitForEvent(harness.engine, (event) => event.type === "thread.reverted"),
+        );
+        expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
+          threadId: ThreadId.make("thread-1"),
+          numTurns: 1,
+        });
+        expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v1\n");
+      }),
   );
 });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -13,10 +13,12 @@ import {
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type * as PlatformError from "effect/PlatformError";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
@@ -91,6 +93,40 @@ const make = Effect.gen(function* () {
   const pullRequests = yield* PullRequestService.PullRequestService;
   const startedTurns = new Map<ThreadId, TurnId>();
   const pending = new Set<ThreadId>();
+  const domainSequenceState = yield* Ref.make<{
+    readonly processed: number;
+    readonly waiters: ReadonlyArray<{
+      readonly sequence: number;
+      readonly deferred: Deferred.Deferred<void>;
+    }>;
+  }>({ processed: -1, waiters: [] });
+
+  const awaitDomainSequence = Effect.fn("CheckpointReactor.awaitDomainSequence")(function* (
+    sequence: number,
+  ) {
+    const deferred = yield* Deferred.make<void>();
+    const shouldWait = yield* Ref.modify(domainSequenceState, (state) =>
+      state.processed >= sequence
+        ? [false, state]
+        : [true, { ...state, waiters: [...state.waiters, { sequence, deferred }] }],
+    );
+    if (shouldWait) yield* Deferred.await(deferred);
+  });
+
+  const markDomainSequence = Effect.fn("CheckpointReactor.markDomainSequence")(function* (
+    sequence: number,
+  ) {
+    const ready = yield* Ref.modify(domainSequenceState, (state) => [
+      state.waiters.filter((waiter) => waiter.sequence <= sequence),
+      {
+        processed: Math.max(state.processed, sequence),
+        waiters: state.waiters.filter((waiter) => waiter.sequence > sequence),
+      },
+    ]);
+    yield* Effect.forEach(ready, (waiter) => Deferred.succeed(waiter.deferred, undefined), {
+      discard: true,
+    });
+  });
 
   const appendRevertFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -755,9 +791,18 @@ const make = Effect.gen(function* () {
         return;
       }
 
+      // The scoped restore diffs the target against a snapshot of the current
+      // workspace, so only the newest checkpoint qualifies. When it is missing
+      // the diff would compare unrelated snapshots, so restore falls back to
+      // applying the target tree directly.
+      const fromCheckpointRef = thread.checkpoints.find(
+        (checkpoint) =>
+          checkpoint.status !== "missing" && checkpoint.checkpointTurnCount === currentTurnCount,
+      )?.checkpointRef;
       const restored = yield* checkpointStore.restoreCheckpoint({
         cwd: checkpointCwd,
         checkpointRef: targetCheckpointRef,
+        ...(fromCheckpointRef !== undefined ? { fromCheckpointRef } : {}),
         fallbackToHead: event.payload.turnCount === 0,
       });
       if (!restored) {
@@ -928,13 +973,17 @@ const make = Effect.gen(function* () {
           cause: Cause.pretty(cause),
         });
       }),
+      Effect.andThen(
+        input.source === "domain" ? markDomainSequence(input.event.sequence) : Effect.void,
+      ),
     );
 
   const worker = yield* makeDrainableWorker(processInputSafely);
 
   const start: CheckpointReactorShape["start"] = Effect.fn("start")(function* () {
+    const domainEvents = yield* orchestrationEngine.subscribeDomainEvents;
     yield* forkParked(
-      Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
+      Stream.runForEach(domainEvents, (event) => {
         if (
           event.type !== "thread.turn-start-requested" &&
           event.type !== "thread.message-sent" &&
@@ -964,6 +1013,7 @@ const make = Effect.gen(function* () {
   return {
     start,
     drain: worker.drain.pipe(Effect.andThen(statusRefreshWorker.drain)),
+    awaitDomainSequence,
   } satisfies CheckpointReactorShape;
 });
 

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -56,6 +56,7 @@ describe("OrchestrationReactor", () => {
               return Effect.void;
             },
             drain: Effect.void,
+            awaitDomainSequence: () => Effect.void,
           }),
         ),
         Layer.provideMerge(
@@ -112,9 +113,9 @@ describe("OrchestrationReactor", () => {
     await Effect.runPromise(reactor.start().pipe(Scope.provide(scope)));
 
     expect(started).toEqual([
+      "checkpoint-reactor",
       "provider-runtime-ingestion",
       "provider-command-reactor",
-      "checkpoint-reactor",
       "thread-deletion-reactor",
       "thread-pull-request-reactor",
       "thread-settlement-reactor",

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
@@ -25,9 +25,10 @@ export const makeOrchestrationReactor = Effect.gen(function* () {
   const agentAwarenessRelay = yield* AgentAwarenessRelay.AgentAwarenessRelay;
 
   const start: OrchestrationReactorShape["start"] = Effect.fn("start")(function* () {
+    // Subscribe the checkpoint barrier before either provider path can emit work.
+    yield* checkpointReactor.start();
     yield* providerRuntimeIngestion.start();
     yield* providerCommandReactor.start();
-    yield* checkpointReactor.start();
     yield* threadDeletionReactor.start();
     yield* threadPullRequestReactor.start();
     yield* threadSettlementReactor.start();

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../../persistence/Layers/Sqlite.ts";
 import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { ProjectionStateRepository } from "../../persistence/Services/ProjectionState.ts";
+import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import {
@@ -3934,12 +3935,744 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
       ]);
     }),
   );
+
+  it.effect("does not let queued messages consume the retained historical turn quota", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+        eventStore
+          .append(event)
+          .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+      yield* appendAndProject({
+        type: "project.created",
+        eventId: EventId.make("evt-quota-1"),
+        aggregateKind: "project",
+        aggregateId: ProjectId.make("project-quota"),
+        occurredAt: "2026-02-26T12:00:00.000Z",
+        commandId: CommandId.make("cmd-quota-1"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-1"),
+        metadata: {},
+        payload: {
+          projectId: ProjectId.make("project-quota"),
+          title: "Project Quota",
+          workspaceRoot: "/tmp/project-quota",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: "2026-02-26T12:00:00.000Z",
+          updatedAt: "2026-02-26T12:00:00.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.created",
+        eventId: EventId.make("evt-quota-2"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:01.000Z",
+        commandId: CommandId.make("cmd-quota-2"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-2"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          projectId: ProjectId.make("project-quota"),
+          title: "Thread Quota",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("codex"),
+            model: "gpt-5-codex",
+          },
+          runtimeMode: "full-access",
+          branch: null,
+          worktreePath: null,
+          createdAt: "2026-02-26T12:00:01.000Z",
+          updatedAt: "2026-02-26T12:00:01.000Z",
+        },
+      });
+
+      // Turn 1 retains its assistant reply through the turn row, but its user
+      // prompt has no turn link and can only survive through the fallback quota.
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-quota-3"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:02.000Z",
+        commandId: CommandId.make("cmd-quota-3"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-3"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          turnId: TurnId.make("turn-1"),
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-quota/turn/1"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-keep"),
+          completedAt: "2026-02-26T12:00:02.000Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-quota-4"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:02.050Z",
+        commandId: CommandId.make("cmd-quota-4"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-4"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          messageId: MessageId.make("user-prompt-keep"),
+          role: "user",
+          text: "first prompt",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-02-26T12:00:02.050Z",
+          updatedAt: "2026-02-26T12:00:02.050Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-quota-5"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:02.100Z",
+        commandId: CommandId.make("cmd-quota-5"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-5"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          messageId: MessageId.make("assistant-keep"),
+          role: "assistant",
+          text: "kept",
+          turnId: TurnId.make("turn-1"),
+          streaming: false,
+          createdAt: "2026-02-26T12:00:02.100Z",
+          updatedAt: "2026-02-26T12:00:02.100Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.turn-diff-completed",
+        eventId: EventId.make("evt-quota-6"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:03.000Z",
+        commandId: CommandId.make("cmd-quota-6"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-6"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          turnId: TurnId.make("turn-2"),
+          checkpointTurnCount: 2,
+          checkpointRef: CheckpointRef.make("refs/t3/checkpoints/thread-quota/turn/2"),
+          status: "ready",
+          files: [],
+          assistantMessageId: MessageId.make("assistant-remove"),
+          completedAt: "2026-02-26T12:00:03.000Z",
+        },
+      });
+
+      for (const [role, messageId, createdAt] of [
+        ["user", "user-remove", "2026-02-26T12:00:03.050Z"],
+        ["assistant", "assistant-remove", "2026-02-26T12:00:03.100Z"],
+      ] as const) {
+        yield* appendAndProject({
+          type: "thread.message-sent",
+          eventId: EventId.make(`evt-quota-${messageId}`),
+          aggregateKind: "thread",
+          aggregateId: ThreadId.make("thread-quota"),
+          occurredAt: createdAt,
+          commandId: CommandId.make(`cmd-quota-${messageId}`),
+          causationEventId: null,
+          correlationId: CorrelationId.make(`cmd-quota-${messageId}`),
+          metadata: {},
+          payload: {
+            threadId: ThreadId.make("thread-quota"),
+            messageId: MessageId.make(messageId),
+            role,
+            text: "removed",
+            turnId: TurnId.make("turn-2"),
+            streaming: false,
+            createdAt,
+            updatedAt: createdAt,
+          },
+        });
+      }
+
+      // A queued turn start is preserved across the revert, but it is not part
+      // of the retained history and must not fill the turnCount quota.
+      yield* appendAndProject({
+        type: "thread.turn-start-requested",
+        eventId: EventId.make("evt-quota-queued-start"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:03.500Z",
+        commandId: CommandId.make("cmd-quota-queued-start"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-queued-start"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          messageId: MessageId.make("user-queued"),
+          expectsTurnStartAcknowledgement: true,
+          runtimeMode: "full-access",
+          createdAt: "2026-02-26T12:00:03.500Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.message-sent",
+        eventId: EventId.make("evt-quota-queued-message"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:03.600Z",
+        commandId: CommandId.make("cmd-quota-queued-message"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-queued-message"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          messageId: MessageId.make("user-queued"),
+          role: "user",
+          text: "queued",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-02-26T12:00:03.600Z",
+          updatedAt: "2026-02-26T12:00:03.600Z",
+        },
+      });
+
+      yield* appendAndProject({
+        type: "thread.reverted",
+        eventId: EventId.make("evt-quota-revert"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-quota"),
+        occurredAt: "2026-02-26T12:00:04.000Z",
+        commandId: CommandId.make("cmd-quota-revert"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-quota-revert"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.make("thread-quota"),
+          turnCount: 1,
+        },
+      });
+
+      const messageRows = yield* sql<{
+        readonly messageId: string;
+        readonly turnId: string | null;
+        readonly role: string;
+      }>`
+        SELECT
+          message_id AS "messageId",
+          turn_id AS "turnId",
+          role
+        FROM projection_thread_messages
+        WHERE thread_id = 'thread-quota'
+        ORDER BY created_at ASC, message_id ASC
+      `;
+      assert.deepEqual(messageRows, [
+        {
+          messageId: "user-prompt-keep",
+          turnId: null,
+          role: "user",
+        },
+        {
+          messageId: "assistant-keep",
+          turnId: "turn-1",
+          role: "assistant",
+        },
+        {
+          messageId: "user-queued",
+          turnId: null,
+          role: "user",
+        },
+      ]);
+    }),
+  );
 });
 
 it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-"))(
   "OrchestrationProjectionPipeline pending turn cleanup",
   (it) => {
-    it.effect("clears pending turn starts when startup reaches a terminal session state", () =>
+    it.effect("preserves queued start order across revert despite skewed timestamps", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionTurnRepository = yield* ProjectionTurnRepository;
+        const threadId = ThreadId.make("thread-revert-queued-order");
+
+        for (const [label, createdAt] of [
+          ["a", "2026-02-26T13:00:02.000Z"],
+          ["b", "2026-02-26T13:00:01.000Z"],
+        ] as const) {
+          yield* eventStore.append({
+            type: "thread.turn-start-requested",
+            eventId: EventId.make(`evt-revert-queued-order-${label}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: `2026-02-26T13:00:0${label === "a" ? "1" : "2"}.000Z`,
+            commandId: CommandId.make(`cmd-revert-queued-order-${label}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-revert-queued-order-${label}`),
+            metadata: {},
+            payload: {
+              threadId,
+              messageId: MessageId.make(`message-revert-queued-order-${label}`),
+              expectsTurnStartAcknowledgement: true,
+              runtimeMode: "approval-required",
+              createdAt,
+            },
+          });
+        }
+        yield* eventStore.append({
+          type: "thread.reverted",
+          eventId: EventId.make("evt-revert-queued-order-complete"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-02-26T13:00:03.000Z",
+          commandId: CommandId.make("cmd-revert-queued-order-complete"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-revert-queued-order-complete"),
+          metadata: {},
+          payload: { threadId, turnCount: 0 },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const first = yield* projectionTurnRepository.getPendingTurnStartByThreadId({ threadId });
+        assert.isTrue(Option.isSome(first));
+        if (Option.isNone(first)) return;
+        assert.strictEqual(first.value.messageId, "message-revert-queued-order-a");
+
+        yield* projectionTurnRepository.deletePendingTurnStart({
+          threadId,
+          messageId: first.value.messageId,
+        });
+        const second = yield* projectionTurnRepository.getPendingTurnStartByThreadId({ threadId });
+        assert.isTrue(Option.isSome(second));
+        if (Option.isNone(second)) return;
+        assert.strictEqual(second.value.messageId, "message-revert-queued-order-b");
+      }),
+    );
+
+    it.effect("adopts queued pending starts in request order", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.make("thread-queued-adoption");
+
+        for (const index of [1, 2]) {
+          const createdAt = index === 1 ? "2026-02-26T13:00:02.000Z" : "2026-02-26T13:00:01.000Z";
+          yield* eventStore.append({
+            type: "thread.turn-start-requested",
+            eventId: EventId.make(`evt-queued-adoption-${index}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: createdAt,
+            commandId: CommandId.make(`cmd-queued-adoption-${index}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-queued-adoption-${index}`),
+            metadata: {},
+            payload: {
+              threadId,
+              messageId: MessageId.make(`message-queued-adoption-${index}`),
+              expectsTurnStartAcknowledgement: true,
+              runtimeMode: "approval-required",
+              createdAt,
+            },
+          });
+        }
+        yield* eventStore.append({
+          type: "thread.meta-updated",
+          eventId: EventId.make("evt-queued-adoption-acknowledged"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-02-26T13:00:02.500Z",
+          commandId: CommandId.make("cmd-queued-adoption-acknowledged"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-queued-adoption-acknowledged"),
+          metadata: {},
+          payload: {
+            threadId,
+            turnStartAcknowledged: {
+              messageId: MessageId.make("message-queued-adoption-1"),
+              turnId: TurnId.make("turn-queued-adoption-1"),
+            },
+            updatedAt: "2026-02-26T13:00:02.000Z",
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-queued-adoption-running"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-02-26T13:00:03.000Z",
+          commandId: CommandId.make("cmd-queued-adoption-running"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-queued-adoption-running"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: {
+              threadId,
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: TurnId.make("turn-queued-adoption-1"),
+              lastError: null,
+              updatedAt: "2026-02-26T13:00:03.000Z",
+            },
+          },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const rows = yield* sql<{
+          readonly turnId: string | null;
+          readonly messageId: string | null;
+        }>`
+          SELECT turn_id AS "turnId", pending_message_id AS "messageId"
+          FROM projection_turns
+          WHERE thread_id = ${threadId}
+          ORDER BY row_id ASC
+        `;
+        assert.deepEqual(rows, [
+          { turnId: null, messageId: "message-queued-adoption-2" },
+          { turnId: "turn-queued-adoption-1", messageId: "message-queued-adoption-1" },
+        ]);
+      }),
+    );
+
+    it.effect("keeps concurrent starts correlated when acknowledgements race runtime events", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+
+        for (const acknowledgeFirst of [true, false]) {
+          const suffix = acknowledgeFirst ? "ack-first" : "runtime-first";
+          const threadId = ThreadId.make(`thread-concurrent-${suffix}`);
+          const targetTurnId = TurnId.make(`turn-concurrent-b-${suffix}`);
+          let sequence = 0;
+          const appendStart = (label: "a" | "b") =>
+            eventStore.append({
+              type: "thread.turn-start-requested",
+              eventId: EventId.make(`evt-concurrent-${suffix}-${++sequence}`),
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              occurredAt: `2026-02-26T13:45:0${sequence}.000Z`,
+              commandId: CommandId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              causationEventId: null,
+              correlationId: CorrelationId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              metadata: {},
+              payload: {
+                threadId,
+                messageId: MessageId.make(`message-concurrent-${label}-${suffix}`),
+                expectsTurnStartAcknowledgement: true,
+                runtimeMode: "approval-required" as const,
+                createdAt: `2026-02-26T13:45:0${sequence}.000Z`,
+              },
+            });
+          const appendAcknowledgement = () =>
+            eventStore.append({
+              type: "thread.meta-updated",
+              eventId: EventId.make(`evt-concurrent-${suffix}-${++sequence}`),
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              occurredAt: `2026-02-26T13:45:0${sequence}.000Z`,
+              commandId: CommandId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              causationEventId: null,
+              correlationId: CorrelationId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              metadata: {},
+              payload: {
+                threadId,
+                turnStartAcknowledged: {
+                  messageId: MessageId.make(`message-concurrent-b-${suffix}`),
+                  turnId: targetTurnId,
+                },
+                updatedAt: `2026-02-26T13:45:0${sequence}.000Z`,
+              },
+            });
+          const appendRunning = () =>
+            eventStore.append({
+              type: "thread.session-set",
+              eventId: EventId.make(`evt-concurrent-${suffix}-${++sequence}`),
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              occurredAt: `2026-02-26T13:45:0${sequence}.000Z`,
+              commandId: CommandId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              causationEventId: null,
+              correlationId: CorrelationId.make(`cmd-concurrent-${suffix}-${sequence}`),
+              metadata: {},
+              payload: {
+                threadId,
+                session: {
+                  threadId,
+                  status: "running" as const,
+                  providerName: "codex",
+                  runtimeMode: "approval-required" as const,
+                  activeTurnId: targetTurnId,
+                  lastError: null,
+                  updatedAt: `2026-02-26T13:45:0${sequence}.000Z`,
+                },
+              },
+            });
+
+          yield* appendStart("a");
+          yield* appendStart("b");
+          if (acknowledgeFirst) yield* appendAcknowledgement();
+          yield* appendRunning();
+          if (!acknowledgeFirst) yield* appendAcknowledgement();
+        }
+
+        yield* projectionPipeline.bootstrap;
+
+        for (const suffix of ["ack-first", "runtime-first"]) {
+          const rows = yield* sql<{
+            readonly turnId: string | null;
+            readonly messageId: string | null;
+            readonly state: string;
+          }>`
+            SELECT
+              turn_id AS "turnId",
+              pending_message_id AS "messageId",
+              state
+            FROM projection_turns
+            WHERE thread_id = ${`thread-concurrent-${suffix}`}
+            ORDER BY row_id ASC
+          `;
+          assert.deepEqual(rows, [
+            {
+              turnId: null,
+              messageId: `message-concurrent-a-${suffix}`,
+              state: "pending",
+            },
+            {
+              turnId: `turn-concurrent-b-${suffix}`,
+              messageId: `message-concurrent-b-${suffix}`,
+              state: "running",
+            },
+          ]);
+        }
+      }),
+    );
+
+    for (const acknowledgeFirst of [true, false]) {
+      it.effect(
+        `adopts only the correlated turn with acknowledgement ${acknowledgeFirst ? "before" : "after"} an unrelated turn`,
+        () =>
+          Effect.gen(function* () {
+            const projectionPipeline = yield* OrchestrationProjectionPipeline;
+            const eventStore = yield* OrchestrationEventStore;
+            const sql = yield* SqlClient.SqlClient;
+            const threadId = ThreadId.make(`thread-correlated-submission-${acknowledgeFirst}`);
+            const messageId = MessageId.make(`message-correlated-submission-${acknowledgeFirst}`);
+            const targetTurnId = TurnId.make(`turn-correlated-submission-${acknowledgeFirst}`);
+
+            yield* eventStore.append({
+              type: "thread.turn-start-requested",
+              eventId: EventId.make(`evt-correlated-submission-requested-${acknowledgeFirst}`),
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              occurredAt: "2026-02-26T13:30:00.000Z",
+              commandId: CommandId.make(`cmd-correlated-submission-requested-${acknowledgeFirst}`),
+              causationEventId: null,
+              correlationId: CorrelationId.make(
+                `cmd-correlated-submission-requested-${acknowledgeFirst}`,
+              ),
+              metadata: {},
+              payload: {
+                threadId,
+                messageId,
+                expectsTurnStartAcknowledgement: true,
+                runtimeMode: "approval-required",
+                createdAt: "2026-02-26T13:30:00.000Z",
+              },
+            });
+            const acknowledge = eventStore.append({
+              type: "thread.meta-updated",
+              eventId: EventId.make(`evt-correlated-submission-acknowledged-${acknowledgeFirst}`),
+              aggregateKind: "thread",
+              aggregateId: threadId,
+              occurredAt: "2026-02-26T13:30:01.000Z",
+              commandId: CommandId.make(
+                `cmd-correlated-submission-acknowledged-${acknowledgeFirst}`,
+              ),
+              causationEventId: null,
+              correlationId: CorrelationId.make(
+                `cmd-correlated-submission-acknowledged-${acknowledgeFirst}`,
+              ),
+              metadata: {},
+              payload: {
+                threadId,
+                turnStartAcknowledged: { messageId, turnId: targetTurnId },
+                updatedAt: "2026-02-26T13:30:00.000Z",
+              },
+            });
+            if (acknowledgeFirst) yield* acknowledge;
+            for (const [index, session] of [
+              {
+                status: "running" as const,
+                activeTurnId: TurnId.make("turn-unrelated"),
+              },
+              { status: "ready" as const, activeTurnId: null },
+              { status: "running" as const, activeTurnId: targetTurnId },
+            ].entries()) {
+              if (!acknowledgeFirst && index === 2) yield* acknowledge;
+              const updatedAt = `2026-02-26T13:30:0${index + 2}.000Z`;
+              yield* eventStore.append({
+                type: "thread.session-set",
+                eventId: EventId.make(
+                  `evt-correlated-submission-session-${acknowledgeFirst}-${index}`,
+                ),
+                aggregateKind: "thread",
+                aggregateId: threadId,
+                occurredAt: updatedAt,
+                commandId: CommandId.make(
+                  `cmd-correlated-submission-session-${acknowledgeFirst}-${index}`,
+                ),
+                causationEventId: null,
+                correlationId: CorrelationId.make(
+                  `cmd-correlated-submission-session-${acknowledgeFirst}-${index}`,
+                ),
+                metadata: {},
+                payload: {
+                  threadId,
+                  session: {
+                    threadId,
+                    status: session.status,
+                    providerName: "codex",
+                    runtimeMode: "approval-required",
+                    activeTurnId: session.activeTurnId,
+                    lastError: null,
+                    updatedAt,
+                  },
+                },
+              });
+            }
+
+            yield* projectionPipeline.bootstrap;
+
+            const rows = yield* sql<{
+              readonly turnId: string | null;
+              readonly messageId: string | null;
+              readonly state: string;
+            }>`
+          SELECT
+            turn_id AS "turnId",
+            pending_message_id AS "messageId",
+            state
+          FROM projection_turns
+          WHERE thread_id = ${threadId}
+          ORDER BY row_id ASC
+        `;
+            assert.deepEqual(rows, [
+              { turnId: "turn-unrelated", messageId: null, state: "completed" },
+              {
+                turnId: `turn-correlated-submission-${acknowledgeFirst}`,
+                messageId: `message-correlated-submission-${acknowledgeFirst}`,
+                state: "running",
+              },
+            ]);
+          }),
+      );
+    }
+
+    it.effect("preserves submitted turn correlation across a revert", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.make("thread-submitted-revert");
+        const messageId = MessageId.make("message-submitted-revert");
+        const turnId = TurnId.make("turn-submitted-revert");
+        const createdAt = "2026-02-26T13:40:00.000Z";
+
+        yield* eventStore.append({
+          type: "thread.turn-start-requested",
+          eventId: EventId.make("evt-submitted-revert-requested"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.make("cmd-submitted-revert-requested"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-submitted-revert-requested"),
+          metadata: {},
+          payload: {
+            threadId,
+            messageId,
+            expectsTurnStartAcknowledgement: true,
+            runtimeMode: "approval-required",
+            createdAt,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.meta-updated",
+          eventId: EventId.make("evt-submitted-revert-acknowledged"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.make("cmd-submitted-revert-acknowledged"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-submitted-revert-acknowledged"),
+          metadata: {},
+          payload: {
+            threadId,
+            turnStartAcknowledged: { messageId, turnId },
+            updatedAt: createdAt,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.reverted",
+          eventId: EventId.make("evt-submitted-revert-complete"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: createdAt,
+          commandId: CommandId.make("cmd-submitted-revert-complete"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-submitted-revert-complete"),
+          metadata: {},
+          payload: { threadId, turnCount: 0 },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const rows = yield* sql<{
+          readonly messageId: string;
+          readonly state: string;
+          readonly submittedTurnId: string | null;
+        }>`
+          SELECT
+            pending_message_id AS "messageId",
+            state,
+            submitted_turn_id AS "submittedTurnId"
+          FROM projection_turns
+          WHERE thread_id = ${threadId}
+        `;
+        assert.deepEqual(rows, [
+          {
+            messageId: "message-submitted-revert",
+            state: "submitted",
+            submittedTurnId: "turn-submitted-revert",
+          },
+        ]);
+      }),
+    );
+
+    it.effect("keeps newer pending turn starts when a stale session reaches a terminal state", () =>
       Effect.gen(function* () {
         const projectionPipeline = yield* OrchestrationProjectionPipeline;
         const eventStore = yield* OrchestrationEventStore;
@@ -3961,6 +4694,25 @@ it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-
             payload: {
               threadId,
               messageId: MessageId.make(`message-terminal-${status}`),
+              expectsTurnStartAcknowledgement: true,
+              runtimeMode: "approval-required",
+              createdAt: requestedAt,
+            },
+          });
+          yield* eventStore.append({
+            type: "thread.turn-start-requested",
+            eventId: EventId.make(`evt-newer-pending-${status}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: requestedAt,
+            commandId: CommandId.make(`cmd-newer-pending-${status}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-newer-pending-${status}`),
+            metadata: {},
+            payload: {
+              threadId,
+              messageId: MessageId.make(`message-newer-${status}`),
+              expectsTurnStartAcknowledgement: true,
               runtimeMode: "approval-required",
               createdAt: requestedAt,
             },
@@ -3992,13 +4744,33 @@ it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-
 
         yield* projectionPipeline.bootstrap;
 
-        const pendingRows = yield* sql<{ readonly threadId: string }>`
-          SELECT thread_id AS "threadId"
+        const pendingRows = yield* sql<{
+          readonly threadId: string;
+          readonly messageId: string;
+        }>`
+          SELECT
+            thread_id AS "threadId",
+            pending_message_id AS "messageId"
           FROM projection_turns
           WHERE turn_id IS NULL
             AND state = 'pending'
+            AND thread_id LIKE 'thread-terminal-%'
+          ORDER BY thread_id ASC
         `;
-        assert.deepEqual(pendingRows, []);
+        assert.deepEqual(pendingRows, [
+          { threadId: "thread-terminal-error", messageId: "message-terminal-error" },
+          { threadId: "thread-terminal-error", messageId: "message-newer-error" },
+          {
+            threadId: "thread-terminal-interrupted",
+            messageId: "message-terminal-interrupted",
+          },
+          {
+            threadId: "thread-terminal-interrupted",
+            messageId: "message-newer-interrupted",
+          },
+          { threadId: "thread-terminal-stopped", messageId: "message-terminal-stopped" },
+          { threadId: "thread-terminal-stopped", messageId: "message-newer-stopped" },
+        ]);
       }),
     );
 
@@ -4024,6 +4796,7 @@ it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-
             payload: {
               threadId,
               messageId: MessageId.make(messageId),
+              expectsTurnStartAcknowledgement: true,
               runtimeMode: "full-access",
               createdAt,
             },
@@ -4064,10 +4837,189 @@ it.layer(makeProjectionPipelinePrefixedTestLayer("t3-pending-turn-terminal-test-
         assert.deepEqual(pendingRows, [{ messageId: "new-message" }]);
       }),
     );
+
+    it.effect("clears submitted starts whose turn never surfaced once the session dies", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+
+        // A per-request send failure marks the session "error" without killing
+        // it, so errored sessions keep their submissions while interrupted and
+        // stopped sessions cannot surface the acknowledged turn.
+        for (const [index, status] of (["error", "interrupted", "stopped"] as const).entries()) {
+          const threadId = ThreadId.make(`thread-orphan-${status}`);
+          const messageId = MessageId.make(`message-orphan-${status}`);
+          const at = `2026-02-26T16:00:0${index}.000Z`;
+          yield* eventStore.append({
+            type: "thread.turn-start-requested",
+            eventId: EventId.make(`evt-orphan-start-${status}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: at,
+            commandId: CommandId.make(`cmd-orphan-start-${status}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-orphan-start-${status}`),
+            metadata: {},
+            payload: {
+              threadId,
+              messageId,
+              expectsTurnStartAcknowledgement: true,
+              runtimeMode: "approval-required",
+              createdAt: at,
+            },
+          });
+          yield* eventStore.append({
+            type: "thread.meta-updated",
+            eventId: EventId.make(`evt-orphan-ack-${status}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: at,
+            commandId: CommandId.make(`cmd-orphan-ack-${status}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-orphan-ack-${status}`),
+            metadata: {},
+            payload: {
+              threadId,
+              turnStartAcknowledged: {
+                messageId,
+                turnId: TurnId.make(`turn-orphan-${status}`),
+              },
+              updatedAt: at,
+            },
+          });
+          yield* eventStore.append({
+            type: "thread.session-set",
+            eventId: EventId.make(`evt-orphan-settle-${status}`),
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: at,
+            commandId: CommandId.make(`cmd-orphan-settle-${status}`),
+            causationEventId: null,
+            correlationId: CorrelationId.make(`cmd-orphan-settle-${status}`),
+            metadata: {},
+            payload: {
+              threadId,
+              session: {
+                threadId,
+                status,
+                providerName: "codex",
+                runtimeMode: "approval-required",
+                activeTurnId: null,
+                lastError: status === "error" ? "startup failed" : null,
+                updatedAt: at,
+              },
+            },
+          });
+        }
+
+        // An acknowledgement landing after the session died resolves the
+        // pending row instead of recording a submission nothing can consume.
+        const deadThreadId = ThreadId.make("thread-orphan-late-ack");
+        const deadMessageId = MessageId.make("message-orphan-late-ack");
+        yield* eventStore.append({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-orphan-late-session"),
+          aggregateKind: "thread",
+          aggregateId: deadThreadId,
+          occurredAt: "2026-02-26T16:00:10.000Z",
+          commandId: CommandId.make("cmd-orphan-late-session"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-orphan-late-session"),
+          metadata: {},
+          payload: {
+            threadId: deadThreadId,
+            session: {
+              threadId: deadThreadId,
+              status: "ready",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: "2026-02-26T16:00:10.000Z",
+            },
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.turn-start-requested",
+          eventId: EventId.make("evt-orphan-late-start"),
+          aggregateKind: "thread",
+          aggregateId: deadThreadId,
+          occurredAt: "2026-02-26T16:00:11.000Z",
+          commandId: CommandId.make("cmd-orphan-late-start"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-orphan-late-start"),
+          metadata: {},
+          payload: {
+            threadId: deadThreadId,
+            messageId: deadMessageId,
+            expectsTurnStartAcknowledgement: true,
+            runtimeMode: "approval-required",
+            createdAt: "2026-02-26T16:00:11.000Z",
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-orphan-late-stop"),
+          aggregateKind: "thread",
+          aggregateId: deadThreadId,
+          occurredAt: "2026-02-26T16:00:12.000Z",
+          commandId: CommandId.make("cmd-orphan-late-stop"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-orphan-late-stop"),
+          metadata: {},
+          payload: {
+            threadId: deadThreadId,
+            session: {
+              threadId: deadThreadId,
+              status: "stopped",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: "2026-02-26T16:00:12.000Z",
+            },
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.meta-updated",
+          eventId: EventId.make("evt-orphan-late-ack"),
+          aggregateKind: "thread",
+          aggregateId: deadThreadId,
+          occurredAt: "2026-02-26T16:00:13.000Z",
+          commandId: CommandId.make("cmd-orphan-late-ack"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-orphan-late-ack"),
+          metadata: {},
+          payload: {
+            threadId: deadThreadId,
+            turnStartAcknowledged: {
+              messageId: deadMessageId,
+              turnId: TurnId.make("turn-orphan-late-ack"),
+            },
+            updatedAt: "2026-02-26T16:00:13.000Z",
+          },
+        });
+
+        yield* projectionPipeline.bootstrap;
+
+        const rows = yield* sql<{
+          readonly threadId: string;
+          readonly state: string;
+        }>`
+          SELECT thread_id AS "threadId", state
+          FROM projection_turns
+          WHERE turn_id IS NULL
+            AND thread_id LIKE 'thread-orphan-%'
+          ORDER BY thread_id ASC
+        `;
+        assert.deepEqual(rows, [{ threadId: "thread-orphan-error", state: "submitted" }]);
+      }),
+    );
   },
 );
 
-it.effect("restores pending turn-start metadata across projection pipeline restart", () =>
+it.effect("restores acknowledged turn-start metadata across projection pipeline restart", () =>
   Effect.gen(function* () {
     const { dbPath } = yield* ServerConfig;
     const persistenceLayer = makeSqlitePersistenceLive(dbPath);
@@ -4109,8 +5061,26 @@ it.effect("restores pending turn-start metadata across projection pipeline resta
             threadId: sourcePlanThreadId,
             planId: sourcePlanId,
           },
+          expectsTurnStartAcknowledgement: true,
           runtimeMode: "approval-required",
           createdAt: turnStartedAt,
+        },
+      });
+
+      yield* eventStore.append({
+        type: "thread.meta-updated",
+        eventId: EventId.make("evt-restart-ack"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: turnStartedAt,
+        commandId: CommandId.make("cmd-restart-ack"),
+        causationEventId: null,
+        correlationId: CorrelationId.make("cmd-restart-ack"),
+        metadata: {},
+        payload: {
+          threadId,
+          turnStartAcknowledged: { messageId, turnId },
+          updatedAt: turnStartedAt,
         },
       });
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1,6 +1,7 @@
 import {
   ApprovalRequestId,
   isImportedAgentSessionMessageId,
+  MessageId,
   UserInputAttachmentAnswerPayload,
   type ChatAttachment,
   type OrchestrationEvent,
@@ -208,14 +209,19 @@ function retainProjectionMessagesAfterRevert(
   messages: ReadonlyArray<ProjectionThreadMessage>,
   turns: ReadonlyArray<ProjectionTurn>,
   turnCount: number,
+  preservedMessageIds: ReadonlySet<string>,
 ): ReadonlyArray<ProjectionThreadMessage> {
-  const retainedMessageIds = new Set<string>();
+  const retainedMessageIds = new Set(preservedMessageIds);
+  // Queued messages preserved across the revert are not part of the retained
+  // turn history, so they must not consume the historical-message quota below.
+  const nonHistoricalMessageIds = new Set(preservedMessageIds);
   const retainedTurnIds = new Set<string>();
   const keptTurns = turns.filter(
     (turn) =>
-      turn.turnId !== null &&
-      turn.checkpointTurnCount !== null &&
-      turn.checkpointTurnCount <= turnCount,
+      (turn.turnId !== null &&
+        turn.checkpointTurnCount !== null &&
+        turn.checkpointTurnCount <= turnCount) ||
+      (turn.turnId === null && turn.pendingMessageId !== null),
   );
   for (const turn of keptTurns) {
     if (turn.turnId !== null) {
@@ -223,6 +229,9 @@ function retainProjectionMessagesAfterRevert(
     }
     if (turn.pendingMessageId !== null) {
       retainedMessageIds.add(turn.pendingMessageId);
+      if (turn.turnId === null) {
+        nonHistoricalMessageIds.add(turn.pendingMessageId);
+      }
     }
     if (turn.assistantMessageId !== null) {
       retainedMessageIds.add(turn.assistantMessageId);
@@ -243,7 +252,8 @@ function retainProjectionMessagesAfterRevert(
     (message) =>
       message.role === "user" &&
       !isImportedAgentSessionMessageId(message.messageId) &&
-      retainedMessageIds.has(message.messageId),
+      retainedMessageIds.has(message.messageId) &&
+      !nonHistoricalMessageIds.has(message.messageId),
   ).length;
   const missingUserCount = Math.max(0, turnCount - retainedUserCount);
   if (missingUserCount > 0) {
@@ -1185,6 +1195,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             existingRows,
             existingTurns,
             event.payload.turnCount,
+            new Set(event.payload.preservedMessageIds ?? []),
           );
           if (keptRows.length === existingRows.length) {
             return;
@@ -1359,23 +1370,16 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
 
         case "thread.turn-start-requested": {
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
-            threadId: event.payload.threadId,
-          });
-          if (Option.isSome(pendingTurnStart)) {
-            const pendingMessage = yield* projectionThreadMessageRepository.getByMessageId({
-              messageId: pendingTurnStart.value.messageId,
-            });
-            if (
-              Option.isSome(pendingMessage) &&
-              pendingMessage.value.role === "user" &&
-              (pendingMessage.value.attachments?.length ?? 0) === 0 &&
-              pendingMessage.value.text.trim().toLowerCase() === "/compact"
-            ) {
-              return;
-            }
+          // Only starts that expect an acknowledgement get a durable
+          // placeholder — events written before the acknowledgement contract
+          // existed have no ack to consume the row and would replay as failed
+          // starts at startup. Starts queued behind a compaction are
+          // re-dispatched after it with the same message id, so the insert
+          // dedupes by message id and stays idempotent.
+          if (event.payload.expectsTurnStartAcknowledgement !== true) {
+            return;
           }
-          yield* projectionTurnRepository.replacePendingTurnStart({
+          yield* projectionTurnRepository.insertPendingTurnStart({
             threadId: event.payload.threadId,
             messageId: event.payload.messageId,
             sourceProposedPlanThreadId: event.payload.sourceProposedPlan?.threadId ?? null,
@@ -1385,50 +1389,87 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
           return;
         }
 
-        case "thread.activity-appended": {
-          if (event.payload.activity.kind === "context-compaction") {
-            const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
-              event.payload,
-            );
+        case "thread.meta-updated": {
+          const acknowledgement = event.payload.turnStartAcknowledged;
+          if (acknowledgement === undefined) return;
+          const existingTurn = yield* projectionTurnRepository.getByTurnId({
+            threadId: event.payload.threadId,
+            turnId: acknowledgement.turnId,
+          });
+          if (Option.isNone(existingTurn)) {
+            // A stopped or interrupted session can never surface the
+            // acknowledged turn; resolve the pending row rather than leaving a
+            // submission marker nothing will consume.
+            const session = yield* projectionThreadSessionRepository.getByThreadId({
+              threadId: event.payload.threadId,
+            });
             if (
-              Option.isNone(pendingTurnStart) ||
-              String(pendingTurnStart.value.messageId) !==
-                extractActivityRequestId(event.payload.activity.payload)
+              Option.isSome(session) &&
+              (session.value.status === "stopped" || session.value.status === "interrupted")
             ) {
+              yield* projectionTurnRepository.deletePendingTurnStart({
+                threadId: event.payload.threadId,
+                messageId: acknowledgement.messageId,
+              });
               return;
             }
-            yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
+          }
+          yield* projectionTurnRepository.markPendingTurnStartSubmitted({
+            threadId: event.payload.threadId,
+            messageId: acknowledgement.messageId,
+            turnId: acknowledgement.turnId,
+          });
+          if (Option.isSome(existingTurn)) {
+            const submittedTurnStart =
+              yield* projectionTurnRepository.getSubmittedTurnStartByTurnId({
+                threadId: event.payload.threadId,
+                turnId: acknowledgement.turnId,
+              });
+            if (existingTurn.value.pendingMessageId === null && Option.isSome(submittedTurnStart)) {
+              yield* projectionTurnRepository.upsertByTurnId({
+                ...existingTurn.value,
+                pendingMessageId: submittedTurnStart.value.messageId,
+                sourceProposedPlanThreadId: submittedTurnStart.value.sourceProposedPlanThreadId,
+                sourceProposedPlanId: submittedTurnStart.value.sourceProposedPlanId,
+                requestedAt: submittedTurnStart.value.requestedAt,
+                startedAt: existingTurn.value.startedAt ?? submittedTurnStart.value.requestedAt,
+              });
+            }
+            yield* projectionTurnRepository.deletePendingTurnStart({
+              threadId: event.payload.threadId,
+              messageId: acknowledgement.messageId,
+            });
+            return;
+          }
+          return;
+        }
+
+        case "thread.activity-appended": {
+          if (
+            event.payload.activity.kind === "context-compaction" ||
+            event.payload.activity.kind === "provider.auth.signed-out"
+          ) {
+            const requestId = extractActivityRequestId(event.payload.activity.payload);
+            if (requestId === null) return;
+            yield* projectionTurnRepository.deletePendingTurnStart({
+              threadId: event.payload.threadId,
+              messageId: MessageId.make(String(requestId)),
+            });
             return;
           }
           if (event.payload.activity.kind !== "provider.turn.start.failed") return;
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId(
-            event.payload,
-          );
-          if (
-            Option.isNone(pendingTurnStart) ||
-            String(pendingTurnStart.value.messageId) !==
-              extractActivityRequestId(event.payload.activity.payload)
-          ) {
-            return;
-          }
-          yield* projectionTurnRepository.deletePendingTurnStartByThreadId(event.payload);
+          const requestId = extractActivityRequestId(event.payload.activity.payload);
+          if (requestId === null) return;
+          yield* projectionTurnRepository.deletePendingTurnStart({
+            threadId: event.payload.threadId,
+            messageId: MessageId.make(String(requestId)),
+          });
           return;
         }
 
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
-            if (
-              (event.payload.session.status === "ready" &&
-                event.commandId?.startsWith("server:provider-session-set:") === true) ||
-              event.payload.session.status === "error" ||
-              event.payload.session.status === "stopped" ||
-              event.payload.session.status === "interrupted"
-            ) {
-              yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
-                threadId: event.payload.threadId,
-              });
-            }
             // Leaving the "running" session status is the turn-end signal:
             // settle still-running turns so their duration reflects the whole
             // turn rather than the last assistant message.
@@ -1455,6 +1496,29 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
                     }),
               { concurrency: 1 },
             );
+            yield* Effect.forEach(
+              existingTurns.filter((turn) => turn.turnId !== null && turn.state === "running"),
+              (turn) =>
+                turn.turnId === null
+                  ? Effect.void
+                  : projectionTurnRepository.deleteSubmittedTurnStartsByTurnId({
+                      threadId: event.payload.threadId,
+                      turnId: turn.turnId,
+                    }),
+              { concurrency: 1 },
+            );
+            // A dead session also ends acknowledged starts whose turn never
+            // surfaced; an idle or errored session may still pick an
+            // acknowledged send up, since a per-request failure does not prove
+            // the provider session is gone.
+            if (
+              event.payload.session.status === "interrupted" ||
+              event.payload.session.status === "stopped"
+            ) {
+              yield* projectionTurnRepository.deleteSubmittedTurnStartsByThreadId({
+                threadId: event.payload.threadId,
+              });
+            }
             return;
           }
 
@@ -1484,9 +1548,16 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             threadId: event.payload.threadId,
             turnId,
           });
-          const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+          // Assign a durable message only after its acknowledgement names this turn.
+          // Runtime lifecycle checks may inspect a pending candidate without adopting it.
+          const adoptableTurnStart = yield* projectionTurnRepository.getSubmittedTurnStartByTurnId({
             threadId: event.payload.threadId,
+            turnId,
           });
+          const pendingTurnStart =
+            Option.isSome(existingTurn) && existingTurn.value.pendingMessageId !== null
+              ? Option.none()
+              : adoptableTurnStart;
           if (Option.isSome(existingTurn)) {
             const nextState =
               existingTurn.value.state === "completed" || existingTurn.value.state === "error"
@@ -1548,9 +1619,12 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             });
           }
 
-          yield* projectionTurnRepository.deletePendingTurnStartByThreadId({
-            threadId: event.payload.threadId,
-          });
+          if (Option.isSome(pendingTurnStart)) {
+            yield* projectionTurnRepository.deletePendingTurnStart({
+              threadId: event.payload.threadId,
+              messageId: pendingTurnStart.value.messageId,
+            });
+          }
           return;
         }
 
@@ -1592,24 +1666,31 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               startedAt: existingTurn.value.startedAt ?? event.payload.createdAt,
               requestedAt: existingTurn.value.requestedAt ?? event.payload.createdAt,
             });
-            return;
+          } else {
+            yield* projectionTurnRepository.upsertByTurnId({
+              turnId: event.payload.turnId,
+              threadId: event.payload.threadId,
+              pendingMessageId: null,
+              sourceProposedPlanThreadId: null,
+              sourceProposedPlanId: null,
+              assistantMessageId: event.payload.messageId,
+              state: settlesTurn ? "completed" : "running",
+              requestedAt: event.payload.createdAt,
+              startedAt: event.payload.createdAt,
+              completedAt: settlesTurn ? event.payload.updatedAt : null,
+              checkpointTurnCount: null,
+              checkpointRef: null,
+              checkpointStatus: null,
+              checkpointFiles: [],
+            });
           }
-          yield* projectionTurnRepository.upsertByTurnId({
-            turnId: event.payload.turnId,
-            threadId: event.payload.threadId,
-            pendingMessageId: null,
-            sourceProposedPlanThreadId: null,
-            sourceProposedPlanId: null,
-            assistantMessageId: event.payload.messageId,
-            state: settlesTurn ? "completed" : "running",
-            requestedAt: event.payload.createdAt,
-            startedAt: event.payload.createdAt,
-            completedAt: settlesTurn ? event.payload.updatedAt : null,
-            checkpointTurnCount: null,
-            checkpointRef: null,
-            checkpointStatus: null,
-            checkpointFiles: [],
-          });
+          // A settled turn can never consume an acknowledged start waiting on it.
+          if (settlesTurn) {
+            yield* projectionTurnRepository.deleteSubmittedTurnStartsByTurnId({
+              threadId: event.payload.threadId,
+              turnId: event.payload.turnId,
+            });
+          }
           return;
         }
 
@@ -1629,23 +1710,27 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               startedAt: existingTurn.value.startedAt ?? event.payload.createdAt,
               requestedAt: existingTurn.value.requestedAt ?? event.payload.createdAt,
             });
-            return;
+          } else {
+            yield* projectionTurnRepository.upsertByTurnId({
+              turnId: event.payload.turnId,
+              threadId: event.payload.threadId,
+              pendingMessageId: null,
+              sourceProposedPlanThreadId: null,
+              sourceProposedPlanId: null,
+              assistantMessageId: null,
+              state: "interrupted",
+              requestedAt: event.payload.createdAt,
+              startedAt: event.payload.createdAt,
+              completedAt: event.payload.createdAt,
+              checkpointTurnCount: null,
+              checkpointRef: null,
+              checkpointStatus: null,
+              checkpointFiles: [],
+            });
           }
-          yield* projectionTurnRepository.upsertByTurnId({
-            turnId: event.payload.turnId,
+          yield* projectionTurnRepository.deleteSubmittedTurnStartsByTurnId({
             threadId: event.payload.threadId,
-            pendingMessageId: null,
-            sourceProposedPlanThreadId: null,
-            sourceProposedPlanId: null,
-            assistantMessageId: null,
-            state: "interrupted",
-            requestedAt: event.payload.createdAt,
-            startedAt: event.payload.createdAt,
-            completedAt: event.payload.createdAt,
-            checkpointTurnCount: null,
-            checkpointRef: null,
-            checkpointStatus: null,
-            checkpointFiles: [],
+            turnId: event.payload.turnId,
           });
           return;
         }
@@ -1687,51 +1772,38 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
               requestedAt: existingTurn.value.requestedAt ?? event.payload.completedAt,
               completedAt: event.payload.completedAt,
             });
-            return;
+          } else {
+            yield* projectionTurnRepository.upsertByTurnId({
+              turnId: event.payload.turnId,
+              threadId: event.payload.threadId,
+              pendingMessageId: null,
+              sourceProposedPlanThreadId: null,
+              sourceProposedPlanId: null,
+              assistantMessageId: event.payload.assistantMessageId,
+              state: turnStillRunning ? "running" : nextState,
+              requestedAt: event.payload.completedAt,
+              startedAt: event.payload.completedAt,
+              completedAt: event.payload.completedAt,
+              checkpointTurnCount: event.payload.checkpointTurnCount,
+              checkpointRef: event.payload.checkpointRef,
+              checkpointStatus: event.payload.status,
+              checkpointFiles: event.payload.files,
+            });
           }
-          yield* projectionTurnRepository.upsertByTurnId({
-            turnId: event.payload.turnId,
-            threadId: event.payload.threadId,
-            pendingMessageId: null,
-            sourceProposedPlanThreadId: null,
-            sourceProposedPlanId: null,
-            assistantMessageId: event.payload.assistantMessageId,
-            state: turnStillRunning ? "running" : nextState,
-            requestedAt: event.payload.completedAt,
-            startedAt: event.payload.completedAt,
-            completedAt: event.payload.completedAt,
-            checkpointTurnCount: event.payload.checkpointTurnCount,
-            checkpointRef: event.payload.checkpointRef,
-            checkpointStatus: event.payload.status,
-            checkpointFiles: event.payload.files,
-          });
+          if (!turnStillRunning) {
+            yield* projectionTurnRepository.deleteSubmittedTurnStartsByTurnId({
+              threadId: event.payload.threadId,
+              turnId: event.payload.turnId,
+            });
+          }
           return;
         }
 
         case "thread.reverted": {
-          const existingTurns = yield* projectionTurnRepository.listByThreadId({
+          yield* projectionTurnRepository.deleteTurnsAfterCheckpoint({
             threadId: event.payload.threadId,
+            turnCount: event.payload.turnCount,
           });
-          const keptTurns = existingTurns.filter(
-            (turn) =>
-              turn.turnId !== null &&
-              turn.checkpointTurnCount !== null &&
-              turn.checkpointTurnCount <= event.payload.turnCount,
-          );
-          yield* projectionTurnRepository.deleteByThreadId({
-            threadId: event.payload.threadId,
-          });
-          yield* Effect.forEach(
-            keptTurns,
-            (turn) =>
-              turn.turnId === null
-                ? Effect.void
-                : projectionTurnRepository.upsertByTurnId({
-                    ...turn,
-                    turnId: turn.turnId,
-                  }),
-            { concurrency: 1 },
-          ).pipe(Effect.asVoid);
           return;
         }
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2094,6 +2094,127 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
     }),
   );
 
+  it.effect("reconstructs submitted turn identity for orphan reconciliation", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_turns`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_state`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-submitted-restart',
+          'Submitted Restart Project',
+          '/tmp/project-submitted-restart',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          '[]',
+          '2026-09-08T04:00:00.000Z',
+          '2026-09-08T04:00:01.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model_selection_json,
+          runtime_mode,
+          interaction_mode,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          latest_user_message_at,
+          pending_approval_count,
+          pending_user_input_count,
+          has_actionable_proposed_plan,
+          created_at,
+          updated_at,
+          archived_at,
+          deleted_at
+        )
+        VALUES (
+          'thread-submitted-restart',
+          'project-submitted-restart',
+          'Submitted Restart Thread',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          'full-access',
+          'default',
+          NULL,
+          NULL,
+          NULL,
+          '2026-09-08T04:00:02.000Z',
+          0,
+          0,
+          0,
+          '2026-09-08T04:00:02.000Z',
+          '2026-09-08T04:00:02.000Z',
+          NULL,
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id,
+          turn_id,
+          pending_message_id,
+          submitted_turn_id,
+          source_proposed_plan_thread_id,
+          source_proposed_plan_id,
+          assistant_message_id,
+          state,
+          requested_at,
+          started_at,
+          completed_at,
+          checkpoint_turn_count,
+          checkpoint_ref,
+          checkpoint_status,
+          checkpoint_files_json
+        )
+        VALUES (
+          'thread-submitted-restart',
+          NULL,
+          'message-submitted-restart',
+          'turn-submitted-restart',
+          NULL,
+          NULL,
+          NULL,
+          'submitted',
+          '2026-09-08T04:00:02.000Z',
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          '[]'
+        )
+      `;
+
+      const commandReadModel = yield* snapshotQuery.getCommandReadModel();
+      assert.deepEqual(commandReadModel.threads[0]?.submittedTurnStarts, [
+        {
+          messageId: asMessageId("message-submitted-restart"),
+          turnId: asTurnId("turn-submitted-restart"),
+        },
+      ]);
+    }),
+  );
+
   it.effect("searches active user messages and canonical assistant outputs", () =>
     Effect.gen(function* () {
       const snapshotQuery = yield* ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -205,6 +205,20 @@ const TurnStartMessageLookupInput = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
 });
+const PendingTurnStartRowSchema = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  requestedAt: IsoDateTime,
+});
+const PendingTurnStartRowsInput = Schema.Struct({
+  throughSequence: NonNegativeInt,
+});
+const SubmittedTurnStartRowSchema = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnId: TurnId,
+  requestedAt: IsoDateTime,
+});
 const ThreadActivityKindsLookupInput = Schema.Struct({
   threadId: ThreadId,
   activityKinds: Schema.Array(Schema.String),
@@ -366,6 +380,21 @@ function mapTitleRegeneration(row: Schema.Schema.Type<typeof ProjectionThreadDbR
         startedAt: row.titleRegenerationStartedAt,
       }
     : null;
+}
+
+function groupSubmittedTurnStarts(
+  rows: ReadonlyArray<Schema.Schema.Type<typeof SubmittedTurnStartRowSchema>>,
+) {
+  const grouped = new Map<
+    string,
+    Array<{ readonly messageId: MessageId; readonly turnId: TurnId }>
+  >();
+  for (const row of rows) {
+    const starts = grouped.get(row.threadId) ?? [];
+    starts.push({ messageId: row.messageId, turnId: row.turnId });
+    grouped.set(row.threadId, starts);
+  }
+  return grouped;
 }
 
 function mapSessionRow(
@@ -1300,6 +1329,50 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       FROM projection_thread_messages
       WHERE thread_id = ${threadId} AND message_id = ${messageId}
       LIMIT 1
+    `,
+  });
+
+  const listPendingTurnStartRows = SqlSchema.findAll({
+    Request: PendingTurnStartRowsInput,
+    Result: PendingTurnStartRowSchema,
+    execute: ({ throughSequence }) => sql`
+      SELECT
+        pending.thread_id AS "threadId",
+        pending.pending_message_id AS "messageId",
+        pending.requested_at AS "requestedAt"
+      FROM projection_turns AS pending
+      WHERE pending.turn_id IS NULL
+        AND pending.state = 'pending'
+        AND pending.pending_message_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM orchestration_events AS requested
+          WHERE requested.aggregate_kind = 'thread'
+            AND requested.stream_id = pending.thread_id
+            AND requested.event_type = 'thread.turn-start-requested'
+            AND requested.sequence <= ${throughSequence}
+            AND json_extract(requested.payload_json, '$.messageId') = pending.pending_message_id
+        )
+      ORDER BY pending.row_id ASC
+    `,
+  });
+
+  const listSubmittedTurnStartRows = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: SubmittedTurnStartRowSchema,
+    execute: () => sql`
+      SELECT
+        thread_id AS "threadId",
+        pending_message_id AS "messageId",
+        submitted_turn_id AS "turnId",
+        requested_at AS "requestedAt"
+      FROM projection_turns
+      WHERE turn_id IS NULL
+        AND state = 'submitted'
+        AND pending_message_id IS NOT NULL
+        AND submitted_turn_id IS NOT NULL
+        AND checkpoint_turn_count IS NULL
+      ORDER BY thread_id ASC, row_id ASC
     `,
   });
 
@@ -2342,6 +2415,14 @@ pending_approval_requests AS (
               ),
             ),
           ),
+          listSubmittedTurnStartRows(undefined).pipe(
+            Effect.mapError(
+              toPersistenceSqlOrDecodeError(
+                "ProjectionSnapshotQuery.getCommandReadModel:listSubmittedTurnStarts:query",
+                "ProjectionSnapshotQuery.getCommandReadModel:listSubmittedTurnStarts:decodeRows",
+              ),
+            ),
+          ),
           listProjectionStateRows(undefined).pipe(
             Effect.mapError(
               toPersistenceSqlOrDecodeError(
@@ -2361,6 +2442,7 @@ pending_approval_requests AS (
             pullRequestRows,
             sessionRows,
             latestTurnRows,
+            submittedTurnStartRows,
             stateRows,
           ]) =>
             Effect.gen(function* () {
@@ -2433,6 +2515,13 @@ pending_approval_requests AS (
                   updatedAt = maxIso(updatedAt, row.completedAt);
                 }
               }
+              for (let index = 0; index < submittedTurnStartRows.length; index += 1) {
+                const row = submittedTurnStartRows[index];
+                if (!row) {
+                  continue;
+                }
+                updatedAt = maxIso(updatedAt, row.requestedAt);
+              }
               for (let index = 0; index < stateRows.length; index += 1) {
                 const row = stateRows[index];
                 if (!row) {
@@ -2442,6 +2531,7 @@ pending_approval_requests AS (
               }
 
               const latestTurnByThread = new Map<string, OrchestrationLatestTurn>();
+              const submittedTurnStartsByThread = groupSubmittedTurnStarts(submittedTurnStartRows);
               for (let index = 0; index < latestTurnRows.length; index += 1) {
                 const row = latestTurnRows[index];
                 if (!row) {
@@ -2476,6 +2566,7 @@ pending_approval_requests AS (
                 if (!row) {
                   continue;
                 }
+                const submittedTurnStarts = submittedTurnStartsByThread.get(row.threadId) ?? [];
                 threads.push({
                   id: row.threadId,
                   projectId: row.projectId,
@@ -2504,6 +2595,7 @@ pending_approval_requests AS (
                   pinOrderKey: row.pinOrderKey ?? null,
                   activeOrderKey: row.activeOrderKey ?? null,
                   titleRegeneration: mapTitleRegeneration(row),
+                  ...(submittedTurnStarts.length === 0 ? {} : { submittedTurnStarts }),
                   deletedAt: row.deletedAt,
                   messages: [],
                   proposedPlans: proposedPlansByThread.get(row.threadId) ?? [],
@@ -3233,6 +3325,18 @@ pending_approval_requests AS (
     }));
   });
 
+  const listPendingTurnStarts: ProjectionSnapshotQueryShape["listPendingTurnStarts"] = (
+    throughSequence,
+  ) =>
+    listPendingTurnStartRows({ throughSequence }).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionSnapshotQuery.listPendingTurnStarts:query",
+          "ProjectionSnapshotQuery.listPendingTurnStarts:decodeRow",
+        ),
+      ),
+    );
+
   // Contiguous turn range bounding a windowed detail read; undefined loads the
   // full thread. Resolved from a window request inside the snapshot
   // transaction (see getThreadDetailSnapshot).
@@ -3693,6 +3797,7 @@ pending_approval_requests AS (
     getThreadShellById,
     getThreadRuntimeContext,
     getTurnStartMessage,
+    listPendingTurnStarts,
     getThreadDetailById,
     getThreadDetailSnapshot,
   } satisfies ProjectionSnapshotQueryShape;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -67,6 +67,7 @@ import {
 } from "./ProviderCommandReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
+import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Clock from "effect/Clock";
@@ -173,7 +174,12 @@ describe("ProviderCommandReactor", () => {
     readonly requiresNewThreadForModelChange?: boolean;
     readonly unreadableHistory?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
+    readonly turnStartAcknowledgementDispatchFailures?: number;
+    readonly startupTurnStartFailureDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly turnStartBeforeStart?: "one" | "two";
+    readonly failPendingTurnStartSnapshot?: boolean;
+    readonly turnStartDuringPendingSnapshot?: boolean;
     readonly serverActivation?: Effect.Effect<void>;
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
     readonly beforeTurnStartDispatch?: () => Effect.Effect<void>;
@@ -185,6 +191,7 @@ describe("ProviderCommandReactor", () => {
       session: ProviderSession,
     ) => Effect.Effect<ProviderSession, ProviderServiceError>;
     readonly tryHandlePromptCommandEffect?: ProviderAuthService["Service"]["tryHandlePromptCommand"];
+    readonly awaitCheckpointSequenceEffect?: (sequence: number) => Effect.Effect<void>;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir =
@@ -270,7 +277,34 @@ describe("ProviderCommandReactor", () => {
         turnId: asTurnId("turn-1"),
       }),
     );
-    const compactThread = vi.fn((_: ThreadId) => input?.compactThreadEffect?.() ?? Effect.void);
+    // Like ProviderService, only complete after recording the compacted
+    // activity that clears the `/compact` request's pending turn start.
+    const compactThread = vi.fn(
+      (threadId: ThreadId, _modelSelection?: unknown, requestId?: string) =>
+        (input?.compactThreadEffect?.() ?? Effect.void).pipe(
+          Effect.andThen(
+            Effect.suspend(() => {
+              const createdAt = "2026-01-01T00:00:00.000Z";
+              return engine.dispatch({
+                type: "thread.activity.append",
+                commandId: CommandId.make(`cmd-compacted-${requestId}`),
+                threadId,
+                activity: {
+                  id: EventId.make(`activity-compacted-${requestId}`),
+                  tone: "info",
+                  kind: "context-compaction",
+                  summary: "Context compacted",
+                  payload: { state: "compacted", requestId },
+                  turnId: null,
+                  createdAt,
+                },
+                createdAt,
+              });
+            }).pipe(Effect.orDie),
+          ),
+          Effect.asVoid,
+        ),
+    );
     const interruptTurn = vi.fn((_: unknown) => input?.interruptTurnEffect?.() ?? Effect.void);
     const respondToRequest = vi.fn<ProviderServiceShape["respondToRequest"]>(() => Effect.void);
     const respondToUserInput = vi.fn<ProviderServiceShape["respondToUserInput"]>(() => Effect.void);
@@ -415,7 +449,49 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(RepositoryIdentityResolver.layer),
       Layer.provide(SqlitePersistenceMemory),
     );
+    const reactorProjectionSnapshotLayer = Layer.effect(
+      ProjectionSnapshotQuery,
+      Effect.gen(function* () {
+        const query = yield* ProjectionSnapshotQuery;
+        const engine = yield* OrchestrationEngineService;
+        return {
+          ...query,
+          listPendingTurnStarts: (throughSequence) => {
+            if (input?.failPendingTurnStartSnapshot === true) {
+              return Effect.die(new Error("Injected pending turn-start snapshot failure"));
+            }
+            return (query.listPendingTurnStarts?.(throughSequence) ?? Effect.succeed([])).pipe(
+              Effect.tap(() =>
+                input?.turnStartDuringPendingSnapshot === true
+                  ? engine
+                      .dispatch({
+                        type: "thread.turn.start",
+                        commandId: CommandId.make("cmd-turn-start-during-pending-snapshot"),
+                        threadId: ThreadId.make("thread-1"),
+                        message: {
+                          messageId: MessageId.make("message-turn-start-during-pending-snapshot"),
+                          role: "user",
+                          text: "Retain the turn committed during reactor startup",
+                          attachments: [],
+                        },
+                        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+                        runtimeMode: "approval-required",
+                        createdAt: now,
+                      })
+                      .pipe(Effect.orDie)
+                  : Effect.void,
+              ),
+            );
+          },
+        } satisfies ProjectionSnapshotQuery["Service"];
+      }),
+    ).pipe(Layer.provide(projectionSnapshotLayer), Layer.provide(orchestrationLayer));
+    const awaitCheckpointSequence = vi.fn(
+      (sequence: number) => input?.awaitCheckpointSequenceEffect?.(sequence) ?? Effect.void,
+    );
     let titleRegenerationCompletionDispatchAttempts = 0;
+    let turnStartAcknowledgementDispatchAttempts = 0;
+    let startupTurnStartFailureDispatchAttempts = 0;
     const reactorOrchestrationLayer = Layer.effect(
       OrchestrationEngineService,
       Effect.gen(function* () {
@@ -425,6 +501,30 @@ describe("ProviderCommandReactor", () => {
           readThreadEvents: engine.readThreadEvents,
           getThreadReplayStats: engine.getThreadReplayStats,
           dispatch: (command) => {
+            if (command.type === "thread.turn.start.acknowledge") {
+              return Effect.suspend(() => {
+                turnStartAcknowledgementDispatchAttempts += 1;
+                if (
+                  turnStartAcknowledgementDispatchAttempts <=
+                  (input?.turnStartAcknowledgementDispatchFailures ?? 0)
+                ) {
+                  return Effect.die(new Error("Injected turn start acknowledgement failure"));
+                }
+                return engine.dispatch(command);
+              });
+            }
+            if (
+              command.type === "thread.activity.append" &&
+              command.activity.kind === "provider.turn.start.failed"
+            ) {
+              startupTurnStartFailureDispatchAttempts += 1;
+              if (
+                startupTurnStartFailureDispatchAttempts <=
+                (input?.startupTurnStartFailureDispatchFailures ?? 0)
+              ) {
+                return Effect.die(new Error("Injected startup turn failure dispatch failure"));
+              }
+            }
             if (command.type === "thread.title.regeneration.complete") {
               titleRegenerationCompletionDispatchAttempts += 1;
               if (
@@ -460,7 +560,7 @@ describe("ProviderCommandReactor", () => {
     ).pipe(Layer.provide(orchestrationLayer));
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(reactorOrchestrationLayer),
-      Layer.provideMerge(projectionSnapshotLayer),
+      Layer.provideMerge(reactorProjectionSnapshotLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
       Layer.provide(Layer.mock(ProviderAuthService, { tryHandlePromptCommand })),
       Layer.provideMerge(makeProviderRegistryLayer(providerSnapshots as never)),
@@ -489,6 +589,13 @@ describe("ProviderCommandReactor", () => {
         }),
       ),
       Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        Layer.succeed(CheckpointReactor, {
+          start: () => Effect.void,
+          drain: Effect.void,
+          awaitDomainSequence: awaitCheckpointSequence,
+        }),
+      ),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
@@ -578,6 +685,27 @@ describe("ProviderCommandReactor", () => {
         }),
       );
     }
+    const pendingTurnStartCount = input?.turnStartBeforeStart === "two" ? 2 : 1;
+    if (input?.turnStartBeforeStart !== undefined) {
+      for (let index = 1; index <= pendingTurnStartCount; index += 1) {
+        await runEffect(
+          engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`cmd-turn-start-before-reactor-start-${index}`),
+            threadId: ThreadId.make("thread-1"),
+            message: {
+              messageId: MessageId.make(`message-turn-start-before-reactor-start-${index}`),
+              role: "user",
+              text: `This start cannot be replayed after restart (${index})`,
+              attachments: [],
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            createdAt: now,
+          }),
+        );
+      }
+    }
 
     scope = await Effect.runPromise(Scope.make("sequential"));
     await Effect.runPromise(
@@ -605,6 +733,18 @@ describe("ProviderCommandReactor", () => {
             `;
           }),
         ),
+      readTurnStartPlaceholders: () =>
+        runtime!.runPromise(
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient;
+            return yield* sql<{ readonly messageId: string; readonly state: string }>`
+              SELECT pending_message_id AS "messageId", state
+              FROM projection_turns
+              WHERE turn_id IS NULL
+              ORDER BY row_id ASC
+            `;
+          }),
+        ),
       tryHandlePromptCommand,
       startSession,
       sendTurn,
@@ -623,11 +763,229 @@ describe("ProviderCommandReactor", () => {
       stateDir,
       drain,
       runEffect,
+      awaitCheckpointSequence,
       get titleRegenerationCompletionDispatchAttempts() {
         return titleRegenerationCompletionDispatchAttempts;
       },
+      get turnStartAcknowledgementDispatchAttempts() {
+        return turnStartAcknowledgementDispatchAttempts;
+      },
+      get startupTurnStartFailureDispatchAttempts() {
+        return startupTurnStartFailureDispatchAttempts;
+      },
     };
   }
+
+  effectIt.effect("waits for checkpoint side effects before starting a later provider turn", () =>
+    Effect.gen(function* () {
+      let barrierPassed = false;
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          awaitCheckpointSequenceEffect: () =>
+            Effect.sync(() => {
+              barrierPassed = true;
+            }),
+        }),
+      );
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-after-checkpoint-side-effects"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: MessageId.make("message-after-checkpoint-side-effects"),
+          role: "user",
+          text: "Continue after revert",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      yield* Effect.promise(() =>
+        waitFor(
+          () =>
+            harness.awaitCheckpointSequence.mock.calls.length === 1 ||
+            harness.sendTurn.mock.calls.length === 1,
+        ),
+      );
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.awaitCheckpointSequence).toHaveBeenCalledTimes(1);
+      expect(harness.awaitCheckpointSequence).toHaveBeenCalledWith(expect.any(Number));
+      expect(barrierPassed).toBe(true);
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  effectIt.effect("retries an accepted turn until its acknowledgement is durable", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() =>
+        createHarness({ turnStartAcknowledgementDispatchFailures: 2 }),
+      );
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-with-retried-acknowledgement"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: MessageId.make("message-turn-with-retried-acknowledgement"),
+          role: "user",
+          text: "Keep the accepted provider turn durable",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+
+      yield* Effect.promise(() =>
+        waitFor(() => harness.turnStartAcknowledgementDispatchAttempts === 3),
+      );
+      yield* Effect.promise(() =>
+        waitFor(async () => {
+          const placeholders = await harness.readTurnStartPlaceholders();
+          return placeholders[0]?.state === "submitted";
+        }),
+      );
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      expect(yield* Effect.promise(() => harness.readTurnStartPlaceholders())).toEqual([
+        { messageId: "message-turn-with-retried-acknowledgement", state: "submitted" },
+      ]);
+    }),
+  );
+
+  effectIt.effect("starts a turn accepted while an earlier checkpoint revert completes", () =>
+    Effect.gen(function* () {
+      const barrier = yield* Deferred.make<void>();
+      const harness = yield* Effect.promise(() =>
+        createHarness({
+          awaitCheckpointSequenceEffect: () => Deferred.await(barrier),
+        }),
+      );
+      const messageId = MessageId.make("message-accepted-during-checkpoint-revert");
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-accepted-during-checkpoint-revert"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId,
+          role: "user",
+          text: "Continue after revert",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      yield* Effect.promise(() =>
+        waitFor(() => harness.awaitCheckpointSequence.mock.calls.length === 1),
+      );
+
+      yield* harness.engine.dispatch({
+        type: "thread.revert.complete",
+        commandId: CommandId.make("cmd-complete-earlier-checkpoint-revert"),
+        threadId: ThreadId.make("thread-1"),
+        turnCount: 0,
+        createdAt: "2026-01-01T00:00:02.000Z",
+      });
+      yield* Deferred.succeed(barrier, undefined);
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      const readModel = yield* Effect.promise(() => harness.readModel());
+      expect(readModel.threads[0]?.messages.some((message) => message.id === messageId)).toBe(true);
+      expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([]);
+    }),
+  );
+
+  effectIt.effect("does not replay a successful steering send after the active turn finishes", () =>
+    Effect.gen(function* () {
+      const harness = yield* Effect.promise(() => createHarness());
+      const threadId = ThreadId.make("thread-1");
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-first-successful-send"),
+        threadId,
+        message: {
+          messageId: MessageId.make("message-first-successful-send"),
+          role: "user",
+          text: "Start the turn",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      });
+      yield* Effect.promise(() =>
+        waitFor(() => harness.awaitCheckpointSequence.mock.calls.length === 1),
+      );
+      yield* Effect.promise(() => harness.drain());
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-first-send-running"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: TurnId.make("turn-1"),
+          lastError: null,
+          updatedAt: "2026-01-01T00:00:02.000Z",
+        },
+        createdAt: "2026-01-01T00:00:02.000Z",
+      });
+
+      yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-successful-steering-send"),
+        threadId,
+        message: {
+          messageId: MessageId.make("message-successful-steering-send"),
+          role: "user",
+          text: "Steer the active turn",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: "2026-01-01T00:00:03.000Z",
+      });
+      yield* Effect.promise(() =>
+        waitFor(() => harness.awaitCheckpointSequence.mock.calls.length === 2),
+      );
+      yield* Effect.promise(() => harness.drain());
+      expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+      yield* Effect.promise(() =>
+        waitFor(async () => (await harness.readTurnStartPlaceholders()).length === 0),
+      );
+      expect(yield* Effect.promise(() => harness.readTurnStartPlaceholders())).toEqual([]);
+      yield* harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.make("cmd-steered-turn-ready"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          providerInstanceId: ProviderInstanceId.make("codex"),
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-01-01T00:00:04.000Z",
+        },
+        createdAt: "2026-01-01T00:00:04.000Z",
+      });
+      yield* Effect.promise(() => harness.drain());
+
+      expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+      expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([]);
+      expect(yield* Effect.promise(() => harness.readTurnStartPlaceholders())).toEqual([]);
+    }),
+  );
 
   effectIt.effect.each(["new", "ready", "stopped"] as const)(
     "handles sign-out for a %s thread before worktree repair, text helpers, or startup",
@@ -1152,6 +1510,7 @@ describe("ProviderCommandReactor", () => {
           ),
         ).toEqual([]);
         expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([
+          { threadId: "thread-1" },
           { threadId: "thread-1" },
         ]);
 
@@ -1866,6 +2225,88 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.title).toBe("Thread");
     expect(thread?.titleRegeneration).toBeNull();
+  });
+
+  it("marks every turn start left pending across reactor startup as failed", async () => {
+    const harness = await createHarness({ turnStartBeforeStart: "two" });
+
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(await harness.readPendingTurnStarts()).toEqual([]);
+    const readModel = await harness.readModel();
+    const startupFailures = readModel.threads[0]?.activities.filter(
+      (activity) => activity.kind === "provider.turn.start.failed",
+    );
+    expect(
+      startupFailures
+        ?.flatMap((activity) =>
+          typeof activity.payload === "object" &&
+          activity.payload !== null &&
+          "requestId" in activity.payload &&
+          typeof activity.payload.requestId === "string"
+            ? [activity.payload.requestId]
+            : [],
+        )
+        .toSorted(),
+    ).toEqual([
+      "message-turn-start-before-reactor-start-1",
+      "message-turn-start-before-reactor-start-2",
+    ]);
+    expect(
+      startupFailures?.every(
+        (activity) =>
+          typeof activity.payload === "object" &&
+          activity.payload !== null &&
+          "detail" in activity.payload &&
+          typeof activity.payload.detail === "string" &&
+          activity.payload.detail.includes("server restarted"),
+      ),
+    ).toBe(true);
+  });
+
+  it("continues clearing startup turn starts after one failure dispatch fails", async () => {
+    const harness = await createHarness({
+      turnStartBeforeStart: "two",
+      startupTurnStartFailureDispatchFailures: 1,
+    });
+
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(harness.startupTurnStartFailureDispatchAttempts).toBe(2);
+    expect(await harness.readTurnStartPlaceholders()).toEqual([
+      { messageId: "message-turn-start-before-reactor-start-1", state: "pending" },
+    ]);
+    const readModel = await harness.readModel();
+    expect(
+      readModel.threads[0]?.activities.flatMap((activity) =>
+        activity.kind === "provider.turn.start.failed" &&
+        typeof activity.payload === "object" &&
+        activity.payload !== null &&
+        "requestId" in activity.payload &&
+        typeof activity.payload.requestId === "string"
+          ? [activity.payload.requestId]
+          : [],
+      ),
+    ).toEqual(["message-turn-start-before-reactor-start-2"]);
+  });
+
+  it("fails reactor startup when pending turn starts cannot be read", async () => {
+    await expect(createHarness({ failPendingTurnStartSnapshot: true })).rejects.toThrow(
+      "Injected pending turn-start snapshot failure",
+    );
+  });
+
+  it("processes a turn committed during the startup snapshot handoff", async () => {
+    const harness = await createHarness({ turnStartDuringPendingSnapshot: true });
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await waitFor(async () => (await harness.readPendingTurnStarts()).length === 0);
+    await harness.drain();
+
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      input: "Retain the turn committed during reactor startup",
+    });
+    expect(await harness.readPendingTurnStarts()).toEqual([]);
   });
 
   it("continues clearing startup title regeneration state after one completion fails", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2,8 +2,10 @@ import {
   type ChatAttachment,
   CommandId,
   EventId,
+  MessageId,
   type ModelSelection,
   type OrchestrationEvent,
+  type OrchestrationProposedPlanId,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -45,6 +47,7 @@ import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+import * as CheckpointReactor from "../Services/CheckpointReactor.ts";
 import {
   ProviderCommandReactor,
   type ProviderCommandReactorShape,
@@ -325,6 +328,7 @@ const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerAuthService = yield* ProviderAuthService;
   const providerService = yield* ProviderService;
+  const checkpointReactor = yield* CheckpointReactor.CheckpointReactor;
   const providerRegistry = yield* ProviderRegistry;
   const gitWorkflow = yield* GitWorkflowService;
   const fileSystem = yield* FileSystem.FileSystem;
@@ -1274,9 +1278,58 @@ const make = Effect.gen(function* () {
     processThreadTitleRegenerationSafely,
   );
 
+  const acknowledgeTurnStartSubmission = Effect.fn("acknowledgeTurnStartSubmission")(
+    function* (input: {
+      readonly threadId: ThreadId;
+      readonly messageId: MessageId;
+      readonly turnId: TurnId;
+      readonly sourceProposedPlan?: {
+        readonly threadId: ThreadId;
+        readonly planId: OrchestrationProposedPlanId;
+      };
+    }) {
+      const command = {
+        type: "thread.turn.start.acknowledge" as const,
+        commandId: yield* serverCommandId("thread-turn-start-acknowledge"),
+        threadId: input.threadId,
+        messageId: input.messageId,
+        turnId: input.turnId,
+        ...(input.sourceProposedPlan !== undefined
+          ? { sourceProposedPlan: input.sourceProposedPlan }
+          : {}),
+      };
+      const dispatch = orchestrationEngine.dispatch(command).pipe(Effect.asVoid);
+      yield* dispatch.pipe(
+        Effect.sandbox,
+        Effect.tapError((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.void
+            : Effect.logWarning("provider command reactor retrying turn start acknowledgement", {
+                threadId: input.threadId,
+                messageId: input.messageId,
+                cause: Cause.pretty(cause),
+              }),
+        ),
+        Effect.retry({
+          while: (cause) => !Cause.hasInterrupts(cause),
+          schedule: Schedule.exponential("100 millis").pipe(
+            Schedule.modifyDelay(({ duration }) =>
+              Effect.succeed(Duration.min(duration, Duration.seconds(5))),
+            ),
+          ),
+        }),
+        Effect.catch((cause) => Effect.failCause(cause)),
+      );
+    },
+  );
+
   const processTurnStartRequested = Effect.fn("processTurnStartRequested")(function* (
     receivedEvent: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
   ) {
+    // Checkpoint and provider reactors consume the same ordered domain stream on
+    // independent workers. Cross this sequence barrier before a later turn can
+    // mutate files or provider history that an earlier revert is still restoring.
+    yield* checkpointReactor.awaitDomainSequence(receivedEvent.sequence);
     const resumed =
       receivedEvent.commandId !== null ? resumedTurnStarts.get(receivedEvent.commandId) : undefined;
     const event = resumed ? { ...receivedEvent, payload: resumed.event.payload } : receivedEvent;
@@ -1389,7 +1442,7 @@ const make = Effect.gen(function* () {
           tone: "info",
           kind: "provider.auth.signed-out",
           summary: "Provider signed out",
-          payload: { providerInstanceId: instanceId },
+          payload: { providerInstanceId: instanceId, requestId: event.payload.messageId },
           turnId: null,
           createdAt: event.payload.createdAt,
         },
@@ -1565,9 +1618,20 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const send = providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure));
+    const send = providerService.sendTurn(sendTurnRequest.value).pipe(
+      Effect.matchCauseEffect({
+        onFailure: recoverTurnStartFailure,
+        onSuccess: (turn) =>
+          acknowledgeTurnStartSubmission({
+            threadId: event.payload.threadId,
+            messageId: event.payload.messageId,
+            turnId: turn.turnId,
+            ...(event.payload.sourceProposedPlan !== undefined
+              ? { sourceProposedPlan: event.payload.sourceProposedPlan }
+              : {}),
+          }),
+      }),
+    );
     // The forked send settles `sent` from here on, so drop the entry the post-processing hook uses.
     if (resumed && event.commandId !== null) resumedTurnStarts.delete(event.commandId);
     yield* send.pipe(
@@ -1933,6 +1997,11 @@ const make = Effect.gen(function* () {
         ).pipe(Effect.as([]));
       }),
     );
+    const domainEvents = yield* orchestrationEngine.subscribeDomainEvents;
+    const handoffSequence = yield* orchestrationEngine.latestSequence;
+    const interruptedTurnStarts = yield* (
+      projectionSnapshotQuery.listPendingTurnStarts?.(handoffSequence) ?? Effect.succeed([])
+    ).pipe(Effect.orDie);
     const processEvent = Effect.fn("processEvent")(function* (event: OrchestrationEvent) {
       if (
         (event.type === "thread.meta-updated" && event.payload.regenerateTitle === true) ||
@@ -1948,22 +2017,54 @@ const make = Effect.gen(function* () {
       }
     });
 
-    // Subscribe before returning, even while event handling waits for server activation.
-    const domainEvents = yield* orchestrationEngine.subscribeDomainEvents;
-    yield* forkParked(Stream.runForEach(domainEvents, processEvent));
+    const liveDomainEvents = domainEvents.pipe(
+      Stream.filter((event) => event.sequence > handoffSequence),
+    );
 
     // The domain event stream is hot, so work pending before this reactor
     // starts cannot be resumed. Correlated completions only clear the request
     // captured here, leaving any newer request untouched.
-    const clearInterrupted = clearInterruptedThreadTitleRegenerations(
-      interruptedTitleRegenerations,
+    const clearInterruptedTurnStarts = Effect.forEach(
+      interruptedTurnStarts,
+      (pending) =>
+        appendProviderFailureActivity({
+          threadId: pending.threadId,
+          kind: "provider.turn.start.failed",
+          summary: "Provider turn start failed",
+          detail:
+            "The server restarted before this turn could start. Send the message again to continue.",
+          turnId: null,
+          createdAt: pending.requestedAt,
+          requestId: pending.messageId,
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.failCause(cause)
+              : Effect.logWarning(
+                  "provider command reactor failed to clear interrupted turn start",
+                  {
+                    threadId: pending.threadId,
+                    messageId: pending.messageId,
+                    cause: Cause.pretty(cause),
+                  },
+                ),
+          ),
+        ),
+      { concurrency: 1, discard: true },
+    );
+    const clearInterrupted = Effect.all(
+      [
+        clearInterruptedThreadTitleRegenerations(interruptedTitleRegenerations),
+        clearInterruptedTurnStarts,
+      ],
+      { concurrency: 1, discard: true },
     ).pipe(
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
           return Effect.interrupt;
         }
         return Effect.logWarning(
-          "provider command reactor failed to clear interrupted title regenerations",
+          "provider command reactor failed to clear interrupted startup work",
           {
             cause: Cause.pretty(cause),
           },
@@ -1973,8 +2074,11 @@ const make = Effect.gen(function* () {
     const activation = yield* ServerActivation;
     if (activation === undefined) {
       yield* clearInterrupted;
+      yield* forkParked(Stream.runForEach(liveDomainEvents, processEvent));
     } else {
-      yield* forkParked(clearInterrupted);
+      yield* forkParked(
+        clearInterrupted.pipe(Effect.andThen(Stream.runForEach(liveDomainEvents, processEvent))),
+      );
     }
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -704,6 +704,15 @@ describe("ProviderRuntimeIngestion", () => {
       createdAt: "2026-01-01T00:00:05.000Z",
     });
     await harness.drain();
+    // The provider command reactor supplies this exact message/turn receipt.
+    // Until it arrives, the lifecycle event must not consume a pending message.
+    await harness.dispatch({
+      type: "thread.turn.start.acknowledge",
+      commandId: CommandId.make("opencode-pending-acknowledged"),
+      threadId,
+      messageId: asMessageId("opencode-pending-message"),
+      turnId: asTurnId("opencode-pending-turn"),
+    });
     const startedThread = (await harness.readModel()).threads.find(
       (entry) => entry.id === threadId,
     );

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1393,9 +1393,10 @@ const make = Effect.gen(function* () {
 
   const getSourceProposedPlanReferenceForPendingTurnStart = Effect.fn(
     "getSourceProposedPlanReferenceForPendingTurnStart",
-  )(function* (threadId: ThreadId) {
-    const pendingTurnStart = yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+  )(function* (threadId: ThreadId, turnId: TurnId) {
+    const pendingTurnStart = yield* projectionTurnRepository.getAdoptableTurnStartByThreadId({
       threadId,
+      turnId,
     });
     if (Option.isNone(pendingTurnStart)) {
       return null;
@@ -1433,7 +1434,15 @@ const make = Effect.gen(function* () {
       return null;
     }
 
-    return yield* getSourceProposedPlanReferenceForPendingTurnStart(threadId);
+    const existingTurn = yield* projectionTurnRepository.getByTurnId({
+      threadId,
+      turnId: eventTurnId,
+    });
+    if (Option.isSome(existingTurn) && existingTurn.value.pendingMessageId !== null) {
+      return null;
+    }
+
+    return yield* getSourceProposedPlanReferenceForPendingTurnStart(threadId, eventTurnId);
   });
 
   const markSourceProposedPlanImplemented = Effect.fn("markSourceProposedPlanImplemented")(
@@ -1498,7 +1507,7 @@ const make = Effect.gen(function* () {
         event.type === "turn.started" ||
         isTerminalTurn ||
         isCompactedThreadState
-          ? yield* projectionTurnRepository.getPendingTurnStartByThreadId({
+          ? yield* projectionTurnRepository.getUnresolvedTurnStartByThreadId({
               threadId: thread.id,
             })
           : Option.none();
@@ -1646,6 +1655,38 @@ const make = Effect.gen(function* () {
             },
             createdAt: now,
           });
+        }
+
+        // A turn.started processed before its acknowledgement cannot resolve
+        // the source plan through pending-start lookups; by the time the turn
+        // ends the late ack may have bound the plan reference to the turn row,
+        // so retry the mark here.
+        if (isTerminalTurn && eventTurnId !== undefined) {
+          const turn = yield* projectionTurnRepository.getByTurnId({
+            threadId: thread.id,
+            turnId: eventTurnId,
+          });
+          const sourceThreadId = Option.getOrNull(turn)?.sourceProposedPlanThreadId ?? null;
+          const sourcePlanId = Option.getOrNull(turn)?.sourceProposedPlanId ?? null;
+          if (sourceThreadId !== null && sourcePlanId !== null) {
+            yield* markSourceProposedPlanImplemented(
+              sourceThreadId,
+              sourcePlanId,
+              thread.id,
+              now,
+            ).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning(
+                  "provider runtime ingestion failed to mark source proposed plan",
+                  {
+                    eventId: event.eventId,
+                    eventType: event.type,
+                    cause: Cause.pretty(cause),
+                  },
+                ),
+              ),
+            );
+          }
         }
       }
 

--- a/apps/server/src/orchestration/Services/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Services/CheckpointReactor.ts
@@ -30,6 +30,9 @@ export interface CheckpointReactorShape {
    * Intended for test use to replace timing-sensitive sleeps.
    */
   readonly drain: Effect.Effect<void>;
+
+  /** Wait until checkpoint side effects have processed through a domain event sequence. */
+  readonly awaitDomainSequence: (sequence: number) => Effect.Effect<void>;
 }
 
 /**

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -232,6 +232,16 @@ export interface ProjectionSnapshotQueryShape {
     ProjectionRepositoryError
   >;
 
+  /** Read pending starts that a newly-created hot reactor cannot replay. */
+  readonly listPendingTurnStarts?: (throughSequence: number) => Effect.Effect<
+    ReadonlyArray<{
+      readonly threadId: ThreadId;
+      readonly messageId: MessageId;
+      readonly requestedAt: string;
+    }>,
+    ProjectionRepositoryError
+  >;
+
   /**
    * Read a single active thread detail snapshot by id.
    */

--- a/apps/server/src/orchestration/decider.settled.test.ts
+++ b/apps/server/src/orchestration/decider.settled.test.ts
@@ -5,6 +5,8 @@ import {
   ProjectId,
   ProviderInstanceId,
   ThreadId,
+  TurnId,
+  OrchestrationProposedPlanId,
   type OrchestrationEvent,
   type OrchestrationReadModel,
   type OrchestrationSession,
@@ -33,6 +35,7 @@ function makeReadModel(
     readonly snoozedUntil?: string | null;
     readonly snoozedAt?: string | null;
   } = {},
+  latestTurn: OrchestrationThread["latestTurn"] = null,
 ): OrchestrationReadModel {
   return {
     snapshotSequence: 0,
@@ -48,7 +51,7 @@ function makeReadModel(
         branch: null,
         worktreePath: null,
         pullRequests: [],
-        latestTurn: null,
+        latestTurn,
         createdAt: NOW,
         updatedAt: NOW,
         archivedAt,
@@ -80,6 +83,35 @@ function makeSession(status: OrchestrationSession["status"]): OrchestrationSessi
     updatedAt: NOW,
   };
 }
+
+const projectQueuedTurnStart = Effect.fn("projectQueuedTurnStart")(function* (
+  messageId: MessageId,
+  createdAt: string,
+) {
+  let readModel = makeReadModel(null);
+  const result = yield* decideOrchestrationCommand({
+    command: {
+      type: "thread.turn.start",
+      commandId: CommandId.make(`cmd-start-${messageId}`),
+      threadId: ThreadId.make("thread-1"),
+      message: {
+        messageId,
+        role: "user",
+        text: "Continue",
+        attachments: [],
+      },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      createdAt,
+    },
+    readModel,
+  });
+  const events = Array.isArray(result) ? result : [result];
+  for (const [index, event] of events.entries()) {
+    readModel = yield* projectEvent(readModel, { ...event, sequence: index + 1 });
+  }
+  return readModel;
+});
 
 it.layer(NodeServices.layer)("settled thread decider", (it) => {
   it.effect("preserves the activity stamp when automatically settling", () =>
@@ -848,6 +880,234 @@ it.layer(NodeServices.layer)("settled thread decider", (it) => {
       expect(unconditionalEvents.map((event) => event.type)).toEqual([
         "thread.session-stop-requested",
       ]);
+    }),
+  );
+
+  it.effect("rejects checkpoint reverts while a turn is active or queued", () =>
+    Effect.gen(function* () {
+      for (const status of ["starting", "running"] as const) {
+        const error = yield* decideOrchestrationCommand({
+          command: {
+            type: "thread.checkpoint.revert",
+            commandId: CommandId.make(`cmd-revert-${status}`),
+            threadId: ThreadId.make("thread-1"),
+            turnCount: 0,
+            createdAt: NOW,
+          },
+          readModel: makeReadModel(null, null, makeSession(status)),
+        }).pipe(Effect.flip);
+        expect(error).toMatchObject({
+          _tag: "OrchestrationCommandInvariantError",
+          detail: "Interrupt the current turn before reverting checkpoints.",
+        });
+      }
+
+      const latestTurnError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.checkpoint.revert",
+          commandId: CommandId.make("cmd-revert-active-turn"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          createdAt: NOW,
+        },
+        readModel: makeReadModel(
+          null,
+          null,
+          makeSession("ready"),
+          [],
+          [],
+          {},
+          {
+            turnId: TurnId.make("turn-1"),
+            state: "running",
+            requestedAt: NOW,
+            startedAt: NOW,
+            completedAt: null,
+            assistantMessageId: null,
+          },
+        ),
+      }).pipe(Effect.flip);
+      expect(latestTurnError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const pendingMessageId = MessageId.make("message-revert-queued");
+      const queuedReadModel = yield* projectQueuedTurnStart(
+        pendingMessageId,
+        "2025-12-31T23:55:00.000Z",
+      );
+      const queuedError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.checkpoint.revert",
+          commandId: CommandId.make("cmd-revert-queued-turn"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          createdAt: NOW,
+        },
+        readModel: queuedReadModel,
+      }).pipe(Effect.flip);
+      expect(queuedError._tag).toBe("OrchestrationCommandInvariantError");
+
+      const acknowledgement = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start.acknowledge",
+          commandId: CommandId.make("cmd-acknowledge-queued-turn"),
+          threadId: ThreadId.make("thread-1"),
+          messageId: pendingMessageId,
+          turnId: TurnId.make("turn-acknowledged-before-running"),
+        },
+        readModel: queuedReadModel,
+      });
+      let acknowledgedReadModel = yield* projectEvent(queuedReadModel, {
+        ...(Array.isArray(acknowledgement) ? acknowledgement[0]! : acknowledgement),
+        sequence: queuedReadModel.snapshotSequence + 1,
+      });
+      for (const [status, activeTurnId] of [
+        ["running", TurnId.make("turn-unrelated-running")],
+        ["ready", null],
+      ] as const) {
+        const sessionSet = yield* decideOrchestrationCommand({
+          command: {
+            type: "thread.session.set",
+            commandId: CommandId.make(`cmd-session-${status}-after-acknowledgement`),
+            threadId: ThreadId.make("thread-1"),
+            session: {
+              ...makeSession(status),
+              activeTurnId,
+            },
+            createdAt: NOW,
+          },
+          readModel: acknowledgedReadModel,
+        });
+        for (const event of Array.isArray(sessionSet) ? sessionSet : [sessionSet]) {
+          acknowledgedReadModel = yield* projectEvent(acknowledgedReadModel, {
+            ...event,
+            sequence: acknowledgedReadModel.snapshotSequence + 1,
+          });
+        }
+      }
+      expect(acknowledgedReadModel.threads[0]?.pendingTurnStartMessageId).toBeNull();
+      expect(acknowledgedReadModel.threads[0]?.submittedTurnStarts).toEqual([
+        {
+          messageId: pendingMessageId,
+          turnId: TurnId.make("turn-acknowledged-before-running"),
+        },
+      ]);
+      const acknowledgedError = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.checkpoint.revert",
+          commandId: CommandId.make("cmd-revert-acknowledged-before-running"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          createdAt: NOW,
+        },
+        readModel: acknowledgedReadModel,
+      }).pipe(Effect.flip);
+      expect(acknowledgedError._tag).toBe("OrchestrationCommandInvariantError");
+    }),
+  );
+
+  it.effect("marks the source plan when the acknowledgement lands after its turn surfaced", () =>
+    Effect.gen(function* () {
+      const sourceThread: OrchestrationThread = {
+        ...makeReadModel(null).threads[0]!,
+        id: ThreadId.make("thread-source"),
+        proposedPlans: [
+          {
+            id: OrchestrationProposedPlanId.make("plan-1"),
+            turnId: TurnId.make("turn-source"),
+            planMarkdown: "plan",
+            createdAt: NOW,
+            implementedAt: null,
+            implementationThreadId: null,
+            updatedAt: NOW,
+          },
+        ],
+      };
+      const baseReadModel = makeReadModel(
+        null,
+        null,
+        makeSession("running"),
+        [],
+        [],
+        {},
+        {
+          turnId: TurnId.make("turn-late"),
+          state: "running",
+          requestedAt: NOW,
+          startedAt: NOW,
+          completedAt: null,
+          assistantMessageId: null,
+        },
+      );
+      const readModel: OrchestrationReadModel = {
+        ...baseReadModel,
+        threads: [...baseReadModel.threads, sourceThread],
+      };
+
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start.acknowledge",
+          commandId: CommandId.make("cmd-late-ack"),
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("message-late"),
+          turnId: TurnId.make("turn-late"),
+          sourceProposedPlan: {
+            threadId: sourceThread.id,
+            planId: sourceThread.proposedPlans[0]!.id,
+          },
+        },
+        readModel,
+      });
+      const events = Array.isArray(result) ? result : [result];
+      expect(events.map((event) => event.type)).toEqual([
+        "thread.meta-updated",
+        "thread.proposed-plan-upserted",
+      ]);
+      const upsert = events[1]!;
+      expect(upsert.aggregateId).toBe(sourceThread.id);
+      if (upsert.type === "thread.proposed-plan-upserted") {
+        expect(upsert.payload.proposedPlan.implementedAt).not.toBeNull();
+        expect(upsert.payload.proposedPlan.implementationThreadId).toBe("thread-1");
+      }
+
+      // An acknowledgement for a turn that never surfaced leaves the plan open.
+      const early = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.turn.start.acknowledge",
+          commandId: CommandId.make("cmd-early-ack"),
+          threadId: ThreadId.make("thread-1"),
+          messageId: MessageId.make("message-early"),
+          turnId: TurnId.make("turn-not-yet"),
+          sourceProposedPlan: {
+            threadId: sourceThread.id,
+            planId: sourceThread.proposedPlans[0]!.id,
+          },
+        },
+        readModel,
+      });
+      const earlyEvents = Array.isArray(early) ? early : [early];
+      expect(earlyEvents.map((event) => event.type)).toEqual(["thread.meta-updated"]);
+    }),
+  );
+
+  it.effect("preserves a pending turn start when its client clock is behind", () =>
+    Effect.gen(function* () {
+      const pendingMessageId = MessageId.make("message-revert-clock-skew");
+      const readModel = yield* projectQueuedTurnStart(pendingMessageId, "2025-12-31T23:55:00.000Z");
+      const result = yield* decideOrchestrationCommand({
+        command: {
+          type: "thread.revert.complete",
+          commandId: CommandId.make("cmd-revert-complete-clock-skew"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          createdAt: "2026-01-01T00:00:13.000Z",
+        },
+        readModel,
+      });
+
+      expect(result).toMatchObject({
+        type: "thread.reverted",
+        payload: { preservedMessageIds: [pendingMessageId] },
+      });
     }),
   );
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -104,11 +104,26 @@ function openRequests(thread: Pick<OrchestrationThread, "activities">) {
   return requests;
 }
 
-/** Apply the shared shell-level rule to the detailed command read model. */
+/** Prefer the event-ordered pending identity, with the timestamp rule only as
+ * a compatibility fallback for read models projected before the field existed. */
 function hasQueuedTurnStartForThread(
-  thread: Pick<OrchestrationThread, "messages" | "latestTurn" | "session">,
+  thread: Pick<
+    OrchestrationThread,
+    | "messages"
+    | "latestTurn"
+    | "session"
+    | "pendingTurnStartMessageId"
+    | "submittedTurnStarts"
+    | "turnStartSubmissionRendezvous"
+  >,
   now: string,
 ): boolean {
+  if (
+    thread.pendingTurnStartMessageId != null ||
+    (thread.submittedTurnStarts?.length ?? 0) > 0 ||
+    (thread.turnStartSubmissionRendezvous?.requests.length ?? 0) > 0
+  )
+    return true;
   let latestUserMessageAt: string | null = null;
   let latestUserMessageAtMs = Number.NEGATIVE_INFINITY;
   for (const message of thread.messages) {
@@ -1223,6 +1238,71 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.turn.start.acknowledge": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const occurredAt = yield* nowIso;
+      const metaUpdatedEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.meta-updated",
+        payload: {
+          threadId: command.threadId,
+          turnStartAcknowledged: {
+            messageId: command.messageId,
+            turnId: command.turnId,
+          },
+          // Submission state must not reorder the thread in clients.
+          updatedAt: thread.updatedAt,
+        },
+      };
+      // A provider can surface the turn before this acknowledgement lands; the
+      // turn.started path then cannot resolve the source plan through
+      // pending-start lookups, so mark it here when it is still open.
+      const sourceRef = command.sourceProposedPlan;
+      const lateSourcePlan =
+        sourceRef !== undefined &&
+        thread.latestTurn !== null &&
+        thread.latestTurn.turnId === command.turnId
+          ? readModel.threads
+              .find((entry) => entry.id === sourceRef.threadId)
+              ?.proposedPlans.find((plan) => plan.id === sourceRef.planId)
+          : undefined;
+      if (
+        sourceRef === undefined ||
+        lateSourcePlan === undefined ||
+        lateSourcePlan.implementedAt !== null
+      ) {
+        return metaUpdatedEvent;
+      }
+      const planUpsertedEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...(yield* withEventBase({
+          aggregateKind: "thread",
+          aggregateId: sourceRef.threadId,
+          occurredAt,
+          commandId: command.commandId,
+        })),
+        type: "thread.proposed-plan-upserted",
+        payload: {
+          threadId: sourceRef.threadId,
+          proposedPlan: {
+            ...lateSourcePlan,
+            implementedAt: occurredAt,
+            implementationThreadId: command.threadId,
+            updatedAt: occurredAt,
+          },
+        },
+      };
+      return [metaUpdatedEvent, planUpsertedEvent];
+    }
+
     case "thread.runtime-mode.set": {
       yield* requireThread({
         readModel,
@@ -1338,6 +1418,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           messageId: command.message.messageId,
+          expectsTurnStartAcknowledgement: true,
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),
@@ -1643,11 +1724,26 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
 
     case "thread.conversation.revert":
     case "thread.checkpoint.revert": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      if (
+        thread.session?.status === "starting" ||
+        thread.session?.status === "running" ||
+        thread.latestTurn?.state === "running" ||
+        thread.pendingTurnStartMessageId != null ||
+        (thread.submittedTurnStarts?.length ?? 0) > 0 ||
+        (thread.turnStartSubmissionRendezvous?.requests.length ?? 0) > 0
+      ) {
+        return yield* Effect.fail(
+          new OrchestrationCommandInvariantError({
+            commandType: command.type,
+            detail: "Interrupt the current turn before reverting checkpoints.",
+          }),
+        );
+      }
       return {
         ...(yield* withEventBase({
           aggregateKind: "thread",
@@ -1946,7 +2042,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.revert.complete": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
@@ -1962,6 +2058,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           turnCount: command.turnCount,
+          preservedMessageIds:
+            thread.pendingCheckpointRevertMessageIds ??
+            (thread.pendingTurnStartMessageId == null ? [] : [thread.pendingTurnStartMessageId]),
         },
       };
     }

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -6,11 +6,13 @@ import {
   ThreadId,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import { it as effectIt } from "@effect/vitest";
 import { describe, expect, it } from "vite-plus/test";
 
 import { createEmptyReadModel, projectEvent } from "./projector.ts";
+import { decideOrchestrationCommand } from "./decider.ts";
 
 function makeEvent(input: {
   sequence: number;
@@ -555,6 +557,663 @@ describe("orchestration projector", () => {
             : "completed",
         );
       }),
+  );
+
+  effectIt.effect("does not let a stale terminal session clear a newer pending turn", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-07T23:00:00.000Z";
+      const threadId = "thread-stale-terminal";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `stale-terminal-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Stale terminal",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      for (const [index, messageId] of ["older-request", "newer-request"].entries()) {
+        model = yield* projectEvent(
+          model,
+          event(index + 2, "thread.turn-start-requested", {
+            threadId,
+            messageId,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now,
+          }),
+        );
+      }
+      model = yield* projectEvent(
+        model,
+        event(4, "thread.session-set", {
+          threadId,
+          session: {
+            threadId,
+            status: "error",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: "older request failed",
+            updatedAt: now,
+          },
+        }),
+      );
+
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBe("newer-request");
+    }),
+  );
+
+  effectIt.effect("keeps acknowledged starts guarded until their provider turn is running", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-07T23:30:00.000Z";
+      const threadId = "thread-correlated-start-acknowledgement";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `correlated-start-acknowledgement-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Correlated acknowledgement",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(2, "thread.turn-start-requested", {
+          threadId,
+          messageId: "newer-request",
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: now,
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(3, "thread.meta-updated", {
+          threadId,
+          turnStartAcknowledged: {
+            messageId: "older-request",
+            turnId: "turn-provider-acknowledged",
+          },
+          updatedAt: now,
+        }),
+      );
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBe("newer-request");
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([
+        {
+          messageId: "older-request",
+          turnId: "turn-provider-acknowledged",
+        },
+      ]);
+
+      model = yield* projectEvent(
+        model,
+        event(4, "thread.meta-updated", {
+          threadId,
+          turnStartAcknowledged: {
+            messageId: "newer-request",
+            turnId: "turn-provider-acknowledged",
+          },
+          updatedAt: now,
+        }),
+      );
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBe("newer-request");
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([
+        {
+          messageId: "older-request",
+          turnId: "turn-provider-acknowledged",
+        },
+        {
+          messageId: "newer-request",
+          turnId: "turn-provider-acknowledged",
+        },
+      ]);
+
+      model = yield* projectEvent(
+        model,
+        event(5, "thread.session-set", {
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: "turn-provider-acknowledged",
+            lastError: null,
+            updatedAt: now,
+          },
+        }),
+      );
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBeNull();
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([]);
+
+      model = yield* projectEvent(
+        model,
+        event(6, "thread.turn-start-requested", {
+          threadId,
+          messageId: "steering-request",
+          expectsTurnStartAcknowledgement: true,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: now,
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(7, "thread.session-set", {
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
+          },
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(8, "thread.meta-updated", {
+          threadId,
+          turnStartAcknowledged: {
+            messageId: "steering-request",
+            turnId: "turn-provider-acknowledged",
+          },
+          updatedAt: now,
+        }),
+      );
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBeNull();
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([]);
+      expect(model.threads[0]?.turnStartSubmissionRendezvous).toBeNull();
+    }),
+  );
+
+  effectIt.effect("does not re-guard a turn acknowledged after its lifecycle was observed", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-08T01:50:00.000Z";
+      const threadId = "thread-late-start-acknowledgement";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `late-start-acknowledgement-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Late start acknowledgement",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(2, "thread.turn-start-requested", {
+          threadId,
+          messageId: "request-a",
+          expectsTurnStartAcknowledgement: true,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: now,
+        }),
+      );
+      for (const [sequence, status, activeTurnId] of [
+        [3, "running", "turn-a"],
+        [4, "ready", null],
+      ] as const) {
+        model = yield* projectEvent(
+          model,
+          event(sequence, "thread.session-set", {
+            threadId,
+            session: {
+              threadId,
+              status,
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId,
+              lastError: null,
+              updatedAt: now,
+            },
+          }),
+        );
+      }
+      model = yield* projectEvent(
+        model,
+        event(5, "thread.turn-start-requested", {
+          threadId,
+          messageId: "request-b",
+          expectsTurnStartAcknowledgement: true,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: now,
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(6, "thread.session-set", {
+          threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: "turn-b",
+            lastError: null,
+            updatedAt: now,
+          },
+        }),
+      );
+      model = yield* projectEvent(
+        model,
+        event(7, "thread.meta-updated", {
+          threadId,
+          turnStartAcknowledged: { messageId: "request-a", turnId: "turn-a" },
+          updatedAt: now,
+        }),
+      );
+
+      expect(model.threads[0]?.pendingTurnStartMessageId).toBeNull();
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([]);
+      expect(model.threads[0]?.turnStartSubmissionRendezvous).toEqual({
+        requests: [{ messageId: "request-b", observedTurnIds: ["turn-b"] }],
+      });
+      model = yield* projectEvent(
+        model,
+        event(8, "thread.activity-appended", {
+          threadId,
+          activity: {
+            id: "request-b-failed",
+            tone: "error",
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            payload: { requestId: "request-b" },
+            turnId: null,
+            createdAt: now,
+          },
+        }),
+      );
+      expect(model.threads[0]?.turnStartSubmissionRendezvous).toBeNull();
+    }),
+  );
+
+  effectIt.effect("clears only the submitted start correlated to a provider failure", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-08T04:30:00.000Z";
+      const threadId = "thread-correlated-submitted-failure";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `correlated-submitted-failure-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Correlated submitted failure",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      for (const [sequence, messageId, turnId] of [
+        [2, "request-a", "turn-a"],
+        [3, "request-b", "turn-b"],
+      ] as const) {
+        model = yield* projectEvent(
+          model,
+          event(sequence, "thread.meta-updated", {
+            threadId,
+            turnStartAcknowledged: { messageId, turnId },
+            updatedAt: now,
+          }),
+        );
+      }
+
+      model = yield* projectEvent(
+        model,
+        event(4, "thread.activity-appended", {
+          threadId,
+          activity: {
+            id: "request-a-failed",
+            tone: "error",
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            payload: { requestId: "request-a" },
+            turnId: "turn-a",
+            createdAt: now,
+          },
+        }),
+      );
+
+      expect(model.threads[0]?.submittedTurnStarts).toEqual([
+        { messageId: "request-b", turnId: "turn-b" },
+      ]);
+    }),
+  );
+
+  effectIt.effect("does not enroll legacy turn history in submission rendezvous state", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-08T01:55:00.000Z";
+      const threadId = "thread-legacy-start-history";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `legacy-start-history-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Legacy start history",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      for (let turn = 1; turn <= 3; turn += 1) {
+        const baseSequence = turn * 3 - 1;
+        model = yield* projectEvent(
+          model,
+          event(baseSequence, "thread.turn-start-requested", {
+            threadId,
+            messageId: `legacy-request-${turn}`,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now,
+          }),
+        );
+        for (const [offset, status, activeTurnId] of [
+          [1, "running", `legacy-turn-${turn}`],
+          [2, "ready", null],
+        ] as const) {
+          model = yield* projectEvent(
+            model,
+            event(baseSequence + offset, "thread.session-set", {
+              threadId,
+              session: {
+                threadId,
+                status,
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId,
+                lastError: null,
+                updatedAt: now,
+              },
+            }),
+          );
+        }
+      }
+
+      expect(model.threads[0]?.turnStartSubmissionRendezvous).toBeNull();
+    }),
+  );
+
+  effectIt.effect(
+    "matches every acknowledgement when concurrent starts share a provider turn",
+    () =>
+      Effect.gen(function* () {
+        const now = "2026-09-08T02:30:00.000Z";
+        const threadId = "thread-shared-provider-turn";
+        const providerTurnId = "turn-shared-provider";
+        const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+          makeEvent({
+            sequence,
+            type,
+            payload,
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: now,
+            commandId: `shared-provider-turn-${sequence}`,
+          });
+        type Step = "request-a" | "request-b" | "ack-a" | "ack-b" | "running" | "terminal";
+        const permutations = (steps: readonly Step[]): Step[][] =>
+          steps.length === 0
+            ? [[]]
+            : steps.flatMap((step, index) =>
+                permutations(steps.filter((_, candidateIndex) => candidateIndex !== index)).map(
+                  (tail) => [step, ...tail],
+                ),
+              );
+        const orders = permutations([
+          "request-a",
+          "request-b",
+          "ack-a",
+          "ack-b",
+          "running",
+          "terminal",
+        ]).filter(
+          (order) =>
+            order.indexOf("request-a") < order.indexOf("ack-a") &&
+            order.indexOf("request-b") < order.indexOf("ack-b") &&
+            order.indexOf("running") < order.indexOf("terminal") &&
+            order.indexOf("request-a") < order.indexOf("terminal") &&
+            order.indexOf("request-b") < order.indexOf("terminal"),
+        );
+        expect(orders).toHaveLength(66);
+
+        for (const [caseIndex, order] of orders.entries()) {
+          let sequence = 1;
+          let model = yield* projectEvent(
+            createEmptyReadModel(now),
+            event(sequence, "thread.created", {
+              threadId,
+              projectId: "project-1",
+              title: "Shared provider turn",
+              modelSelection: { instanceId: "claude", model: "test" },
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: null,
+              worktreePath: null,
+              createdAt: now,
+              updatedAt: now,
+            }),
+          );
+          for (const [stepIndex, step] of order.entries()) {
+            sequence += 1;
+            if (step === "request-a" || step === "request-b") {
+              const messageId = step === "request-a" ? "request-a" : "request-b";
+              model = yield* projectEvent(
+                model,
+                event(sequence, "thread.turn-start-requested", {
+                  threadId,
+                  messageId,
+                  expectsTurnStartAcknowledgement: true,
+                  runtimeMode: "full-access",
+                  interactionMode: "default",
+                  createdAt: now,
+                }),
+              );
+            } else if (step === "ack-a" || step === "ack-b") {
+              const messageId = step === "ack-a" ? "request-a" : "request-b";
+              model = yield* projectEvent(
+                model,
+                event(sequence, "thread.meta-updated", {
+                  threadId,
+                  turnStartAcknowledged: { messageId, turnId: providerTurnId },
+                  updatedAt: now,
+                }),
+              );
+            } else {
+              const running = step === "running";
+              model = yield* projectEvent(
+                model,
+                event(sequence, "thread.session-set", {
+                  threadId,
+                  session: {
+                    threadId,
+                    status: running ? "running" : "ready",
+                    providerName: "claude",
+                    runtimeMode: "full-access",
+                    activeTurnId: running ? providerTurnId : null,
+                    lastError: null,
+                    updatedAt: now,
+                  },
+                }),
+              );
+            }
+
+            const revert = decideOrchestrationCommand({
+              command: {
+                type: "thread.checkpoint.revert",
+                commandId: CommandId.make(`shared-turn-revert-${caseIndex}-${sequence}`),
+                threadId: ThreadId.make(threadId),
+                turnCount: 0,
+                createdAt: now,
+              },
+              readModel: model,
+            }).pipe(Effect.provide(NodeServices.layer));
+            if (stepIndex < order.length - 1) {
+              const error = yield* revert.pipe(Effect.flip);
+              expect(error._tag).toBe("OrchestrationCommandInvariantError");
+            } else {
+              const result = yield* revert;
+              const events = Array.isArray(result) ? result : [result];
+              expect(events[0]?.type).toBe("thread.checkpoint-revert-requested");
+            }
+          }
+
+          expect(model.threads[0]?.pendingTurnStartMessageId).toBeNull();
+          expect(model.threads[0]?.submittedTurnStarts).toEqual([]);
+          expect(model.threads[0]?.turnStartSubmissionRendezvous).toBeNull();
+        }
+      }),
+  );
+
+  effectIt.effect("keeps queued messages reserved when one of consecutive reverts fails", () =>
+    Effect.gen(function* () {
+      const now = "2026-09-08T00:00:00.000Z";
+      const threadId = "thread-consecutive-revert-failure";
+      const event = (sequence: number, type: OrchestrationEvent["type"], payload: unknown) =>
+        makeEvent({
+          sequence,
+          type,
+          payload,
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: `consecutive-revert-${sequence}`,
+        });
+      let model = yield* projectEvent(
+        createEmptyReadModel(now),
+        event(1, "thread.created", {
+          threadId,
+          projectId: "project-1",
+          title: "Consecutive revert failure",
+          modelSelection: { instanceId: "codex", model: "test" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+      for (const sequence of [2, 3]) {
+        model = yield* projectEvent(
+          model,
+          event(sequence, "thread.checkpoint-revert-requested", {
+            threadId,
+            turnCount: 0,
+            createdAt: now,
+          }),
+        );
+      }
+      for (const [index, messageId] of ["queued-1", "queued-2"].entries()) {
+        model = yield* projectEvent(
+          model,
+          event(index + 4, "thread.turn-start-requested", {
+            threadId,
+            messageId,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now,
+          }),
+        );
+      }
+      model = yield* projectEvent(
+        model,
+        event(6, "thread.activity-appended", {
+          threadId,
+          activity: {
+            id: "revert-failed-1",
+            kind: "checkpoint.revert.failed",
+            summary: "Checkpoint revert failed",
+            tone: "error",
+            turnId: null,
+            createdAt: now,
+            payload: { detail: "first revert failed" },
+          },
+        }),
+      );
+
+      expect(model.threads[0]?.pendingCheckpointRevertCount).toBe(1);
+      expect(model.threads[0]?.pendingCheckpointRevertMessageIds).toEqual(["queued-1", "queued-2"]);
+    }),
   );
 
   it("updates canonical thread runtime mode from thread.runtime-mode-set", async () => {

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -32,6 +32,7 @@ import {
   ProjectMetaUpdatedPayload,
   ThreadActivityAppendedPayload,
   ThreadArchivedPayload,
+  ThreadCheckpointRevertRequestedPayload,
   ThreadCreatedPayload,
   ThreadDeletedPayload,
   ThreadInteractionModeSetPayload,
@@ -51,6 +52,7 @@ import {
   ThreadUnsnoozedPayload,
   ThreadRevertedPayload,
   ThreadSessionSetPayload,
+  ThreadTurnStartRequestedPayload,
   ThreadTurnDiffCompletedPayload,
 } from "./Schemas.ts";
 
@@ -84,6 +86,30 @@ function checkpointStatusToLatestTurnState(status: "ready" | "missing" | "error"
   if (status === "error") return "error" as const;
   // Match SQL and client projections: a missing git ref is not an interruption.
   return "completed" as const;
+}
+
+function turnStartRequestIdClearedByActivity(
+  activity: OrchestrationThread["activities"][number],
+): string | null {
+  if (
+    (activity.kind !== "context-compaction" &&
+      activity.kind !== "provider.turn.start.failed" &&
+      activity.kind !== "provider.auth.signed-out") ||
+    !Predicate.isObject(activity.payload)
+  ) {
+    return null;
+  }
+  return typeof activity.payload.requestId === "string" ? activity.payload.requestId : null;
+}
+
+function activityClearsPendingTurnStart(
+  thread: OrchestrationThread,
+  activity: OrchestrationThread["activities"][number],
+): boolean {
+  return (
+    thread.pendingTurnStartMessageId != null &&
+    turnStartRequestIdClearedByActivity(activity) === thread.pendingTurnStartMessageId
+  );
 }
 
 /**
@@ -203,8 +229,9 @@ function retainThreadMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
   turnCount: number,
+  preservedMessageIds: ReadonlySet<string>,
 ): ReadonlyArray<OrchestrationMessage> {
-  const retainedMessageIds = new Set<string>();
+  const retainedMessageIds = new Set(preservedMessageIds);
   for (const message of messages) {
     if (message.role === "system" || isImportedAgentSessionMessageId(message.id)) {
       retainedMessageIds.add(message.id);
@@ -215,11 +242,14 @@ function retainThreadMessagesAfterRevert(
     }
   }
 
+  // Queued messages preserved across the revert are not part of the retained
+  // turn history, so they must not consume the historical-message quota below.
   const retainedUserCount = messages.filter(
     (message) =>
       message.role === "user" &&
       !isImportedAgentSessionMessageId(message.id) &&
-      retainedMessageIds.has(message.id),
+      retainedMessageIds.has(message.id) &&
+      !preservedMessageIds.has(message.id),
   ).length;
   const missingUserCount = Math.max(0, turnCount - retainedUserCount);
   if (missingUserCount > 0) {
@@ -588,10 +618,50 @@ export function projectEvent(
       return decodeForEvent(ThreadMetaUpdatedPayload, event.payload, event.type, "payload").pipe(
         Effect.map((payload) => {
           const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) return nextBase;
+          const acknowledgement = payload.turnStartAcknowledged;
+          const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
+          const acknowledgedRequest =
+            acknowledgement === undefined
+              ? undefined
+              : rendezvous?.requests.find(
+                  (request) => request.messageId === acknowledgement.messageId,
+                );
+          const acknowledgedTurnAlreadyRunning =
+            acknowledgement !== undefined &&
+            thread.session?.status === "running" &&
+            thread.session.activeTurnId === acknowledgement.turnId;
+          const acknowledgedTurnAlreadyObserved =
+            acknowledgement !== undefined &&
+            (acknowledgedRequest?.observedTurnIds ?? []).includes(acknowledgement.turnId);
+          // A provider can finish a turn before its start acknowledgement
+          // lands; the settled turn can never consume the submission.
+          const acknowledgedTurnAlreadySettled =
+            acknowledgement !== undefined &&
+            thread.latestTurn !== null &&
+            thread.latestTurn.turnId === acknowledgement.turnId &&
+            thread.latestTurn.state !== "running";
+          // A stopped or interrupted session can never surface the
+          // acknowledged turn, so the submission is resolved rather than
+          // recorded.
+          const acknowledgedSessionDead =
+            acknowledgement !== undefined &&
+            (thread.session?.status === "stopped" || thread.session?.status === "interrupted");
+          const acknowledgementAlreadyAdopted =
+            acknowledgedTurnAlreadyRunning ||
+            acknowledgedTurnAlreadyObserved ||
+            acknowledgedTurnAlreadySettled ||
+            acknowledgedSessionDead;
+          const remainingRequests =
+            acknowledgement === undefined
+              ? (rendezvous?.requests ?? [])
+              : (rendezvous?.requests ?? []).filter(
+                  (request) => request.messageId !== acknowledgement.messageId,
+                );
           // Legacy single-link events replay into the link array so the
           // derived linkedPullRequest and pullRequests never disagree.
           const legacyLinkPatch =
-            thread !== undefined && payload.linkedPullRequest !== undefined
+            payload.linkedPullRequest !== undefined
               ? pullRequestsPatch(
                   thread,
                   legacyLinkToPullRequests(
@@ -622,6 +692,31 @@ export function projectEvent(
                 ? { branchPullRequest: payload.branchPullRequest }
                 : {}),
               ...legacyLinkPatch,
+              ...(acknowledgement !== undefined
+                ? {
+                    pendingTurnStartMessageId:
+                      acknowledgement.messageId === thread.pendingTurnStartMessageId &&
+                      acknowledgementAlreadyAdopted
+                        ? null
+                        : (thread.pendingTurnStartMessageId ?? null),
+                    submittedTurnStarts: acknowledgementAlreadyAdopted
+                      ? (thread.submittedTurnStarts ?? []).filter(
+                          (entry) => entry.turnId !== acknowledgement.turnId,
+                        )
+                      : [
+                          ...(thread.submittedTurnStarts ?? []).filter(
+                            (entry) => entry.messageId !== acknowledgement.messageId,
+                          ),
+                          acknowledgement,
+                        ],
+                    turnStartSubmissionRendezvous:
+                      remainingRequests.length === 0
+                        ? null
+                        : {
+                            requests: remainingRequests,
+                          },
+                  }
+                : {}),
               updatedAt: payload.updatedAt,
             }),
           };
@@ -738,6 +833,75 @@ export function projectEvent(
         })),
       );
 
+    case "thread.turn-start-requested":
+      return decodeForEvent(
+        ThreadTurnStartRequestedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) {
+            return nextBase;
+          }
+          const activeTurnId =
+            thread.session?.status === "running" ? thread.session.activeTurnId : null;
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              ...(payload.modelSelection !== undefined
+                ? { modelSelection: payload.modelSelection }
+                : {}),
+              runtimeMode: payload.runtimeMode,
+              interactionMode: payload.interactionMode,
+              pendingTurnStartMessageId: payload.messageId,
+              ...(payload.expectsTurnStartAcknowledgement === true
+                ? {
+                    turnStartSubmissionRendezvous: {
+                      requests: [
+                        ...(thread.turnStartSubmissionRendezvous?.requests ?? []).filter(
+                          (request) => request.messageId !== payload.messageId,
+                        ),
+                        {
+                          messageId: payload.messageId,
+                          observedTurnIds: activeTurnId === null ? [] : [activeTurnId],
+                        },
+                      ],
+                    },
+                  }
+                : {}),
+              pendingCheckpointRevertMessageIds:
+                thread.pendingCheckpointRevertMessageIds == null
+                  ? null
+                  : [...thread.pendingCheckpointRevertMessageIds, payload.messageId],
+              updatedAt: event.occurredAt,
+            }),
+          };
+        }),
+      );
+
+    case "thread.checkpoint-revert-requested":
+      return decodeForEvent(
+        ThreadCheckpointRevertRequestedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) return nextBase;
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              pendingCheckpointRevertMessageIds: thread.pendingCheckpointRevertMessageIds ?? [],
+              pendingCheckpointRevertCount: (thread.pendingCheckpointRevertCount ?? 0) + 1,
+              updatedAt: event.occurredAt,
+            }),
+          };
+        }),
+      );
+
     case "thread.message-sent":
       return Effect.gen(function* () {
         const payload = yield* decodeForEvent(
@@ -824,10 +988,39 @@ export function projectEvent(
         // Leaving the "running" session status is the turn-end signal: settle
         // a still-running latest turn so its duration reflects the whole turn.
         const settledTurnState = settledTurnStateForSessionStatus(session.status);
+        const activeTurnId = session.status === "running" ? session.activeTurnId : null;
+        const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
         return {
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             session,
+            pendingTurnStartMessageId:
+              session.status === "running" && session.activeTurnId !== null
+                ? null
+                : (thread.pendingTurnStartMessageId ?? null),
+            submittedTurnStarts:
+              activeTurnId !== null
+                ? (thread.submittedTurnStarts ?? []).filter(
+                    (entry) => entry.turnId !== activeTurnId,
+                  )
+                : // Acknowledged starts die with their session; an idle or
+                  // errored session may still pick them up, since a
+                  // per-request failure does not prove the session is gone.
+                  session.status === "interrupted" || session.status === "stopped"
+                  ? []
+                  : (thread.submittedTurnStarts ?? []),
+            turnStartSubmissionRendezvous:
+              activeTurnId === null || rendezvous === null || rendezvous.requests.length === 0
+                ? rendezvous
+                : {
+                    requests: rendezvous.requests.map((request) => ({
+                      ...request,
+                      observedTurnIds: [
+                        ...request.observedTurnIds.filter((turnId) => turnId !== activeTurnId),
+                        activeTurnId,
+                      ],
+                    })),
+                  },
             latestTurn:
               session.status === "running" && session.activeTurnId !== null
                 ? {
@@ -950,6 +1143,11 @@ export function projectEvent(
           ...nextBase,
           threads: updateThread(nextBase.threads, payload.threadId, {
             checkpoints,
+            submittedTurnStarts: turnStillRunning
+              ? (thread.submittedTurnStarts ?? [])
+              : (thread.submittedTurnStarts ?? []).filter(
+                  (entry) => entry.turnId !== payload.turnId,
+                ),
             latestTurn: turnStillRunning
               ? thread.latestTurn
               : {
@@ -992,6 +1190,7 @@ export function projectEvent(
             thread.messages,
             retainedTurnIds,
             payload.turnCount,
+            new Set(payload.preservedMessageIds ?? []),
           ).slice(-MAX_THREAD_MESSAGES);
           const proposedPlans = retainThreadProposedPlansAfterRevert(
             thread.proposedPlans,
@@ -1012,6 +1211,10 @@ export function projectEvent(
                   assistantMessageId: latestCheckpoint.assistantMessageId,
                 };
 
+          const pendingCheckpointRevertCount = Math.max(
+            0,
+            (thread.pendingCheckpointRevertCount ?? 1) - 1,
+          );
           return {
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
@@ -1020,6 +1223,12 @@ export function projectEvent(
               proposedPlans,
               activities,
               latestTurn,
+              pendingCheckpointRevertMessageIds:
+                pendingCheckpointRevertCount === 0
+                  ? null
+                  : (thread.pendingCheckpointRevertMessageIds ?? []),
+              pendingCheckpointRevertCount:
+                pendingCheckpointRevertCount === 0 ? null : pendingCheckpointRevertCount,
               updatedAt: event.occurredAt,
             }),
           };
@@ -1045,11 +1254,48 @@ export function projectEvent(
               payload.activity,
             ].toSorted(compareThreadActivities),
           );
+          const pendingTurnStartMessageId = activityClearsPendingTurnStart(thread, payload.activity)
+            ? null
+            : (thread.pendingTurnStartMessageId ?? null);
+          const clearedRequestId = turnStartRequestIdClearedByActivity(payload.activity);
+          const submittedTurnStarts =
+            clearedRequestId === null
+              ? (thread.submittedTurnStarts ?? [])
+              : (thread.submittedTurnStarts ?? []).filter(
+                  (entry) => entry.messageId !== clearedRequestId,
+                );
+          const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
+          const remainingRequests =
+            clearedRequestId === null
+              ? (rendezvous?.requests ?? [])
+              : (rendezvous?.requests ?? []).filter(
+                  (request) => request.messageId !== clearedRequestId,
+                );
+          const turnStartSubmissionRendezvous =
+            rendezvous === null
+              ? null
+              : remainingRequests.length === 0
+                ? null
+                : { requests: remainingRequests };
+          const revertFailed = payload.activity.kind === "checkpoint.revert.failed";
+          const pendingCheckpointRevertCount = revertFailed
+            ? Math.max(0, (thread.pendingCheckpointRevertCount ?? 1) - 1)
+            : (thread.pendingCheckpointRevertCount ?? null);
+          const pendingCheckpointRevertMessageIds =
+            revertFailed && pendingCheckpointRevertCount === 0
+              ? null
+              : (thread.pendingCheckpointRevertMessageIds ?? null);
 
           return {
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
               activities,
+              pendingTurnStartMessageId,
+              submittedTurnStarts,
+              turnStartSubmissionRendezvous,
+              pendingCheckpointRevertMessageIds,
+              pendingCheckpointRevertCount:
+                pendingCheckpointRevertCount === 0 ? null : pendingCheckpointRevertCount,
               updatedAt: event.occurredAt,
             }),
           };

--- a/apps/server/src/persistence/Layers/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Layers/ProjectionTurns.ts
@@ -9,12 +9,20 @@ import * as Struct from "effect/Struct";
 
 import { toPersistenceDecodeError, toPersistenceSqlError } from "../Errors.ts";
 import {
+  AcknowledgeProjectionPendingTurnStartInput,
   ClearCheckpointTurnConflictInput,
+  DeleteProjectionPendingTurnStartInput,
+  DeleteProjectionSubmittedTurnStartsByThreadInput,
+  DeleteProjectionSubmittedTurnStartsInput,
+  DeleteProjectionTurnsAfterCheckpointInput,
   DeleteProjectionTurnsByThreadInput,
+  GetProjectionAdoptableTurnStartInput,
   GetProjectionPendingTurnStartInput,
+  GetProjectionSubmittedTurnStartInput,
   GetProjectionTurnByTurnIdInput,
   ListProjectionTurnsByThreadInput,
   ProjectionPendingTurnStart,
+  ProjectionSubmittedTurnStart,
   ProjectionTurn,
   ProjectionTurnById,
   ProjectionTurnRepository,
@@ -51,6 +59,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           thread_id,
           turn_id,
           pending_message_id,
+          submitted_turn_id,
           source_proposed_plan_thread_id,
           source_proposed_plan_id,
           assistant_message_id,
@@ -67,6 +76,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           ${row.threadId},
           ${row.turnId},
           ${row.pendingMessageId},
+          NULL,
           ${row.sourceProposedPlanThreadId},
           ${row.sourceProposedPlanId},
           ${row.assistantMessageId},
@@ -96,14 +106,54 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
       `,
   });
 
-  const clearPendingProjectionTurnsByThread = SqlSchema.void({
-    Request: DeleteProjectionTurnsByThreadInput,
+  const deletePendingProjectionTurn = SqlSchema.void({
+    Request: DeleteProjectionPendingTurnStartInput,
+    execute: ({ threadId, messageId }) =>
+      sql`
+        DELETE FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state IN ('pending', 'submitted')
+          AND pending_message_id = ${messageId}
+          AND checkpoint_turn_count IS NULL
+      `,
+  });
+
+  const markPendingProjectionTurnSubmitted = SqlSchema.void({
+    Request: AcknowledgeProjectionPendingTurnStartInput,
+    execute: ({ threadId, messageId, turnId }) =>
+      sql`
+        UPDATE projection_turns
+        SET state = 'submitted', submitted_turn_id = ${turnId}
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'pending'
+          AND pending_message_id = ${messageId}
+          AND checkpoint_turn_count IS NULL
+      `,
+  });
+
+  const deleteSubmittedProjectionTurnsByTurn = SqlSchema.void({
+    Request: DeleteProjectionSubmittedTurnStartsInput,
+    execute: ({ threadId, turnId }) =>
+      sql`
+        DELETE FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'submitted'
+          AND submitted_turn_id = ${turnId}
+          AND checkpoint_turn_count IS NULL
+      `,
+  });
+
+  const deleteSubmittedProjectionTurnsByThread = SqlSchema.void({
+    Request: DeleteProjectionSubmittedTurnStartsByThreadInput,
     execute: ({ threadId }) =>
       sql`
         DELETE FROM projection_turns
         WHERE thread_id = ${threadId}
           AND turn_id IS NULL
-          AND state = 'pending'
+          AND state = 'submitted'
           AND checkpoint_turn_count IS NULL
       `,
   });
@@ -116,6 +166,56 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           thread_id,
           turn_id,
           pending_message_id,
+          submitted_turn_id,
+          source_proposed_plan_thread_id,
+          source_proposed_plan_id,
+          assistant_message_id,
+          state,
+          requested_at,
+          started_at,
+          completed_at,
+          checkpoint_turn_count,
+          checkpoint_ref,
+          checkpoint_status,
+          checkpoint_files_json
+        )
+        SELECT
+          ${row.threadId},
+          NULL,
+          ${row.messageId},
+          NULL,
+          ${row.sourceProposedPlanThreadId},
+          ${row.sourceProposedPlanId},
+          NULL,
+          'pending',
+          ${row.requestedAt},
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          '[]'
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM projection_turns
+          WHERE thread_id = ${row.threadId}
+            AND turn_id IS NULL
+            AND pending_message_id = ${row.messageId}
+            AND state IN ('pending', 'submitted')
+            AND checkpoint_turn_count IS NULL
+        )
+      `,
+  });
+
+  const insertSubmittedProjectionTurn = SqlSchema.void({
+    Request: ProjectionSubmittedTurnStart,
+    execute: (row) =>
+      sql`
+        INSERT INTO projection_turns (
+          thread_id,
+          turn_id,
+          pending_message_id,
+          submitted_turn_id,
           source_proposed_plan_thread_id,
           source_proposed_plan_id,
           assistant_message_id,
@@ -132,10 +232,11 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           ${row.threadId},
           NULL,
           ${row.messageId},
+          ${row.turnId},
           ${row.sourceProposedPlanThreadId},
           ${row.sourceProposedPlanId},
           NULL,
-          'pending',
+          'submitted',
           ${row.requestedAt},
           NULL,
           NULL,
@@ -164,7 +265,93 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
           AND state = 'pending'
           AND pending_message_id IS NOT NULL
           AND checkpoint_turn_count IS NULL
-        ORDER BY requested_at DESC
+        ORDER BY row_id ASC
+        LIMIT 1
+      `,
+  });
+
+  const getUnresolvedProjectionTurn = SqlSchema.findOneOption({
+    Request: GetProjectionPendingTurnStartInput,
+    Result: ProjectionPendingTurnStart,
+    execute: ({ threadId }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          pending_message_id AS "messageId",
+          source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
+          source_proposed_plan_id AS "sourceProposedPlanId",
+          requested_at AS "requestedAt"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state IN ('pending', 'submitted')
+          AND pending_message_id IS NOT NULL
+          AND checkpoint_turn_count IS NULL
+        ORDER BY row_id ASC
+        LIMIT 1
+      `,
+  });
+
+  const getAdoptableProjectionTurn = SqlSchema.findOneOption({
+    Request: GetProjectionAdoptableTurnStartInput,
+    Result: ProjectionPendingTurnStart,
+    execute: ({ threadId, turnId }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          pending_message_id AS "messageId",
+          source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
+          source_proposed_plan_id AS "sourceProposedPlanId",
+          requested_at AS "requestedAt"
+        FROM projection_turns AS candidate
+        WHERE candidate.thread_id = ${threadId}
+          AND candidate.turn_id IS NULL
+          AND (
+            (candidate.state = 'submitted' AND candidate.submitted_turn_id = ${turnId})
+            OR (
+              candidate.state = 'pending'
+              AND (
+                SELECT COUNT(*)
+                FROM projection_turns AS pending
+                WHERE pending.thread_id = ${threadId}
+                  AND pending.turn_id IS NULL
+                  AND pending.state = 'pending'
+                  AND pending.pending_message_id IS NOT NULL
+                  AND pending.checkpoint_turn_count IS NULL
+              ) = 1
+            )
+          )
+          AND candidate.pending_message_id IS NOT NULL
+          AND candidate.checkpoint_turn_count IS NULL
+        ORDER BY
+          CASE
+            WHEN candidate.state = 'submitted' AND candidate.submitted_turn_id = ${turnId} THEN 0
+            ELSE 1
+          END,
+          candidate.row_id ASC
+        LIMIT 1
+      `,
+  });
+
+  const getSubmittedProjectionTurn = SqlSchema.findOneOption({
+    Request: GetProjectionSubmittedTurnStartInput,
+    Result: ProjectionPendingTurnStart,
+    execute: ({ threadId, turnId }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          pending_message_id AS "messageId",
+          source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
+          source_proposed_plan_id AS "sourceProposedPlanId",
+          requested_at AS "requestedAt"
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NULL
+          AND state = 'submitted'
+          AND submitted_turn_id = ${turnId}
+          AND pending_message_id IS NOT NULL
+          AND checkpoint_turn_count IS NULL
+        ORDER BY row_id ASC
         LIMIT 1
       `,
   });
@@ -177,6 +364,7 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           turn_id AS "turnId",
+          submitted_turn_id AS "submittedTurnId",
           pending_message_id AS "pendingMessageId",
           source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
           source_proposed_plan_id AS "sourceProposedPlanId",
@@ -254,6 +442,20 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
       `,
   });
 
+  const deleteProjectionTurnsAfterCheckpoint = SqlSchema.void({
+    Request: DeleteProjectionTurnsAfterCheckpointInput,
+    execute: ({ threadId, turnCount }) =>
+      sql`
+        DELETE FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND turn_id IS NOT NULL
+          AND (
+            checkpoint_turn_count IS NULL
+            OR checkpoint_turn_count > ${turnCount}
+          )
+      `,
+  });
+
   const upsertByTurnId: ProjectionTurnRepositoryShape["upsertByTurnId"] = (row) =>
     upsertProjectionTurnById(row).pipe(
       Effect.mapError(
@@ -264,18 +466,50 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
       ),
     );
 
-  const replacePendingTurnStart: ProjectionTurnRepositoryShape["replacePendingTurnStart"] = (row) =>
-    sql
-      .withTransaction(
-        clearPendingProjectionTurnsByThread({ threadId: row.threadId }).pipe(
-          Effect.flatMap(() => insertPendingProjectionTurn(row)),
+  const insertPendingTurnStart: ProjectionTurnRepositoryShape["insertPendingTurnStart"] = (row) =>
+    insertPendingProjectionTurn(row).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionTurnRepository.insertPendingTurnStart:query",
+          "ProjectionTurnRepository.insertPendingTurnStart:encodeRequest",
         ),
-      )
-      .pipe(
+      ),
+    );
+
+  const insertSubmittedTurnStart: ProjectionTurnRepositoryShape["insertSubmittedTurnStart"] = (
+    row,
+  ) =>
+    insertSubmittedProjectionTurn(row).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionTurnRepository.insertSubmittedTurnStart:query",
+          "ProjectionTurnRepository.insertSubmittedTurnStart:encodeRequest",
+        ),
+      ),
+    );
+
+  const markPendingTurnStartSubmitted: ProjectionTurnRepositoryShape["markPendingTurnStartSubmitted"] =
+    (input) =>
+      markPendingProjectionTurnSubmitted(input).pipe(
         Effect.mapError(
-          toPersistenceSqlOrDecodeError(
-            "ProjectionTurnRepository.replacePendingTurnStart:query",
-            "ProjectionTurnRepository.replacePendingTurnStart:encodeRequest",
+          toPersistenceSqlError("ProjectionTurnRepository.markPendingTurnStartSubmitted:query"),
+        ),
+      );
+
+  const deleteSubmittedTurnStartsByTurnId: ProjectionTurnRepositoryShape["deleteSubmittedTurnStartsByTurnId"] =
+    (input) =>
+      deleteSubmittedProjectionTurnsByTurn(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlError("ProjectionTurnRepository.deleteSubmittedTurnStartsByTurnId:query"),
+        ),
+      );
+
+  const deleteSubmittedTurnStartsByThreadId: ProjectionTurnRepositoryShape["deleteSubmittedTurnStartsByThreadId"] =
+    (input) =>
+      deleteSubmittedProjectionTurnsByThread(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlError(
+            "ProjectionTurnRepository.deleteSubmittedTurnStartsByThreadId:query",
           ),
         ),
       );
@@ -288,13 +522,36 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
         ),
       );
 
-  const deletePendingTurnStartByThreadId: ProjectionTurnRepositoryShape["deletePendingTurnStartByThreadId"] =
+  const getUnresolvedTurnStartByThreadId: ProjectionTurnRepositoryShape["getUnresolvedTurnStartByThreadId"] =
     (input) =>
-      clearPendingProjectionTurnsByThread(input).pipe(
+      getUnresolvedProjectionTurn(input).pipe(
         Effect.mapError(
-          toPersistenceSqlError("ProjectionTurnRepository.deletePendingTurnStartByThreadId:query"),
+          toPersistenceSqlError("ProjectionTurnRepository.getUnresolvedTurnStartByThreadId:query"),
         ),
       );
+
+  const getAdoptableTurnStartByThreadId: ProjectionTurnRepositoryShape["getAdoptableTurnStartByThreadId"] =
+    (input) =>
+      getAdoptableProjectionTurn(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlError("ProjectionTurnRepository.getAdoptableTurnStartByThreadId:query"),
+        ),
+      );
+
+  const getSubmittedTurnStartByTurnId: ProjectionTurnRepositoryShape["getSubmittedTurnStartByTurnId"] =
+    (input) =>
+      getSubmittedProjectionTurn(input).pipe(
+        Effect.mapError(
+          toPersistenceSqlError("ProjectionTurnRepository.getSubmittedTurnStartByTurnId:query"),
+        ),
+      );
+
+  const deletePendingTurnStart: ProjectionTurnRepositoryShape["deletePendingTurnStart"] = (input) =>
+    deletePendingProjectionTurn(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionTurnRepository.deletePendingTurnStart:query"),
+      ),
+    );
 
   const listByThreadId: ProjectionTurnRepositoryShape["listByThreadId"] = (input) =>
     listProjectionTurnsByThread(input).pipe(
@@ -337,11 +594,28 @@ const makeProjectionTurnRepository = Effect.gen(function* () {
       Effect.mapError(toPersistenceSqlError("ProjectionTurnRepository.deleteByThreadId:query")),
     );
 
+  const deleteTurnsAfterCheckpoint: ProjectionTurnRepositoryShape["deleteTurnsAfterCheckpoint"] = (
+    input,
+  ) =>
+    deleteProjectionTurnsAfterCheckpoint(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionTurnRepository.deleteTurnsAfterCheckpoint:query"),
+      ),
+    );
+
   return {
     upsertByTurnId,
-    replacePendingTurnStart,
+    insertPendingTurnStart,
+    insertSubmittedTurnStart,
+    markPendingTurnStartSubmitted,
+    deleteSubmittedTurnStartsByTurnId,
+    deleteSubmittedTurnStartsByThreadId,
     getPendingTurnStartByThreadId,
-    deletePendingTurnStartByThreadId,
+    getUnresolvedTurnStartByThreadId,
+    getAdoptableTurnStartByThreadId,
+    getSubmittedTurnStartByTurnId,
+    deletePendingTurnStart,
+    deleteTurnsAfterCheckpoint,
     listByThreadId,
     getByTurnId,
     clearCheckpointTurnConflict,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -63,6 +63,7 @@ import Migration0048 from "./Migrations/048_ProjectionThreadBranchPullRequest.ts
 import Migration0049 from "./Migrations/049_ProjectionThreadsActiveOrderKey.ts";
 import Migration0050 from "./Migrations/050_ProjectionThreadPullRequests.ts";
 import Migration0051 from "./Migrations/051_ProjectionThreadMessageContext.ts";
+import Migration0052 from "./Migrations/052_ProjectionTurnSubmissionCorrelation.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -126,6 +127,7 @@ const migrationEntries = [
   [49, "ProjectionThreadsActiveOrderKey", Migration0049],
   [50, "ProjectionThreadPullRequests", Migration0050],
   [51, "ProjectionThreadMessageContext", Migration0051],
+  [52, "ProjectionTurnSubmissionCorrelation", Migration0052],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/052_ProjectionTurnSubmissionCorrelation.ts
+++ b/apps/server/src/persistence/Migrations/052_ProjectionTurnSubmissionCorrelation.ts
@@ -1,0 +1,11 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE projection_turns
+    ADD COLUMN submitted_turn_id TEXT
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionTurns.ts
+++ b/apps/server/src/persistence/Services/ProjectionTurns.ts
@@ -26,6 +26,7 @@ import type { ProjectionRepositoryError } from "../Errors.ts";
 
 export const ProjectionTurnState = Schema.Literals([
   "pending",
+  "submitted",
   "running",
   "interrupted",
   "completed",
@@ -36,6 +37,7 @@ export type ProjectionTurnState = typeof ProjectionTurnState.Type;
 export const ProjectionTurn = Schema.Struct({
   threadId: ThreadId,
   turnId: Schema.NullOr(TurnId),
+  submittedTurnId: Schema.NullOr(TurnId),
   pendingMessageId: Schema.NullOr(MessageId),
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
@@ -78,6 +80,12 @@ export const ProjectionPendingTurnStart = Schema.Struct({
 });
 export type ProjectionPendingTurnStart = typeof ProjectionPendingTurnStart.Type;
 
+export const ProjectionSubmittedTurnStart = Schema.Struct({
+  ...ProjectionPendingTurnStart.fields,
+  turnId: TurnId,
+});
+export type ProjectionSubmittedTurnStart = typeof ProjectionSubmittedTurnStart.Type;
+
 export const ListProjectionTurnsByThreadInput = Schema.Struct({
   threadId: ThreadId,
 });
@@ -94,10 +102,52 @@ export const GetProjectionPendingTurnStartInput = Schema.Struct({
 });
 export type GetProjectionPendingTurnStartInput = typeof GetProjectionPendingTurnStartInput.Type;
 
+export const GetProjectionAdoptableTurnStartInput = Schema.Struct({
+  threadId: ThreadId,
+  turnId: TurnId,
+});
+export type GetProjectionAdoptableTurnStartInput = typeof GetProjectionAdoptableTurnStartInput.Type;
+
+export const GetProjectionSubmittedTurnStartInput = GetProjectionAdoptableTurnStartInput;
+export type GetProjectionSubmittedTurnStartInput = typeof GetProjectionSubmittedTurnStartInput.Type;
+
+export const DeleteProjectionPendingTurnStartInput = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+});
+export type DeleteProjectionPendingTurnStartInput =
+  typeof DeleteProjectionPendingTurnStartInput.Type;
+
+export const AcknowledgeProjectionPendingTurnStartInput = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnId: TurnId,
+});
+export type AcknowledgeProjectionPendingTurnStartInput =
+  typeof AcknowledgeProjectionPendingTurnStartInput.Type;
+
+export const DeleteProjectionSubmittedTurnStartsInput = Schema.Struct({
+  threadId: ThreadId,
+  turnId: TurnId,
+});
+export type DeleteProjectionSubmittedTurnStartsInput =
+  typeof DeleteProjectionSubmittedTurnStartsInput.Type;
+
 export const DeleteProjectionTurnsByThreadInput = Schema.Struct({
   threadId: ThreadId,
 });
 export type DeleteProjectionTurnsByThreadInput = typeof DeleteProjectionTurnsByThreadInput.Type;
+
+export const DeleteProjectionSubmittedTurnStartsByThreadInput = DeleteProjectionTurnsByThreadInput;
+export type DeleteProjectionSubmittedTurnStartsByThreadInput =
+  typeof DeleteProjectionSubmittedTurnStartsByThreadInput.Type;
+
+export const DeleteProjectionTurnsAfterCheckpointInput = Schema.Struct({
+  threadId: ThreadId,
+  turnCount: NonNegativeInt,
+});
+export type DeleteProjectionTurnsAfterCheckpointInput =
+  typeof DeleteProjectionTurnsAfterCheckpointInput.Type;
 
 export const ClearCheckpointTurnConflictInput = Schema.Struct({
   threadId: ThreadId,
@@ -115,24 +165,74 @@ export interface ProjectionTurnRepositoryShape {
   ) => Effect.Effect<void, ProjectionRepositoryError>;
 
   /**
-   * Replaces any existing pending-start placeholder rows for a thread with exactly one latest pending-start row.
+   * Inserts one pending-start placeholder. Multiple accepted starts may wait
+   * behind serialized checkpoint work and must remain independently durable.
    */
-  readonly replacePendingTurnStart: (
+  readonly insertPendingTurnStart: (
     row: ProjectionPendingTurnStart,
   ) => Effect.Effect<void, ProjectionRepositoryError>;
 
+  /** Restores an accepted placeholder without making it eligible for startup resubmission. */
+  readonly insertSubmittedTurnStart: (
+    row: ProjectionSubmittedTurnStart,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /** Marks one correlated start as accepted by the provider so startup does not replay it. */
+  readonly markPendingTurnStartSubmitted: (
+    input: AcknowledgeProjectionPendingTurnStartInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /** Clears accepted steering placeholders correlated to a provider turn after it settles. */
+  readonly deleteSubmittedTurnStartsByTurnId: (
+    input: DeleteProjectionSubmittedTurnStartsInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
   /**
-   * Returns the newest pending-start placeholder for a thread; this is expected to be at most one row after replacement writes.
+   * Clears every accepted-start placeholder on a thread once the session
+   * settles, including submissions whose turn never surfaced as running.
+   */
+  readonly deleteSubmittedTurnStartsByThreadId: (
+    input: DeleteProjectionSubmittedTurnStartsByThreadInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /**
+   * Returns the oldest start that has not yet been accepted by a provider.
+   * Startup reconciliation uses this to exclude acknowledged submissions.
    */
   readonly getPendingTurnStartByThreadId: (
     input: GetProjectionPendingTurnStartInput,
   ) => Effect.Effect<Option.Option<ProjectionPendingTurnStart>, ProjectionRepositoryError>;
 
   /**
-   * Deletes only pending-start placeholder rows (`turnId = null`) for a thread and leaves concrete turn rows untouched.
+   * Returns the oldest start placeholder the provider has not yet consumed,
+   * pending or submitted. Lifecycle presence checks use this so a queued
+   * second start still counts while it cannot be correlated yet.
    */
-  readonly deletePendingTurnStartByThreadId: (
+  readonly getUnresolvedTurnStartByThreadId: (
     input: GetProjectionPendingTurnStartInput,
+  ) => Effect.Effect<Option.Option<ProjectionPendingTurnStart>, ProjectionRepositoryError>;
+
+  /** Returns the oldest pending start or acknowledgement belonging to this provider turn. */
+  readonly getAdoptableTurnStartByThreadId: (
+    input: GetProjectionAdoptableTurnStartInput,
+  ) => Effect.Effect<Option.Option<ProjectionPendingTurnStart>, ProjectionRepositoryError>;
+
+  /** Returns only the accepted start correlated to this provider turn. */
+  readonly getSubmittedTurnStartByTurnId: (
+    input: GetProjectionSubmittedTurnStartInput,
+  ) => Effect.Effect<Option.Option<ProjectionPendingTurnStart>, ProjectionRepositoryError>;
+
+  /**
+   * Deletes one correlated pending-start placeholder and leaves other queued
+   * starts and concrete turn rows untouched.
+   */
+  readonly deletePendingTurnStart: (
+    input: DeleteProjectionPendingTurnStartInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+
+  /** Deletes concrete turns beyond a revert boundary without disturbing queued start order. */
+  readonly deleteTurnsAfterCheckpoint: (
+    input: DeleteProjectionTurnsAfterCheckpointInput,
   ) => Effect.Effect<void, ProjectionRepositoryError>;
 
   /**

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -41,6 +41,7 @@ import * as ThreadPlanProgress from "../orchestration/ThreadPlanProgress.ts";
 import * as OrchestrationEngine from "../orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ProviderCommandReactor } from "../orchestration/Services/ProviderCommandReactor.ts";
+import { CheckpointReactor } from "../orchestration/Services/CheckpointReactor.ts";
 import { ProviderSessionDirectoryLive } from "../provider/Layers/ProviderSessionDirectory.ts";
 import { makeProviderServiceLive } from "../provider/Layers/ProviderService.ts";
 import {
@@ -932,6 +933,13 @@ it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
           Layer.provide(Layer.mock(VcsStatusBroadcaster)({})),
           Layer.provide(Layer.mock(TextGeneration)({})),
           Layer.provide(ServerSettingsService.layerTest()),
+          Layer.provide(
+            Layer.succeed(CheckpointReactor, {
+              start: () => Effect.void,
+              drain: Effect.void,
+              awaitDomainSequence: () => Effect.void,
+            }),
+          ),
         );
 
         yield* engine.dispatch({

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -79,6 +79,8 @@ export function shouldPublishAgentAwarenessEvent(event: OrchestrationEvent): boo
       // before the real running state arrives. Provider lifecycle events publish
       // the authoritative starting/running state instead.
       return false;
+    case "thread.meta-updated":
+      return event.payload.turnStartAcknowledged === undefined;
     case "thread.proposed-plan-upserted":
     case "thread.runtime-mode-set":
     case "thread.interaction-mode-set":

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -69,8 +69,8 @@ import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationReactor.ts";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.ts";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
-import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor.ts";
-import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
+import * as ProviderCommandReactor from "./orchestration/Layers/ProviderCommandReactor.ts";
+import * as CheckpointReactor from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import * as ThreadSettlementReactor from "./orchestration/ThreadSettlementReactor.ts";
 import * as PullRequestSyncReactor from "./orchestration/PullRequestSyncReactor.ts";
@@ -277,11 +277,15 @@ const PlatformServicesLive = Layer.unwrap(
   }),
 );
 
+const CheckpointAndProviderCommandReactorsLive =
+  ProviderCommandReactor.ProviderCommandReactorLive.pipe(
+    Layer.provideMerge(CheckpointReactor.CheckpointReactorLive),
+  );
+
 const ReactorLayerLive = Layer.empty.pipe(
   Layer.provideMerge(OrchestrationReactorLive),
   Layer.provideMerge(ProviderRuntimeIngestionLive),
-  Layer.provideMerge(ProviderCommandReactorLive),
-  Layer.provideMerge(CheckpointReactorLive),
+  Layer.provideMerge(CheckpointAndProviderCommandReactorsLive),
   Layer.provideMerge(ThreadDeletionReactorLive),
   Layer.provideMerge(ThreadSettlementReactor.layer),
   Layer.provideMerge(PullRequestSyncReactor.layer),

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   type OrchestrationCommand,
   type OrchestrationSessionStatus,
+  MessageId,
   ProviderDriverKind,
   ProviderInstanceId,
   type ProviderSendTurnInput,
@@ -584,6 +585,172 @@ it.effect("reconciles multiple active and archived orphans but skips live sessio
           );
           assert.deepStrictEqual(binding.resumeCursor, { cursor: binding.threadId });
         }
+      }),
+    ),
+  );
+});
+
+it.effect("clears acknowledged starts when orphan reconciliation abandons the session", () => {
+  const messageId = MessageId.make("message-acknowledged-before-restart");
+  const turnId = TurnId.make("turn-acknowledged-before-restart");
+  const thread = {
+    ...makeThread("thread-acknowledged-before-restart", "starting"),
+    submittedTurnStarts: [{ messageId, turnId }],
+  };
+  const dispatched: OrchestrationCommand[] = [];
+
+  return runReconciliation({
+    threads: [thread],
+    directory: {
+      getBinding: () => Effect.succeed(Option.none()),
+      upsert: () => Effect.void,
+      recordImportedTranscript: () => Effect.die("unused"),
+      getProvider: () => Effect.die("unused"),
+      listThreadIds: () => Effect.die("unused"),
+      listBindings: () => Effect.succeed([]),
+    },
+    dispatch: (command) =>
+      Effect.sync(() => dispatched.push(command)).pipe(Effect.as({ sequence: dispatched.length })),
+  }).pipe(
+    Effect.tap(() =>
+      Effect.sync(() => {
+        assert.deepStrictEqual(
+          dispatched.map((command) =>
+            command.type === "thread.session.set"
+              ? { type: command.type, status: command.session.status }
+              : command.type === "thread.activity.append"
+                ? {
+                    type: command.type,
+                    kind: command.activity.kind,
+                    requestId:
+                      typeof command.activity.payload === "object" &&
+                      command.activity.payload !== null &&
+                      "requestId" in command.activity.payload
+                        ? command.activity.payload.requestId
+                        : null,
+                  }
+                : { type: command.type },
+          ),
+          [
+            {
+              type: "thread.activity.append",
+              kind: "provider.turn.start.failed",
+              requestId: messageId,
+            },
+            { type: "thread.session.set", status: "error" },
+          ],
+        );
+      }),
+    ),
+  );
+});
+
+it.effect("clears acknowledged starts on dead sessions that are not otherwise orphaned", () => {
+  const messageId = MessageId.make("message-acknowledged-errored-session");
+  const turnId = TurnId.make("turn-acknowledged-errored-session");
+  const thread = {
+    ...makeThread("thread-acknowledged-errored-session", "error"),
+    submittedTurnStarts: [{ messageId, turnId }],
+  };
+  const dispatched: OrchestrationCommand[] = [];
+
+  return runReconciliation({
+    threads: [thread],
+    directory: {
+      getBinding: () => Effect.succeed(Option.none()),
+      upsert: () => Effect.void,
+      recordImportedTranscript: () => Effect.die("unused"),
+      getProvider: () => Effect.die("unused"),
+      listThreadIds: () => Effect.die("unused"),
+      listBindings: () => Effect.succeed([]),
+    },
+    dispatch: (command) =>
+      Effect.sync(() => dispatched.push(command)).pipe(Effect.as({ sequence: dispatched.length })),
+  }).pipe(
+    Effect.tap(() =>
+      Effect.sync(() => {
+        assert.deepStrictEqual(
+          dispatched.map((command) =>
+            command.type === "thread.activity.append" &&
+            command.activity.payload !== null &&
+            typeof command.activity.payload === "object" &&
+            "requestId" in command.activity.payload
+              ? {
+                  type: command.type,
+                  kind: command.activity.kind,
+                  requestId: command.activity.payload.requestId,
+                }
+              : { type: command.type },
+          ),
+          [
+            {
+              type: "thread.activity.append",
+              kind: "provider.turn.start.failed",
+              requestId: messageId,
+            },
+          ],
+        );
+      }),
+    ),
+  );
+});
+
+it.effect("clears later orphaned starts while keeping a failed cleanup retryable", () => {
+  const failedMessageId = MessageId.make("message-cleanup-fails");
+  const clearedMessageId = MessageId.make("message-cleanup-succeeds");
+  const thread = {
+    ...makeThread("thread-cleanup-fails", "starting"),
+    submittedTurnStarts: [
+      { messageId: failedMessageId, turnId: TurnId.make("turn-cleanup-fails") },
+      { messageId: clearedMessageId, turnId: TurnId.make("turn-cleanup-succeeds") },
+    ],
+  };
+  const dispatched: OrchestrationCommand[] = [];
+
+  return runReconciliation({
+    threads: [thread],
+    directory: {
+      getBinding: () => Effect.succeed(Option.none()),
+      upsert: () => Effect.void,
+      recordImportedTranscript: () => Effect.die("unused"),
+      getProvider: () => Effect.die("unused"),
+      listThreadIds: () => Effect.die("unused"),
+      listBindings: () => Effect.succeed([]),
+    },
+    dispatch: (command) =>
+      Effect.sync(() => dispatched.push(command)).pipe(
+        Effect.flatMap(() =>
+          command.type === "thread.activity.append" &&
+          command.activity.payload !== null &&
+          typeof command.activity.payload === "object" &&
+          "requestId" in command.activity.payload &&
+          command.activity.payload.requestId === failedMessageId
+            ? Effect.fail(
+                new OrchestrationCommandInvariantError({
+                  commandType: command.type,
+                  detail: "cleanup failed",
+                }),
+              )
+            : Effect.succeed({ sequence: dispatched.length }),
+        ),
+      ),
+  }).pipe(
+    Effect.tap(() =>
+      Effect.sync(() => {
+        assert.deepStrictEqual(
+          dispatched.map((command) =>
+            command.type === "thread.activity.append" &&
+            command.activity.payload !== null &&
+            typeof command.activity.payload === "object" &&
+            "requestId" in command.activity.payload
+              ? { type: command.type, requestId: command.activity.payload.requestId }
+              : { type: command.type },
+          ),
+          [
+            { type: "thread.activity.append", requestId: failedMessageId },
+            { type: "thread.activity.append", requestId: clearedMessageId },
+          ],
+        );
       }),
     ),
   );

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MODEL,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_SERVER_SETTINGS,
+  EventId,
   type ServerSettings as ServerSettingsValue,
   type ModelSelection,
   type OrchestrationProjectShell,
@@ -539,6 +540,47 @@ export const reconcileProviderSessions = Effect.gen(function* () {
       !liveThreadIds.has(thread.id),
   );
 
+  const clearSubmittedTurnStarts = (orphanedThread: (typeof threads)[number]) =>
+    Effect.forEach(
+      orphanedThread.submittedTurnStarts ?? [],
+      (submitted) =>
+        Effect.gen(function* () {
+          const createdAt = DateTime.formatIso(yield* DateTime.now);
+          const commandId = CommandId.make(yield* crypto.randomUUIDv4);
+          const eventId = EventId.make(yield* crypto.randomUUIDv4);
+          yield* orchestrationEngine.dispatch({
+            type: "thread.activity.append",
+            commandId,
+            threadId: orphanedThread.id,
+            activity: {
+              id: eventId,
+              tone: "error",
+              kind: "provider.turn.start.failed",
+              summary: "Provider turn start failed",
+              payload: {
+                detail:
+                  "The server restarted after the provider accepted this turn but before it started.",
+                requestId: submitted.messageId,
+              },
+              turnId: submitted.turnId,
+              createdAt,
+            },
+            createdAt,
+          });
+        }).pipe(
+          Effect.as(true),
+          Effect.catchCause((cause) =>
+            Cause.hasInterrupts(cause)
+              ? Effect.failCause(cause)
+              : Effect.logWarning(
+                  "failed to clear an acknowledged turn start during orphan reconciliation",
+                  { threadId: orphanedThread.id, messageId: submitted.messageId, cause },
+                ).pipe(Effect.as(false)),
+          ),
+        ),
+      { concurrency: 1 },
+    );
+
   for (const thread of orphanedThreads) {
     const session = thread.session;
     if (session === null) {
@@ -611,6 +653,11 @@ export const reconcileProviderSessions = Effect.gen(function* () {
                 ),
           ),
         );
+
+        const submittedStartCleanup = yield* clearSubmittedTurnStarts(thread);
+        if (submittedStartCleanup.some((cleared) => !cleared)) {
+          return;
+        }
 
         yield* Effect.gen(function* () {
           const reconciledAt = DateTime.formatIso(yield* DateTime.now);
@@ -733,6 +780,21 @@ export const reconcileProviderSessions = Effect.gen(function* () {
     }
 
     yield* settleAsError(ORPHANED_PROVIDER_SESSION_ERROR);
+  }
+
+  // Threads whose provider session is gone without being orphaned above can
+  // still hold acknowledged starts that will never surface their turn; fail
+  // them out so the stale submission cannot block reverts indefinitely.
+  const orphanedThreadIds = new Set(orphanedThreads.map((thread) => thread.id));
+  for (const thread of threads) {
+    if (
+      liveThreadIds.has(thread.id) ||
+      orphanedThreadIds.has(thread.id) ||
+      (thread.submittedTurnStarts?.length ?? 0) === 0
+    ) {
+      continue;
+    }
+    yield* clearSubmittedTurnStarts(thread);
   }
 }).pipe(
   Effect.catchCause((cause) =>

--- a/apps/server/src/vcs/GitVcsDriver.test.ts
+++ b/apps/server/src/vcs/GitVcsDriver.test.ts
@@ -99,7 +99,9 @@ it.effect("restores empty checkpoints without changing paths outside the workspa
             fallbackToHead: false,
           }),
         );
-        assert.isFalse(yield* fileSystem.exists(addedPath));
+        // Restores never delete untracked files; staged additions are index
+        // state and return to the checkpoint's tracked set.
+        assert.strictEqual(yield* fileSystem.exists(addedPath), !staged);
       }
       yield* fileSystem.writeFileString(
         path.join(root, ".git", "info", "exclude"),
@@ -112,7 +114,7 @@ it.effect("restores empty checkpoints without changing paths outside the workspa
         yield* driver.checkpoints.restoreCheckpoint({ cwd, checkpointRef, fallbackToHead: false }),
       );
       assert.strictEqual(yield* fileSystem.readFileString(path.join(cwd, "ignored.txt")), "keep\n");
-      assert.isFalse(yield* fileSystem.exists(path.join(cwd, "untracked")));
+      assert.isTrue(yield* fileSystem.exists(path.join(cwd, "untracked")));
       if (nested) {
         assert.strictEqual(
           yield* fileSystem.readFileString(path.join(root, "outside.txt")),
@@ -126,6 +128,38 @@ it.effect("restores empty checkpoints without changing paths outside the workspa
         assert.strictEqual(staged.stdout.trim(), "outside.txt");
       }
     }
+  }).pipe(Effect.scoped, Effect.provide(GitContractLayer)),
+);
+
+it.effect("recreates a nested workspace directory emptied by restore before resetting", () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const driver = yield* GitVcsDriver.makeVcsDriverShape();
+    const root = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-nested-restore-" });
+    yield* runGit(root, ["init"]);
+    yield* runGit(root, ["config", "user.email", "test@test.com"]);
+    yield* runGit(root, ["config", "user.name", "Test"]);
+    yield* fileSystem.writeFileString(path.join(root, "root.txt"), "root\n");
+    yield* runGit(root, ["add", "."]);
+    yield* runGit(root, ["commit", "-m", "initial"]);
+
+    const cwd = path.join(root, "nested");
+    yield* fileSystem.makeDirectory(cwd, { recursive: true });
+    const checkpointRef = CheckpointRef.make("refs/t3/checkpoints/nested-empty");
+    yield* driver.checkpoints.captureCheckpoint({ cwd, checkpointRef });
+
+    // Tracking the nested workspace's only file and restoring to a checkpoint
+    // without it removes the directory itself; the driver must recreate it
+    // before the follow-up reset runs.
+    yield* fileSystem.writeFileString(path.join(cwd, "only.txt"), "new\n");
+    yield* runGit(root, ["add", "nested/only.txt"]);
+
+    assert.isTrue(
+      yield* driver.checkpoints.restoreCheckpoint({ cwd, checkpointRef, fallbackToHead: false }),
+    );
+    assert.isTrue(yield* fileSystem.exists(cwd));
+    assert.isFalse(yield* fileSystem.exists(path.join(cwd, "only.txt")));
   }).pipe(Effect.scoped, Effect.provide(GitContractLayer)),
 );
 

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -811,64 +811,121 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
         return false;
       }
 
-      const tracked = yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["ls-files", "--cached", `--with-tree=${commitOid}`, "-z", "--", "."],
-      });
-      // An empty index and checkpoint have nothing for git restore's pathspec to match.
-      if (tracked.stdout.length > 0) {
-        yield* execute({
-          operation,
-          cwd: input.cwd,
-          args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
-        });
-      }
-      // Restoring away the last tracked file can remove a nested workspace directory.
-      yield* fileSystem.makeDirectory(input.cwd, { recursive: true }).pipe(
-        Effect.mapError(
-          (cause) =>
-            new VcsProcessExitError({
-              operation,
-              command: "git restore",
-              cwd: input.cwd,
-              exitCode: 0,
-              detail: `Could not recreate the checkpoint workspace: ${cause.message}`,
-            }),
-        ),
-      );
-      const cleaned = yield* execute({
-        operation,
-        cwd: input.cwd,
-        args: ["clean", "-fd", "--", "."],
-        allowNonZeroExit: true,
-      });
-      if (cleaned.exitCode !== 0) {
-        // Git can remove every child, then fail trying to remove './' itself.
-        const emptiedWorkspace =
-          cleaned.exitCode === 1 &&
-          /^warning: failed to remove \.\/: [^\n]+$/.test(cleaned.stderr.trim()) &&
-          (yield* fileSystem.readDirectory(input.cwd).pipe(
-            Effect.map((entries) => entries.length === 0),
-            Effect.catch(() => Effect.succeed(false)),
-          ));
-        if (!emptiedWorkspace)
-          return yield* new VcsProcessExitError({
-            operation,
-            command: "git clean",
-            cwd: input.cwd,
-            exitCode: cleaned.exitCode,
-            detail: cleaned.stderr.trim() || "Could not clean the checkpoint workspace.",
-          });
-      }
+      // Restoring away the last tracked file can remove a nested workspace
+      // directory; recreate it before any further Git command runs in it.
+      const restoreWorkspaceDirectory = fileSystem
+        .makeDirectory(input.cwd, {
+          recursive: true,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new VcsProcessExitError({
+                operation,
+                command: "git restore",
+                cwd: input.cwd,
+                exitCode: 0,
+                detail: `Could not recreate the checkpoint workspace: ${cause.message}`,
+              }),
+          ),
+        );
 
-      const headExists = yield* hasHeadCommit(input.cwd);
-      if (headExists) {
+      // The projected source ref can outlive the ref itself; fall back to the
+      // target-only restore rather than rejecting a valid rollback.
+      const current =
+        input.fromCheckpointRef === undefined
+          ? null
+          : yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
+      if (current !== null) {
+        const changedPaths = yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: [
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "--relative",
+            "-z",
+            `${commitOid}^{commit}`,
+            `${current}^{commit}`,
+            "--",
+            ".",
+          ],
+          maxOutputBytes: CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
+          outputMode: "error",
+        });
+        if (changedPaths.stdout.length === 0) {
+          return true;
+        }
+
+        // Limit the restore to paths changed by the discarded turns. Files edited after
+        // the current checkpoint but absent from that diff belong to concurrent user work.
         yield* execute({
           operation,
           cwd: input.cwd,
-          args: ["reset", "--quiet", "--", "."],
+          args: [
+            "--literal-pathspecs",
+            "restore",
+            "--source",
+            current,
+            "--staged",
+            "--pathspec-from-file=-",
+            "--pathspec-file-nul",
+          ],
+          stdin: changedPaths.stdout,
         });
+        yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: [
+            "--literal-pathspecs",
+            "restore",
+            "--source",
+            commitOid,
+            "--worktree",
+            "--staged",
+            "--pathspec-from-file=-",
+            "--pathspec-file-nul",
+          ],
+          stdin: changedPaths.stdout,
+        });
+        yield* restoreWorkspaceDirectory;
+        if (yield* hasHeadCommit(input.cwd)) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: [
+              "--literal-pathspecs",
+              "reset",
+              "--quiet",
+              "--pathspec-from-file=-",
+              "--pathspec-file-nul",
+            ],
+            stdin: changedPaths.stdout,
+          });
+        }
+      } else {
+        const tracked = yield* execute({
+          operation,
+          cwd: input.cwd,
+          args: ["ls-files", "--cached", `--with-tree=${commitOid}`, "-z", "--", "."],
+        });
+        // An empty index and checkpoint have nothing for git restore's pathspec to match.
+        if (tracked.stdout.length > 0) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
+          });
+          yield* restoreWorkspaceDirectory;
+        }
+        if (yield* hasHeadCommit(input.cwd)) {
+          yield* execute({
+            operation,
+            cwd: input.cwd,
+            args: ["reset", "--quiet", "--", "."],
+          });
+        }
       }
 
       return true;

--- a/apps/server/src/vcs/VcsDriver.ts
+++ b/apps/server/src/vcs/VcsDriver.ts
@@ -22,6 +22,8 @@ export interface VcsCaptureCheckpointInput {
 export interface VcsRestoreCheckpointInput {
   readonly cwd: string;
   readonly checkpointRef: CheckpointRef;
+  /** Current checkpoint whose added files should be removed by the rollback. */
+  readonly fromCheckpointRef?: CheckpointRef;
   readonly fallbackToHead?: boolean;
 }
 

--- a/packages/client-runtime/src/state/threadReducer.test.ts
+++ b/packages/client-runtime/src/state/threadReducer.test.ts
@@ -11,7 +11,7 @@ import {
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
-import type { OrchestrationThread } from "@t3tools/contracts";
+import type { OrchestrationEvent, OrchestrationThread } from "@t3tools/contracts";
 
 import { applyThreadDetailEvent } from "./threadReducer.ts";
 
@@ -523,6 +523,480 @@ describe("applyThreadDetailEvent", () => {
       if (unlinked.kind !== "updated") throw new Error("expected update");
       expect(unlinked.thread.pullRequests).toEqual([]);
       expect(unlinked.thread.linkedPullRequest).toBeNull();
+    });
+  });
+
+  describe("pending turn start", () => {
+    it("tracks the accepted message until a provider turn adopts it", () => {
+      const messageId = MessageId.make("message-pending-turn-start");
+      const requested = applyThreadDetailEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 5,
+        occurredAt: "2026-04-01T05:00:00.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.turn-start-requested",
+        payload: {
+          threadId: baseThread.id,
+          messageId,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: "2026-04-01T04:55:00.000Z",
+        },
+      });
+      expect(requested.kind).toBe("updated");
+      if (requested.kind !== "updated") return;
+      expect(requested.thread.pendingTurnStartMessageId).toBe(messageId);
+
+      const adopted = applyThreadDetailEvent(requested.thread, {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: "2026-04-01T05:00:01.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.session-set",
+        payload: {
+          threadId: baseThread.id,
+          session: {
+            threadId: baseThread.id,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: TurnId.make("turn-pending-turn-start"),
+            lastError: null,
+            updatedAt: "2026-04-01T05:00:01.000Z",
+          },
+        },
+      });
+      expect(adopted.kind).toBe("updated");
+      if (adopted.kind === "updated") {
+        expect(adopted.thread.pendingTurnStartMessageId).toBeNull();
+      }
+    });
+
+    it("does not let a stale terminal session clear a newer pending turn", () => {
+      const newerMessageId = MessageId.make("message-newer-pending-turn-start");
+      const pendingThread = {
+        ...baseThread,
+        pendingTurnStartMessageId: newerMessageId,
+      };
+      const result = applyThreadDetailEvent(pendingThread, {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: "2026-04-01T05:00:01.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.session-set",
+        payload: {
+          threadId: baseThread.id,
+          session: {
+            threadId: baseThread.id,
+            status: "error",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: "older request failed",
+            updatedAt: "2026-04-01T05:00:01.000Z",
+          },
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.pendingTurnStartMessageId).toBe(newerMessageId);
+      }
+    });
+
+    it("keeps acknowledged starts guarded until their provider turn is running", () => {
+      const newerMessageId = MessageId.make("message-newer-pending-turn-start");
+      const pendingThread = {
+        ...baseThread,
+        pendingTurnStartMessageId: newerMessageId,
+      };
+      const acknowledge = (messageId: MessageId, thread = pendingThread) =>
+        applyThreadDetailEvent(thread, {
+          ...baseEventFields,
+          sequence: 6,
+          occurredAt: "2026-04-01T05:00:01.000Z",
+          aggregateKind: "thread" as const,
+          aggregateId: baseThread.id,
+          type: "thread.meta-updated" as const,
+          payload: {
+            threadId: baseThread.id,
+            turnStartAcknowledged: {
+              messageId,
+              turnId: TurnId.make("turn-provider-acknowledged"),
+            },
+            updatedAt: thread.updatedAt,
+          },
+        });
+
+      const stale = acknowledge(MessageId.make("message-older-pending-turn-start"));
+      expect(stale.kind).toBe("updated");
+      if (stale.kind === "updated") {
+        expect(stale.thread.pendingTurnStartMessageId).toBe(newerMessageId);
+      }
+
+      const current = acknowledge(newerMessageId);
+      expect(current.kind).toBe("updated");
+      if (current.kind === "updated") {
+        expect(current.thread.pendingTurnStartMessageId).toBe(newerMessageId);
+        expect(current.thread.submittedTurnStarts).toEqual([
+          {
+            messageId: newerMessageId,
+            turnId: TurnId.make("turn-provider-acknowledged"),
+          },
+        ]);
+      }
+
+      const running = acknowledge(newerMessageId, {
+        ...pendingThread,
+        session: {
+          threadId: pendingThread.id,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: TurnId.make("turn-provider-acknowledged"),
+          lastError: null,
+          updatedAt: pendingThread.updatedAt,
+        },
+      });
+      expect(running.kind).toBe("updated");
+      if (running.kind === "updated") {
+        expect(running.thread.pendingTurnStartMessageId).toBeNull();
+        expect(running.thread.submittedTurnStarts).toEqual([]);
+      }
+    });
+
+    it("does not re-guard a turn acknowledged after its lifecycle was observed", () => {
+      const requestA = MessageId.make("message-late-ack-a");
+      const turnA = TurnId.make("turn-late-ack-a");
+      const turnB = TurnId.make("turn-late-ack-b");
+      const withEvent = (thread: typeof baseThread, event: OrchestrationEvent) => {
+        const result = applyThreadDetailEvent(thread, event);
+        expect(result.kind).toBe("updated");
+        return result.kind === "updated" ? result.thread : thread;
+      };
+      let thread = withEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: "2026-04-01T05:00:01.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.turn-start-requested",
+        payload: {
+          threadId: baseThread.id,
+          messageId: requestA,
+          expectsTurnStartAcknowledgement: true,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: "2026-04-01T05:00:01.000Z",
+        },
+      });
+      for (const [sequence, status, activeTurnId] of [
+        [7, "running", turnA],
+        [8, "ready", null],
+        [9, "running", turnB],
+      ] as const) {
+        thread = withEvent(thread, {
+          ...baseEventFields,
+          sequence,
+          occurredAt: `2026-04-01T05:00:0${sequence - 5}.000Z`,
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.session-set",
+          payload: {
+            threadId: baseThread.id,
+            session: {
+              threadId: baseThread.id,
+              status,
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId,
+              lastError: null,
+              updatedAt: `2026-04-01T05:00:0${sequence - 5}.000Z`,
+            },
+          },
+        });
+      }
+      thread = withEvent(thread, {
+        ...baseEventFields,
+        sequence: 10,
+        occurredAt: "2026-04-01T05:00:05.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.meta-updated",
+        payload: {
+          threadId: baseThread.id,
+          turnStartAcknowledged: { messageId: requestA, turnId: turnA },
+          updatedAt: thread.updatedAt,
+        },
+      });
+
+      expect(thread.pendingTurnStartMessageId).toBeNull();
+      expect(thread.submittedTurnStarts).toEqual([]);
+      expect(thread.turnStartSubmissionRendezvous).toBeNull();
+    });
+
+    it("clears only the submitted start correlated to a provider failure", () => {
+      const messageA = MessageId.make("message-submitted-failure-a");
+      const messageB = MessageId.make("message-submitted-failure-b");
+      const result = applyThreadDetailEvent(
+        {
+          ...baseThread,
+          submittedTurnStarts: [
+            { messageId: messageA, turnId: TurnId.make("turn-submitted-failure-a") },
+            { messageId: messageB, turnId: TurnId.make("turn-submitted-failure-b") },
+          ],
+        },
+        {
+          ...baseEventFields,
+          sequence: 11,
+          occurredAt: "2026-04-01T05:15:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.activity-appended",
+          payload: {
+            threadId: baseThread.id,
+            activity: {
+              id: EventId.make("activity-submitted-failure-a"),
+              tone: "error",
+              kind: "provider.turn.start.failed",
+              summary: "Provider turn start failed",
+              payload: { requestId: messageA },
+              turnId: TurnId.make("turn-submitted-failure-a"),
+              createdAt: "2026-04-01T05:15:00.000Z",
+            },
+          },
+        },
+      );
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.submittedTurnStarts).toEqual([
+          { messageId: messageB, turnId: TurnId.make("turn-submitted-failure-b") },
+        ]);
+      }
+    });
+
+    it("recognizes a reused running turn when its steering acknowledgement is late", () => {
+      const turnId = TurnId.make("turn-steering-late-ack");
+      const messageId = MessageId.make("message-steering-late-ack");
+      let thread: OrchestrationThread = {
+        ...baseThread,
+        session: {
+          threadId: baseThread.id,
+          status: "running",
+          providerName: "claude",
+          runtimeMode: "full-access",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: "2026-04-01T05:30:00.000Z",
+        },
+      };
+      for (const event of [
+        {
+          ...baseEventFields,
+          sequence: 6,
+          occurredAt: "2026-04-01T05:30:01.000Z",
+          aggregateKind: "thread" as const,
+          aggregateId: baseThread.id,
+          type: "thread.turn-start-requested" as const,
+          payload: {
+            threadId: baseThread.id,
+            messageId,
+            expectsTurnStartAcknowledgement: true as const,
+            runtimeMode: "full-access" as const,
+            interactionMode: "default" as const,
+            createdAt: "2026-04-01T05:30:01.000Z",
+          },
+        },
+        {
+          ...baseEventFields,
+          sequence: 7,
+          occurredAt: "2026-04-01T05:30:02.000Z",
+          aggregateKind: "thread" as const,
+          aggregateId: baseThread.id,
+          type: "thread.session-set" as const,
+          payload: {
+            threadId: baseThread.id,
+            session: {
+              threadId: baseThread.id,
+              status: "ready" as const,
+              providerName: "claude",
+              runtimeMode: "full-access" as const,
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: "2026-04-01T05:30:02.000Z",
+            },
+          },
+        },
+        {
+          ...baseEventFields,
+          sequence: 8,
+          occurredAt: "2026-04-01T05:30:03.000Z",
+          aggregateKind: "thread" as const,
+          aggregateId: baseThread.id,
+          type: "thread.meta-updated" as const,
+          payload: {
+            threadId: baseThread.id,
+            turnStartAcknowledged: { messageId, turnId },
+            updatedAt: "2026-04-01T05:30:00.000Z",
+          },
+        },
+      ]) {
+        const result = applyThreadDetailEvent(thread, event);
+        expect(result.kind).toBe("updated");
+        if (result.kind === "updated") thread = result.thread;
+      }
+
+      expect(thread.pendingTurnStartMessageId).toBeNull();
+      expect(thread.submittedTurnStarts).toEqual([]);
+      expect(thread.turnStartSubmissionRendezvous).toBeNull();
+    });
+
+    it("does not enroll legacy turn history in submission rendezvous state", () => {
+      const requested = applyThreadDetailEvent(baseThread, {
+        ...baseEventFields,
+        sequence: 6,
+        occurredAt: "2026-04-01T05:00:01.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.turn-start-requested",
+        payload: {
+          threadId: baseThread.id,
+          messageId: MessageId.make("legacy-message"),
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          createdAt: "2026-04-01T05:00:01.000Z",
+        },
+      });
+      expect(requested.kind).toBe("updated");
+      if (requested.kind !== "updated") return;
+      const running = applyThreadDetailEvent(requested.thread, {
+        ...baseEventFields,
+        sequence: 7,
+        occurredAt: "2026-04-01T05:00:02.000Z",
+        aggregateKind: "thread",
+        aggregateId: baseThread.id,
+        type: "thread.session-set",
+        payload: {
+          threadId: baseThread.id,
+          session: {
+            threadId: baseThread.id,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: TurnId.make("legacy-turn"),
+            lastError: null,
+            updatedAt: "2026-04-01T05:00:02.000Z",
+          },
+        },
+      });
+      expect(running.kind).toBe("updated");
+      if (running.kind === "updated") {
+        expect(running.thread.turnStartSubmissionRendezvous).toBeNull();
+      }
+    });
+
+    it("matches every acknowledgement when concurrent starts share a provider turn", () => {
+      const messageA = MessageId.make("message-shared-turn-a");
+      const messageB = MessageId.make("message-shared-turn-b");
+      const turnId = TurnId.make("turn-shared-provider");
+      let thread = baseThread;
+      const events: OrchestrationEvent[] = [
+        ...[messageA, messageB].map((messageId, index): OrchestrationEvent => ({
+          ...baseEventFields,
+          sequence: index + 6,
+          occurredAt: "2026-04-01T05:45:00.000Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.turn-start-requested",
+          payload: {
+            threadId: baseThread.id,
+            messageId,
+            expectsTurnStartAcknowledgement: true,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: "2026-04-01T05:45:00.000Z",
+          },
+        })),
+        {
+          ...baseEventFields,
+          sequence: 8,
+          occurredAt: "2026-04-01T05:45:01.000Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.session-set",
+          payload: {
+            threadId: baseThread.id,
+            session: {
+              threadId: baseThread.id,
+              status: "running",
+              providerName: "claude",
+              runtimeMode: "full-access",
+              activeTurnId: turnId,
+              lastError: null,
+              updatedAt: "2026-04-01T05:45:01.000Z",
+            },
+          },
+        },
+        {
+          ...baseEventFields,
+          sequence: 9,
+          occurredAt: "2026-04-01T05:45:02.000Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.meta-updated",
+          payload: {
+            threadId: baseThread.id,
+            turnStartAcknowledged: { messageId: messageA, turnId },
+            updatedAt: baseThread.updatedAt,
+          },
+        },
+        {
+          ...baseEventFields,
+          sequence: 10,
+          occurredAt: "2026-04-01T05:45:02.500Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.session-set",
+          payload: {
+            threadId: baseThread.id,
+            session: {
+              threadId: baseThread.id,
+              status: "ready",
+              providerName: "claude",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: "2026-04-01T05:45:02.500Z",
+            },
+          },
+        },
+        {
+          ...baseEventFields,
+          sequence: 11,
+          occurredAt: "2026-04-01T05:45:03.000Z",
+          aggregateKind: "thread",
+          aggregateId: baseThread.id,
+          type: "thread.meta-updated",
+          payload: {
+            threadId: baseThread.id,
+            turnStartAcknowledged: { messageId: messageB, turnId },
+            updatedAt: baseThread.updatedAt,
+          },
+        },
+      ];
+      for (const event of events) {
+        const result = applyThreadDetailEvent(thread, event);
+        expect(result.kind).toBe("updated");
+        if (result.kind === "updated") thread = result.thread;
+      }
+
+      expect(thread.pendingTurnStartMessageId).toBeNull();
+      expect(thread.submittedTurnStarts).toEqual([]);
+      expect(thread.turnStartSubmissionRendezvous).toBeNull();
     });
   });
 
@@ -1526,6 +2000,52 @@ describe("applyThreadDetailEvent", () => {
           "Imported prompt",
           "Imported answer",
         ]);
+      }
+    });
+
+    it("keeps a user message accepted after the revert was requested", () => {
+      const pendingMessageId = MessageId.make("message-accepted-during-revert");
+      const threadWithPendingMessage: OrchestrationThread = {
+        ...baseThread,
+        messages: [
+          {
+            id: MessageId.make("reverted-user-message"),
+            role: "user",
+            text: "Discard this turn",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T01:00:00.000Z",
+            updatedAt: "2026-04-01T01:00:00.000Z",
+          },
+          {
+            id: pendingMessageId,
+            role: "user",
+            text: "Continue after revert",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-04-01T02:00:00.000Z",
+            updatedAt: "2026-04-01T02:00:00.000Z",
+          },
+        ],
+      };
+
+      const result = applyThreadDetailEvent(threadWithPendingMessage, {
+        ...baseEventFields,
+        sequence: 14,
+        occurredAt: "2026-04-01T02:00:01.000Z",
+        aggregateKind: "thread",
+        aggregateId: ThreadId.make("thread-1"),
+        type: "thread.reverted",
+        payload: {
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          preservedMessageIds: [pendingMessageId],
+        },
+      });
+
+      expect(result.kind).toBe("updated");
+      if (result.kind === "updated") {
+        expect(result.thread.messages.map((message) => message.id)).toEqual([pendingMessageId]);
       }
     });
 

--- a/packages/client-runtime/src/state/threadReducer.ts
+++ b/packages/client-runtime/src/state/threadReducer.ts
@@ -16,6 +16,7 @@ import type {
 import { threadPullRequestKeysEqual } from "@t3tools/shared/threadPullRequests";
 import { isImportedAgentSessionMessageId } from "@t3tools/contracts";
 import { compareDateTimeStrings } from "@t3tools/shared/dateTime";
+import * as Predicate from "effect/Predicate";
 
 export type ThreadDetailReducerResult =
   | { readonly kind: "updated"; readonly thread: OrchestrationThread }
@@ -70,6 +71,28 @@ const activityIdIndex = new WeakMap<
   ReadonlyArray<OrchestrationThreadActivity>,
   Set<OrchestrationThreadActivity["id"]>
 >();
+
+function turnStartRequestIdClearedByActivity(activity: OrchestrationThreadActivity): string | null {
+  if (
+    (activity.kind !== "context-compaction" &&
+      activity.kind !== "provider.turn.start.failed" &&
+      activity.kind !== "provider.auth.signed-out") ||
+    !Predicate.isObject(activity.payload)
+  ) {
+    return null;
+  }
+  return typeof activity.payload.requestId === "string" ? activity.payload.requestId : null;
+}
+
+function activityClearsPendingTurnStart(
+  thread: OrchestrationThread,
+  activity: OrchestrationThreadActivity,
+): boolean {
+  return (
+    thread.pendingTurnStartMessageId != null &&
+    turnStartRequestIdClearedByActivity(activity) === thread.pendingTurnStartMessageId
+  );
+}
 
 /**
  * Matches the validity rule in `deriveLatestContextWindowSnapshot` (and the
@@ -250,7 +273,43 @@ export function applyThreadDetailEvent(
       };
 
     // ── Thread metadata ─────────────────────────────────────────────
-    case "thread.meta-updated":
+    case "thread.meta-updated": {
+      const acknowledgement = event.payload.turnStartAcknowledged;
+      const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
+      const acknowledgedRequest =
+        acknowledgement === undefined
+          ? undefined
+          : rendezvous?.requests.find((request) => request.messageId === acknowledgement.messageId);
+      const acknowledgedTurnAlreadyRunning =
+        acknowledgement !== undefined &&
+        thread.session?.status === "running" &&
+        thread.session.activeTurnId === acknowledgement.turnId;
+      const acknowledgedTurnAlreadyObserved =
+        acknowledgement !== undefined &&
+        (acknowledgedRequest?.observedTurnIds ?? []).includes(acknowledgement.turnId);
+      // A provider can finish a turn before its start acknowledgement
+      // lands; the settled turn can never consume the submission.
+      const acknowledgedTurnAlreadySettled =
+        acknowledgement !== undefined &&
+        thread.latestTurn !== null &&
+        thread.latestTurn.turnId === acknowledgement.turnId &&
+        thread.latestTurn.state !== "running";
+      // A stopped or interrupted session can never surface the acknowledged
+      // turn, so the submission is resolved rather than recorded.
+      const acknowledgedSessionDead =
+        acknowledgement !== undefined &&
+        (thread.session?.status === "stopped" || thread.session?.status === "interrupted");
+      const acknowledgementAlreadyAdopted =
+        acknowledgedTurnAlreadyRunning ||
+        acknowledgedTurnAlreadyObserved ||
+        acknowledgedTurnAlreadySettled ||
+        acknowledgedSessionDead;
+      const remainingRequests =
+        acknowledgement === undefined
+          ? (rendezvous?.requests ?? [])
+          : (rendezvous?.requests ?? []).filter(
+              (request) => request.messageId !== acknowledgement.messageId,
+            );
       return {
         kind: "updated",
         thread: {
@@ -275,9 +334,35 @@ export function applyThreadDetailEvent(
           ...(event.payload.activeOrderKey !== undefined
             ? { activeOrderKey: event.payload.activeOrderKey }
             : {}),
+          ...(acknowledgement !== undefined
+            ? {
+                pendingTurnStartMessageId:
+                  acknowledgement.messageId === thread.pendingTurnStartMessageId &&
+                  acknowledgementAlreadyAdopted
+                    ? null
+                    : (thread.pendingTurnStartMessageId ?? null),
+                submittedTurnStarts: acknowledgementAlreadyAdopted
+                  ? (thread.submittedTurnStarts ?? []).filter(
+                      (entry) => entry.turnId !== acknowledgement.turnId,
+                    )
+                  : [
+                      ...(thread.submittedTurnStarts ?? []).filter(
+                        (entry) => entry.messageId !== acknowledgement.messageId,
+                      ),
+                      acknowledgement,
+                    ],
+                turnStartSubmissionRendezvous:
+                  remainingRequests.length === 0
+                    ? null
+                    : {
+                        requests: remainingRequests,
+                      },
+              }
+            : {}),
           updatedAt: event.payload.updatedAt,
         },
       };
+    }
 
     case "thread.pull-request-linked": {
       const link = event.payload.link;
@@ -334,7 +419,9 @@ export function applyThreadDetailEvent(
       };
 
     // ── Turn lifecycle ──────────────────────────────────────────────
-    case "thread.turn-start-requested":
+    case "thread.turn-start-requested": {
+      const activeTurnId =
+        thread.session?.status === "running" ? thread.session.activeTurnId : null;
       return {
         kind: "updated",
         thread: {
@@ -344,9 +431,26 @@ export function applyThreadDetailEvent(
             : {}),
           runtimeMode: event.payload.runtimeMode,
           interactionMode: event.payload.interactionMode,
+          pendingTurnStartMessageId: event.payload.messageId,
+          ...(event.payload.expectsTurnStartAcknowledgement === true
+            ? {
+                turnStartSubmissionRendezvous: {
+                  requests: [
+                    ...(thread.turnStartSubmissionRendezvous?.requests ?? []).filter(
+                      (request) => request.messageId !== event.payload.messageId,
+                    ),
+                    {
+                      messageId: event.payload.messageId,
+                      observedTurnIds: activeTurnId === null ? [] : [activeTurnId],
+                    },
+                  ],
+                },
+              }
+            : {}),
           updatedAt: event.occurredAt,
         },
       };
+    }
 
     case "thread.turn-interrupt-requested": {
       if (event.payload.turnId === undefined) {
@@ -477,6 +581,9 @@ export function applyThreadDetailEvent(
       // Leaving the "running" session status is the turn-end signal: settle a
       // still-running latest turn so its duration reflects the whole turn.
       const settledTurnState = settledTurnStateForSessionStatus(event.payload.session.status);
+      const activeTurnId =
+        event.payload.session.status === "running" ? event.payload.session.activeTurnId : null;
+      const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
       const latestTurn = reuseLatestTurn(
         thread.latestTurn,
         event.payload.session.status === "running" && event.payload.session.activeTurnId !== null
@@ -516,6 +623,33 @@ export function applyThreadDetailEvent(
         thread: {
           ...thread,
           session: event.payload.session,
+          pendingTurnStartMessageId:
+            event.payload.session.status === "running" &&
+            event.payload.session.activeTurnId !== null
+              ? null
+              : (thread.pendingTurnStartMessageId ?? null),
+          submittedTurnStarts:
+            activeTurnId !== null
+              ? (thread.submittedTurnStarts ?? []).filter((entry) => entry.turnId !== activeTurnId)
+              : // Acknowledged starts die with their session; an idle or
+                // errored session may still pick them up, since a per-request
+                // failure does not prove the session is gone.
+                event.payload.session.status === "interrupted" ||
+                  event.payload.session.status === "stopped"
+                ? []
+                : (thread.submittedTurnStarts ?? []),
+          turnStartSubmissionRendezvous:
+            activeTurnId === null || rendezvous === null || rendezvous.requests.length === 0
+              ? rendezvous
+              : {
+                  requests: rendezvous.requests.map((request) => ({
+                    ...request,
+                    observedTurnIds: [
+                      ...request.observedTurnIds.filter((turnId) => turnId !== activeTurnId),
+                      activeTurnId,
+                    ],
+                  })),
+                },
           latestTurn,
           updatedAt: event.occurredAt,
         },
@@ -604,7 +738,17 @@ export function applyThreadDetailEvent(
 
       return {
         kind: "updated",
-        thread: { ...thread, checkpoints, latestTurn, updatedAt: event.occurredAt },
+        thread: {
+          ...thread,
+          checkpoints,
+          submittedTurnStarts: diffTurnStillRunning
+            ? (thread.submittedTurnStarts ?? [])
+            : (thread.submittedTurnStarts ?? []).filter(
+                (entry) => entry.turnId !== event.payload.turnId,
+              ),
+          latestTurn,
+          updatedAt: event.occurredAt,
+        },
       };
     }
 
@@ -625,6 +769,7 @@ export function applyThreadDetailEvent(
         thread.messages,
         retainedTurnIds,
         event.payload.turnCount,
+        new Set(event.payload.preservedMessageIds ?? []),
       );
       const proposedPlans = pipe(
         thread.proposedPlans,
@@ -674,6 +819,29 @@ export function applyThreadDetailEvent(
       // thread.reverted that discards turns can still resolve a value from
       // the turns that survive.
       const supersedesContextWindow = isResolvableContextWindowActivity(activity);
+      const pendingTurnStartMessageId = activityClearsPendingTurnStart(thread, activity)
+        ? null
+        : (thread.pendingTurnStartMessageId ?? null);
+      const clearedRequestId = turnStartRequestIdClearedByActivity(activity);
+      const submittedTurnStarts =
+        clearedRequestId === null
+          ? (thread.submittedTurnStarts ?? [])
+          : (thread.submittedTurnStarts ?? []).filter(
+              (entry) => entry.messageId !== clearedRequestId,
+            );
+      const rendezvous = thread.turnStartSubmissionRendezvous ?? null;
+      const remainingRequests =
+        clearedRequestId === null
+          ? (rendezvous?.requests ?? [])
+          : (rendezvous?.requests ?? []).filter(
+              (request) => request.messageId !== clearedRequestId,
+            );
+      const turnStartSubmissionRendezvous =
+        rendezvous === null
+          ? null
+          : remainingRequests.length === 0
+            ? null
+            : { requests: remainingRequests };
       // Live streams append in order: an unseen id sorting at/after the tail
       // of a known-sorted array appends without re-filtering and re-sorting
       // the whole history on every event. The id set moves forward to the new
@@ -695,6 +863,9 @@ export function applyThreadDetailEvent(
           thread: {
             ...thread,
             activities,
+            pendingTurnStartMessageId,
+            submittedTurnStarts,
+            turnStartSubmissionRendezvous,
             updatedAt: event.occurredAt,
           },
         };
@@ -717,7 +888,14 @@ export function applyThreadDetailEvent(
 
       return {
         kind: "updated",
-        thread: { ...thread, activities, updatedAt: event.occurredAt },
+        thread: {
+          ...thread,
+          activities,
+          pendingTurnStartMessageId,
+          submittedTurnStarts,
+          turnStartSubmissionRendezvous,
+          updatedAt: event.occurredAt,
+        },
       };
     }
 
@@ -819,8 +997,9 @@ function retainMessagesAfterRevert(
   messages: ReadonlyArray<OrchestrationMessage>,
   retainedTurnIds: ReadonlySet<string>,
   turnCount: number,
+  preservedMessageIds: ReadonlySet<string>,
 ): OrchestrationMessage[] {
-  const retainedMessageIds = new Set<string>();
+  const retainedMessageIds = new Set(preservedMessageIds);
   for (const message of messages) {
     if (message.role === "system" || isImportedAgentSessionMessageId(message.id)) {
       retainedMessageIds.add(message.id);
@@ -830,11 +1009,14 @@ function retainMessagesAfterRevert(
   }
 
   for (const role of ["user", "assistant"] as const) {
+    // Queued messages preserved across the revert are not part of the retained
+    // turn history, so they must not consume the historical-message quota below.
     const retainedCount = messages.filter(
       (message) =>
         message.role === role &&
         !isImportedAgentSessionMessageId(message.id) &&
-        retainedMessageIds.has(message.id),
+        retainedMessageIds.has(message.id) &&
+        !preservedMessageIds.has(message.id),
     ).length;
     const missingCount = Math.max(0, turnCount - retainedCount);
     const fallbackMessages = messages

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -1249,7 +1249,20 @@ it.effect(
       assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
       assert.strictEqual(parsed.interactionMode, DEFAULT_PROVIDER_INTERACTION_MODE);
       assert.strictEqual(parsed.sourceProposedPlan, undefined);
+      assert.strictEqual(parsed.expectsTurnStartAcknowledgement, undefined);
     }),
+);
+
+it.effect("decodes correlated thread.turn-start-requested acknowledgement metadata", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartRequestedPayload({
+      threadId: "thread-1",
+      messageId: "msg-1",
+      expectsTurnStartAcknowledgement: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(parsed.expectsTurnStartAcknowledgement, true);
+  }),
 );
 
 it.effect("decodes thread.turn-start-requested source proposed plan metadata when present", () =>

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -747,6 +747,42 @@ export const OrchestrationThread = Schema.Struct({
   activeOrderKey: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   // Pending-only state. Optional so older servers remain compatible.
   titleRegeneration: Schema.optional(Schema.NullOr(ThreadTitleRegeneration)),
+  // The accepted user message waiting for a provider turn to adopt it. Kept
+  // explicitly so command admission and revert completion never infer queue
+  // order from clocks on remote clients.
+  pendingTurnStartMessageId: Schema.optional(Schema.NullOr(MessageId)),
+  // Provider-accepted starts that have not yet been matched to a running
+  // lifecycle event. Revert admission keeps these starts quiescent even when
+  // overlapping session events clear the single UI-facing pending identity.
+  submittedTurnStarts: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        messageId: MessageId,
+        turnId: TurnId,
+      }),
+    ),
+  ),
+  // Request-scoped rendezvous for provider lifecycles that can race their
+  // durable submission acknowledgement. Legacy event history never enrolls,
+  // so replay cannot accumulate old turn ids in this pending-only state.
+  turnStartSubmissionRendezvous: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        requests: Schema.Array(
+          Schema.Struct({
+            messageId: MessageId,
+            observedTurnIds: Schema.Array(TurnId),
+          }),
+        ),
+      }),
+    ),
+  ),
+  // User messages accepted after a checkpoint revert begins. The server uses
+  // this pending-only list to preserve every queued start when the revert lands.
+  pendingCheckpointRevertMessageIds: Schema.optional(Schema.NullOr(Schema.Array(MessageId))),
+  // Number of checkpoint reverts still in flight for this thread. Consecutive
+  // requests share the preservation list until their final completion lands.
+  pendingCheckpointRevertCount: Schema.optional(Schema.NullOr(NonNegativeInt)),
   deletedAt: Schema.NullOr(IsoDateTime),
   messages: Schema.Array(OrchestrationMessage),
   proposedPlans: Schema.Array(OrchestrationProposedPlan).pipe(
@@ -1457,6 +1493,15 @@ const ThreadRevertCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadTurnStartAcknowledgeCommand = Schema.Struct({
+  type: Schema.Literal("thread.turn.start.acknowledge"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnId: TurnId,
+  sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+});
+
 const ThreadTitleRegenerationCompleteCommand = Schema.Struct({
   type: Schema.Literal("thread.title.regeneration.complete"),
   commandId: CommandId,
@@ -1503,6 +1548,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadTurnDiffCompleteCommand,
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
+  ThreadTurnStartAcknowledgeCommand,
   ThreadTitleRegenerationCompleteCommand,
   ThreadPullRequestSyncCommand,
   ThreadPullRequestLinkSyncCommand,
@@ -1681,6 +1727,14 @@ export const ThreadMetaUpdatedPayload = Schema.Struct({
   previousTitle: Schema.optional(TrimmedNonEmptyString),
   /** Pending state shared with clients. Null clears a matching request. */
   titleRegeneration: Schema.optional(Schema.NullOr(ThreadTitleRegeneration)),
+  /** Successful provider submission correlated to both the accepted message and provider turn.
+      Carried on the existing metadata event for compatibility with older clients. */
+  turnStartAcknowledged: Schema.optional(
+    Schema.Struct({
+      messageId: MessageId,
+      turnId: TurnId,
+    }),
+  ),
   modelSelection: Schema.optional(ModelSelection),
   branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   worktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
@@ -1744,6 +1798,9 @@ export const ThreadMessageSentPayload = Schema.Struct({
 export const ThreadTurnStartRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
+  // Optional for event compatibility. New starts opt into the correlated
+  // acknowledgement rendezvous; historical starts replay without it.
+  expectsTurnStartAcknowledgement: Schema.optional(Schema.Literal(true)),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
@@ -1785,6 +1842,7 @@ export const ThreadCheckpointRevertRequestedPayload = Schema.Struct({
 export const ThreadRevertedPayload = Schema.Struct({
   threadId: ThreadId,
   turnCount: NonNegativeInt,
+  preservedMessageIds: Schema.optional(Schema.Array(MessageId)),
 });
 
 export const ThreadSessionStopRequestedPayload = Schema.Struct({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -170,7 +170,7 @@ export default defineConfig({
       // Legacy manual Effect runners tracked as debt: no net-new occurrences.
       // Lower a ceiling when you migrate a file, and delete its entry at zero.
       ...Object.entries({
-        "apps/server/src/orchestration/Layers/CheckpointReactor.test.ts": 42,
+        "apps/server/src/orchestration/Layers/CheckpointReactor.test.ts": 39,
         "apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts": 5,
         "apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts": 4,
         "apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts": 66,


### PR DESCRIPTION
Latest head `118cdf618b` is rebased on current upstream `main` (`b1e223e2b0`), preserving this fix through the upstream rewind changes (#11338, #11358). All 424 focused tests pass; server, client-runtime, and contracts typechecks pass; scoped lint and format are clean.

## What Changed

Checkpoint restore now changes only paths owned by the selected checkpoints instead of broadly cleaning the worktree. Capture, restore, and provider-start work are serialized so a restore cannot race a later turn into the filesystem or provider history.

The same checkpoint boundary preserves every accepted queued message through concurrent and failed reverts. Pending and provider-submitted starts carry durable message/turn correlation through projection rebuilds, restart, steering, acknowledgement/runtime reordering, stale unrelated session events, and skewed client timestamps. Revert now deletes only concrete turns beyond its checkpoint boundary, leaving queued placeholder identities and their accepted order intact. A request-scoped rendezvous handles the narrow case where a provider lifecycle completes before its durable start acknowledgement; legacy event replay does not enroll or accumulate historical turns.

Provider-accepted starts now keep retrying their durable acknowledgement without sending the prompt again. Startup cleanup attempts every submitted entry even if one correlated failure activity cannot be persisted. If any entry fails, it keeps the session nonterminal so that entry remains retryable on the next restart; successfully persisted entries still clear independently. When cleanup succeeds, restart persists each correlated failure before making the session terminal, and server/client projections clear only that submitted identity.

This is one dependent checkpoint/revert correctness boundary despite the 38-file diff. The original scoped Git fix exposed loss windows in the event, SQL projection, reactor, startup reconciliation, and client read-model paths; splitting those layers would knowingly leave accepted work deletable, reorderable, or replayable between PRs. The independent restart snapshot query remains split into stacked PR #10611.

## Why

The Linux core nightly reproduced R08 deleting `unrelated.txt`, a user file outside the agent checkpoint. Focused red tests then reproduced checkpoint capture racing index restore, queued messages disappearing or changing order during revert, provider starts replaying after restart, stale terminal events clearing newer work, failed-turn files surviving restore, startup snapshot/subscription gaps, acknowledgement/runtime races permanently blocking later settle or revert commands, acknowledgement dispatch failing twice after one successful provider send, one failed startup cleanup preventing later submitted starts from clearing, and an acknowledged orphan remaining submitted after its session became terminal.

The repaired model quiesces checkpoint work before later provider starts, scopes Git restore to checkpoint-owned paths, and keeps request correlation state until the matching lifecycle or failure resolves it.

## Rebase follow-up

At `118cdf618b` the rebase preserved the fix through upstream's rewind feature (`restoreFiles === false`, `rollbackConversation`) and upstream migration numbering (this PR's correlation migration moved to `052`). Six read-only Codex/Sol high review rounds on the evolving head surfaced and fixed: a scoped-restore arg drop, `/compact`-queued starts losing durable rows, orphaned submitted rows after dead sessions and settle-time acknowledgement, failed-send cleanup deleting unrelated accepted starts, late-acknowledged source plans staying actionable, preserved queued messages inflating the historical retention quota, nested-workspace cwd removal before `git reset`, non-live non-orphan threads skipping startup sweep, and a missing source-checkpoint fallback to target-only restore.

Known limitation: adapters whose `sendTurn` resolves only at prompt completion (Cursor, Antigravity) acknowledge at completion rather than at acceptance; the turn.started-to-acknowledgement window keeps upstream's pre-existing behavior for those providers. Closing it needs an adapter-level admission receipt and is a per-adapter contract decision.

## Verification at `118cdf618b`

- 424/424 focused tests pass across 13 files covering Git checkpoint restore, checkpoint/provider reactors, projection pipeline and replay, startup reconciliation, settle/revert admission, server/client projectors, decider, snapshot query, imports, and contracts. The submission-rendezvous regression exhausts all 66 causally valid request A/B, acknowledgement A/B, running, and terminal orderings.
- Scoped lint exits 0 (pre-existing unused-parameter warnings only); formatting clean; server, `@t3tools/client-runtime`, and `@t3tools/contracts` typechecks exit 0.
- Independent review: six read-only Codex gpt-5.6-sol high rounds (`codex exec -s read-only --ephemeral`) on the evolving head; all actionable findings verified against source and fixed except the known limitation above. Round 6's remaining finding is that limitation.

## Earlier verification

At prior head `92801988d` rebased on `7220dfe2c949476eaa7d21eccbcd3a0ce0eddb49`, 377/377 focused tests passed and a read-only Codex/Sol review found no actionable issues on that head.

The retained integration package at product head `0fcaff9445b5ca4ccaf4bef255419ec44e6f532d` passed the production Linux core suite 16/16 with harness head `f9c916b1d596375eaee1669b49cbaa861da1b582` and image digest `sha256:9510753c8e09ead6321ac91c71d13dbbf1163ebe4de909f9eb0786d3a9cd2e41`. This is intermediate product evidence—not proof for this PR head. The final exact-head multi-PR integration package, desktop artifact, and complete production receipt are missing, so this PR remains a draft.

This is a nonvisual filesystem/event-ordering repair. Screenshots and interaction video would not demonstrate the authoritative Git, persistence, or receipt boundaries and are not included.

## Checklist

- [ ] This PR is small and focused — it is one concern, but the required cross-layer invariant is large; see the dependency explanation above
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable to this nonvisual change
- [x] Interaction video is not applicable to this nonvisual change

Coordination trace: T3 thread 7ad33008-15c5-4aa9-829b-bb38e2fba8d7

Updated with SWE-2 in the Devin harness; independent review by Codex gpt-5.6-sol. Earlier work used GPT-6 in the Codex/T3 harness.
