### PR TITLE
feat(web): highlight sidebar threads waiting for input

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1348,10 +1348,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     [onThreadActivate, openPrLink, openPullRequestsInRightPanel, pr, props.isActive, threadRef],
   );
 
-  // All sidebar rows share one surface model. Live threads used to look
-  // like elevated cards while settled threads were plain rows, leaving neither
-  // a useful hierarchy nor a reliable hover cue. Status now lives in the row
-  // content; surface is reserved for interaction (hover, multi-select, route).
+  // Row backgrounds show interaction state; an inset ring keeps pending
+  // input visible without changing the row size or clipping at scroll edges.
   const rowSurfaceClassName = cn(
     "group/sidebar-row relative w-full cursor-pointer overflow-hidden rounded-md text-left outline-none select-none",
     props.isActive
@@ -1363,7 +1361,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
           : shouldRecede
             ? "text-sidebar-muted-foreground/75 hover:bg-sidebar-row-hover hover:text-sidebar-foreground"
             : "bg-transparent text-sidebar-foreground hover:bg-sidebar-row-hover",
+    status === "input" && "inset-ring-2 inset-ring-indigo-500 dark:inset-ring-indigo-400",
     isInFlight &&
+      status !== "input" &&
       !props.isActive &&
       !isSelected &&
       "opacity-70 transition-opacity hover:opacity-100",


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

### ELI5
Threads waiting for an answer now have a visible indigo ring in the sidebar.

### Problem
The small "Input" label was easy to miss, especially because inactive rows were dimmed.

### Fix
Add a static 2px inset ring and keep input rows at full opacity in the current web/desktop sidebar. The ring follows the existing input status, including clearing after an answer, and preserves row dimensions.

Validation: 158 sidebar logic tests, web typecheck, formatting, and focused lint passed with existing lint warnings. Browser checks covered light/dark themes, active state, input clearing/restoring, and unchanged dimensions. Code review found no actionable issues.

### UI Changes
Captured in Chromium on a temporary dev route rendering the actual sidebar row component with fixed fixtures.

#### Before
| Light | Dark |
| --- | --- |
| ![Before in light theme](https://github.com/flamboh/t3code/releases/download/sidebar-input-ring-evidence-20260908/before-light.png) | ![Before in dark theme](https://github.com/flamboh/t3code/releases/download/sidebar-input-ring-evidence-20260908/before-dark.png) |

#### After
| Light | Dark |
| --- | --- |
| ![After in light theme](https://github.com/flamboh/t3code/releases/download/sidebar-input-ring-evidence-20260908/after-light.png) | ![After in dark theme](https://github.com/flamboh/t3code/releases/download/sidebar-input-ring-evidence-20260908/after-dark.png) |

Made with GPT-6 in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Highlight sidebar threads waiting for input with indigo ring
> Updates `SidebarThreadRow` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/10633/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to show an indigo inset ring when thread status is `input`. It also prevents the in-flight opacity dimming from applying to `input` rows so they remain fully visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d67652.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - In-progress threads awaiting input now display a highlighted indigo outline for improved visibility.
  - Other in-progress threads continue to use dimmed styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->