### PR TITLE
fix(web): tone the SnapShot overlay from the captured image

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -5265,6 +5265,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                             {image.source?.kind === "snap-shot" ? (
                               <SnapShotAttachmentDetails
                                 source={image.source}
+                                src={image.previewUrl}
                                 className={cn(
                                   upload?.status === "uploading" && "bottom-4",
                                   upload?.status === "failed" && "bottom-8",

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1380,7 +1380,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
                   </div>
                 )}
                 {image.previewUrl && image.source?.kind === "snap-shot" ? (
-                  <SnapShotAttachmentDetails source={image.source} />
+                  <SnapShotAttachmentDetails source={image.source} src={image.previewUrl} />
                 ) : null}
               </div>
             ))}

--- a/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
+++ b/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
@@ -202,26 +202,26 @@ export function SnapShotAttachmentDetails({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 flex min-w-0 items-center gap-1.5 bg-linear-to-t from-black/85 via-black/55 to-transparent px-2.5 pb-2 pt-6",
+        "pointer-events-none absolute inset-x-0 bottom-0 flex min-w-0 items-center gap-1.5 bg-linear-to-t from-white/85 via-white/55 to-transparent px-2.5 pb-2 pt-6 dark:from-black/85 dark:via-black/55",
         className,
       )}
     >
       {source.appIconDataUrl ? (
         <img src={source.appIconDataUrl} alt="" className="size-7 shrink-0 rounded-md" />
       ) : (
-        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-white/20 text-[10px] font-medium text-white uppercase">
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-black/10 text-[10px] font-medium text-foreground uppercase dark:bg-white/20 dark:text-white">
           {source.appName.slice(0, 1)}
         </div>
       )}
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium leading-3.5 text-white">
+        <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium leading-3.5 text-foreground dark:text-white">
           <span className="truncate">{source.appName}</span>
           <SnapShotContentsButton
             source={source}
-            className="pointer-events-auto text-white/60 hover:bg-white/10 hover:text-white focus-visible:ring-white/70"
+            className="pointer-events-auto text-foreground/60 hover:bg-black/10 hover:text-foreground focus-visible:ring-foreground/70 dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-white/70"
           />
         </div>
-        <div className="truncate text-[9px] leading-3.5 text-white/70">
+        <div className="truncate text-[9px] leading-3.5 text-foreground/70 dark:text-white/70">
           {source.windowTitle || "Captured window"}
         </div>
       </div>

--- a/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
+++ b/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
@@ -1,9 +1,15 @@
 import type { SnapShotSource } from "@t3tools/contracts";
 import { ImageIcon, TextIcon } from "lucide-react";
-import { Suspense, use, useMemo, type CSSProperties } from "react";
+import { Suspense, use, useEffect, useMemo, useState, type CSSProperties } from "react";
 
 import { useTheme } from "../../hooks/useTheme";
 import { resolveDiffThemeName } from "../../lib/diffRendering";
+import {
+  rgbCss,
+  sampleSnapShotBottomColor,
+  snapShotOverlayTone,
+  type SnapShotOverlayTone,
+} from "../../lib/snapShotOverlayTone";
 import { getSyntaxHighlighterPromise } from "../../lib/syntaxHighlighting";
 import { cn } from "../../lib/utils";
 import { RenderErrorBoundary } from "../RenderErrorBoundary";
@@ -192,33 +198,76 @@ export function SnapShotContentsButton({
   );
 }
 
