### PR TITLE
fix(desktop): resolve local media linked from remote threads

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5473,6 +5473,43 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("serves absolute host media without a local thread and rejects relative media", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const directory = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-host-media-" });
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const threadId = ThreadId.make("thread-on-another-environment");
+
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            for (const [name, mimeType] of [
+              ["screenshot.png", "image/png"],
+              ["recording.mp4", "video/mp4"],
+            ] as const) {
+              const filePath = path.join(directory, name);
+              yield* fileSystem.writeFileString(filePath, "host media bytes");
+              const issued = yield* client[WS_METHODS.assetsCreateUrl]({
+                resource: { _tag: "media-file", threadId, path: filePath },
+              });
+              const response = yield* HttpClient.get(issued.relativeUrl);
+              assert.equal(response.status, 200);
+              assert.equal(response.headers["content-type"], mimeType);
+              assert.equal(yield* response.text, "host media bytes");
+
+              const error = yield* client[WS_METHODS.assetsCreateUrl]({
+                resource: { _tag: "media-file", threadId, path: name },
+              }).pipe(Effect.flip);
+              assert.equal(error._tag, "AssetWorkspaceContextNotFoundError");
+            }
+          }),
+        ),
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("uploads image bytes through a signed URL issued by websocket rpc", () =>
     Effect.gen(function* () {
       const config = yield* buildAppUnderTest();

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -9,6 +9,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -2390,9 +2391,12 @@ const makeWsRpcLayer = (
           observeRpcEffect(
             WS_METHODS.assetsCreateUrl,
             Effect.gen(function* () {
+              const path = yield* Path.Path;
+              // An absolute media path can be linked from a thread on another environment.
               if (
                 input.resource._tag === "attachment" ||
-                input.resource._tag === "native-app-icon"
+                input.resource._tag === "native-app-icon" ||
+                (input.resource._tag === "media-file" && path.isAbsolute(input.resource.path))
               ) {
                 return yield* issueAssetUrl({ resource: input.resource });
               }

--- a/apps/web/src/state/assets.ts
+++ b/apps/web/src/state/assets.ts
@@ -2,22 +2,30 @@ import {
   createAssetEnvironmentAtoms,
   createProjectFaviconUrlAtomFamily,
 } from "@t3tools/client-runtime/state/assets";
+import { Atom } from "effect/unstable/reactivity";
 
 import { connectionAtomRuntime } from "../connection/runtime";
 import { projectFaviconCache } from "../assets/projectFaviconCache";
 import { isElectron } from "../env";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
-import { environmentSession, readPreparedConnection } from "./session";
+import { environmentSession } from "./session";
+
+const localMediaEnvironment = Atom.make((get) => {
+  if (!isElectron) return null;
+  const environmentId = get(primaryEnvironmentIdAtom);
+  if (environmentId === null) return null;
+  const connection = get(environmentSession.preparedConnectionValueAtom(environmentId));
+  // The session's bootstrap config clears on disconnect and refreshes on reconnect.
+  const config = get(environmentSession.initialConfigValueAtom(environmentId));
+  return connection._tag === "None" || config === null
+    ? null
+    : { environmentId, httpBaseUrl: connection.value.httpBaseUrl };
+});
 
 export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime, {
-  localMediaEnvironment: () => {
-    if (!isElectron) return null;
-    const environmentId = appAtomRegistry.get(primaryEnvironmentIdAtom);
-    if (environmentId === null) return null;
-    const connection = readPreparedConnection(environmentId);
-    return connection === null ? null : { environmentId, httpBaseUrl: connection.httpBaseUrl };
-  },
+  localMediaEnvironment: () => appAtomRegistry.get(localMediaEnvironment),
+  localMediaRefreshTrigger: localMediaEnvironment,
 });
 
 export const projectFaviconUrlAtom = createProjectFaviconUrlAtomFamily({

--- a/apps/web/src/state/assets.ts
+++ b/apps/web/src/state/assets.ts
@@ -5,9 +5,20 @@ import {
 
 import { connectionAtomRuntime } from "../connection/runtime";
 import { projectFaviconCache } from "../assets/projectFaviconCache";
-import { environmentSession } from "./session";
+import { isElectron } from "../env";
+import { appAtomRegistry } from "../rpc/atomRegistry";
+import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
+import { environmentSession, readPreparedConnection } from "./session";
 
-export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime);
+export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime, {
+  localMediaEnvironment: () => {
+    if (!isElectron) return null;
+    const environmentId = appAtomRegistry.get(primaryEnvironmentIdAtom);
+    if (environmentId === null) return null;
+    const connection = readPreparedConnection(environmentId);
+    return connection === null ? null : { environmentId, httpBaseUrl: connection.httpBaseUrl };
+  },
+});
 
 export const projectFaviconUrlAtom = createProjectFaviconUrlAtomFamily({
   imageCache: projectFaviconCache,

--- a/apps/web/src/state/assets.ts
+++ b/apps/web/src/state/assets.ts
@@ -7,7 +7,6 @@ import { Atom } from "effect/unstable/reactivity";
 import { connectionAtomRuntime } from "../connection/runtime";
 import { projectFaviconCache } from "../assets/projectFaviconCache";
 import { isElectron } from "../env";
-import { appAtomRegistry } from "../rpc/atomRegistry";
 import { primaryEnvironmentIdAtom } from "./primaryEnvironment";
 import { environmentSession } from "./session";
 
@@ -23,10 +22,10 @@ const localMediaEnvironment = Atom.make((get) => {
     : { environmentId, httpBaseUrl: connection.value.httpBaseUrl };
 });
 
-export const assetEnvironment = createAssetEnvironmentAtoms(connectionAtomRuntime, {
-  localMediaEnvironment: () => appAtomRegistry.get(localMediaEnvironment),
-  localMediaRefreshTrigger: localMediaEnvironment,
-});
+export const assetEnvironment = createAssetEnvironmentAtoms(
+  connectionAtomRuntime,
+  localMediaEnvironment,
+);
 
 export const projectFaviconUrlAtom = createProjectFaviconUrlAtomFamily({
   imageCache: projectFaviconCache,

--- a/packages/client-runtime/src/state/assets.test.ts
+++ b/packages/client-runtime/src/state/assets.test.ts
@@ -67,6 +67,7 @@ describe("createAssetEnvironmentAtoms", () => {
     { name: "remote success", path: "/tmp/clip.mp4", success: true },
     { name: "relative path", path: "clip.mp4" },
     { name: "no primary", path: "/tmp/clip.mp4", primary: "none" },
+    { name: "primary reconnect", path: "/tmp/frame.png", primary: "reconnecting" },
     { name: "same environment", path: "/tmp/clip.mp4", primary: "same" },
     { name: "non-media", path: "/tmp/report.html" },
     { name: "authorization failure", path: "/tmp/clip.mp4", error: "auth" },
@@ -133,20 +134,22 @@ describe("createAssetEnvironmentAtoms", () => {
           followStream: (id, stream) =>
             Stream.provideService(stream, EnvironmentSupervisor, supervisors.get(id)!),
         } as EnvironmentRegistry["Service"]);
+        const registry = AtomRegistry.make();
+        yield* Effect.addFinalizer(() => Effect.sync(() => registry.dispose()));
+        const localTarget = {
+          environmentId: scenario.primary === "same" ? remoteId : localId,
+          httpBaseUrl: "https://local.test",
+        };
+        const localEnvironment = Atom.make<typeof localTarget | null>(
+          scenario.primary === "none" || scenario.primary === "reconnecting" ? null : localTarget,
+        );
         const assets = createAssetEnvironmentAtoms(
           Atom.runtime(Layer.succeed(EnvironmentRegistry, environments)),
           {
-            localMediaEnvironment: () =>
-              scenario.primary === "none"
-                ? null
-                : {
-                    environmentId: scenario.primary === "same" ? remoteId : localId,
-                    httpBaseUrl: "https://local.test",
-                  },
+            localMediaEnvironment: () => registry.get(localEnvironment),
+            localMediaRefreshTrigger: localEnvironment,
           },
         );
-        const registry = AtomRegistry.make();
-        yield* Effect.addFinalizer(() => Effect.sync(() => registry.dispose()));
         const query = assets.createUrl({ environmentId: remoteId, input: { resource } });
         const result = AtomRegistry.getResult(registry, query, { suspendOnWaiting: true });
         if (scenario.fallback || scenario.success) {
@@ -159,6 +162,11 @@ describe("createAssetEnvironmentAtoms", () => {
           expect(yield* Effect.flip(result)).toEqual(error);
         }
         expect(calls).toEqual(scenario.fallback ? [remoteId, localId] : [remoteId]);
+        if (scenario.primary === "reconnecting") {
+          registry.set(localEnvironment, localTarget);
+          expect((yield* result).relativeUrl).toBe("https://local.test/api/assets/local/media");
+          expect(calls).toEqual([remoteId, remoteId, localId]);
+        }
       }).pipe(Effect.scoped),
     );
   }

--- a/packages/client-runtime/src/state/assets.test.ts
+++ b/packages/client-runtime/src/state/assets.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, it } from "@effect/vitest";
-import { type AssetCreateUrlResult, EnvironmentId } from "@t3tools/contracts";
+import {
+  type AssetCreateUrlResult,
+  AssetWorkspaceAssetNotFoundError,
+  AssetWorkspaceAssetInspectionError,
+  AssetWorkspaceContextNotFoundError,
+  EnvironmentAuthorizationError,
+  EnvironmentId,
+  ThreadId,
+  WS_METHODS,
+} from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as Option from "effect/Option";
 import * as Layer from "effect/Layer";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
-import type { EnvironmentRegistry } from "../connection/registry.ts";
+import { EnvironmentRegistry } from "../connection/registry.ts";
+import {
+  AVAILABLE_CONNECTION_STATE,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import type { RpcSession } from "../rpc/session.ts";
+import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 import { createProjectFaviconCache } from "../projectFaviconCache.ts";
 import {
   createAssetEnvironmentAtoms,
@@ -37,6 +58,111 @@ describe("asset collection keys", () => {
 });
 
 describe("createAssetEnvironmentAtoms", () => {
+  for (const scenario of [
+    { name: "missing video", path: "/tmp/clip.mp4", fallback: true },
+    { name: "literal filename characters", path: "/tmp/frame#one?two.png", fallback: true },
+    { name: "windows path", path: "C:\\Users\\demo\\clip.mp4", fallback: true },
+    { name: "inspection failure", path: "/tmp/clip.mp4", error: "inspection", fallback: true },
+    { name: "foreign thread", path: "/tmp/clip.mp4", error: "context", fallback: true },
+    { name: "remote success", path: "/tmp/clip.mp4", success: true },
+    { name: "relative path", path: "clip.mp4" },
+    { name: "no primary", path: "/tmp/clip.mp4", primary: "none" },
+    { name: "same environment", path: "/tmp/clip.mp4", primary: "same" },
+    { name: "non-media", path: "/tmp/report.html" },
+    { name: "authorization failure", path: "/tmp/clip.mp4", error: "auth" },
+  ]) {
+    it.effect(`uses the correct environment for ${scenario.name}`, () =>
+      Effect.gen(function* () {
+        const remoteId = EnvironmentId.make("remote");
+        const localId = EnvironmentId.make("local");
+        const resource = {
+          _tag: "media-file" as const,
+          threadId: ThreadId.make("foreign-thread"),
+          path: scenario.path,
+        };
+        const error =
+          scenario.error === "auth"
+            ? new EnvironmentAuthorizationError({
+                message: "denied",
+                requiredScope: "orchestration:read",
+              })
+            : scenario.error === "inspection"
+              ? new AssetWorkspaceAssetInspectionError({ resource, cause: new Error("unreadable") })
+              : scenario.error === "context"
+                ? new AssetWorkspaceContextNotFoundError({ resource })
+                : new AssetWorkspaceAssetNotFoundError({ resource });
+        const calls: EnvironmentId[] = [];
+        const supervisors = new Map<EnvironmentId, EnvironmentSupervisor["Service"]>();
+        for (const environmentId of [remoteId, localId]) {
+          const client = {
+            [WS_METHODS.assetsCreateUrl]: () => {
+              calls.push(environmentId);
+              return environmentId === remoteId && !scenario.success
+                ? Effect.fail(error)
+                : Effect.succeed({
+                    relativeUrl: `/api/assets/${environmentId}/media`,
+                    expiresAt: 999999,
+                  });
+            },
+          } as unknown as WsRpcProtocolClient;
+          const session = { client } as RpcSession;
+          supervisors.set(
+            environmentId,
+            EnvironmentSupervisor.of({
+              target: new PrimaryConnectionTarget({
+                environmentId,
+                label: environmentId,
+                httpBaseUrl: `https://${environmentId}.test`,
+                wsBaseUrl: `wss://${environmentId}.test`,
+              }),
+              state: yield* SubscriptionRef.make<SupervisorConnectionState>({
+                ...AVAILABLE_CONNECTION_STATE,
+                phase: "connected" as const,
+              }),
+              session: yield* SubscriptionRef.make(Option.some(session)),
+              prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
+              connect: Effect.void,
+              disconnect: Effect.void,
+              retryNow: Effect.void,
+            }),
+          );
+        }
+        const environments = EnvironmentRegistry.of({
+          run: (id, effect) =>
+            Effect.provideService(effect, EnvironmentSupervisor, supervisors.get(id)!),
+          followStream: (id, stream) =>
+            Stream.provideService(stream, EnvironmentSupervisor, supervisors.get(id)!),
+        } as EnvironmentRegistry["Service"]);
+        const assets = createAssetEnvironmentAtoms(
+          Atom.runtime(Layer.succeed(EnvironmentRegistry, environments)),
+          {
+            localMediaEnvironment: () =>
+              scenario.primary === "none"
+                ? null
+                : {
+                    environmentId: scenario.primary === "same" ? remoteId : localId,
+                    httpBaseUrl: "https://local.test",
+                  },
+          },
+        );
+        const registry = AtomRegistry.make();
+        yield* Effect.addFinalizer(() => Effect.sync(() => registry.dispose()));
+        const query = assets.createUrl({ environmentId: remoteId, input: { resource } });
+        const result = AtomRegistry.getResult(registry, query, { suspendOnWaiting: true });
+        if (scenario.fallback || scenario.success) {
+          expect((yield* result).relativeUrl).toBe(
+            scenario.fallback
+              ? "https://local.test/api/assets/local/media"
+              : "/api/assets/remote/media",
+          );
+        } else {
+          expect(yield* Effect.flip(result)).toEqual(error);
+        }
+        expect(calls).toEqual(scenario.fallback ? [remoteId, localId] : [remoteId]);
+      }).pipe(Effect.scoped),
+    );
+  }
+
   it("keys asset URL queries by environment and resource", () => {
     const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
       EnvironmentRegistry,

--- a/packages/client-runtime/src/state/assets.test.ts
+++ b/packages/client-runtime/src/state/assets.test.ts
@@ -145,10 +145,7 @@ describe("createAssetEnvironmentAtoms", () => {
         );
         const assets = createAssetEnvironmentAtoms(
           Atom.runtime(Layer.succeed(EnvironmentRegistry, environments)),
-          {
-            localMediaEnvironment: () => registry.get(localEnvironment),
-            localMediaRefreshTrigger: localEnvironment,
-          },
+          localEnvironment,
         );
         const query = assets.createUrl({ environmentId: remoteId, input: { resource } });
         const result = AtomRegistry.getResult(registry, query, { suspendOnWaiting: true });

--- a/packages/client-runtime/src/state/assets.ts
+++ b/packages/client-runtime/src/state/assets.ts
@@ -20,8 +20,8 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
-import { EnvironmentRegistry } from "../connection/registry.ts";
-import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import { request } from "../rpc/client.ts";
 import type { ProjectFaviconCache, ProjectFaviconTarget } from "../projectFaviconCache.ts";
 import { createEnvironmentQueryAtomFamily } from "./runtime.ts";
@@ -99,12 +99,13 @@ export function assetUrlStateFromResult(
 }
 
 export function createAssetEnvironmentAtoms<R, E>(
-  runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
+  runtime: Atom.AtomRuntime<EnvironmentRegistry.EnvironmentRegistry | R, E>,
   options?: {
     readonly localMediaEnvironment?: () => {
       readonly environmentId: EnvironmentId;
       readonly httpBaseUrl: string;
     } | null;
+    readonly localMediaRefreshTrigger?: Atom.Atom<unknown>;
   },
 ) {
   const execute = Effect.fn("assets.createUrl")(function* (input: AssetCreateUrlInput) {
@@ -124,9 +125,9 @@ export function createAssetEnvironmentAtoms<R, E>(
       )
         return yield* error;
       const local = options?.localMediaEnvironment?.();
-      const supervisor = yield* EnvironmentSupervisor;
+      const supervisor = yield* EnvironmentSupervisor.EnvironmentSupervisor;
       if (!local || local.environmentId === supervisor.target.environmentId) return yield* error;
-      const registry = yield* EnvironmentRegistry;
+      const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
       const result = yield* registry.run(
         local.environmentId,
         request(WS_METHODS.assetsCreateUrl, input),
@@ -148,6 +149,8 @@ export function createAssetEnvironmentAtoms<R, E>(
     staleTimeMs: ASSET_URL_STALE_TIME_MS,
     idleTtlMs: ASSET_URL_IDLE_TTL_MS,
     refreshIntervalMs: ASSET_URL_REFRESH_INTERVAL_MS,
+    refreshTrigger: ({ input }) =>
+      input.resource._tag === "media-file" ? options?.localMediaRefreshTrigger : undefined,
   });
   const createUrlsFamily = Atom.family((key: string) => {
     const [environmentId, resources] = parseAssetCollectionKey(key);

--- a/packages/client-runtime/src/state/assets.ts
+++ b/packages/client-runtime/src/state/assets.ts
@@ -1,8 +1,5 @@
 import {
   type AssetCreateUrlInput,
-  type AssetWorkspaceAssetNotFoundError,
-  type AssetWorkspaceAssetInspectionError,
-  type AssetWorkspaceContextNotFoundError,
   type AssetCreateUrlResult,
   type AssetImageDimensions,
   AssetResource,
@@ -17,8 +14,9 @@ import {
 } from "@t3tools/shared/projectFavicon";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import * as EnvironmentRegistry from "../connection/registry.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
@@ -100,48 +98,40 @@ export function assetUrlStateFromResult(
 
 export function createAssetEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry.EnvironmentRegistry | R, E>,
-  options?: {
-    readonly localMediaEnvironment?: () => {
-      readonly environmentId: EnvironmentId;
-      readonly httpBaseUrl: string;
-    } | null;
-    readonly localMediaRefreshTrigger?: Atom.Atom<unknown>;
-  },
+  localMediaEnvironment?: Atom.Atom<{
+    readonly environmentId: EnvironmentId;
+    readonly httpBaseUrl: string;
+  } | null>,
 ) {
   const execute = Effect.fn("assets.createUrl")(function* (input: AssetCreateUrlInput) {
-    const localFallback = Effect.fn(function* (
-      error:
-        | AssetWorkspaceAssetNotFoundError
-        | AssetWorkspaceAssetInspectionError
-        | AssetWorkspaceContextNotFoundError,
-    ) {
-      const resource = input.resource;
-      if (resource._tag !== "media-file") return yield* error;
-      const basename = resource.path.split(/[\\/]/).at(-1) ?? "";
-      const extension = basename.slice(basename.lastIndexOf("."));
-      if (
-        mediaMimeTypeFromExtension(extension) === null ||
-        !(resource.path.startsWith("/") || isWindowsAbsolutePath(resource.path))
-      )
-        return yield* error;
-      const local = options?.localMediaEnvironment?.();
-      const supervisor = yield* EnvironmentSupervisor.EnvironmentSupervisor;
-      if (!local || local.environmentId === supervisor.target.environmentId) return yield* error;
-      const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
-      const result = yield* registry.run(
-        local.environmentId,
-        request(WS_METHODS.assetsCreateUrl, input),
-      );
-      // Callers resolve against the thread's server, so preserve the local server's origin.
-      return { ...result, relativeUrl: new URL(result.relativeUrl, local.httpBaseUrl).href };
-    });
-    return yield* request(WS_METHODS.assetsCreateUrl, input).pipe(
-      Effect.catchTags({
-        AssetWorkspaceAssetNotFoundError: localFallback,
-        AssetWorkspaceAssetInspectionError: localFallback,
-        AssetWorkspaceContextNotFoundError: localFallback,
-      }),
+    const result = yield* request(WS_METHODS.assetsCreateUrl, input).pipe(Effect.result);
+    if (Result.isSuccess(result)) return result.success;
+    const error = result.failure;
+    const resource = input.resource;
+    const local = localMediaEnvironment
+      ? (yield* AtomRegistry.AtomRegistry).get(localMediaEnvironment)
+      : null;
+    const supervisor = yield* EnvironmentSupervisor.EnvironmentSupervisor;
+    if (
+      !local ||
+      local.environmentId === supervisor.target.environmentId ||
+      !(
+        error._tag === "AssetWorkspaceAssetNotFoundError" ||
+        error._tag === "AssetWorkspaceAssetInspectionError" ||
+        error._tag === "AssetWorkspaceContextNotFoundError"
+      ) ||
+      resource._tag !== "media-file" ||
+      !(resource.path.startsWith("/") || isWindowsAbsolutePath(resource.path)) ||
+      mediaMimeTypeFromExtension(resource.path.slice(resource.path.lastIndexOf("."))) === null
+    )
+      return yield* error;
+    const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+    const asset = yield* registry.run(
+      local.environmentId,
+      request(WS_METHODS.assetsCreateUrl, input),
     );
+    // Callers resolve against the thread's server, so preserve the local server's origin.
+    return { ...asset, relativeUrl: new URL(asset.relativeUrl, local.httpBaseUrl).href };
   });
   const createUrl = createEnvironmentQueryAtomFamily(runtime, {
     label: "environment-data:assets:create-url",
@@ -150,7 +140,7 @@ export function createAssetEnvironmentAtoms<R, E>(
     idleTtlMs: ASSET_URL_IDLE_TTL_MS,
     refreshIntervalMs: ASSET_URL_REFRESH_INTERVAL_MS,
     refreshTrigger: ({ input }) =>
-      input.resource._tag === "media-file" ? options?.localMediaRefreshTrigger : undefined,
+      input.resource._tag === "media-file" ? localMediaEnvironment : undefined,
   });
   const createUrlsFamily = Atom.family((key: string) => {
     const [environmentId, resources] = parseAssetCollectionKey(key);

--- a/packages/client-runtime/src/state/assets.ts
+++ b/packages/client-runtime/src/state/assets.ts
@@ -1,10 +1,16 @@
 import {
+  type AssetCreateUrlInput,
+  type AssetWorkspaceAssetNotFoundError,
+  type AssetWorkspaceAssetInspectionError,
+  type AssetWorkspaceContextNotFoundError,
   type AssetCreateUrlResult,
   type AssetImageDimensions,
   AssetResource,
   EnvironmentId,
   WS_METHODS,
 } from "@t3tools/contracts";
+import { mediaMimeTypeFromExtension } from "@t3tools/shared/filePreview";
+import { isWindowsAbsolutePath } from "@t3tools/shared/path";
 import {
   getProjectFaviconResourceKey,
   isProjectFaviconFallbackUrl,
@@ -14,9 +20,11 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
-import type { EnvironmentRegistry } from "../connection/registry.ts";
+import { EnvironmentRegistry } from "../connection/registry.ts";
+import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import { request } from "../rpc/client.ts";
 import type { ProjectFaviconCache, ProjectFaviconTarget } from "../projectFaviconCache.ts";
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import { createEnvironmentQueryAtomFamily } from "./runtime.ts";
 
 const ASSET_URL_REFRESH_INTERVAL_MS = 30 * 60_000;
 const ASSET_URL_STALE_TIME_MS = 5 * 60_000;
@@ -92,10 +100,51 @@ export function assetUrlStateFromResult(
 
 export function createAssetEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
+  options?: {
+    readonly localMediaEnvironment?: () => {
+      readonly environmentId: EnvironmentId;
+      readonly httpBaseUrl: string;
+    } | null;
+  },
 ) {
-  const createUrl = createEnvironmentRpcQueryAtomFamily(runtime, {
+  const execute = Effect.fn("assets.createUrl")(function* (input: AssetCreateUrlInput) {
+    const localFallback = Effect.fn(function* (
+      error:
+        | AssetWorkspaceAssetNotFoundError
+        | AssetWorkspaceAssetInspectionError
+        | AssetWorkspaceContextNotFoundError,
+    ) {
+      const resource = input.resource;
+      if (resource._tag !== "media-file") return yield* error;
+      const basename = resource.path.split(/[\\/]/).at(-1) ?? "";
+      const extension = basename.slice(basename.lastIndexOf("."));
+      if (
+        mediaMimeTypeFromExtension(extension) === null ||
+        !(resource.path.startsWith("/") || isWindowsAbsolutePath(resource.path))
+      )
+        return yield* error;
+      const local = options?.localMediaEnvironment?.();
+      const supervisor = yield* EnvironmentSupervisor;
+      if (!local || local.environmentId === supervisor.target.environmentId) return yield* error;
+      const registry = yield* EnvironmentRegistry;
+      const result = yield* registry.run(
+        local.environmentId,
+        request(WS_METHODS.assetsCreateUrl, input),
+      );
+      // Callers resolve against the thread's server, so preserve the local server's origin.
+      return { ...result, relativeUrl: new URL(result.relativeUrl, local.httpBaseUrl).href };
+    });
+    return yield* request(WS_METHODS.assetsCreateUrl, input).pipe(
+      Effect.catchTags({
+        AssetWorkspaceAssetNotFoundError: localFallback,
+        AssetWorkspaceAssetInspectionError: localFallback,
+        AssetWorkspaceContextNotFoundError: localFallback,
+      }),
+    );
+  });
+  const createUrl = createEnvironmentQueryAtomFamily(runtime, {
     label: "environment-data:assets:create-url",
-    tag: WS_METHODS.assetsCreateUrl,
+    execute,
     staleTimeMs: ASSET_URL_STALE_TIME_MS,
     idleTtlMs: ASSET_URL_IDLE_TTL_MS,
     refreshIntervalMs: ASSET_URL_REFRESH_INTERVAL_MS,

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -486,7 +486,7 @@ export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
     Input,
     A,
     E,
-    EnvironmentSupervisor | EnvironmentRegistry | R
+    EnvironmentSupervisor | EnvironmentRegistry | AtomRegistry.AtomRegistry | R
   >,
 ): (target: {
   readonly environmentId: EnvironmentIdType;

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -482,7 +482,12 @@ export function followStreamInEnvironment<A, E, R>(
 
 export function createEnvironmentQueryAtomFamily<R, ER, Input, A, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, ER>,
-  options: EnvironmentQueryAtomOptions<Input, A, E, EnvironmentSupervisor | R>,
+  options: EnvironmentQueryAtomOptions<
+    Input,
+    A,
+    E,
+    EnvironmentSupervisor | EnvironmentRegistry | R
+  >,
 ): (target: {
   readonly environmentId: EnvironmentIdType;
   readonly input: Input;


### PR DESCRIPTION
remote threads try to load desktop images and recordings from the remote server, where the files may not exist. desktop now retries eligible missing absolute media paths against its local server. remote files retain priority; relative paths and authorization failures do not fall back. previews refresh when the local server reconnects.

validation: 74 focused signing/rpc/asset/query tests passed before simplification; 46 focused asset/query tests, client-runtime/web typechecks, and scoped lint passed on this head. github checks pass.

e2e: real linux electron client, two independently authenticated servers, and a seeded remote conversation. filesystem permissions made the media inaccessible to the remote server and readable by the desktop server. image rendering and full-size preview, eight-second video playback, seeking to four seconds, and retry after restoring a missing video passed. checked light/dark appearance and 1100×780 / 1200×1100 viewports. the mac-specific setup remains untested.

before: base client asset wiring, same thread and files.

![before: remote thread cannot load local image or video](https://uploads-production-47e4.up.railway.app/files/0802b7c5-48fb-4846-baf0-646a2b68b57e/t3-media-before.png)

after: current head, image loaded and video seeked to 0:04.

![after: local image and video render in the remote thread](https://uploads-production-47e4.up.railway.app/files/8c6d3ec2-f765-4cd3-b13b-4d793649428b/t3-media-after.png)

![eight seconds of desktop video playback through local fallback](https://uploads-production-47e4.up.railway.app/files/cae8684c-9a84-49fd-ac3b-787fa9a09828/t3-media-playback.gif)

model: gpt-6. harness: codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix local media resolution for remote threads via local environment fallback
> - Adds direct asset URL issuance for absolute media-file paths in the `assetsCreateUrl` websocket RPC handler in [ws.ts](https://github.com/pingdotgg/t3code/pull/10619/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125), so absolute media can be served without resolving a workspace for the referenced thread.
> - Updates `createAssetEnvironmentAtoms` in [assets.ts](https://github.com/pingdotgg/t3code/pull/10619/files#diff-e4d6b86d6446338ff104d18e3def1fd2c404c0cb4c3596f5b1cccf6a58fc8227) to retry eligible absolute media-file requests against a distinct configured local environment after asset-not-found, asset-inspection, or workspace-context errors, rewriting the result against the local HTTP base URL.
> - Supplies the connected primary Electron environment as the local media fallback in [assets.ts](https://github.com/pingdotgg/t3code/pull/10619/files#diff-b2ecd7587814972cf0a8c9896d45d893adf5f8008c1b0fe90fc873eb52242e72), and refreshes media queries when that fallback context changes.
> - Adds integration tests in [server.test.ts](https://github.com/pingdotgg/t3code/pull/10619/files#diff-311d34bc81e1c9cdae991c24771a5c0b8f02084dc94251982be7466403965b9f) and parameterized fallback tests in [assets.test.ts](https://github.com/pingdotgg/t3code/pull/10619/files#diff-b217b919e27297b7edc9ecab1e33ee046171fc81b5f85236090b34e2c37e4540).
> - Behavioral Change: media URL queries now perform an additional local-environment retry for absolute paths with recognized media extensions when the target environment returns specific workspace-resolution failures; non-media and relative paths are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20bd171.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Media assets using absolute paths now generate valid URLs even when no local thread workspace is available.
  - Improved media URL resolution across local, remote, reconnecting, and foreign-thread environments.
  - PNG and MP4 assets now return the expected content types and file data.
  - Relative media paths continue to report clear workspace-context errors when required context is unavailable.
  - Added support for Windows-style absolute media paths and filenames containing literal special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
