### PR TITLE
fix(server): report capped content searches as truncated

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -572,8 +572,36 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         }
         expect(byPath.get("src/dense.ts")).toBe(100);
         expect(byPath.get("src/other.ts")).toBe(1);
+        expect(result.truncated).toBe(true);
       }),
     );
+
+    for (const { lines, limit, expectedCount, truncated } of [
+      { lines: 100, limit: 500, expectedCount: 100, truncated: false },
+      { lines: 101, limit: 500, expectedCount: 100, truncated: true },
+      { lines: 2, limit: 1, expectedCount: 1, truncated: true },
+      { lines: 2, limit: 2, expectedCount: 2, truncated: false },
+    ]) {
+      it.effect(`reports completeness for ${lines} matching lines with limit ${limit}`, () =>
+        Effect.gen(function* () {
+          const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-boundary-" });
+          yield* writeTextFile(cwd, "matches.txt", "needle\n".repeat(lines));
+
+          const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+          const result = yield* workspaceEntries.searchContents({
+            cwd,
+            query: "needle",
+            limit,
+            caseSensitive: true,
+            wholeWord: false,
+            useRegex: false,
+          });
+
+          expect(result.matches).toHaveLength(expectedCount);
+          expect(result.truncated).toBe(truncated);
+        }),
+      );
+    }
 
     it.effect("preserves regex escapes during case-insensitive searches", () =>
       Effect.gen(function* () {

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -478,11 +478,12 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
     // Grep cursors advance by file, so whole-word post-filtering needs enough
     // raw candidates from the current file before moving to the next one.
     const rawPageSize = input.wholeWord
-      ? Math.max(input.limit, CONTENT_SEARCH_MAX_MATCHES_PER_FILE)
-      : input.limit;
+      ? Math.max(input.limit, CONTENT_SEARCH_MAX_MATCHES_PER_FILE) + 1
+      : input.limit + 1;
     const matches: Array<ProjectSearchContentsResult["matches"][number]> = [];
     let nextCursor: GrepCursor | null = null;
     let regexFallbackError: string | undefined;
+    let perFileTruncated = false;
 
     do {
       const remainingTimeBudgetMs = Math.max(1, Math.ceil(deadline - performance.now()));
@@ -491,14 +492,23 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
           mode: regexMode ? "regex" : "plain",
           smartCase: !input.caseSensitive && !regexMode,
           // A single dense file must not consume the whole result page.
-          maxMatchesPerFile: Math.min(CONTENT_SEARCH_MAX_MATCHES_PER_FILE, rawPageSize),
+          maxMatchesPerFile: Math.min(CONTENT_SEARCH_MAX_MATCHES_PER_FILE + 1, rawPageSize),
           pageSize: rawPageSize,
           cursor: nextCursor,
           timeBudgetMs: remainingTimeBudgetMs,
         }),
       );
 
+      // The native cursor advances by file and does not report per-file truncation.
+      // Read one extra line to distinguish a full file from a capped one.
+      const linesByPath = new Map<string, number>();
       for (const match of result.items) {
+        const lineCount = (linesByPath.get(match.relativePath) ?? 0) + 1;
+        linesByPath.set(match.relativePath, lineCount);
+        if (lineCount > CONTENT_SEARCH_MAX_MATCHES_PER_FILE) {
+          perFileTruncated = true;
+          continue;
+        }
         const matchRanges = mapContentMatchRanges(match.lineContent, match.matchRanges).filter(
           (range) => !input.wholeWord || isWholeWordRange(match.lineContent, range),
         );
@@ -516,7 +526,7 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
 
     return {
       matches: matches.slice(0, input.limit),
-      truncated: matches.length > input.limit || nextCursor !== null,
+      truncated: perFileTruncated || matches.length > input.limit || nextCursor !== null,
       ...(regexFallbackError !== undefined ? { regexFallbackError } : {}),
     };
   });


### PR DESCRIPTION
Workspace content search caps results at 100 matching lines per file, but reports a complete result when that cap drops matches. A workspace with 300 matching lines in one file and one in another returns 101 results with `truncated: false`, so the existing search count omits its “+” indicator.

Read one extra matching line to detect per-file and overall result truncation, while retaining the existing 100-line output cap and search time budget. Exact-boundary results remain complete.

Validation: the real-filesystem regression fails on upstream main and passes with the fix. All 43 focused workspace-entry and search-index tests pass, including per-file and overall limit boundaries. Targeted lint, formatting, server typecheck, and diff checks pass. Desktop/browser interaction and Windows execution have not been verified.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `searchContents` to report `truncated` when per-file match cap is exceeded
> - Content searches in [WorkspaceSearchIndex.ts](https://github.com/pingdotgg/t3code/pull/10616/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093) now request one extra raw candidate beyond the requested limit and one beyond `CONTENT_SEARCH_MAX_MATCHES_PER_FILE`, enabling detection of capped results.
> - Per-file candidates beyond `CONTENT_SEARCH_MAX_MATCHES_PER_FILE` are counted and discarded, and the result reports `truncated=true` when the per-file cap is hit — even if the returned match list does not exceed the overall limit.
> - Adds boundary tests in [WorkspaceEntries.test.ts](https://github.com/pingdotgg/t3code/pull/10616/files#diff-6d95ae743d3d76a69c3093d3bfe3097cfa1d2a7e58a9e45e5f26d304479160b8) covering exact-limit (not truncated), above-limit (truncated), and per-file cap scenarios.
> - Behavioral Change: searches that previously returned complete results when a single file exceeded the per-file match cap now correctly report `truncated=true`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a38cb97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search results now correctly indicate when matches were truncated because a file reached the per-file match limit.
  - Improved handling of result limits and boundary cases to provide more accurate truncation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->