+/**
+ * Samples the thumbnail's bottom band so the overlay can extend the image in
+ * its own tone. Null until the sample lands or when the pixels are unreadable.
+ */
+function useSnapShotOverlayTone(src: string | undefined): SnapShotOverlayTone | null {
+  const [tone, setTone] = useState<SnapShotOverlayTone | null>(null);
+  useEffect(() => {
+    if (src === undefined) return;
+    let cancelled = false;
+    void sampleSnapShotBottomColor(src).then((color) => {
+      if (cancelled) return;
+      setTone(color === null ? null : snapShotOverlayTone(color));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [src]);
+  return src === undefined ? null : tone;
+}
+
 export function SnapShotAttachmentDetails({
   source,
+  src,
   className,
 }: {
   source: SnapShotSource;
+  /** Thumbnail URL the overlay sits on; sampled for the overlay's tone. */
+  src?: string | undefined;
   className?: string;
 }) {
+  const tone = useSnapShotOverlayTone(src);
+  const style = useMemo<CSSProperties | undefined>(
+    () =>
+      tone === null
+        ? undefined
+        : ({
+            "--snap-shot-scrim": rgbCss(tone.scrim),
+            "--snap-shot-scrim-mid": rgbCss(tone.scrim, 0.7),
+            "--snap-shot-text": rgbCss(tone.text),
+            "--snap-shot-text-muted": rgbCss(tone.text, 0.72),
+            "--snap-shot-badge": rgbCss(tone.text, 0.14),
+          } as CSSProperties),
+    [tone],
+  );
   return (
     <div
+      style={style}
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 flex min-w-0 items-center gap-1.5 bg-linear-to-t from-white/85 via-white/55 to-transparent px-2.5 pb-2 pt-6 dark:from-black/85 dark:via-black/55",
+        "pointer-events-none absolute inset-x-0 bottom-0 flex min-w-0 items-center gap-1.5 px-2.5 pb-2 pt-6",
+        "[--snap-shot-scrim:rgb(0_0_0)] [--snap-shot-scrim-mid:rgb(0_0_0/70%)] [--snap-shot-text:rgb(255_255_255)] [--snap-shot-text-muted:rgb(255_255_255/72%)] [--snap-shot-badge:rgb(255_255_255/14%)]",
+        "bg-linear-to-t from-(--snap-shot-scrim) via-(--snap-shot-scrim-mid) to-transparent text-(--snap-shot-text)",
         className,
       )}
     >
       {source.appIconDataUrl ? (
         <img src={source.appIconDataUrl} alt="" className="size-7 shrink-0 rounded-md" />
       ) : (
-        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-black/10 text-[10px] font-medium text-foreground uppercase dark:bg-white/20 dark:text-white">
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-(--snap-shot-badge) text-[10px] font-medium uppercase">
           {source.appName.slice(0, 1)}
         </div>
       )}
       <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium leading-3.5 text-foreground dark:text-white">
+        <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium leading-3.5">
           <span className="truncate">{source.appName}</span>
-          <SnapShotContentsButton source={source} className="pointer-events-auto" />
+          <SnapShotContentsButton
+            source={source}
+            className="pointer-events-auto text-(--snap-shot-text-muted) hover:bg-(--snap-shot-badge) hover:text-(--snap-shot-text)"
+          />
         </div>
-        <div className="truncate text-[9px] leading-3.5 text-foreground/70 dark:text-white/70">
+        <div className="truncate text-[9px] leading-3.5 text-(--snap-shot-text-muted)">
           {source.windowTitle || "Captured window"}
         </div>
       </div>

--- a/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
+++ b/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
@@ -201,21 +201,26 @@ export function SnapShotContentsButton({
 /**
  * Samples the thumbnail's bottom band so the overlay can extend the image in
  * its own tone. Null until the sample lands or when the pixels are unreadable.
+ * The result is keyed by URL so a thumbnail that swaps from its blob preview
+ * to the uploaded asset never wears the previous image's tone.
  */
 function useSnapShotOverlayTone(src: string | undefined): SnapShotOverlayTone | null {
-  const [tone, setTone] = useState<SnapShotOverlayTone | null>(null);
+  const [sample, setSample] = useState<{
+    readonly src: string;
+    readonly tone: SnapShotOverlayTone | null;
+  } | null>(null);
   useEffect(() => {
     if (src === undefined) return;
     let cancelled = false;
     void sampleSnapShotBottomColor(src).then((color) => {
       if (cancelled) return;
-      setTone(color === null ? null : snapShotOverlayTone(color));
+      setSample({ src, tone: color === null ? null : snapShotOverlayTone(color) });
     });
     return () => {
       cancelled = true;
     };
   }, [src]);
-  return src === undefined ? null : tone;
+  return sample !== null && sample.src === src ? sample.tone : null;
 }
 
 export function SnapShotAttachmentDetails({

--- a/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
+++ b/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
@@ -216,10 +216,7 @@ export function SnapShotAttachmentDetails({
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium leading-3.5 text-foreground dark:text-white">
           <span className="truncate">{source.appName}</span>
-          <SnapShotContentsButton
-            source={source}
-            className="pointer-events-auto text-foreground/60 hover:bg-black/10 hover:text-foreground focus-visible:ring-foreground/70 dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-white/70"
-          />
+          <SnapShotContentsButton source={source} className="pointer-events-auto" />
         </div>
         <div className="truncate text-[9px] leading-3.5 text-foreground/70 dark:text-white/70">
           {source.windowTitle || "Captured window"}

--- a/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
+++ b/apps/web/src/components/chat/SnapShotAttachmentDetails.tsx
@@ -135,10 +135,12 @@ export function SnapShotContentsButton({
   source,
   className,
   side = "top",
+  variant = "ghost-muted",
 }: {
   source: SnapShotSource;
   className?: string;
   side?: "top" | "right" | "bottom" | "left";
+  variant?: "ghost-muted" | "overlay";
 }) {
   const includesAccessibility = snapShotIncludesAccessibility(source);
   const ContentsIcon = includesAccessibility ? TextIcon : ImageIcon;
@@ -159,7 +161,7 @@ export function SnapShotContentsButton({
                   className={cn("[--control-icon-color:currentColor]", className)}
                   onClick={(event) => event.stopPropagation()}
                   size="icon-micro"
-                  variant="ghost-muted"
+                  variant={variant}
                 />
               }
             />
@@ -269,7 +271,8 @@ export function SnapShotAttachmentDetails({
           <span className="truncate">{source.appName}</span>
           <SnapShotContentsButton
             source={source}
-            className="pointer-events-auto text-(--snap-shot-text-muted) hover:bg-(--snap-shot-badge) hover:text-(--snap-shot-text)"
+            variant="overlay"
+            className="pointer-events-auto"
           />
         </div>
         <div className="truncate text-[9px] leading-3.5 text-(--snap-shot-text-muted)">

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -49,6 +49,10 @@ const buttonVariants = cva(
         glass:
           "surface-glass [--control-icon-color:var(--contrast-muted-foreground)] border-border/60 text-foreground shadow-sm [:hover,[data-pressed]]:border-border",
         link: "border-transparent underline-offset-4 [:hover,[data-pressed]]:underline",
+        /** For controls placed over imagery: inherits the surrounding text color
+         * and tints its hover from it, so the host decides the tone. */
+        overlay:
+          "border-transparent text-current opacity-72 [:hover,[data-pressed]]:bg-current/14 [:hover,[data-pressed]]:opacity-100",
         outline:
           "[--control-icon-color:var(--contrast-muted-foreground)] border-input bg-popover not-dark:bg-clip-padding text-foreground shadow-xs/5 not-disabled:not-active:not-data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:bg-input/32 dark:not-disabled:before:shadow-[0_-1px_--theme(--color-white/2%)] dark:not-disabled:not-active:not-data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)] [:disabled,:active,[data-pressed]]:shadow-none [:hover,[data-pressed]]:bg-accent/50 dark:[:hover,[data-pressed]]:bg-input/64",
         secondary:

--- a/apps/web/src/lib/snapShotOverlayTone.test.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { averageOpaqueColor, snapShotOverlayTone } from "./snapShotOverlayTone";
+import {
+  averageOpaqueColor,
+  coverCrop,
+  SNAP_SHOT_FRAME_ASPECT,
+  snapShotOverlayTone,
+} from "./snapShotOverlayTone";
 
 describe("snapShotOverlayTone", () => {
   it("puts white text on a scrim darker than a dark capture", () => {
@@ -52,5 +57,33 @@ describe("averageOpaqueColor", () => {
 
   it("returns null for a fully transparent band", () => {
     expect(averageOpaqueColor(new Uint8ClampedArray([1, 2, 3, 0, 4, 5, 6, 0]))).toBeNull();
+  });
+});
+
+describe("coverCrop", () => {
+  it("keeps a frame-shaped image whole", () => {
+    expect(coverCrop(520, 280, SNAP_SHOT_FRAME_ASPECT)).toEqual({
+      x: 0,
+      y: 0,
+      width: 520,
+      height: 280,
+    });
+  });
+
+  it("crops the top and bottom of a portrait capture, so the sampled band is mid-image", () => {
+    const crop = coverCrop(400, 800, SNAP_SHOT_FRAME_ASPECT);
+    expect(crop.x).toBe(0);
+    expect(crop.width).toBe(400);
+    expect(crop.height).toBeCloseTo(400 / SNAP_SHOT_FRAME_ASPECT);
+    expect(crop.y).toBeCloseTo((800 - crop.height) / 2);
+    expect(crop.y + crop.height).toBeLessThan(800);
+  });
+
+  it("crops the sides of an ultra-wide capture and keeps its full height", () => {
+    const crop = coverCrop(3000, 500, SNAP_SHOT_FRAME_ASPECT);
+    expect(crop.y).toBe(0);
+    expect(crop.height).toBe(500);
+    expect(crop.width).toBeCloseTo(500 * SNAP_SHOT_FRAME_ASPECT);
+    expect(crop.x).toBeCloseTo((3000 - crop.width) / 2);
   });
 });

--- a/apps/web/src/lib/snapShotOverlayTone.test.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { averageOpaqueColor, snapShotOverlayTone } from "./snapShotOverlayTone";
+
+describe("snapShotOverlayTone", () => {
+  it("puts white text on a scrim darker than a dark capture", () => {
+    const tone = snapShotOverlayTone({ r: 40, g: 44, b: 52 });
+    expect(tone.text).toEqual({ r: 255, g: 255, b: 255 });
+    expect(tone.scrim.r).toBeLessThan(40);
+    expect(tone.scrim.g).toBeLessThan(44);
+    expect(tone.scrim.b).toBeLessThan(52);
+  });
+
+  it("puts dark text on a scrim lighter than a light capture", () => {
+    const tone = snapShotOverlayTone({ r: 235, g: 236, b: 240 });
+    expect(tone.text).toEqual({ r: 24, g: 24, b: 27 });
+    expect(tone.scrim.r).toBeGreaterThan(235);
+    expect(tone.scrim.g).toBeGreaterThan(236);
+    expect(tone.scrim.b).toBeGreaterThan(240);
+  });
+
+  it("splits mid-tones at the equal-contrast luminance", () => {
+    // Luminance just under 0.179 → white text; just over → dark text.
+    expect(snapShotOverlayTone({ r: 117, g: 117, b: 117 }).text.r).toBe(255);
+    expect(snapShotOverlayTone({ r: 120, g: 120, b: 120 }).text.r).toBe(24);
+  });
+
+  it("keeps the scrim's hue so it extends the image", () => {
+    const tone = snapShotOverlayTone({ r: 200, g: 60, b: 60 });
+    expect(tone.scrim.r).toBeGreaterThan(tone.scrim.g);
+    expect(tone.scrim.g).toEqual(tone.scrim.b);
+  });
+});
+
+describe("averageOpaqueColor", () => {
+  it("weights pixels by alpha and skips transparent ones", () => {
+    const pixels = new Uint8ClampedArray([
+      // fully opaque black
+      0, 0, 0, 255,
+      // fully transparent white must not count
+      255, 255, 255, 0,
+      // half-transparent white counts half
+      255, 255, 255, 128,
+    ]);
+    const color = averageOpaqueColor(pixels);
+    expect(color).not.toBeNull();
+    // (0*1 + 255*0.502) / 1.502 ≈ 85
+    expect(color!.r).toBe(85);
+    expect(color!.g).toBe(85);
+    expect(color!.b).toBe(85);
+  });
+
+  it("returns null for a fully transparent band", () => {
+    expect(averageOpaqueColor(new Uint8ClampedArray([1, 2, 3, 0, 4, 5, 6, 0]))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/snapShotOverlayTone.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.ts
@@ -1,0 +1,136 @@
+/**
+ * Picks overlay colors for a SnapShot thumbnail from the pixels the overlay
+ * sits on, so the app label reads on any capture in any theme. The scrim
+ * extends the image's own bottom band, pushed away from mid-tones so the
+ * chosen text color keeps contrast.
+ */
+
+export interface RgbColor {
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+}
+
+export interface SnapShotOverlayTone {
+  /** Base color of the scrim gradient behind the label. */
+  readonly scrim: RgbColor;
+  /** Label color, chosen for contrast against the scrim. */
+  readonly text: RgbColor;
+}
+
+const WHITE: RgbColor = { r: 255, g: 255, b: 255 };
+const BLACK: RgbColor = { r: 0, g: 0, b: 0 };
+const NEAR_BLACK: RgbColor = { r: 24, g: 24, b: 27 };
+
+/** Luminance at which black and white text have equal WCAG contrast. */
+const TEXT_LUMINANCE_THRESHOLD = 0.179;
+/** How far the scrim is pushed toward its text's opposite pole. */
+const SCRIM_PUSH = 0.35;
+
+/** Fraction of the image height, measured from the bottom, that the overlay covers. */
+export const SNAP_SHOT_SAMPLE_BAND = 0.3;
+
+function relativeLuminance(color: RgbColor): number {
+  const linearize = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linearize(color.r) + 0.7152 * linearize(color.g) + 0.0722 * linearize(color.b);
+}
+
+function mix(base: RgbColor, toward: RgbColor, amount: number): RgbColor {
+  return {
+    r: Math.round(base.r + (toward.r - base.r) * amount),
+    g: Math.round(base.g + (toward.g - base.g) * amount),
+    b: Math.round(base.b + (toward.b - base.b) * amount),
+  };
+}
+
+export function snapShotOverlayTone(sampled: RgbColor): SnapShotOverlayTone {
+  const dark = relativeLuminance(sampled) < TEXT_LUMINANCE_THRESHOLD;
+  return dark
+    ? { scrim: mix(sampled, BLACK, SCRIM_PUSH), text: WHITE }
+    : { scrim: mix(sampled, WHITE, SCRIM_PUSH), text: NEAR_BLACK };
+}
+
+/** Alpha-weighted mean of RGBA pixels; null when every pixel is transparent. */
+export function averageOpaqueColor(pixels: Uint8ClampedArray): RgbColor | null {
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let weight = 0;
+  for (let index = 0; index + 3 < pixels.length; index += 4) {
+    const alpha = pixels[index + 3]! / 255;
+    if (alpha === 0) continue;
+    r += pixels[index]! * alpha;
+    g += pixels[index + 1]! * alpha;
+    b += pixels[index + 2]! * alpha;
+    weight += alpha;
+  }
+  if (weight === 0) return null;
+  return { r: Math.round(r / weight), g: Math.round(g / weight), b: Math.round(b / weight) };
+}
+
+export function rgbCss(color: RgbColor, alpha?: number): string {
+  return alpha === undefined
+    ? `rgb(${color.r} ${color.g} ${color.b})`
+    : `rgb(${color.r} ${color.g} ${color.b} / ${alpha})`;
+}
+
+const SAMPLE_WIDTH = 16;
+const SAMPLE_HEIGHT = 4;
+const CACHE_LIMIT = 256;
+const sampleCache = new Map<string, Promise<RgbColor | null>>();
+
+function readBottomBand(image: HTMLImageElement): RgbColor | null {
+  const { naturalWidth: width, naturalHeight: height } = image;
+  if (width === 0 || height === 0) return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = SAMPLE_WIDTH;
+  canvas.height = SAMPLE_HEIGHT;
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (context === null) return null;
+  const bandHeight = Math.max(1, Math.round(height * SNAP_SHOT_SAMPLE_BAND));
+  // Drawing the band into a tiny canvas lets the rasterizer do the averaging.
+  context.drawImage(
+    image,
+    0,
+    height - bandHeight,
+    width,
+    bandHeight,
+    0,
+    0,
+    SAMPLE_WIDTH,
+    SAMPLE_HEIGHT,
+  );
+  try {
+    return averageOpaqueColor(context.getImageData(0, 0, SAMPLE_WIDTH, SAMPLE_HEIGHT).data);
+  } catch {
+    // A tainted canvas (asset served without CORS headers) throws here.
+    return null;
+  }
+}
+
+/**
+ * Average color of the image's bottom band, or null when the image cannot be
+ * loaded or read. Results are memoized per URL so the three surfaces that
+ * show the same capture decode it once.
+ */
+export function sampleSnapShotBottomColor(src: string): Promise<RgbColor | null> {
+  const cached = sampleCache.get(src);
+  if (cached) return cached;
+  const pending = new Promise<RgbColor | null>((resolve) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.decoding = "async";
+    image.addEventListener("load", () => resolve(readBottomBand(image)), { once: true });
+    image.addEventListener("error", () => resolve(null), { once: true });
+    image.src = src;
+  });
+  if (sampleCache.size >= CACHE_LIMIT) {
+    const oldest = sampleCache.keys().next().value;
+    if (oldest !== undefined) sampleCache.delete(oldest);
+  }
+  sampleCache.set(src, pending);
+  return pending;
+}

--- a/apps/web/src/lib/snapShotOverlayTone.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.ts
@@ -28,7 +28,7 @@ const TEXT_LUMINANCE_THRESHOLD = 0.179;
 const SCRIM_PUSH = 0.35;
 
 /** Fraction of the image height, measured from the bottom, that the overlay covers. */
-export const SNAP_SHOT_SAMPLE_BAND = 0.3;
+const SAMPLE_BAND = 0.3;
 
 function relativeLuminance(color: RgbColor): number {
   const linearize = (channel: number) => {
@@ -90,7 +90,7 @@ function readBottomBand(image: HTMLImageElement): RgbColor | null {
   canvas.height = SAMPLE_HEIGHT;
   const context = canvas.getContext("2d", { willReadFrequently: true });
   if (context === null) return null;
-  const bandHeight = Math.max(1, Math.round(height * SNAP_SHOT_SAMPLE_BAND));
+  const bandHeight = Math.max(1, Math.round(height * SAMPLE_BAND));
   // Drawing the band into a tiny canvas lets the rasterizer do the averaging.
   context.drawImage(
     image,

--- a/apps/web/src/lib/snapShotOverlayTone.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.ts
@@ -107,7 +107,7 @@ export function coverCrop(
   return { x: 0, y: (height - cropHeight) / 2, width, height: cropHeight };
 }
 
-function readBottomBand(image: HTMLImageElement, frameAspect: number): RgbColor | null {
+function readBottomBand(image: HTMLImageElement): RgbColor | null {
   const { naturalWidth: width, naturalHeight: height } = image;
   if (width === 0 || height === 0) return null;
   const canvas = document.createElement("canvas");
@@ -115,7 +115,7 @@ function readBottomBand(image: HTMLImageElement, frameAspect: number): RgbColor 
   canvas.height = SAMPLE_HEIGHT;
   const context = canvas.getContext("2d", { willReadFrequently: true });
   if (context === null) return null;
-  const crop = coverCrop(width, height, frameAspect);
+  const crop = coverCrop(width, height, SNAP_SHOT_FRAME_ASPECT);
   const bandHeight = Math.max(1, crop.height * SAMPLE_BAND);
   // Drawing the band into a tiny canvas lets the rasterizer do the averaging.
   context.drawImage(
@@ -139,22 +139,18 @@ function readBottomBand(image: HTMLImageElement, frameAspect: number): RgbColor 
 
 /**
  * Average color of the bottom band of the region the thumbnail frame shows, or
- * null when the image cannot be loaded or read. Results are memoized per URL
- * so the surfaces that show the same capture decode it once.
+ * null when the image cannot be loaded or read. Every surface renders the
+ * capture in the same frame, so results are memoized per URL and the surfaces
+ * that show the same capture decode it once.
  */
-export function sampleSnapShotBottomColor(
-  src: string,
-  frameAspect = SNAP_SHOT_FRAME_ASPECT,
-): Promise<RgbColor | null> {
+export function sampleSnapShotBottomColor(src: string): Promise<RgbColor | null> {
   const cached = sampleCache.get(src);
   if (cached) return cached;
   const pending = new Promise<RgbColor | null>((resolve) => {
     const image = new Image();
     image.crossOrigin = "anonymous";
     image.decoding = "async";
-    image.addEventListener("load", () => resolve(readBottomBand(image, frameAspect)), {
-      once: true,
-    });
+    image.addEventListener("load", () => resolve(readBottomBand(image)), { once: true });
     image.addEventListener("error", () => resolve(null), { once: true });
     image.src = src;
   });

--- a/apps/web/src/lib/snapShotOverlayTone.ts
+++ b/apps/web/src/lib/snapShotOverlayTone.ts
@@ -27,8 +27,15 @@ const TEXT_LUMINANCE_THRESHOLD = 0.179;
 /** How far the scrim is pushed toward its text's opposite pole. */
 const SCRIM_PUSH = 0.35;
 
-/** Fraction of the image height, measured from the bottom, that the overlay covers. */
+/** Fraction of the visible thumbnail height, from the bottom, that the overlay covers. */
 const SAMPLE_BAND = 0.3;
+
+/**
+ * Aspect ratio of the frame the thumbnail is rendered into with `object-cover`
+ * (see `SNAP_SHOT_ATTACHMENT_FRAME_CLASS`: w-52 by h-28). Sampling must use the
+ * centered crop that ratio imposes, not the full source image.
+ */
+export const SNAP_SHOT_FRAME_ASPECT = 52 / 28;
 
 function relativeLuminance(color: RgbColor): number {
   const linearize = (channel: number) => {
@@ -82,7 +89,25 @@ const SAMPLE_HEIGHT = 4;
 const CACHE_LIMIT = 256;
 const sampleCache = new Map<string, Promise<RgbColor | null>>();
 
-function readBottomBand(image: HTMLImageElement): RgbColor | null {
+/**
+ * Source rectangle that `object-cover` shows for an image of the given size in
+ * a frame of the given aspect ratio: the largest centered region of that ratio.
+ */
+export function coverCrop(
+  width: number,
+  height: number,
+  frameAspect: number,
+): { x: number; y: number; width: number; height: number } {
+  const imageAspect = width / height;
+  if (imageAspect > frameAspect) {
+    const cropWidth = height * frameAspect;
+    return { x: (width - cropWidth) / 2, y: 0, width: cropWidth, height };
+  }
+  const cropHeight = width / frameAspect;
+  return { x: 0, y: (height - cropHeight) / 2, width, height: cropHeight };
+}
+
+function readBottomBand(image: HTMLImageElement, frameAspect: number): RgbColor | null {
   const { naturalWidth: width, naturalHeight: height } = image;
   if (width === 0 || height === 0) return null;
   const canvas = document.createElement("canvas");
@@ -90,13 +115,14 @@ function readBottomBand(image: HTMLImageElement): RgbColor | null {
   canvas.height = SAMPLE_HEIGHT;
   const context = canvas.getContext("2d", { willReadFrequently: true });
   if (context === null) return null;
-  const bandHeight = Math.max(1, Math.round(height * SAMPLE_BAND));
+  const crop = coverCrop(width, height, frameAspect);
+  const bandHeight = Math.max(1, crop.height * SAMPLE_BAND);
   // Drawing the band into a tiny canvas lets the rasterizer do the averaging.
   context.drawImage(
     image,
-    0,
-    height - bandHeight,
-    width,
+    crop.x,
+    crop.y + crop.height - bandHeight,
+    crop.width,
     bandHeight,
     0,
     0,
@@ -112,18 +138,23 @@ function readBottomBand(image: HTMLImageElement): RgbColor | null {
 }
 
 /**
- * Average color of the image's bottom band, or null when the image cannot be
- * loaded or read. Results are memoized per URL so the three surfaces that
- * show the same capture decode it once.
+ * Average color of the bottom band of the region the thumbnail frame shows, or
+ * null when the image cannot be loaded or read. Results are memoized per URL
+ * so the surfaces that show the same capture decode it once.
  */
-export function sampleSnapShotBottomColor(src: string): Promise<RgbColor | null> {
+export function sampleSnapShotBottomColor(
+  src: string,
+  frameAspect = SNAP_SHOT_FRAME_ASPECT,
+): Promise<RgbColor | null> {
   const cached = sampleCache.get(src);
   if (cached) return cached;
   const pending = new Promise<RgbColor | null>((resolve) => {
     const image = new Image();
     image.crossOrigin = "anonymous";
     image.decoding = "async";
-    image.addEventListener("load", () => resolve(readBottomBand(image)), { once: true });
+    image.addEventListener("load", () => resolve(readBottomBand(image, frameAspect)), {
+      once: true,
+    });
     image.addEventListener("error", () => resolve(null), { once: true });
     image.src = src;
   });


### PR DESCRIPTION
## What Changed

The SnapShot attachment overlay (app icon, app name, window title) was hardcoded to a black-to-transparent gradient with white text, so it clashed with the surrounding card in light mode. Swapping to a theme-colored gradient did not help either: a dark terminal in light mode got a white smear, a light window in dark mode got a black one. The overlay's background is the captured image, not the app theme.

The overlay now takes its tone from the image it sits on:

- A small helper (`snapShotOverlayTone.ts`) loads the thumbnail once per URL, takes the centered crop that `object-cover` shows in the 52:28 frame, draws that crop's bottom band into a 16×4 canvas so the rasterizer averages it, and reads the mean color.
- The scrim gradient extends that color, pushed 35% toward black or white away from mid-tones, and the label picks white or near-black text at the equal-contrast luminance threshold.
- Values are applied as CSS variables on the overlay. The sampled state is keyed to the URL it came from, so a thumbnail that swaps from its blob preview to the uploaded asset never wears the previous image's tone. Until the sample lands, or when the canvas cannot be read, the overlay keeps the black gradient it had on `main`.
- The composer thumbnail, the timeline image, and the expanded image dialog share the one component and now pass the thumbnail URL in. No contract changes; existing captures get this immediately.
- `Button` gains an `overlay` variant that inherits `currentColor` and tints its hover from it. The accessibility-contents button uses it, so the overlay sets the button's tone through its own text color with no call-site color classes.

## Why

Light mode users saw a dark bar on every SnapShot, and any single fixed color is wrong for half of all captures.

## UI Changes

Captured in the web client, same thread, viewport, and scroll position. Only the emulated color scheme and the captured image differ. The light capture is a real attachment from the same thread substituted into the SnapShot slot.

**Before, on `main`** (black gradient regardless of theme or image):

| Light mode | Dark mode |
| --- | --- |
| ![Before, light mode: black gradient with white text over the dark Ghostty capture](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b2bd4574a9c97531/before-light.png) | ![Before, dark mode: black gradient with white text over the dark Ghostty capture](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d2c8ce171fcf35ca/before-dark.png) |

**After** (sampled from the image):

| | Light mode | Dark mode |
| --- | --- | --- |
| Dark capture (Ghostty) | ![After, light mode, dark capture: blue-black scrim with white text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b03190b108d2577e/sample-light.png) | ![After, dark mode, dark capture: blue-black scrim with white text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/052e087bf76f3f6f/sample-dark.png) |
| Light capture (T3 Code) | ![After, light mode, light capture: near-white scrim with dark text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/faefa4f1061dd9e8/sample-lightimg-light.png) | ![After, dark mode, light capture: near-white scrim with dark text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/66241db2018d1b8c/sample-lightimg-dark.png) |

### Broader sample

Two captures are not much of a test, so I surveyed all 221 PNG attachments in a real database, measured the bottom band each one would show in the 52:28 frame, and seeded 14 of them as SnapShots on one message to cover the space: pure black, dark neutral, dark saturated blue, both sides of the text-color threshold, true mid gray, saturated blue, purple, light gray, warm off-white, pure white, a 9:1 ultra-wide strip, and tall dark and light portraits. Each card's subtitle carries the measured luminance, mean color, and source size.

The survey rows are seeded projection data in a disposable worktree copy, not real captures, so the app icons show the fallback initial. Same viewport, scroll, and data in all four grids.

| Before, light mode | Before, dark mode |
| --- | --- |
| ![Before survey, light mode: every card wears the same black gradient with white text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/275e12070dd97907/survey-before-light.png) | ![Before survey, dark mode: every card wears the same black gradient with white text](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5af1cd9c211f5094/survey-before-dark.png) |

| After, light mode | After, dark mode |
| --- | --- |
| ![After survey, light mode: each card's scrim extends its own bottom color, text flips at the threshold](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c1d7d86862486117/survey-light.png) | ![After survey, dark mode: identical tones to light mode, since the image decides](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7d32cfb86ea816f9/survey-dark.png) |

Sampled values read back from the DOM (scrim / text), identical in both themes:

| Case | Measured band | Scrim | Text |
| --- | --- | --- | --- |
| 00 black wide | lum 0.000 | `rgb(1 1 1)` | white |
| 01 dark neutral | lum 0.005 | `rgb(11 11 11)` | white |
| 02 dark blue | lum 0.107, sat 88 | `rgb(33 64 99)` | white |
| 03 just below threshold | lum 0.154 | `rgb(168 168 170)` | dark |
| 04 just above threshold | lum 0.285 | `rgb(176 176 177)` | dark |
| 05 mid gray | lum 0.337 | `rgb(178 178 178)` | dark |
| 06 saturated blue portrait | lum 0.351, sat 160 | `rgb(135 191 252)` | dark |
| 07 purple portrait | lum 0.157, sat 43 | `rgb(75 56 85)` | white |
| 08 light gray | lum 0.608 | `rgb(228 227 231)` | dark |
| 09 warm off-white | lum 0.974 | `rgb(253 254 247)` | dark |
| 10 white | lum 1.000 | `rgb(255 255 255)` | dark |
| 11 ultra-wide | lum 0.011 | `rgb(18 18 18)` | white |
| 12 tall dark portrait | lum 0.003 | `rgb(7 7 7)` | white |
| 13 tall light portrait | lum 0.939 | `rgb(250 250 250)` | dark |

Two things worth knowing from this. Case 03 was measured just under the threshold from the full source image, but the sampler reads the visible cover crop, which lands on a lighter region, so it correctly went to dark text. The survey band is the bottom 30% of the crop, while the survey table measured the full bottom band, so the two agree on direction but not on exact numbers. And the mid-gray cases (04, 05) are the weakest of the set: a 35% push toward white on `rgb(157,157,157)` gives `rgb(178,178,178)`, which is legible but low-contrast against the gray image above it. A stronger push for mid-tones is a one-constant change if that matters.

## Verification

- `snapShotOverlayTone.test.ts` (9 new tests) covers text selection around the luminance threshold, scrim direction, hue preservation, alpha-weighted averaging, and the cover crop for frame-shaped, portrait, and ultra-wide sources. `SnapShotAttachmentDetails.test.tsx` (4 tests) still passes.
- Web typecheck passes. Lint is clean on the new files; the one warning on the existing file is on an untouched line.
- Sampled values observed in the browser: the Ghostty capture produced `rgb(26 29 34)` with white text, the T3 Code capture produced `rgb(252 252 252)` with `rgb(24 24 27)` text.
- Desktop wraps the web client and gets the same behavior. Mobile has no SnapShot overlay.

**Remote connections.** In dev the asset URL is same-origin through the Vite proxy, so the cross-origin read path was not exercised end to end. The backend's CORS middleware is global and the asset route answered a foreign-origin preflight with 204 here. If a remote origin is ever refused, the canvas taints, the read throws, and the overlay keeps the black fallback, which is today's behavior. Worth one look on a real app.t3.codes or tunnel connection.

Implemented with Claude Fable 5.1 in Claude Code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
