### PR TITLE
fix(web): play pull request videos inline

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, PaperclipIcon, PlayIcon } from "lucide-react";
+import { ExternalLinkIcon, PaperclipIcon } from "lucide-react";
 import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
 import { createContext, useContext, useMemo } from "react";
 import type { Options as ReactMarkdownOptions } from "react-markdown";
@@ -6,17 +6,12 @@ import type { Options as ReactMarkdownOptions } from "react-markdown";
 import { cn } from "~/lib/utils";
 
 import ChatMarkdown from "../ChatMarkdown";
+import { MediaVideoPlayer } from "../media/MediaVideoPlayer";
 import { remarkPullRequestAutolinks, splitPullRequestBody } from "./pullRequestMarkdown.logic";
 
 export const PullRequestMarkdownContext = createContext<string | null>(null);
 
-/**
- * A pull request body, rendered with the app's markdown renderer plus a card for each upload
- * embedded in it, which that renderer drops on the floor.
- *
- * These upload URLs do not identify the media format. The card links to GitHub, where the
- * original upload can be opened or downloaded even when its codec cannot play in the client.
- */
+/** Renders PR uploads inline, with retry and an original link when video playback fails. */
 export function PullRequestMarkdown({
   text,
   cwd,
@@ -52,8 +47,18 @@ export function PullRequestMarkdown({
             />
           );
         }
-        const isVideo = segment.media === "video";
-        const Icon = isVideo ? PlayIcon : PaperclipIcon;
+        if (segment.media === "video") {
+          return (
+            <MediaVideoPlayer
+              key={`${segment.id}:${segment.url}`}
+              src={segment.url}
+              originalUrl={segment.url}
+              label="Pull request video"
+              className="w-full"
+              videoClassName="rounded-lg border border-border/60"
+            />
+          );
+        }
         return (
           // A plain anchor rather than the page's openExternal button: the desktop window
           // turns a blocked _blank into openExternal itself, and in a browser tab — where
@@ -65,10 +70,8 @@ export function PullRequestMarkdown({
             target="_blank"
             className="flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-sm hover:bg-muted/60"
           >
-            <Icon aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className="min-w-0 flex-1 truncate">
-              {isVideo ? "Play video on GitHub" : "Open attachment on GitHub"}
-            </span>
+            <PaperclipIcon aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate">Open attachment on GitHub</span>
             <ExternalLinkIcon aria-hidden className="size-3 shrink-0 text-muted-foreground" />
           </a>
         );


### PR DESCRIPTION
PR video uploads currently render as external-link cards. Render them with the shared inline video player, including native controls, retry, and an original-link fallback; changing an upload URL resets its player.

Verified both videos from #9472 through completion in T3's PR tab and exercised failed playback followed by retry. The 29 focused markdown/first-frame tests, web typecheck, targeted lint, and formatting checks pass.

### Before

![PR 9472 video links before the fix](https://uploads-production-47e4.up.railway.app/files/89c343be-86a6-4cb8-a332-5d474ed1bb0e/pr-videos-before.png)

### After

![PR 9472 inline video after playback](https://uploads-production-47e4.up.railway.app/files/942725a3-e73b-439d-8928-71593c2dc590/pr-videos-after.png)

Playback recordings were captured by the desktop preview, but its mac-local artifact paths are not downloadable through the available preview tools. Video evidence upload remains blocked; screenshots above were captured from the same PR.

Built with gpt-6-astra in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Play pull request videos inline in `PullRequestMarkdown`
> - Video uploads now play inline using the shared `MediaVideoPlayer` instead of linking to GitHub.
> - Non-video uploads continue to render as external links but now use `PaperclipIcon` directly with a fixed label.
> - Behavioral Change: Non-video attachments drop the previous attachment card in favor of a fixed label and `PaperclipIcon`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08e8bb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request videos now play inline instead of opening on GitHub.
* **Bug Fixes**
  * Video attachments now use their segment URL for playback and the original-link option.
  * Non-video attachments consistently display the paperclip icon and “Open attachment on GitHub” label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->