### PR TITLE
fix(server): refresh provider session activity on turn lifecycle

### DIFF
--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -59,6 +59,12 @@ export type GetProviderSessionRuntimeInput = typeof GetProviderSessionRuntimeInp
 export const DeleteProviderSessionRuntimeInput = Schema.Struct({ threadId: ThreadId });
 export type DeleteProviderSessionRuntimeInput = typeof DeleteProviderSessionRuntimeInput.Type;
 
+export const TouchProviderSessionRuntimeInput = Schema.Struct({
+  threadId: ThreadId,
+  lastSeenAt: IsoDateTime,
+});
+export type TouchProviderSessionRuntimeInput = typeof TouchProviderSessionRuntimeInput.Type;
+
 export const RecordImportedTranscriptInput = Schema.Struct({
   threadId: ThreadId,
   source: AgentSessionImportSource,
@@ -84,6 +90,15 @@ export class ProviderSessionRuntimeRepository extends Context.Service<
     readonly upsert: (
       runtime: ProviderSessionRuntime,
       options?: ProviderSessionRuntimeUpsertOptions,
+    ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
+
+    /**
+     * Update only `last_seen_at` for an existing runtime row.
+     *
+     * No-op when no row exists for the thread; never creates a row.
+     */
+    readonly touchByThreadId: (
+      input: TouchProviderSessionRuntimeInput,
     ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
 
     /** Record one source file without replacing the current session state. */
@@ -267,6 +282,16 @@ export const make = Effect.gen(function* () {
       `,
   });
 
+  const touchRuntimeRow = SqlSchema.void({
+    Request: TouchProviderSessionRuntimeInput,
+    execute: ({ threadId, lastSeenAt }) =>
+      sql`
+        UPDATE provider_session_runtime
+        SET last_seen_at = ${lastSeenAt}
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
   const recordImportedTranscriptRow = SqlSchema.void({
     Request: RecordImportedTranscriptRequestSchema,
     execute: ({ threadId, source }) =>
@@ -374,6 +399,17 @@ export const make = Effect.gen(function* () {
       ),
     );
 
+  const touchByThreadId: ProviderSessionRuntimeRepository["Service"]["touchByThreadId"] = (input) =>
+    touchRuntimeRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProviderSessionRuntimeRepository.touchByThreadId:query",
+          "ProviderSessionRuntimeRepository.touchByThreadId:encodeRequest",
+          { threadId: input.threadId },
+        ),
+      ),
+    );
+
   const recordImportedTranscript: ProviderSessionRuntimeRepository["Service"]["recordImportedTranscript"] =
     (input) =>
       recordImportedTranscriptRow(input).pipe(
@@ -464,6 +500,7 @@ export const make = Effect.gen(function* () {
 
   return {
     upsert,
+    touchByThreadId,
     recordImportedTranscript,
     getByThreadId,
     list,

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.activity.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.activity.test.ts
@@ -1,0 +1,222 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import {
+  EventId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type OrchestrationThreadShell,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
+
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
+import { ProviderSessionReaper } from "../Services/ProviderSessionReaper.ts";
+import { ProviderService } from "../Services/ProviderService.ts";
+import { ProviderSessionDirectoryLive } from "./ProviderSessionDirectory.ts";
+import { makeProviderSessionReaperLive } from "./ProviderSessionReaper.ts";
+
+const drainFibers = Effect.forEach(Array.from({ length: 10 }), () => Effect.yieldNow, {
+  discard: true,
+});
+
+const defaultModelSelection = {
+  instanceId: ProviderInstanceId.make("claudeAgent"),
+  model: "claude-opus-5",
+} as const;
+
+function completedThreadShell(input: {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId;
+  readonly completedAt: string;
+}): OrchestrationThreadShell {
+  return {
+    id: input.threadId,
+    projectId: ProjectId.make("project-provider-session-reaper-activity"),
+    title: "Provider session reaper activity",
+    modelSelection: defaultModelSelection,
+    interactionMode: "default",
+    runtimeMode: "full-access",
+    branch: null,
+    worktreePath: null,
+    createdAt: input.completedAt,
+    updatedAt: input.completedAt,
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    latestTurn: {
+      turnId: input.turnId,
+      state: "completed",
+      requestedAt: input.completedAt,
+      startedAt: input.completedAt,
+      completedAt: input.completedAt,
+      assistantMessageId: null,
+    },
+    session: {
+      threadId: input.threadId,
+      status: "ready",
+      providerName: "claudeAgent",
+      runtimeMode: "full-access",
+      activeTurnId: null,
+      lastError: null,
+      updatedAt: input.completedAt,
+    },
+    backgroundLiveness: null,
+  };
+}
+
+describe("ProviderSessionReaper turn activity", () => {
+  it.effect("refreshes lastSeenAt when a provider turn completes", () =>
+    Effect.gen(function* () {
+      const runtimeEvents = yield* Queue.unbounded<ProviderRuntimeEvent>();
+      const threadId = ThreadId.make("thread-reaper-turn-activity");
+      const turnId = TurnId.make("turn-reaper-turn-activity");
+      const initialLastSeenAt = "2026-01-01T00:00:00.000Z";
+
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const providerSessionDirectoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = makeProviderSessionReaperLive({
+        inactivityThresholdMs: Number.MAX_SAFE_INTEGER,
+        sweepIntervalMs: 60_000,
+      }).pipe(
+        Layer.provideMerge(providerSessionDirectoryLayer),
+        Layer.provideMerge(runtimeRepositoryLayer),
+        Layer.provideMerge(
+          Layer.mock(ProviderService)({
+            stopSession: () => Effect.void,
+            streamEvents: Stream.fromQueue(runtimeEvents),
+          }),
+        ),
+        Layer.provideMerge(
+          Layer.mock(ProjectionSnapshotQuery)({
+            getThreadShellById: () => Effect.succeed(Option.none()),
+          }),
+        ),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      yield* Effect.gen(function* () {
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        const reaper = yield* ProviderSessionReaper;
+
+        yield* repository.upsert({
+          threadId,
+          providerName: "claudeAgent",
+          providerInstanceId: null,
+          adapterKey: "claudeAgent",
+          runtimeMode: "full-access",
+          status: "running",
+          lastSeenAt: initialLastSeenAt,
+          resumeCursor: { opaque: "resume-turn-activity" },
+          runtimePayload: { marker: "preserve-me" },
+        });
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* reaper.start();
+            yield* Queue.offer(runtimeEvents, {
+              type: "turn.completed",
+              eventId: EventId.make("evt-reaper-turn-completed"),
+              provider: ProviderDriverKind.make("claudeAgent"),
+              threadId,
+              turnId,
+              createdAt: "2026-09-08T00:00:00.000Z",
+              payload: { state: "completed" },
+            });
+            yield* drainFibers;
+
+            const binding = yield* repository.getByThreadId({ threadId });
+            expect(Option.isSome(binding)).toBe(true);
+            if (Option.isNone(binding)) return;
+
+            expect(Date.parse(binding.value.lastSeenAt)).toBeGreaterThan(
+              Date.parse(initialLastSeenAt),
+            );
+            expect(binding.value.runtimePayload).toEqual({ marker: "preserve-me" });
+            expect(binding.value.resumeCursor).toEqual({ opaque: "resume-turn-activity" });
+            expect(binding.value.status).toBe("running");
+          }),
+        );
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("does not reap after projection records a fresh turn completion before the touch lands", () =>
+    Effect.gen(function* () {
+      const runtimeEvents = yield* Queue.unbounded<ProviderRuntimeEvent>();
+      const threadId = ThreadId.make("thread-reaper-completion-race");
+      const turnId = TurnId.make("turn-reaper-completion-race");
+      const completedAt = DateTime.formatIso(yield* DateTime.now);
+      const threadShell = completedThreadShell({ threadId, turnId, completedAt });
+      let stopCount = 0;
+
+      const runtimeRepositoryLayer = ProviderSessionRuntime.layer.pipe(
+        Layer.provide(SqlitePersistenceMemory),
+      );
+      const providerSessionDirectoryLayer = ProviderSessionDirectoryLive.pipe(
+        Layer.provide(runtimeRepositoryLayer),
+      );
+      const layer = makeProviderSessionReaperLive({
+        inactivityThresholdMs: 1_000,
+        sweepIntervalMs: 60_000,
+      }).pipe(
+        Layer.provideMerge(providerSessionDirectoryLayer),
+        Layer.provideMerge(runtimeRepositoryLayer),
+        Layer.provideMerge(
+          Layer.mock(ProviderService)({
+            stopSession: () => Effect.sync(() => void (stopCount += 1)),
+            streamEvents: Stream.fromQueue(runtimeEvents),
+          }),
+        ),
+        Layer.provideMerge(
+          Layer.mock(ProjectionSnapshotQuery)({
+            getThreadShellById: () => Effect.succeed(Option.some(threadShell)),
+          }),
+        ),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      yield* Effect.gen(function* () {
+        const repository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
+        const reaper = yield* ProviderSessionReaper;
+
+        yield* repository.upsert({
+          threadId,
+          providerName: "claudeAgent",
+          providerInstanceId: null,
+          adapterKey: "claudeAgent",
+          runtimeMode: "full-access",
+          status: "running",
+          lastSeenAt: "2026-01-01T00:00:00.000Z",
+          resumeCursor: { opaque: "resume-completion-race" },
+          runtimePayload: null,
+        });
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* reaper.start();
+            yield* drainFibers;
+            expect(stopCount).toBe(0);
+          }),
+        );
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,11 +1,15 @@
+import type { ProviderRuntimeEvent } from "@t3tools/contracts";
 import * as Clock from "effect/Clock";
+import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ProviderSessionRuntime from "../../persistence/ProviderSessionRuntime.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
   ProviderSessionReaper,
@@ -17,15 +21,28 @@ import { ProviderService } from "../Services/ProviderService.ts";
 const DEFAULT_INACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
 const DEFAULT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
+const TURN_ACTIVITY_EVENT_TYPES: ReadonlySet<ProviderRuntimeEvent["type"]> = new Set([
+  "turn.started",
+  "turn.completed",
+  "turn.aborted",
+]);
+
 export interface ProviderSessionReaperLiveOptions {
   readonly inactivityThresholdMs?: number;
   readonly sweepIntervalMs?: number;
 }
 
+const parseOptionalTimestamp = (value: string | null | undefined): number | undefined => {
+  if (value == null) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
 const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =>
   Effect.gen(function* () {
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
+    const runtimeRepository = yield* ProviderSessionRuntime.ProviderSessionRuntimeRepository;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
 
     const inactivityThresholdMs = Math.max(
@@ -33,6 +50,29 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
       options?.inactivityThresholdMs ?? DEFAULT_INACTIVITY_THRESHOLD_MS,
     );
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
+
+    const recordTurnActivity = (event: ProviderRuntimeEvent): Effect.Effect<void> => {
+      if (!TURN_ACTIVITY_EVENT_TYPES.has(event.type)) {
+        return Effect.void;
+      }
+
+      return DateTime.now.pipe(
+        Effect.map(DateTime.formatIso),
+        Effect.flatMap((lastSeenAt) =>
+          runtimeRepository.touchByThreadId({
+            threadId: event.threadId,
+            lastSeenAt,
+          }),
+        ),
+        Effect.catchCause((cause) =>
+          Effect.logWarning("provider.session.reaper.activity-touch-failed", {
+            threadId: event.threadId,
+            eventType: event.type,
+            cause,
+          }),
+        ),
+      );
+    };
 
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
@@ -54,8 +94,9 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           continue;
         }
 
-        const idleDurationMs = now - lastSeenMs;
-        if (idleDurationMs < inactivityThresholdMs) {
+        // Avoid the snapshot read for bindings that are fresh even before
+        // considering projected turn activity.
+        if (now - lastSeenMs < inactivityThresholdMs) {
           continue;
         }
 
@@ -66,8 +107,24 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           yield* Effect.logDebug("provider.session.reaper.skipped-active-turn", {
             threadId: binding.threadId,
             activeTurnId: thread.session.activeTurnId,
-            idleDurationMs,
+            idleDurationMs: now - lastSeenMs,
           });
+          continue;
+        }
+
+        // `turn.completed` can clear activeTurnId before the independent
+        // activity-touch fiber commits its timestamp update. Re-check the
+        // authoritative projected turn timestamps before stopping so that
+        // race cannot reap a session immediately after work finishes.
+        const projectedTurnActivityMs = [
+          parseOptionalTimestamp(thread?.latestTurn?.startedAt),
+          parseOptionalTimestamp(thread?.latestTurn?.completedAt),
+        ].reduce(
+          (latest, timestamp) => (timestamp === undefined ? latest : Math.max(latest, timestamp)),
+          lastSeenMs,
+        );
+        const idleDurationMs = now - projectedTurnActivityMs;
+        if (idleDurationMs < inactivityThresholdMs) {
           continue;
         }
 
@@ -119,6 +176,12 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 
     const start: ProviderSessionReaperShape["start"] = () =>
       Effect.gen(function* () {
+        // `lastSeenAt` is otherwise updated only by explicit session/turn
+        // commands. A foreground turn may run longer than the inactivity
+        // threshold, so refresh the binding at provider turn boundaries. This
+        // gives the session a full idle window after the turn actually ends.
+        yield* forkParked(Stream.runForEach(providerService.streamEvents, recordTurnActivity));
+
         yield* forkParked(
           sweep.pipe(
             Effect.catch((error: unknown) =>
@@ -149,4 +212,6 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
 export const makeProviderSessionReaperLive = (options?: ProviderSessionReaperLiveOptions) =>
   Layer.effect(ProviderSessionReaper, makeProviderSessionReaper(options));
 
-export const ProviderSessionReaperLive = makeProviderSessionReaperLive();
+export const ProviderSessionReaperLive = makeProviderSessionReaperLive().pipe(
+  Layer.provide(ProviderSessionRuntime.layer),
+);


### PR DESCRIPTION
Fixes #10600

## Summary
- refresh provider session `lastSeenAt` when canonical `turn.started`, `turn.completed`, or `turn.aborted` events arrive
- use a targeted timestamp-only persistence update so session status, resume cursor, and runtime payload are not rewritten
- re-check projected `latestTurn.startedAt` / `latestTurn.completedAt` before reaping, closing the race between projection settlement and the timestamp write
- keep high-frequency content and task-progress events out of the write path

## Why
A foreground turn can run longer than the 30-minute inactivity threshold. `activeTurnId` protects it while it is running, but the persisted `lastSeenAt` still reflects the earlier explicit session/turn command. Once the turn settles and `activeTurnId` clears, the next reaper sweep can therefore treat the session as already idle and stop it immediately.

Refreshing the binding at provider turn lifecycle boundaries gives the session a full inactivity window after work actually finishes. The sweep also treats the projected turn lifecycle timestamps as an immediate activity anchor, so it remains safe if projection settlement becomes visible before the independent persistence touch commits.

## Scope
This intentionally takes only the narrow turn-lifecycle slice discussed in #10600. It does not carry the broader task-progress throttling or session-lifecycle changes from older #5524 / #5711.

## Testing
- added `ProviderSessionReaper.activity.test.ts`
- verifies `turn.completed` advances persisted `lastSeenAt` while `runtimePayload`, `resumeCursor`, and `status` remain unchanged
- verifies a freshly completed projected turn prevents reaping even when the persisted timestamp is still stale
- upstream CI pending


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider sessions now remain active while turns are starting, completing, or being aborted.
  * Session activity timestamps are updated without creating records for missing sessions.
  * Reaping now rechecks recent turn activity, preventing active sessions from being stopped prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->