### PR TITLE
fix(desktop): reopen the current thread after an app update

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -72,6 +72,7 @@ import {
 } from "@t3tools/contracts/settings";
 import { isDesktopLocalConnectionTarget, isWslConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
+import { installDesktopUpdate } from "../desktopUpdateRestore";
 import { isElectron } from "../env";
 import { useTerminalFocus } from "../hooks/useTerminalFocus";
 import { useOpenPrLink } from "../lib/openPullRequestLink";
@@ -3649,8 +3650,7 @@ export default function LegacySidebar() {
         setDesktopUpdateActionPending(false);
         return;
       }
-      void bridge
-        .installUpdate()
+      void installDesktopUpdate(bridge)
         .then((result) => {
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -60,6 +60,7 @@ import {
   resolveEnvironmentIdentificationPillLabel,
   useEnvironmentStageLabel,
 } from "../SidebarStageBackdrop";
+import { installDesktopUpdate } from "../../desktopUpdateRestore";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useCustomThemes } from "../../hooks/useCustomThemes";
@@ -329,8 +330,7 @@ function AboutVersionSection() {
         setIsUpdateActionPending(false);
         return;
       }
-      void bridge
-        .installUpdate()
+      void installDesktopUpdate(bridge)
         .catch((error: unknown) => {
           toastManager.add(
             stackedThreadToast({

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -2,6 +2,7 @@ import type { DesktopUpdateState } from "@t3tools/contracts";
 import { TriangleAlertIcon } from "lucide-react";
 import { type ComponentProps, useCallback, useEffect, useId, useRef, useState } from "react";
 import { flushSync } from "react-dom";
+import { installDesktopUpdate } from "../../desktopUpdateRestore";
 import { isElectron } from "../../env";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import { cn } from "../../lib/utils";
@@ -232,8 +233,7 @@ function SidebarUpdateControl() {
         setIsActionPending(false);
         return;
       }
-      void bridge
-        .installUpdate()
+      void installDesktopUpdate(bridge)
         .then((result) => {
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);

--- a/apps/web/src/desktopUpdateRestore.test.ts
+++ b/apps/web/src/desktopUpdateRestore.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  DESKTOP_UPDATE_RESTORE_MAX_AGE_MS,
+  DESKTOP_UPDATE_RESTORE_STORAGE_KEY,
+  resolveDesktopUpdateRestoreLocation,
+  saveDesktopUpdateRestoreLocation,
+  takeDesktopUpdateRestoreLocation,
+} from "./desktopUpdateRestore";
+import { removeLocalStorageItem } from "./hooks/useLocalStorage";
+
+describe("resolveDesktopUpdateRestoreLocation", () => {
+  const now = 1_000_000;
+
+  it("returns a fresh route path", () => {
+    expect(
+      resolveDesktopUpdateRestoreLocation({ location: "/env-1/thread-1", savedAt: now }, now),
+    ).toBe("/env-1/thread-1");
+  });
+
+  it("drops stale hints", () => {
+    const savedAt = now - DESKTOP_UPDATE_RESTORE_MAX_AGE_MS - 1;
+    expect(
+      resolveDesktopUpdateRestoreLocation({ location: "/env-1/thread-1", savedAt }, now),
+    ).toBeNull();
+  });
+
+  it("drops hints saved in the future", () => {
+    expect(
+      resolveDesktopUpdateRestoreLocation({ location: "/env-1/thread-1", savedAt: now + 1 }, now),
+    ).toBeNull();
+  });
+
+  it("drops the index route and anything that is not a route path", () => {
+    expect(resolveDesktopUpdateRestoreLocation({ location: "/", savedAt: now }, now)).toBeNull();
+    expect(resolveDesktopUpdateRestoreLocation({ location: "", savedAt: now }, now)).toBeNull();
+    expect(
+      resolveDesktopUpdateRestoreLocation({ location: "//evil.example", savedAt: now }, now),
+    ).toBeNull();
+    expect(
+      resolveDesktopUpdateRestoreLocation({ location: "https://evil.example", savedAt: now }, now),
+    ).toBeNull();
+  });
+});
+
+describe("takeDesktopUpdateRestoreLocation", () => {
+  beforeEach(() => {
+    removeLocalStorageItem(DESKTOP_UPDATE_RESTORE_STORAGE_KEY);
+  });
+
+  it("returns the saved route once", () => {
+    saveDesktopUpdateRestoreLocation("/env-1/thread-1", 5_000);
+
+    expect(takeDesktopUpdateRestoreLocation(6_000)).toBe("/env-1/thread-1");
+    expect(takeDesktopUpdateRestoreLocation(6_000)).toBeNull();
+  });
+
+  it("returns null when nothing was saved", () => {
+    expect(takeDesktopUpdateRestoreLocation()).toBeNull();
+  });
+});

--- a/apps/web/src/desktopUpdateRestore.ts
+++ b/apps/web/src/desktopUpdateRestore.ts
@@ -49,7 +49,7 @@ export function saveDesktopUpdateRestoreLocation(location: string, now = Date.no
   }
 }
 
-export function clearDesktopUpdateRestoreLocation(): void {
+function clearDesktopUpdateRestoreLocation(): void {
   try {
     removeLocalStorageItem(DESKTOP_UPDATE_RESTORE_STORAGE_KEY);
   } catch (error) {

--- a/apps/web/src/desktopUpdateRestore.ts
+++ b/apps/web/src/desktopUpdateRestore.ts
@@ -1,0 +1,105 @@
+import type { DesktopBridge, DesktopUpdateActionResult } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+import { getDesktopUpdateActionError } from "./components/desktopUpdate.logic";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "./hooks/useLocalStorage";
+
+export const DESKTOP_UPDATE_RESTORE_STORAGE_KEY = "t3code:desktop-update-restore:v1";
+
+// Installing a downloaded update relaunches within seconds. A hint older than
+// this belongs to an install that never came back and must not steer a later
+// cold launch away from the usual fresh draft.
+export const DESKTOP_UPDATE_RESTORE_MAX_AGE_MS = 10 * 60 * 1000;
+
+const DesktopUpdateRestoreSchema = Schema.Struct({
+  location: Schema.String,
+  savedAt: Schema.Number,
+});
+
+type DesktopUpdateRestore = typeof DesktopUpdateRestoreSchema.Type;
+
+/**
+ * Picks the route to reopen after an update relaunch, or null when the saved
+ * hint is missing, stale, or not a route path.
+ */
+export function resolveDesktopUpdateRestoreLocation(
+  saved: DesktopUpdateRestore | null,
+  now: number,
+): string | null {
+  if (saved === null) return null;
+  if (now - saved.savedAt > DESKTOP_UPDATE_RESTORE_MAX_AGE_MS || now < saved.savedAt) return null;
+  if (!saved.location.startsWith("/") || saved.location.startsWith("//")) return null;
+  if (saved.location === "/") return null;
+  return saved.location;
+}
+
+export function saveDesktopUpdateRestoreLocation(location: string, now = Date.now()): void {
+  try {
+    setLocalStorageItem(
+      DESKTOP_UPDATE_RESTORE_STORAGE_KEY,
+      { location, savedAt: now },
+      DesktopUpdateRestoreSchema,
+    );
+  } catch (error) {
+    console.error("Could not persist the desktop update restore location.", error);
+  }
+}
+
+export function clearDesktopUpdateRestoreLocation(): void {
+  try {
+    removeLocalStorageItem(DESKTOP_UPDATE_RESTORE_STORAGE_KEY);
+  } catch (error) {
+    console.error("Could not clear the desktop update restore location.", error);
+  }
+}
+
+/** Reads and clears the saved route so it applies to one launch only. */
+export function takeDesktopUpdateRestoreLocation(now = Date.now()): string | null {
+  let saved: DesktopUpdateRestore | null = null;
+  try {
+    saved = getLocalStorageItem(DESKTOP_UPDATE_RESTORE_STORAGE_KEY, DesktopUpdateRestoreSchema);
+  } catch (error) {
+    console.error("Could not read the desktop update restore location.", error);
+  }
+  clearDesktopUpdateRestoreLocation();
+  return resolveDesktopUpdateRestoreLocation(saved, now);
+}
+
+/**
+ * Installs the downloaded update and remembers the current route so the
+ * relaunched app reopens it instead of landing on a fresh draft. Electron
+ * uses hash history, so the hash carries the whole route.
+ */
+export function installDesktopUpdate(
+  bridge: Pick<DesktopBridge, "installUpdate">,
+): Promise<DesktopUpdateActionResult> {
+  saveDesktopUpdateRestoreLocation(window.location.hash.slice(1));
+  return bridge.installUpdate().then(
+    (result) => {
+      if (!result.accepted || getDesktopUpdateActionError(result) !== null) {
+        clearDesktopUpdateRestoreLocation();
+      }
+      return result;
+    },
+    (error: unknown) => {
+      clearDesktopUpdateRestoreLocation();
+      throw error;
+    },
+  );
+}
+
+/**
+ * Runs once at Electron startup, before the router reads the hash. A launch
+ * that already carries a route keeps it.
+ */
+export function restoreDesktopUpdateLocation(): void {
+  const location = takeDesktopUpdateRestoreLocation();
+  if (location === null) return;
+  const currentHash = window.location.hash;
+  if (currentHash.length > 1 && currentHash !== "#/") return;
+  window.history.replaceState(window.history.state, "", `#${location}`);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,6 +5,7 @@ import { createHashHistory, createBrowserHistory } from "@tanstack/react-router"
 import "./index.css";
 
 import { isElectron } from "./env";
+import { restoreDesktopUpdateLocation } from "./desktopUpdateRestore";
 import { hasCloudPublicConfig } from "./cloud/publicConfig";
 import { getRouter } from "./router";
 import {
@@ -13,6 +14,10 @@ import {
 } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
 import { clearChunkReloadGuard, reloadOnceForChunkLoadError } from "./lib/chunkReloadGuard";
+
+if (isElectron) {
+  restoreDesktopUpdateLocation();
+}
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();

--- a/docs/user/updating.md
+++ b/docs/user/updating.md
@@ -28,7 +28,7 @@ The offered action depends on how the server runs:
 | Action                     | What to do                                                                                                                                                                                      |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Update server**          | Keep the client open while it installs and reconnects. Supported background services update remotely. For a desktop-hosted server, this also closes and relaunches the desktop app on the host. |
-| **Update the desktop app** | Update the desktop app on the machine running the server, then reopen it if needed.                                                                                                             |
+| **Update the desktop app** | Update the desktop app on the machine running the server. It relaunches on the thread you had open.                                                                                             |
 | **Copy update command**    | Stop the command-line server on its host and relaunch with the copied command, keeping your usual startup options.                                                                              |
 
 For a background service, run the matching version's CLI on the host:


### PR DESCRIPTION
Installing a desktop update relaunches the app on the bare app URL. The router uses hash history there, so it lands on the index route and opens a fresh draft instead of the thread that was open.

The install wrapper now saves the current hash route to localStorage before calling the bridge. On the next Electron boot the hint is read once, cleared, and applied before the router is created, so the app starts on the saved thread. Stale hints and install failures are discarded.

Built with Claude Fable 5.1 in Claude Code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore the open Electron thread route after a desktop app update
> - Adds `installDesktopUpdate` in [desktopUpdateRestore.ts](https://github.com/pingdotgg/t3code/pull/10624/files#diff-3270ce09a2646e9df66d1b24f7a7709a0641683eb16141712077fa539674c86c), a shared wrapper that records the current hash route to local storage before calling the desktop bridge and clears the saved hint when the result is not accepted or errors
> - Replaces the direct desktop bridge installation call in `LegacySidebar`, `AboutVersionSection`, and `SidebarUpdateControl` with the shared wrapper so every update entry point persists the restore hint
> - On Electron startup, [main.tsx](https://github.com/pingdotgg/t3code/pull/10624/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) calls `restoreDesktopUpdateLocation` before the router is created, replacing an empty or root hash with the saved route; a non-root hash already in the URL is preserved
> - Saved restore records are versioned in local storage, validated by an Effect schema, and only accepted within ten minutes of saving; root, empty, protocol-relative, and absolute external URLs are rejected
> - Behavioral Change: `restoreDesktopUpdateLocation` mutates `window.location.hash` during startup before history is created; if the saved hint is stale or invalid the hash is left untouched
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7e52bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app updates now reopen the previously active thread after relaunch.
  * Saved restore locations are validated and automatically cleared when expired or invalid.
* **Bug Fixes**
  * Failed or rejected updates no longer leave stale restore information behind.
  * Update installation behaves consistently across desktop update entry points.
* **Documentation**
  * Updated desktop update instructions to reflect automatic thread restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->