### PR TITLE
fix(web): chat text no longer shows through a 1px gap under composer banners

### DIFF
--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -56,7 +56,11 @@ function Surface({
           : "[--chat-composer-attachment-overlap:0px] before:rounded-[1rem]",
         "before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:border before:border-(--chat-composer-attached-outline)",
         "before:bg-[color-mix(in_srgb,var(--chat-composer-attached-surface)_var(--glass-opacity),transparent)] before:bg-[linear-gradient(var(--chat-composer-attached-tint),var(--chat-composer-attached-tint))] before:backdrop-blur-(--glass-blur) before:backdrop-saturate-(--glass-saturation)",
-        "before:mask-[linear-gradient(to_top,transparent_0_var(--chat-composer-attachment-overlap),black_var(--chat-composer-attachment-overlap))] before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)] dark:before:shadow-[0_14px_32px_-18px_rgb(0_0_0/75%)]",
+        // The mask cut-off bleeds one pixel past the seam: Chromium drops the last
+        // device-pixel row of a filtered backdrop when the cut-off lands off the
+        // device-pixel grid, and the composer's surface starts exactly there. The
+        // composer's own glass covers the extra row, so the overlap never shows.
+        "before:mask-[linear-gradient(to_top,transparent_0_calc(var(--chat-composer-attachment-overlap)-1px),black_calc(var(--chat-composer-attachment-overlap)-1px))] before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)] dark:before:shadow-[0_14px_32px_-18px_rgb(0_0_0/75%)]",
         "dark:supports-[(backdrop-filter:blur(1px))_or_(-webkit-backdrop-filter:blur(1px))]:before:bg-[linear-gradient(var(--chat-composer-attached-tint),var(--chat-composer-attached-tint)),linear-gradient(to_top,transparent_0_var(--chat-composer-attachment-overlap),rgb(0_0_0/18%)_var(--chat-composer-attachment-overlap),transparent_calc(var(--chat-composer-attachment-overlap)+10px))]",
         "not-supports-[((backdrop-filter:blur(1px))_or_(-webkit-backdrop-filter:blur(1px)))]:before:bg-(--chat-composer-attached-surface)",
         className,


### PR DESCRIPTION
Replaces #8551, which GitHub would not reopen after the backlog sweep; that PR's closure reason (my own Aug 31 comment) was superseded by the Sep 3 measurements on `main` after #8734, repeated below.

Closes #8546.

## What Changed

On 125% and 150% displays, a crisp line of chat text shows through a one-pixel gap between any attached composer banner ("Monitoring", offline, "This thread is snoozed", "Resume with less context") and the composer. It looks like a rendering glitch every time the timeline scrolls under the banner.

One line in `apps/web/src/components/chat/ComposerBanner.tsx`: the banner's glass mask now ends one pixel below the seam instead of exactly on it, so the banner paints the row the composer never reaches. The composer's own glass sits over that pixel, so the overlap is invisible.

## Why

Chromium drops the last device-pixel row of a `backdrop-filter` surface when its mask cut-off lands between device pixels, and the composer surface starts exactly at that cut-off, so nothing paints the row. A border or shadow on the composer cannot reach it; only the banner's own mask can. A fixed `1px` (not scaled with the `1rem` overlap) because this repairs a device-pixel rounding artefact, not a layout distance.

## UI Changes

Dark theme, DPR 1.25, collapsed resting composer with the snoozed notice attached, chat text scrolled under the join. Before, then after:

<img width="900" alt="Before: a crisp line of chat text leaks through the seam under the snoozed notice" src="https://github.com/user-attachments/assets/04f01b68-aa16-46af-add0-d2b38c4f303f" />
<img width="900" alt="After: the seam is uniformly blurred, no text leak" src="https://github.com/user-attachments/assets/059933a6-bbcb-47d5-beb4-c30892fa769c" />

Seam at 4×, before and after:

<img width="900" alt="Seam magnified 4x: one crisp unblurred row of text at the cut-off" src="https://github.com/user-attachments/assets/21a791bd-6d0e-4550-ae4c-cfd665cda089" />
<img width="900" alt="Seam magnified 4x: the crisp row is gone, blur continuous across the join" src="https://github.com/user-attachments/assets/75bed4e1-1718-43cc-9187-5271dd1d268c" />

No motion, so no video.

## Verification

- Measured in the running app with Playwright, 208 viewport/scroll configurations per DPR on `main` vs this commit: crisp-text leaks at DPR 1.25 / 1.5 / 2 go from 24 / 21 / 0 to 0 / 0 / 0. Rows above the seam are byte-identical before and after.
- The production Tailwind build emits the arbitrary value with valid spacing, matching the sibling `+ 10px` value on the same element.
- At DPR 2 in a 1400-px window the banner bottom lands on a whole device pixel, which is why a Retina window of that size never shows the bug and why it went unreported for a while.

<details>
<summary>Measurement history and alternatives tried</summary>

Per-device-row luminance at the cut-off (Rec. 709), collapsed composer:

| | before | after |
| --- | --- | --- |
| cut-off row peak | 75 | 30 |
| neighbour mean | 18.9 | 18.9 |
| peak / neighbour ratio | 3.97 | 1.59 |

Alternatives, 224 configurations (7 DPRs × 8 sub-pixel phases × ancestor transform × light/dark):

| approach | leaking configs |
| --- | --- |
| `main` | 48 |
| `border-top` or `box-shadow: inset 0 1px 0` on the composer | 48 |
| a separate strip with the same tokens + `backdrop-filter` | 30 |
| **mask bleed 1px** | **0** |

Original report (macOS desktop app, "Resume with less context" banner):

<img width="900" alt="Resume with less context banner with chat text showing through the seam above the composer" src="https://github.com/user-attachments/assets/6bdfcaf0-a6b1-432c-a3f8-d48799df241e" />

Expanded composer with the offline banner, before and after:

<img width="900" alt="Offline banner on the expanded composer with a crisp line of text leaking through the seam" src="https://github.com/user-attachments/assets/e56bd8e0-e726-4bb2-9059-e93bce8bba4c" />
<img width="900" alt="Same offline banner, seam now uniformly blurred" src="https://github.com/user-attachments/assets/d87867df-8aa8-4774-a0bc-7802b6203d4d" />

History: #8733 removed the masked overlap and #8734 restored it into `ComposerBanner.tsx`, which is where the fix now lives.

</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (nothing moves)

Built with Claude Fable 5 in Claude Code.




<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 1px gap showing chat text under composer banner in Chromium
> Adjusts the surface pseudo-element mask gradient in [ComposerBanner.tsx](https://github.com/pingdotgg/t3code/pull/10635/files#diff-319ed522cd774163e07b333af3237cea096961657d60773abcc503c31bb3aebe) so the opaque cutoff sits one pixel before the attachment overlap. This covers a Chromium `backdrop-filter` seam that let chat text bleed through.
> - Risk: changes the rendered boundary of attached and floating glass surfaces by extending the masked region one pixel toward the attachment seam
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f83ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the chat composer’s visual mask cutoff to prevent a subtle rendering artifact in Chromium.
  * Preserved the existing shadow appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->