### PR TITLE
fix(server): preserve Unicode case-insensitive search matches

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -386,6 +386,57 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
 
+    for (const { query, variants } of [
+      { query: "Äpfel", variants: ["Äpfel", "äpfel"] },
+      { query: "äpfel", variants: ["Äpfel", "äpfel"] },
+      { query: "Σ", variants: ["Σ", "σ", "ς"] },
+      { query: "K", variants: ["K", "k", "K"] },
+    ]) {
+      for (const useRegex of [false, true]) {
+        it.effect(`matches Unicode case variants for ${query} (regex: ${useRegex})`, () =>
+          Effect.gen(function* () {
+            const cwd = yield* makeTempDir({ prefix: "t3code-unicode-search-" });
+            yield* writeTextFile(cwd, "words.txt", variants.join("\n"));
+            const entries = yield* WorkspaceEntries.WorkspaceEntries;
+            const input = { cwd, query, limit: 100, wholeWord: false, useRegex };
+            const insensitive = yield* entries.searchContents({ ...input, caseSensitive: false });
+            const sensitive = yield* entries.searchContents({ ...input, caseSensitive: true });
+
+            expect(insensitive.matches.map((match) => match.lineContent)).toEqual(variants);
+            expect(sensitive.matches.map((match) => match.lineContent)).toEqual([query]);
+          }),
+        );
+      }
+    }
+
+    it.effect("keeps case-insensitive literal syntax and Unicode match ranges intact", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTempDir({ prefix: "t3code-unicode-literal-search-" });
+        const query = "Äpfel.[x]+(a)?{2}^$|/\\";
+        yield* writeTextFile(
+          cwd,
+          "words.txt",
+          `🍎 ${query}\n🍎 ${query.toLowerCase()}\nÄpfelZxxaa\n`,
+        );
+        const entries = yield* WorkspaceEntries.WorkspaceEntries;
+        const result = yield* entries.searchContents({
+          cwd,
+          query,
+          limit: 100,
+          caseSensitive: false,
+          wholeWord: true,
+          useRegex: false,
+        });
+
+        expect(result.regexFallbackError).toBeUndefined();
+        expect(result.matches.map((match) => match.lineNumber)).toEqual([1, 2]);
+        for (const match of result.matches) {
+          expect(match.matchRanges).toEqual([{ start: 3, end: 3 + query.length }]);
+          expect(match.lineContent.slice(3).toLowerCase()).toBe(query.toLowerCase());
+        }
+      }),
+    );
+
     it.effect("honors case sensitivity and gitignore rules", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTempDir({ prefix: "t3code-workspace-content-ignore-", git: true });

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -237,11 +237,16 @@ function buildContentSearchQuery(input: Omit<ProjectSearchContentsInput, "cwd">)
   if (input.caseSensitive) {
     return { searchQuery: input.query, regexMode: input.useRegex };
   }
-  // Plain mode relies on smart case: an all-lowercase needle matches
-  // case-insensitively. Regex mode needs an explicit inline flag instead.
-  return input.useRegex
-    ? { searchQuery: `(?i)${input.query}`, regexMode: true }
-    : { searchQuery: input.query.toLowerCase(), regexMode: false };
+  // Plain-mode match ranges miss Unicode case variants. Enable Unicode regex
+  // folding, encoding literal punctuation so the native query parser cannot
+  // reinterpret it as a path/glob constraint before regex matching.
+  const query = input.useRegex
+    ? input.query
+    : input.query.replace(
+        /[/\\^$*+?.()|[\]{}]/g,
+        (character) => `\\x${character.charCodeAt(0).toString(16)}`,
+      );
+  return { searchQuery: `(?iu)${query}`, regexMode: true };
 }
 
 function mapContentMatchRanges(


### PR DESCRIPTION
Case-insensitive workspace content search drops Unicode case variants: searching for `Äpfel` returns only `äpfel`, and `Σ` misses both `Σ` and final sigma `ς`. The native plain search can return matching lines with no usable match ranges, which T3 filters out; regex search also needs Unicode matching explicitly enabled.

Use Unicode-aware case-insensitive regex matching. Encode punctuation in literal queries so it stays literal and cannot become a native path/glob constraint. Case-sensitive searches retain their existing path.

Validation: all nine new real-filesystem regressions fail with the upstream implementation and pass with the fix. All 48 focused workspace-entry/search-index tests, scoped lint/format, and server typecheck pass. Coverage includes accented letters, sigma variants, `K`/`K`, exact case-sensitive controls, literal regex punctuation/backslashes, whole-word filtering, and match offsets after an emoji. A 1,000-file synthetic comparison measured roughly 11–13 ms median searches on both paths; this is not a product-wide performance claim. Browser interaction and Windows execution remain unverified.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Unicode case-insensitive search matches in `buildContentSearchQuery`
> - Case-insensitive workspace content searches now use Unicode-aware regex folding instead of plain lowercase matching or inline case-insensitive flags, so variants like German umlauts, Greek sigma, and Kelvin sign match correctly.
> - Literal queries now encode regex punctuation as hexadecimal escapes before applying the Unicode and case-insensitive regex flags, preventing regex metacharacters in literal text from being interpreted.
> - Adds parameterized tests in [WorkspaceEntries.test.ts](https://github.com/pingdotgg/t3code/pull/10622/files#diff-6d95ae743d3d76a69c3093d3bfe3097cfa1d2a7e58a9e45e5f26d304479160b8) covering Unicode case variants in both literal and regex modes.
> - Behavioral Change: all case-insensitive content queries now return regex mode enabled; literal queries with regex punctuation are treated as text rather than parsed by the native query parser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41863f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content search handling for Unicode characters and case-insensitive matching.
  * Queries containing regex-special characters are now treated literally when regex mode is disabled.
  * Search results now preserve accurate match ranges for Unicode text.
* **Tests**
  * Added coverage for Unicode case variants, regex and literal searches, and special-character queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->