### PR TITLE
test(web): cover the right panel toggle opening and closing the panel

### DIFF
--- a/apps/web/src/components/chat/PanelLayoutControls.test.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.test.tsx
@@ -1,0 +1,141 @@
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { type EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { act, type ReactElement, type ReactNode } from "react";
+import { create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { selectThreadRightPanelState, useRightPanelStore } from "../../rightPanelStore";
+
+// Tooltips position through floating-ui, which needs a window. The hover
+// hint is not under test; the button beneath it is.
+vi.mock("../ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
+  TooltipPopup: () => null,
+}));
+
+import { PanelLayoutControls } from "./PanelLayoutControls";
+
+const threadA = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-A"));
+const threadB = scopeThreadRef("env-1" as EnvironmentId, ThreadId.make("thread-B"));
+
+/**
+ * Stands in for ChatView and the pull-requests route: both read the thread's
+ * panel state from the store and hand the toggle a store-backed handler.
+ */
+function RightPanelToggleProbe({
+  threadRef,
+  available = true,
+}: {
+  threadRef: typeof threadA;
+  available?: boolean;
+}) {
+  const panelState = useRightPanelStore((state) =>
+    selectThreadRightPanelState(state.byThreadKey, threadRef),
+  );
+  return (
+    <PanelLayoutControls
+      terminalAvailable={available}
+      terminalOpen={false}
+      terminalShortcutLabel={null}
+      rightPanelAvailable={available}
+      rightPanelOpen={panelState.isOpen}
+      rightPanelShortcutLabel={null}
+      liveAgentCount={0}
+      onToggleTerminal={() => undefined}
+      onToggleRightPanel={() => useRightPanelStore.getState().toggleVisibility(threadRef)}
+    />
+  );
+}
+
+let renderer: ReactTestRenderer | undefined;
+
+async function mount(element: ReactElement) {
+  await act(() => {
+    renderer = create(element);
+  });
+}
+
+/** The one button a user, a screen reader, or the command palette reaches as the panel toggle. */
+function rightPanelToggle(): ReactTestInstance {
+  const buttons = renderer!.root.findAll(
+    (node) =>
+      node.type === "button" &&
+      typeof node.props["aria-label"] === "string" &&
+      node.props["aria-label"].startsWith("Toggle right panel"),
+  );
+  expect(buttons).toHaveLength(1);
+  return buttons[0]!;
+}
+
+async function press(button: ReactTestInstance) {
+  await act(() => {
+    button.props.onClick({ defaultPrevented: false, nativeEvent: {}, preventDefault() {} });
+  });
+}
+
+const isOpen = (threadRef: typeof threadA) =>
+  selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef).isOpen;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  useRightPanelStore.setState({ byThreadKey: {}, userActionRevisionByThreadKey: {} });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+describe("right panel toggle", () => {
+  it("opens the panel on press and closes it on the next press", async () => {
+    await mount(<RightPanelToggleProbe threadRef={threadA} />);
+    expect(rightPanelToggle().props["aria-pressed"]).toBe(false);
+
+    // A thread with no surfaces yet still opens, to the panel's empty state.
+    await press(rightPanelToggle());
+    expect(isOpen(threadA)).toBe(true);
+    expect(rightPanelToggle().props["aria-pressed"]).toBe(true);
+
+    // One press is one toggle: a double-fired handler would land back on closed.
+    await press(rightPanelToggle());
+    expect(isOpen(threadA)).toBe(false);
+    expect(rightPanelToggle().props["aria-pressed"]).toBe(false);
+  });
+
+  it("keeps surfaces through a close so reopening restores them", async () => {
+    useRightPanelStore.getState().open(threadA, "diff");
+    await mount(<RightPanelToggleProbe threadRef={threadA} />);
+    expect(rightPanelToggle().props["aria-pressed"]).toBe(true);
+
+    await press(rightPanelToggle());
+    expect(isOpen(threadA)).toBe(false);
+
+    await press(rightPanelToggle());
+    const reopened = selectThreadRightPanelState(
+      useRightPanelStore.getState().byThreadKey,
+      threadA,
+    );
+    expect(reopened.isOpen).toBe(true);
+    expect(reopened.activeSurfaceId).toBe("diff");
+  });
+
+  it("only affects the thread it belongs to", async () => {
+    await mount(<RightPanelToggleProbe threadRef={threadA} />);
+    await press(rightPanelToggle());
+    expect(isOpen(threadA)).toBe(true);
+    expect(isOpen(threadB)).toBe(false);
+
+    await act(() => renderer!.update(<RightPanelToggleProbe threadRef={threadB} />));
+    expect(rightPanelToggle().props["aria-pressed"]).toBe(false);
+  });
+
+  it("is disabled without a project and leaves the panel closed", async () => {
+    await mount(<RightPanelToggleProbe threadRef={threadA} available={false} />);
+    expect(rightPanelToggle().props.disabled).toBe(true);
+
+    await press(rightPanelToggle());
+    expect(isOpen(threadA)).toBe(false);
+  });
+});


### PR DESCRIPTION
The right panel toggle in the chat header has regressed several times (#8016, #9517, #9591) and nothing in the suite exercises it. Every one of those was a click that never reached the button, so the store never changed.

This adds a test that mounts the real `PanelLayoutControls` (real base-ui button) against the real right-panel store and presses the button the way ChatView and the pull-requests route wire it. It checks that one press opens the panel for the thread, the next press closes it, an open surface survives a close and comes back on reopen, the toggle only touches its own thread, and an unavailable toggle stays disabled. Verified the test fails when the handler double-fires.

The three past breakages were Electron drag-region hit-testing, which only a real browser can reproduce; this covers everything below that layer.

Work done by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for right panel toggle in `PanelLayoutControls`
> Adds a test module in [PanelLayoutControls.test.tsx](https://github.com/pingdotgg/t3code/pull/10642/files#diff-2e8e34f3bc682211b1e37fe05cd2155768b782e18fedf01ba0c63e1840f2e681) that mounts `PanelLayoutControls` via a probe component and exercises the right-panel toggle button. Tests cover opening and closing the panel, preserving the active diff surface across close/reopen, state isolation between threads, and disabled behavior when the panel is unavailable. Each test resets the right-panel store and cleans up the renderer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a80da74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for opening and closing the right-side panel.
  * Verified that the selected panel surface is preserved when reopening.
  * Confirmed panel state remains independent across threads.
  * Verified the toggle is disabled when the right panel is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->