### PR TITLE
fix(server): resolve macOS app icons through AppKit

### DIFF
--- a/apps/server/src/assets/NativeAppIconResolver.test.ts
+++ b/apps/server/src/assets/NativeAppIconResolver.test.ts
@@ -1,16 +1,22 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as TestClock from "effect/testing/TestClock";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as ServerConfig from "../config.ts";
 import * as NativeAppIconResolver from "./NativeAppIconResolver.ts";
 
-function emptyProcessHandle() {
+function processHandle(output = "") {
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
     exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
@@ -18,7 +24,7 @@ function emptyProcessHandle() {
     kill: () => Effect.void,
     unref: Effect.succeed(Effect.void),
     stdin: Sink.drain,
-    stdout: Stream.empty,
+    stdout: Stream.make(new TextEncoder().encode(output)),
     stderr: Stream.empty,
     all: Stream.empty,
     getInputFd: () => Sink.drain,
@@ -26,17 +32,82 @@ function emptyProcessHandle() {
   });
 }
 
+const testLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3-native-app-icon-test-",
+}).pipe(Layer.provideMerge(Layer.mergeAll(NodeFileSystem.layer, NodePath.layer)));
+
+const makeFixture = Effect.fn(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const config = yield* ServerConfig.ServerConfig;
+  const root = yield* fs.makeTempDirectoryScoped({ prefix: "t3-native-app-bundle-" });
+  const appPath = path.join(root, ".hidden", "Review App.app");
+  // No Resources directory or icon file: native icons can come from asset catalogs.
+  yield* fs.makeDirectory(path.join(appPath, "Contents"), { recursive: true });
+  const canonicalAppPath = yield* fs.realPath(appPath);
+  const commands: Array<ChildProcess.StandardCommand> = [];
+  const state = {
+    nativePath: appPath,
+    nativeFailure: false,
+    spotlightOutput: "",
+    iconFailure: false,
+    version: "1",
+  };
+  const failure = PlatformError.systemError({
+    _tag: "Unknown",
+    module: "ChildProcess",
+    method: "spawn",
+    description: "Native helper failed",
+  });
+  const spawner = ChildProcessSpawner.make((command) =>
+    Effect.gen(function* () {
+      if (!ChildProcess.isStandardCommand(command)) return yield* Effect.die("Unexpected pipe");
+      commands.push(command);
+      switch (command.command) {
+        case "/usr/bin/osascript":
+          if (command.args.length === 5) {
+            if (state.nativeFailure) return yield* failure;
+            return processHandle(state.nativePath);
+          }
+          expect(command.args[4]).toBe(canonicalAppPath);
+          expect(command.args[6]).toBe("64");
+          yield* fs.writeFileString(command.args[5]!, "native PNG");
+          if (state.iconFailure) return yield* failure;
+          return processHandle();
+        case "/usr/bin/mdfind":
+          return processHandle(state.spotlightOutput);
+        case "/usr/bin/mdls":
+          return processHandle("2026-09-07 00:00:00 +0000");
+        case "/usr/bin/plutil":
+          return processHandle(state.version);
+        default:
+          return yield* Effect.die(`Unexpected command: ${command.command}`);
+      }
+    }),
+  );
+  const makeResolver = NativeAppIconResolver.make.pipe(
+    Effect.provideService(HostProcessPlatform, "darwin"),
+    Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+  );
+  const resolver = yield* makeResolver;
+  return {
+    resolver,
+    makeResolver,
+    commands,
+    state,
+    appPath,
+    cacheDirectory: path.join(config.providerStatusCacheDir, "native-app-icons"),
+  };
+});
+
 describe("resolveNativeAppIcon", () => {
   it.effect("escapes Spotlight wildcards and caches misses", () => {
     const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
     const spawner = ChildProcessSpawner.make((command) =>
       Effect.sync(() => {
-        const input = command as unknown as {
-          readonly command: string;
-          readonly args: ReadonlyArray<string>;
-        };
-        commands.push(input);
-        return emptyProcessHandle();
+        if (!ChildProcess.isStandardCommand(command)) throw new Error("Unexpected pipe");
+        commands.push(command);
+        return processHandle();
       }),
     );
     const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
@@ -72,4 +143,104 @@ describe("resolveNativeAppIcon", () => {
       expect(commands).toHaveLength(258);
     }).pipe(Effect.provide(testLayer));
   });
+
+  it.effect("resolves unindexed bundles natively without needing an icon file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const fixture = yield* makeFixture();
+      const app = { _tag: "app-id", appId: "com.example.hidden.dev" } as const;
+      const icon = yield* fixture.resolver.resolve(app);
+      expect(icon).not.toBeNull();
+      expect(yield* fs.readFileString(icon!)).toBe("native PNG");
+      expect(fixture.commands.some((command) => command.command === "/usr/bin/mdfind")).toBe(false);
+      expect(yield* fixture.resolver.resolve(app)).toBe(icon);
+      expect(fixture.commands).toHaveLength(3);
+
+      // A new resolver reuses the PNG on disk; deleting it regenerates the image.
+      const freshResolver = yield* fixture.makeResolver;
+      expect(yield* freshResolver.resolve(app)).toBe(icon);
+      expect(fixture.commands).toHaveLength(5);
+      yield* fs.remove(icon!);
+      expect(yield* freshResolver.resolve(app)).toBe(icon);
+      expect(yield* fs.readFileString(icon!)).toBe("native PNG");
+      expect(fixture.commands).toHaveLength(8);
+
+      fixture.state.version = "2";
+      yield* TestClock.adjust("1 hour");
+      expect(yield* freshResolver.resolve(app)).not.toBe(icon);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  for (const nativeFailure of [false, true]) {
+    it.effect(
+      `falls back to Spotlight when native lookup ${nativeFailure ? "fails" : "misses"}`,
+      () =>
+        Effect.gen(function* () {
+          const fixture = yield* makeFixture();
+          fixture.state.nativePath = "";
+          fixture.state.nativeFailure = nativeFailure;
+          fixture.state.spotlightOutput = `${fixture.appPath}\n`;
+          expect(
+            yield* fixture.resolver.resolve({ _tag: "app-id", appId: "com.example.review" }),
+          ).not.toBeNull();
+          expect(fixture.commands.slice(0, 3).map((command) => command.command)).toEqual([
+            "/usr/bin/osascript",
+            "/usr/bin/mdfind",
+            "/usr/bin/mdls",
+          ]);
+        }).pipe(Effect.provide(testLayer)),
+    );
+  }
+
+  it.effect("resolves display names through Spotlight and renders the native icon", () =>
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture();
+      fixture.state.spotlightOutput = `${fixture.appPath}\n`;
+      expect(
+        yield* fixture.resolver.resolve({ _tag: "display-name", displayName: "Review App" }),
+      ).not.toBeNull();
+      expect(fixture.commands[0]?.command).toBe("/usr/bin/mdfind");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("retries missing applications after a short cache interval", () =>
+    Effect.gen(function* () {
+      const fixture = yield* makeFixture();
+      const app = { _tag: "app-id", appId: "com.example.newly-installed" } as const;
+      fixture.state.nativePath = "";
+      expect(yield* fixture.resolver.resolve(app)).toBeNull();
+      fixture.state.nativePath = fixture.appPath;
+      expect(yield* fixture.resolver.resolve(app)).toBeNull();
+      expect(fixture.commands).toHaveLength(2);
+      yield* TestClock.adjust("30 seconds");
+      expect(yield* fixture.resolver.resolve(app)).not.toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("cleans up failed renders and retries without caching the failure", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const fixture = yield* makeFixture();
+      const app = { _tag: "app-id", appId: "com.example.review" } as const;
+      fixture.state.iconFailure = true;
+      expect(yield* fixture.resolver.resolve(app)).toBeNull();
+      expect(yield* fs.readDirectory(fixture.cacheDirectory)).toEqual([]);
+      fixture.state.iconFailure = false;
+      expect(yield* fixture.resolver.resolve(app)).not.toBeNull();
+      expect(yield* fs.readDirectory(fixture.cacheDirectory)).toHaveLength(1);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  for (const platform of ["linux", "win32"] as const) {
+    it.effect(`does not invoke macOS commands on ${platform}`, () =>
+      Effect.gen(function* () {
+        const spawner = ChildProcessSpawner.make(() => Effect.die("Unexpected macOS command"));
+        const resolver = yield* NativeAppIconResolver.make.pipe(
+          Effect.provideService(HostProcessPlatform, platform),
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        );
+        expect(yield* resolver.resolve({ _tag: "app-id", appId: "com.example.review" })).toBeNull();
+      }).pipe(Effect.provide(testLayer)),
+    );
+  }
 });

--- a/apps/server/src/assets/NativeAppIconResolver.ts
+++ b/apps/server/src/assets/NativeAppIconResolver.ts
@@ -21,7 +21,45 @@ import * as ServerConfig from "../config.ts";
 const ICON_SIZE = 64;
 const COMMAND_TIMEOUT = "5 seconds";
 const RESOLUTION_CACHE_TTL = Duration.hours(1);
+const MISSING_APP_CACHE_TTL = Duration.seconds(30);
 const RESOLUTION_CACHE_MAX_ENTRIES = 256;
+
+// JXA exposes AppKit through the built-in osascript runtime, including on CLI-only
+// installations. These scripts call local APIs; they do not send Apple events or
+// launch applications. App references and paths are passed as arguments, never code.
+const APPLICATION_PATH_SCRIPT = `
+ObjC.import("AppKit");
+function run(argv) {
+  const url = $.NSWorkspace.sharedWorkspace.URLForApplicationWithBundleIdentifier(argv[0]);
+  return url.isNil() ? "" : ObjC.unwrap(url.path);
+}
+`;
+
+const APPLICATION_ICON_SCRIPT = `
+ObjC.import("AppKit");
+function run(argv) {
+  const size = Number(argv[2]);
+  const icon = $.NSWorkspace.sharedWorkspace.iconForFile(argv[0]);
+  const bitmap = $.NSBitmapImageRep.alloc
+    .initWithBitmapDataPlanesPixelsWidePixelsHighBitsPerSampleSamplesPerPixelHasAlphaIsPlanarColorSpaceNameBytesPerRowBitsPerPixel(
+      null, size, size, 8, 4, true, false, $.NSDeviceRGBColorSpace, 0, 0
+    );
+  const context = $.NSGraphicsContext.graphicsContextWithBitmapImageRep(bitmap);
+  $.NSGraphicsContext.saveGraphicsState;
+  try {
+    $.NSGraphicsContext.setCurrentContext(context);
+    icon.drawInRectFromRectOperationFraction(
+      $.NSMakeRect(0, 0, size, size), $.NSZeroRect, $.NSCompositingOperationCopy, 1
+    );
+    context.flushGraphics;
+  } finally {
+    $.NSGraphicsContext.restoreGraphicsState;
+  }
+  const png = bitmap.representationUsingTypeProperties($.NSPNGFileType, $({}));
+  if (!png.writeToFileAtomically(argv[1], true)) throw new Error("Cannot write application icon");
+  return "";
+}
+`;
 
 /** Resolves and caches macOS application icons without exposing host paths to clients. */
 export class NativeAppIconResolver extends Context.Service<
@@ -94,9 +132,23 @@ const resolveApplicationPath = Effect.fn("NativeAppIconResolver.resolveApplicati
   app: ToolActivityNativeAppReference,
 ) {
   const path = yield* Path.Path;
+  if (app._tag === "app-id") {
+    const nativePath = yield* commandOutput("/usr/bin/osascript", [
+      "-l",
+      "JavaScript",
+      "-e",
+      APPLICATION_PATH_SCRIPT,
+      app.appId,
+    ]).pipe(
+      Effect.map((value) => value.trim()),
+      Effect.orElseSucceed(() => ""),
+    );
+    if (path.isAbsolute(nativePath) && nativePath.endsWith(".app")) return nativePath;
+  }
+
   const query =
     app._tag === "app-id"
-      ? `kMDItemCFBundleIdentifier == '${app.appId}'`
+      ? `kMDItemCFBundleIdentifier == '${escapeSpotlightString(app.appId)}'`
       : `kMDItemContentType == 'com.apple.application-bundle' && kMDItemDisplayName == '${escapeSpotlightString(app.displayName)}'`;
   const spotlightOutput = yield* commandOutput("/usr/bin/mdfind", [query]);
   const candidates = spotlightOutput
@@ -140,43 +192,13 @@ const resolveNativeAppIconUncached = Effect.fn("NativeAppIconResolver.resolveUnc
   if (!appPath) return null;
 
   const canonicalAppPath = yield* fileSystem.realPath(appPath);
+  if ((yield* fileSystem.stat(canonicalAppPath)).type !== "Directory") return null;
   const infoPlistPath = path.join(canonicalAppPath, "Contents", "Info.plist");
-  const resourcesDirectory = path.join(canonicalAppPath, "Contents", "Resources");
-  const iconName =
-    (yield* plistValue(infoPlistPath, "CFBundleIconFile")) ||
-    (yield* plistValue(infoPlistPath, "CFBundleIconName"));
-  if (iconName && path.basename(iconName) !== iconName) return null;
-  const iconFileName = iconName ? (path.extname(iconName) ? iconName : `${iconName}.icns`) : null;
-  const resourceEntries = yield* fileSystem
-    .readDirectory(resourcesDirectory)
-    .pipe(Effect.orElseSucceed(() => []));
-  const sourceIconCandidate =
-    (iconFileName ? yield* existingFile(path.join(resourcesDirectory, iconFileName)) : null) ??
-    (yield* existingFile(path.join(resourcesDirectory, "AppIcon.icns"))) ??
-    (resourceEntries.find((entry) => entry.toLowerCase().endsWith(".icns"))
-      ? yield* existingFile(
-          path.join(
-            resourcesDirectory,
-            resourceEntries.find((entry) => entry.toLowerCase().endsWith(".icns"))!,
-          ),
-        )
-      : null);
-  if (!sourceIconCandidate) return null;
-  const sourceIconPath = yield* fileSystem.realPath(sourceIconCandidate);
-  const relativeSource = path.relative(resourcesDirectory, sourceIconPath);
-  if (
-    relativeSource === ".." ||
-    relativeSource.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativeSource)
-  ) {
-    return null;
-  }
-
   const appVersion =
     (yield* plistValue(infoPlistPath, "CFBundleVersion")) ||
     (yield* plistValue(infoPlistPath, "CFBundleShortVersionString"));
   const cacheKey = NodeCrypto.createHash("sha256")
-    .update(`${canonicalAppPath}\0${appVersion}\0${sourceIconPath}`)
+    .update(`nsworkspace-v1\0${ICON_SIZE}\0${canonicalAppPath}\0${appVersion}`)
     .digest("hex");
   const cacheDirectory = path.join(config.providerStatusCacheDir, "native-app-icons");
   const cachePath = path.join(cacheDirectory, `${cacheKey}.png`);
@@ -187,16 +209,14 @@ const resolveNativeAppIconUncached = Effect.fn("NativeAppIconResolver.resolveUnc
     cacheDirectory,
     `.${cacheKey}-${process.pid}-${(yield* Clock.currentTimeMillis).toString(36)}-${NodeCrypto.randomUUID()}.png`,
   );
-  yield* commandOutput("/usr/bin/sips", [
-    "-z",
-    String(ICON_SIZE),
-    String(ICON_SIZE),
-    "-s",
-    "format",
-    "png",
-    sourceIconPath,
-    "--out",
+  yield* commandOutput("/usr/bin/osascript", [
+    "-l",
+    "JavaScript",
+    "-e",
+    APPLICATION_ICON_SCRIPT,
+    canonicalAppPath,
     temporaryPath,
+    String(ICON_SIZE),
   ]).pipe(
     Effect.tap(() => fileSystem.rename(temporaryPath, cachePath)),
     Effect.ensuring(
@@ -220,7 +240,7 @@ export const make = Effect.gen(function* () {
     {
       capacity: RESOLUTION_CACHE_MAX_ENTRIES,
       timeToLive: Exit.match({
-        onSuccess: () => RESOLUTION_CACHE_TTL,
+        onSuccess: (value) => (value === null ? MISSING_APP_CACHE_TTL : RESOLUTION_CACHE_TTL),
         onFailure: () => Duration.zero,
       }),
     },
@@ -240,7 +260,7 @@ export const make = Effect.gen(function* () {
   ) {
     if (
       hostPlatform !== "darwin" ||
-      (app._tag === "display-name" && containsControlCharacter(app.displayName))
+      containsControlCharacter(app._tag === "app-id" ? app.appId : app.displayName)
     ) {
       return null;
     }


### PR DESCRIPTION
## What Changed

- Resolve macOS application paths and render icons through AppKit via `osascript`.
- Support applications without indexed icon files or `Resources` bundles, with Spotlight fallback.
- Cache successful resolutions and retry missing or failed icons appropriately.
- Simplify asset URL resolution so requests stay associated with their target environment.
- Update focused resolver, asset, and KDE feedback tests.

## Why

Some macOS applications store their icons in asset catalogs rather than standalone `.icns` files, causing icon resolution to fail. Using AppKit lets the server obtain the system-rendered icon for any installed application while retaining Spotlight as a fallback. The asset routing changes remove client-side local-environment fallback behavior now that asset requests are handled by the owning server.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve macOS app icons through `NSWorkspace` and `AppKit` instead of `sips`
> - App-id resolution now tries `NSWorkspace` via `osascript` first, falling back to Spotlight when native lookup fails or returns an invalid path; app-id values are escaped before Spotlight queries.
> - Icon rendering replaces `sips` and Info.plist/Resources `.icns` selection with an AppKit JXA script that renders a 64-pixel PNG from the canonical bundle directory into a temporary file before renaming into the cache.
> - Cache keys now use canonical app path and app version instead of icon file metadata, so bundles without a Resources icon file can still resolve.
> - Missing application results are cached for 30 seconds (down from one hour) to allow faster retry; app-id and display-name references with control characters are rejected without command execution.
> - Risk: `resolveNativeAppIconUncached` in [NativeAppIconResolver.ts](https://github.com/pingdotgg/t3code/pull/10649/files#diff-615008179672aa3821a4d570e0c63d6f9e369166fc977124777311f6b6ba131a) now returns null for non-directory canonical paths; bundles relying on a specific `.icns` in Resources will render the system-default AppKit icon instead of that file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c287a19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved native application icon resolution for faster, more reliable results.
  * Added support for resolving applications that are not indexed, with fallback lookup when the primary method cannot find them.
  * Improved display-name resolution and handling of application identifiers.
  * Added cache refresh behavior when applications or generated icons change.
  * Failed icon renders are cleaned up without retaining invalid cached results.
  * Non-macOS platforms avoid invoking macOS-specific services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->