### PR TITLE
feat(mobile): add markdown preview toggle to the file header

### DIFF
--- a/apps/mobile/src/components/AndroidScreenHeader.tsx
+++ b/apps/mobile/src/components/AndroidScreenHeader.tsx
@@ -18,6 +18,7 @@ export function AndroidHeaderIconButton(props: {
   readonly icon: AppSymbolName;
   readonly onPress?: () => void;
   readonly disabled?: boolean;
+  readonly filled?: boolean;
 }) {
   return (
     <Pressable
@@ -27,14 +28,21 @@ export function AndroidHeaderIconButton(props: {
       hitSlop={8}
       onPress={props.onPress}
       className={cn(
-        "size-11 items-center justify-center rounded-full bg-subtle",
+        "size-11 items-center justify-center rounded-full",
+        props.filled ? "bg-primary" : "bg-subtle",
         props.disabled && "opacity-55",
       )}
     >
       <SymbolView
         name={props.icon}
         size={20}
-        tintColorClassName={props.disabled ? "accent-icon-subtle" : "accent-foreground"}
+        tintColorClassName={
+          props.disabled
+            ? "accent-icon-subtle"
+            : props.filled
+              ? "accent-primary-foreground"
+              : "accent-foreground"
+        }
         type="monochrome"
       />
     </Pressable>

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -49,6 +49,9 @@ import {
 } from "../layout/native-mail-search-toolbar";
 import { WorkspaceSidebarToolbar } from "../layout/workspace-sidebar-toolbar";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
+import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../state/preferences";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { AsyncResult } from "effect/unstable/reactivity";
 import { ThreadRouteScreen } from "../threads/ThreadRouteScreen";
 import { FileMarkdownPreview } from "./FileMarkdownPreview";
 import { FileTreeBrowser } from "./FileTreeBrowser";
@@ -547,6 +550,12 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     readonly mode: FileViewMode;
   } | null>(null);
   const [previewRevision, setPreviewRevision] = useState(0);
+  const preferencesResult = useAtomValue(mobilePreferencesAtom);
+  const savePreferences = useAtomSet(updateMobilePreferencesAtom);
+  const markdownPreviewEnabled =
+    AsyncResult.isSuccess(preferencesResult) &&
+    preferencesResult.value.markdownPreviewEnabled === true;
+  const primaryColor = useUniwindTheme()["--color-primary"];
   const previewKey = JSON.stringify([environmentId, cwd, relativePath, previewRevision]);
   const [fullScreenPreview, setFullScreenPreview] = useState<FilePreviewSource | null>(null);
   const isVideoFile = relativePath !== null && isVideoPreviewFile(relativePath);
@@ -554,14 +563,29 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
     relativePath !== null && !isVideoFile && isWorkspaceBrowserPreviewPath(relativePath);
   const isImageFile =
     relativePath !== null && !isVideoFile && isWorkspaceImagePreviewPath(relativePath);
+  const isMarkdownFile = relativePath !== null && isMarkdownPreviewFile(relativePath);
   const canPreview =
     relativePath !== null &&
     (isMarkdownPreviewFile(relativePath) || isBrowserFile || isImageFile || isVideoFile);
   const activeMode =
-    relativePath !== null && modeOverride?.path === relativePath
-      ? modeOverride.mode
-      : defaultViewMode(relativePath);
+    relativePath !== null && targetLine !== null
+      ? "source"
+      : relativePath !== null && modeOverride?.path === relativePath
+        ? modeOverride.mode
+        : isMarkdownFile && markdownPreviewEnabled
+          ? "preview"
+          : defaultViewMode(relativePath);
   const resolvedActiveMode = isVideoFile ? "preview" : canPreview ? activeMode : "source";
+  const handleToggleMarkdownMode = useCallback(() => {
+    if (relativePath === null || targetLine !== null) return;
+    const next: FileViewMode = resolvedActiveMode === "preview" ? "source" : "preview";
+    setModeOverride({ path: relativePath, mode: next });
+    void savePreferences({ markdownPreviewEnabled: next === "preview" });
+  }, [relativePath, resolvedActiveMode, savePreferences, targetLine]);
+  const markdownToggleLabel =
+    isMarkdownFile && resolvedActiveMode === "preview"
+      ? "Show markdown source"
+      : "Show rendered markdown";
   const assetPreviewPath = isBrowserFile || isImageFile || isVideoFile ? relativePath : null;
   const assetPreview = useWorkspaceFileAssetUrlState({
     cwd,
@@ -843,6 +867,14 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
           onBack={handleBack}
           trailing={
             <>
+              {isMarkdownFile && targetLine === null ? (
+                <AndroidHeaderIconButton
+                  accessibilityLabel={markdownToggleLabel}
+                  icon={resolvedActiveMode === "preview" ? "doc.text" : "eye"}
+                  onPress={handleToggleMarkdownMode}
+                  filled={resolvedActiveMode === "preview"}
+                />
+              ) : null}
               {fileInspector.supported ? (
                 <AndroidHeaderIconButton
                   accessibilityLabel={
@@ -882,6 +914,15 @@ export function ThreadFileScreen(props: ThreadFileRouteScreenProps) {
             icon="sidebar.right"
             onPress={toggleAuxiliaryPane}
             separateBackground
+          />
+        ) : null}
+        {isMarkdownFile && targetLine === null ? (
+          <NativeHeaderToolbar.Button
+            accessibilityLabel={markdownToggleLabel}
+            icon={resolvedActiveMode === "preview" ? "doc.text" : "eye"}
+            onPress={handleToggleMarkdownMode}
+            separateBackground
+            tintColor={resolvedActiveMode === "preview" ? primaryColor : undefined}
           />
         ) : null}
         <NativeHeaderToolbar.Menu accessibilityLabel="File actions" icon="ellipsis">

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -26,6 +26,8 @@ export interface Preferences {
   readonly markdownFontSize?: number;
   readonly codeFontSize?: number | null;
   readonly codeWordBreak?: boolean;
+  /** Device-local mirror of web's `renderMarkdown` preference for markdown file previews. */
+  readonly markdownPreviewEnabled?: boolean;
   readonly connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
   readonly collapsedProjectGroups?: readonly string[];
   /** @deprecated Kept temporarily so older OTA bundles retain the selected mode. */
@@ -95,6 +97,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     markdownFontSize?: number;
     codeFontSize?: number | null;
     codeWordBreak?: boolean;
+    markdownPreviewEnabled?: boolean;
     connectOnboardingOptOutAccounts?: ReadonlyArray<string>;
     collapsedProjectGroups?: readonly string[];
     projectGroupingEnabled?: boolean;
@@ -144,6 +147,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     preferences.codeFontSize = parsed.codeFontSize;
   }
   if (typeof parsed.codeWordBreak === "boolean") preferences.codeWordBreak = parsed.codeWordBreak;
+  if (typeof parsed.markdownPreviewEnabled === "boolean") {
+    preferences.markdownPreviewEnabled = parsed.markdownPreviewEnabled;
+  }
   if (Array.isArray(parsed.connectOnboardingOptOutAccounts)) {
     preferences.connectOnboardingOptOutAccounts = parsed.connectOnboardingOptOutAccounts.filter(
       (account): account is string => typeof account === "string",


### PR DESCRIPTION
## Problem

Rendered markdown preview is a one-way door on mobile: every markdown file
opens in preview mode by default, and the source view is only reachable while
you stay on that file. Coming back re-opens preview, so there is no persistent
way to tell the file view "I want to read the markdown source".

## Change

- Add a source/preview toggle button to the file-header toolbar (Android + iOS)
  that shows up only for markdown files (`isMarkdownPreviewFile`).
- Opening a markdown file now defaults to the last mode you chose on device:
  a new `markdownPreviewEnabled` mobile preference persists the choice
  (device-local mirror of the web `renderMarkdown` setting — a global opt-out
  from preview). Per-file overrides still take precedence, and the server
  route `/file?line-N` still opens at the source line.
- The toggle is a two-way door: it always falls back to "show rendered
  markdown" when the file is already in preview, and vice versa.

Verified on a physical device (Tecno LI9, Android 15): toggling switches source
↔ rendered preview per markdown file, and the default sticks across app
restarts.


Built with opencode/big-pickle.
## Screenshots

**Before** — markdown file opens in rendered preview with the toggle active:

![Before](https://github.com/sabraman/t3code/releases/download/pr-10648-images/markdown-before.jpg)

**After** — toggled to markdown source, toggle inactive:

![After](https://github.com/sabraman/t3code/releases/download/pr-10648-images/markdown-after.jpg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preference to open Markdown files in rendered preview mode when no specific line is selected.
  * Markdown files open in source mode when a specific line is selected.
  * Added controls to switch between rendered Markdown and source views, with the preference saved for future use.
  * Added matching view toggle controls to Android and native toolbars.
  * Added filled Android header icon buttons with updated styling.
  * View toggles are unavailable when a specific line is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->