### PR TITLE
fix(native): wait for the KDE feedback test listener

### DIFF
--- a/native/kde-snap-shot/src/feedback.rs
+++ b/native/kde-snap-shot/src/feedback.rs
@@ -221,9 +221,12 @@ mod tests {
         let f = crate::transport_tests::Fixture::new();
         let (send, commands) = async_channel::bounded(4);
         let (done, finished) = mpsc::sync_channel(1);
-        f.client
-            .object_server()
-            .at(
+        // Build with the bridge registered so zbus waits for its method-call listener.
+        // Registering it after build can drop the first call while that listener starts.
+        let bridge = Builder::address(f.address.as_str())
+            .unwrap()
+            .method_timeout(DEADLINE)
+            .serve_at(
                 OBJECT,
                 Bridge {
                     owner: f._server.unique_name().unwrap().to_string(),
@@ -231,8 +234,10 @@ mod tests {
                     done,
                 },
             )
+            .unwrap()
+            .build()
             .unwrap();
-        let destination = f.client.unique_name().unwrap().to_string();
+        let destination = bridge.unique_name().unwrap().to_string();
         let stranger = Builder::address(f.address.as_str())
             .unwrap()
             .method_timeout(DEADLINE)
@@ -275,10 +280,7 @@ mod tests {
         kwin.call::<_, _, ()>("Event", &("{\"event\":\"done\"}",))
             .unwrap();
         finished.recv_timeout(DEADLINE).unwrap();
-        f.client
-            .object_server()
-            .remove::<Bridge, _>(OBJECT)
-            .unwrap();
+        bridge.object_server().remove::<Bridge, _>(OBJECT).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Register the feedback test bridge with `Builder::serve_at` before building its D-Bus connection. zbus waits for the method-call listener during this build, so the first authorization call cannot race listener startup. Keep the existing authorization checks and five-second deadline.

## Why

The [Rust job on main](https://github.com/pingdotgg/t3code/actions/runs/34177451784/job/101909592374) failed in `only_kwin_can_read_commands_or_acknowledge_feedback` even though the latest commit only changed web files. Registering the object on an already-running connection starts the listener asynchronously; the first `Next` call can arrive before its subscription exists and time out instead of returning `AccessDenied`.

## Verification

Before, the unchanged crate reproduced the exact CI failure on iteration 13 when running four test processes on four CPU cores with Rust 1.98.1:

```text
thread 'feedback::tests::only_kwin_can_read_commands_or_acknowledge_feedback' panicked at src/feedback.rs:249:9:
InputOutput(Custom { kind: TimedOut, error: "timed out" })
test result: FAILED. 10 passed; 1 failed
```

After, `cargo test --locked --manifest-path native/kde-snap-shot/Cargo.toml` passes all 11 tests. All 2,000 full-crate runs passed under the same contention, with zero failures. The PR Rust CI job also passes. Rust formatting and `git diff --check` pass.

Screenshots do not apply to this test-only change.

## Checklist

- [x] Small and focused
- [x] Explained the change and cause
- [x] Included before/after test evidence

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved authorization-flow test reliability by validating request handling through an active client connection.
  - Strengthened verification that authorization requests are processed and cleaned up correctly after testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->