### PR TITLE
fix(web): restore pr list diff counts to the top right

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon } from "lucide-react";
+import { SearchIcon, UserCheckIcon } from "lucide-react";
 import { PullRequestStackPopover } from "./PullRequestStackPopover";
 import { memo, type RefCallback } from "react";
 
@@ -197,16 +197,20 @@ function PullRequestRowImpl({
           {entry.labels.length > 0 ? <PullRequestRowLabels labels={entry.labels} /> : null}
           {/* Only a verdict somebody has actually given: "review required" is the absence of
               one, and saying so on every unreviewed row would say nothing. */}
-          {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (
-            <span
-              className={cn(
-                "min-w-0 truncate",
-                entry.reviewDecision === "approved"
-                  ? "text-emerald-600/90 dark:text-emerald-400/80"
-                  : "text-amber-600/90 dark:text-amber-400/80",
-              )}
-            >
-              {entry.reviewDecision === "approved" ? "Approved" : "Changes requested"}
+          {entry.reviewDecision === "approved" ? (
+            <Tooltip>
+              <TooltipTrigger render={<span className="inline-flex shrink-0" />}>
+                <UserCheckIcon
+                  aria-hidden
+                  className="size-3.5 text-emerald-600/90 dark:text-emerald-400/80"
+                />
+                <span className="sr-only">Approved</span>
+              </TooltipTrigger>
+              <TooltipPopup>Approved</TooltipPopup>
+            </Tooltip>
+          ) : entry.reviewDecision === "changes-requested" ? (
+            <span className="min-w-0 truncate text-amber-600/90 dark:text-amber-400/80">
+              Changes requested
             </span>
           ) : null}
           {entry.checksState === undefined ? null : (

--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -121,7 +121,7 @@ function PullRequestRowImpl({
         <span className="col-start-1 row-start-1 block truncate text-sm font-medium text-foreground">
           {entry.title}
         </span>
-        <span className="col-start-2 row-start-1 flex max-w-36 items-center justify-self-end gap-2 text-xs">
+        <span className="col-start-2 row-start-1 flex items-center justify-self-end gap-2 text-xs">
           {entry.stack ? (
             <PullRequestStackPopover
               environmentId={entry.environmentId}
@@ -137,31 +137,11 @@ function PullRequestRowImpl({
               }
             />
           ) : null}
-          {/* Only a verdict somebody has actually given: "review required" is the absence of
-              one, and saying so on every unreviewed row would say nothing. */}
-          {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (
-            <span
-              className={cn(
-                "sr-only @md/pr-row:not-sr-only @md/pr-row:min-w-0 @md/pr-row:truncate",
-                entry.reviewDecision === "approved"
-                  ? "text-emerald-600/90 dark:text-emerald-400/80"
-                  : "text-amber-600/90 dark:text-amber-400/80",
-              )}
-            >
-              {entry.reviewDecision === "approved" ? "Approved" : "Changes requested"}
-            </span>
-          ) : null}
-          {entry.checksState === undefined ? null : (
-            <PullRequestChecksPopover
-              checksState={entry.checksState}
-              environmentId={entry.environmentId}
-              reference={{
-                projectId: entry.projectId,
-                repository: entry.repository,
-                number: entry.number,
-              }}
-            />
-          )}
+          <PullRequestDiffStat
+            additions={entry.additions}
+            deletions={entry.deletions}
+            className="shrink-0 whitespace-nowrap text-[11px]"
+          />
         </span>
         <PullRequestMetaLine className="@container/pr-row-meta col-start-1 row-start-2 overflow-hidden text-xs text-muted-foreground/70">
           {matchedElsewhere ? (
@@ -215,9 +195,33 @@ function PullRequestRowImpl({
             labelClassName="sr-only @xs/pr-row-meta:not-sr-only @xs/pr-row-meta:truncate"
           />
           {entry.labels.length > 0 ? <PullRequestRowLabels labels={entry.labels} /> : null}
+          {/* Only a verdict somebody has actually given: "review required" is the absence of
+              one, and saying so on every unreviewed row would say nothing. */}
+          {entry.reviewDecision === "approved" || entry.reviewDecision === "changes-requested" ? (
+            <span
+              className={cn(
+                "min-w-0 truncate",
+                entry.reviewDecision === "approved"
+                  ? "text-emerald-600/90 dark:text-emerald-400/80"
+                  : "text-amber-600/90 dark:text-amber-400/80",
+              )}
+            >
+              {entry.reviewDecision === "approved" ? "Approved" : "Changes requested"}
+            </span>
+          ) : null}
+          {entry.checksState === undefined ? null : (
+            <PullRequestChecksPopover
+              checksState={entry.checksState}
+              environmentId={entry.environmentId}
+              reference={{
+                projectId: entry.projectId,
+                repository: entry.repository,
+                number: entry.number,
+              }}
+            />
+          )}
         </PullRequestMetaLine>
         <span className="col-start-2 row-start-2 flex items-center justify-self-end gap-3 whitespace-nowrap text-[11px] text-muted-foreground/70 tabular-nums">
-          <PullRequestDiffStat additions={entry.additions} deletions={entry.deletions} />
           <span className="hidden @sm/pr-row:inline">
             {formatRelativeTimeLabel(entry.updatedAt)}
           </span>


### PR DESCRIPTION
Restores PR diff counts to the top right and review/CI status after the labels. Approved reviews use a person-check icon with an Approved tooltip; the existing CI popover and main's stack control retain their actions.

Rebased onto main. Eight existing checks/stack tests, scoped lint/formatting and web typecheck passed. Verified the actual GitHub list in dark/wide and light/narrow layouts, plus populated CI results.

![before: approved text after labels](https://uploads-production-47e4.up.railway.app/files/0394928a-1685-4fdc-a881-e95a729ef2cf/pr-review-icon-before.png)

![after: human-check icon after labels](https://uploads-production-47e4.up.railway.app/files/8881d806-a24d-48a1-a0ff-8db4e56029b9/pr-review-icon-after.png)

Implemented with `gpt-6` in Codex.
