### PR TITLE
fix(web): add bottom padding to project actions header

### DIFF
--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -1290,7 +1290,7 @@ function ProjectDetail({
               }
             />
           ) : null}
-          <div className="flex min-h-8 flex-col items-start gap-3 px-3 pt-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-4">
+          <div className="flex min-h-8 flex-col items-start gap-3 px-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-4">
             <div className="min-w-0">
               <h3 className="text-base font-semibold text-foreground">Actions</h3>
               <p className="text-pretty text-sm text-muted-foreground">


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

## ELI5
Give the project Actions header breathing room above the divider.

## Problem
The header only had top padding. Its description touched the divider on desktop, and the action buttons touched it at narrow widths.

## Fix
Change `pt-4` to `py-4`, preserving 16px above the header and adding 16px below it. This shared web/desktop layout applies to inherited and overridden project actions.

Validation: web typecheck and targeted formatting passed. Targeted lint reports one existing memo-dependency warning at line 696. Code review found no actionable issues. Used test-t3-app with isolated state to verify empty layouts at 1440px and 390px, plus adding and resetting an action at 390px without horizontal overflow. Chromium resource failures required bundled dev mode and prevented completing the populated desktop check. Native clients were not run.

## UI Changes

### Before

![Desktop before](https://github.com/flamboh/t3code/releases/download/actions-spacing-evidence-20260908/before-desktop.png)

![Narrow before](https://github.com/flamboh/t3code/releases/download/actions-spacing-evidence-20260908/before-narrow.png)

### After

![Desktop after](https://github.com/flamboh/t3code/releases/download/actions-spacing-evidence-20260908/after-desktop.png)

![Narrow after](https://github.com/flamboh/t3code/releases/download/actions-spacing-evidence-20260908/after-narrow.png)

<details>
<summary>Populated narrow layout</summary>

![Populated narrow after](https://github.com/flamboh/t3code/releases/download/actions-spacing-evidence-20260908/after-populated-narrow.png)

</details>

Made with GPT-6 in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bottom padding to Actions section in `ProjectSettingsPanel`
> Updates the Actions container in [ProjectSettingsPanel.tsx](https://github.com/pingdotgg/t3code/pull/10634/files#diff-0240d4863349583155edae77c3bfab65683d7e019508379850a5b96167960cdc) to use equal vertical padding instead of top padding only. Existing top padding and responsive layout classes are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 242a64a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted spacing around the **Actions** section header in project settings for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->