### PR TITLE
feat(web): preview linked pull requests from the sidebar footer

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -1,11 +1,12 @@
 import {
   ArrowLeftIcon,
+  ArrowUpRightIcon,
   ChartNoAxesColumnIcon,
   GitPullRequestIcon,
   SettingsIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 import { Link, useCanGoBack, useLocation, useNavigate } from "@tanstack/react-router";
 
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
@@ -29,6 +30,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "../ui/sidebar";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { readPullRequestListPreferences } from "../pullRequest/pullRequestListPreferences";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
@@ -106,27 +108,109 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
   );
 }
 
+/**
+ * A footer icon button. Without a `preview` a press navigates to the page and
+ * hover shows the label. With one, a press opens a glance at the page instead,
+ * whose heading leads on to the page; the preview only mounts while open, so
+ * its data subscriptions never run for an idle footer.
+ */
 function SidebarUtilityItem({
   icon,
   label,
   onClick,
+  preview,
 }: {
   icon: ReactNode;
   label: string;
   onClick: () => void;
+  preview?: ReactNode;
 }) {
+  if (!preview) {
+    return (
+      <SidebarMenuItem className="shrink-0">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <SidebarMenuButton aria-label={label} onClick={onClick} size="icon">
+                {icon}
+              </SidebarMenuButton>
+            }
+          />
+          <TooltipPopup side="top">{label}</TooltipPopup>
+        </Tooltip>
+      </SidebarMenuItem>
+    );
+  }
+  return (
+    <SidebarUtilityPreviewItem icon={icon} label={label} onClick={onClick}>
+      {preview}
+    </SidebarUtilityPreviewItem>
+  );
+}
+
+function SidebarUtilityPreviewItem({
+  icon,
+  label,
+  onClick,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  // Opens on press only, never on hover: a panel that appears by itself is easy to trigger by
+  // accident. Base UI moves focus in on open and back to the trigger on Escape or outside press.
+  const [open, setOpen] = useState(false);
   return (
     <SidebarMenuItem className="shrink-0">
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <SidebarMenuButton aria-label={label} onClick={onClick} size="icon">
-              {icon}
-            </SidebarMenuButton>
-          }
-        />
-        <TooltipPopup side="top">{label}</TooltipPopup>
-      </Tooltip>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Tooltip disabled={open}>
+          <TooltipTrigger
+            render={
+              <PopoverTrigger
+                render={
+                  <SidebarMenuButton aria-label={label} size="icon">
+                    {icon}
+                  </SidebarMenuButton>
+                }
+              />
+            }
+          />
+          <TooltipPopup side="top">{label}</TooltipPopup>
+        </Tooltip>
+        <PopoverPopup
+          align="center"
+          aria-label={label}
+          className="max-w-none shadow-xl shadow-black/25"
+          // Rows are links that navigate in place; close so the glance does not outlive the page
+          // it was about. Link handlers stop propagation, so this runs during capture.
+          onClickCapture={(event) => {
+            if (event.target instanceof Element && event.target.closest("a")) setOpen(false);
+          }}
+          side="top"
+          tooltipStyle
+          viewportClassName="not-data-transitioning:overflow-y-auto"
+        >
+          <div className="flex w-72 max-w-[calc(100vw-3rem)] flex-col gap-2 p-1 text-xs">
+            <button
+              aria-label={`Open ${label}`}
+              className="group/preview-heading -mx-1 flex w-fit items-center gap-1 rounded-sm px-1 text-sm leading-5 font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                setOpen(false);
+                onClick();
+              }}
+              type="button"
+            >
+              <span className="underline-offset-2 group-hover/preview-heading:underline">
+                {label}
+              </span>
+              <ArrowUpRightIcon aria-hidden className="size-3.5 text-muted-foreground" />
+            </button>
+            {children}
+          </div>
+        </PopoverPopup>
+      </Popover>
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -34,6 +34,7 @@ import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { readPullRequestListPreferences } from "../pullRequest/pullRequestListPreferences";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
+import { SidebarPullRequestsPreview } from "./SidebarPullRequestsPreview";
 import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
@@ -291,6 +292,8 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
               icon={<GitPullRequestIcon />}
               label="Pull Requests"
               onClick={handlePullRequestsClick}
+              // A drawer tap goes straight to the page; the glance is for the docked sidebar.
+              preview={isMobile ? undefined : <SidebarPullRequestsPreview />}
             />
           ) : null}
           <SidebarUtilityItem

--- a/apps/web/src/components/sidebar/SidebarPullRequestsPreview.logic.test.ts
+++ b/apps/web/src/components/sidebar/SidebarPullRequestsPreview.logic.test.ts
@@ -1,0 +1,126 @@
+import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  collectPullRequestPreviewEntries,
+  type PullRequestPreviewThread,
+} from "./SidebarPullRequestsPreview.logic";
+
+const NOW = "2026-09-08T12:00:00.000Z";
+const env = "env-1" as EnvironmentId;
+
+function thread(
+  id: string,
+  overrides: Partial<PullRequestPreviewThread> = {},
+): PullRequestPreviewThread {
+  return {
+    id: id as PullRequestPreviewThread["id"],
+    environmentId: env,
+    title: `Thread ${id}`,
+    branch: null,
+    archivedAt: null,
+    settledOverride: null,
+    linkedPullRequest: null,
+    branchPullRequest: null,
+    snoozedUntil: null,
+    snoozedAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    session: null,
+    latestTurn: null,
+    ...overrides,
+  };
+}
+
+function pr(number: number) {
+  return {
+    projectId: "project-1" as ProjectId,
+    repository: "t3tools/t3code",
+    number,
+    url: `https://github.com/t3tools/t3code/pull/${number}`,
+  };
+}
+
+const capabilities = new Map([[env, { threadSettlement: true, threadSnooze: true }]]);
+
+describe("collectPullRequestPreviewEntries", () => {
+  it("keeps only unarchived, unsettled threads that have a pull request", () => {
+    const entries = collectPullRequestPreviewEntries(
+      [
+        thread("a", { linkedPullRequest: pr(1) }),
+        thread("b"),
+        thread("c", { linkedPullRequest: pr(2), archivedAt: NOW }),
+        thread("d", { linkedPullRequest: pr(3), settledOverride: "settled" }),
+        thread("e", { branchPullRequest: pr(4) }),
+      ],
+      capabilities,
+      NOW,
+    );
+    expect(entries.map((entry) => entry.reference.number)).toEqual([1, 4]);
+    expect(entries.every((entry) => !entry.snoozed)).toBe(true);
+  });
+
+  it("prefers the linked pull request over the branch match", () => {
+    const [entry] = collectPullRequestPreviewEntries(
+      [thread("a", { linkedPullRequest: pr(7), branchPullRequest: pr(8) })],
+      capabilities,
+      NOW,
+    );
+    expect(entry?.reference.number).toBe(7);
+  });
+
+  it("lists active threads first, then snoozed threads by wake time", () => {
+    const entries = collectPullRequestPreviewEntries(
+      [
+        thread("late", { linkedPullRequest: pr(1), snoozedUntil: "2026-09-09T12:00:00.000Z" }),
+        thread("soon", { linkedPullRequest: pr(2), snoozedUntil: "2026-09-08T13:00:00.000Z" }),
+        thread("active", { linkedPullRequest: pr(3) }),
+        thread("woken", { linkedPullRequest: pr(4), snoozedUntil: "2026-09-08T11:00:00.000Z" }),
+      ],
+      capabilities,
+      NOW,
+    );
+    expect(entries.map((entry) => [entry.reference.number, entry.snoozed])).toEqual([
+      [3, false],
+      [4, false],
+      [2, true],
+      [1, true],
+    ]);
+  });
+
+  it("treats settled threads as active on servers without settlement", () => {
+    const entries = collectPullRequestPreviewEntries(
+      [thread("a", { linkedPullRequest: pr(1), settledOverride: "settled" })],
+      new Map([[env, { threadSettlement: false, threadSnooze: false }]]),
+      NOW,
+    );
+    expect(entries).toHaveLength(1);
+  });
+
+  it("counts a pull request as active when an active thread shares it with a snoozed one", () => {
+    const entries = collectPullRequestPreviewEntries(
+      [
+        thread("napping", { linkedPullRequest: pr(1), snoozedUntil: "2026-09-09T12:00:00.000Z" }),
+        thread("awake", { branchPullRequest: pr(1) }),
+      ],
+      capabilities,
+      NOW,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.thread.id).toBe("awake");
+    expect(entries[0]?.snoozed).toBe(false);
+  });
+
+  it("shows a pull request once when several threads share it", () => {
+    const entries = collectPullRequestPreviewEntries(
+      [
+        thread("a", { linkedPullRequest: pr(1) }),
+        thread("b", { branchPullRequest: { ...pr(1), repository: "T3Tools/T3Code" } }),
+      ],
+      capabilities,
+      NOW,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.thread.id).toBe("a");
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarPullRequestsPreview.logic.ts
+++ b/apps/web/src/components/sidebar/SidebarPullRequestsPreview.logic.ts
@@ -1,0 +1,77 @@
+import {
+  effectiveSnoozed,
+  type ThreadSnoozeShell,
+} from "@t3tools/client-runtime/state/thread-settled";
+import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/models";
+import type { EnvironmentId, ThreadLinkedPullRequest } from "@t3tools/contracts";
+
+export type PullRequestPreviewThread = ThreadSnoozeShell &
+  Pick<
+    EnvironmentThreadShell,
+    | "id"
+    | "environmentId"
+    | "title"
+    | "branch"
+    | "archivedAt"
+    | "settledOverride"
+    | "linkedPullRequest"
+    | "branchPullRequest"
+  >;
+
+export interface PullRequestPreviewCapabilities {
+  readonly threadSettlement?: boolean | undefined;
+  readonly threadSnooze?: boolean | undefined;
+}
+
+export interface PullRequestPreviewEntry {
+  readonly thread: PullRequestPreviewThread;
+  readonly reference: ThreadLinkedPullRequest;
+  readonly snoozed: boolean;
+}
+
+/**
+ * The pull requests the sidebar's active and snoozed shelves are tracking, one
+ * row per pull request. Uses the sidebar's lifecycle classification (archived,
+ * settled, snoozed) so a hidden thread does not resurface here; the project
+ * scope filter is deliberately not applied, since the Pull Requests page reads
+ * every project too. Active threads come first, then snoozed ones by wake time.
+ * A pull request tracked by both an active and a snoozed thread counts as active.
+ */
+export function collectPullRequestPreviewEntries(
+  threads: ReadonlyArray<PullRequestPreviewThread>,
+  capabilitiesByEnvironment: ReadonlyMap<EnvironmentId, PullRequestPreviewCapabilities | undefined>,
+  now: string,
+): ReadonlyArray<PullRequestPreviewEntry> {
+  const byPullRequest = new Map<string, PullRequestPreviewEntry>();
+  for (const thread of threads) {
+    if (thread.archivedAt !== null) continue;
+    const reference = thread.linkedPullRequest ?? thread.branchPullRequest;
+    if (!reference) continue;
+    const capabilities = capabilitiesByEnvironment.get(thread.environmentId);
+    const isSnoozed = capabilities?.threadSnooze === true && effectiveSnoozed(thread, { now });
+    if (
+      !isSnoozed &&
+      capabilities?.threadSettlement === true &&
+      thread.settledOverride === "settled"
+    ) {
+      continue;
+    }
+    const key = [
+      thread.environmentId,
+      reference.projectId,
+      reference.repository.toLowerCase(),
+      reference.number,
+    ].join("\0");
+    const existing = byPullRequest.get(key);
+    if (existing && (!existing.snoozed || isSnoozed)) continue;
+    byPullRequest.set(key, { thread, reference, snoozed: isSnoozed });
+  }
+  const entries = [...byPullRequest.values()];
+  const active = entries.filter((entry) => !entry.snoozed);
+  const snoozed = entries.filter((entry) => entry.snoozed);
+  snoozed.sort(
+    (left, right) =>
+      Date.parse(left.thread.snoozedUntil ?? "") - Date.parse(right.thread.snoozedUntil ?? ""),
+  );
+  return [...active, ...snoozed];
+}

--- a/apps/web/src/components/sidebar/SidebarPullRequestsPreview.tsx
+++ b/apps/web/src/components/sidebar/SidebarPullRequestsPreview.tsx
@@ -1,0 +1,126 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { useRouter } from "@tanstack/react-router";
+import { AlarmClockIcon, CircleDashedIcon } from "lucide-react";
+import { type MouseEvent, useCallback, useMemo, useState } from "react";
+
+import { useOpenPrLink } from "../../lib/openPullRequestLink";
+import { cn } from "../../lib/utils";
+import { useServerConfigs, useThreadShells } from "../../state/entities";
+import { resolvePullRequestState } from "../pullRequest/pullRequestPresentation";
+import { buildThreadRouteParams } from "../../threadRoutes";
+import { useLinkedThreadPullRequest } from "../ThreadStatusIndicators";
+import {
+  collectPullRequestPreviewEntries,
+  type PullRequestPreviewEntry,
+} from "./SidebarPullRequestsPreview.logic";
+
+const MAX_PULL_REQUEST_ROWS = 8;
+
+type OpenPullRequest = (
+  event: MouseEvent<HTMLAnchorElement>,
+  entry: PullRequestPreviewEntry,
+  url: string,
+) => void;
+
+function PullRequestPreviewRow({
+  entry,
+  onOpen,
+}: {
+  readonly entry: PullRequestPreviewEntry;
+  readonly onOpen: OpenPullRequest;
+}) {
+  const detail = useLinkedThreadPullRequest(entry.thread.environmentId, entry.reference);
+  const pr = detail?.pr ?? null;
+  const state = pr
+    ? resolvePullRequestState({ state: pr.state, isDraft: pr.isDraft === true })
+    : null;
+  const title = pr?.title ?? entry.thread.branch ?? entry.thread.title;
+  const url = pr?.url ?? entry.reference.url;
+  const Icon = state?.Icon ?? CircleDashedIcon;
+  return (
+    <li>
+      {/* A real link, like the sidebar badge: cmd/ctrl+click and middle-click
+          open the host, a plain click opens T3's pull request view. */}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(event) => onOpen(event, entry, url)}
+        className={cn(
+          "group/pr-preview -mx-1 flex items-center gap-2 rounded-sm px-1 leading-5 underline-offset-2 outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          entry.snoozed && "text-muted-foreground",
+        )}
+      >
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-0.5 tabular-nums",
+            state?.toneClassName ?? "text-muted-foreground/60",
+          )}
+        >
+          <Icon role="img" aria-label={state?.label ?? "Loading"} className="size-3 shrink-0" />
+          <span className="group-hover/pr-preview:underline">#{entry.reference.number}</span>
+        </span>
+        <span className="min-w-0 truncate group-hover/pr-preview:underline">{title}</span>
+        {entry.snoozed ? (
+          <AlarmClockIcon aria-label="Snoozed" className="ms-auto size-3 shrink-0 opacity-70" />
+        ) : null}
+      </a>
+    </li>
+  );
+}
+
+/**
+ * The pull requests behind the sidebar's active and snoozed threads, for a
+ * glance before opening the page. The footer item supplies the frame and
+ * heading. Mounted only while the popover is open, so the footer itself never
+ * subscribes to thread state.
+ */
+export function SidebarPullRequestsPreview() {
+  const threads = useThreadShells();
+  const serverConfigs = useServerConfigs();
+  // One clock per open: the popover is short-lived and must not tick.
+  const [now] = useState(() => new Date().toISOString());
+  const entries = useMemo(() => {
+    const capabilities = new Map(
+      [...serverConfigs].map(([id, config]) => [id, config.environment.capabilities] as const),
+    );
+    return collectPullRequestPreviewEntries(threads, capabilities, now);
+  }, [now, serverConfigs, threads]);
+  const openPrLink = useOpenPrLink();
+  const router = useRouter();
+  const handleOpen = useCallback<OpenPullRequest>(
+    (event, entry, url) => {
+      const threadRef = scopeThreadRef(entry.thread.environmentId, entry.thread.id);
+      // Opened in the right panel: go to the thread that owns it, as the sidebar badge does.
+      if (openPrLink(event, url, threadRef)) {
+        void router.navigate({
+          to: "/$environmentId/$threadId",
+          params: buildThreadRouteParams(threadRef),
+        });
+      }
+    },
+    [openPrLink, router],
+  );
+  const visible = entries.slice(0, MAX_PULL_REQUEST_ROWS);
+  const hidden = entries.length - visible.length;
+
+  if (entries.length === 0) {
+    return (
+      <span className="leading-5 text-muted-foreground">
+        No pull requests on your active threads.
+      </span>
+    );
+  }
+  return (
+    <ul className="flex flex-col">
+      {visible.map((entry) => (
+        <PullRequestPreviewRow
+          key={scopedThreadKey(scopeThreadRef(entry.thread.environmentId, entry.thread.id))}
+          entry={entry}
+          onOpen={handleOpen}
+        />
+      ))}
+      {hidden > 0 ? <li className="leading-5 text-muted-foreground">+{hidden} more</li> : null}
+    </ul>
+  );
+}


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Claude Fable 5.1 on behalf of Oliver**

## ELI5

Press the sidebar's Pull Requests button to preview linked PRs and open one directly. The panel's heading leads on to the full page.

## Problem

Checking a thread's PR currently requires opening the Pull Requests page.

## Implementation

Independent of #10651. Both PRs start with the same commit that lets a footer item open a preview on press, so either can merge first. The second one rebases and that commit drops out of its diff.

Show up to eight PRs from active and snoozed threads, with state icons, colored numbers, and “+N more” for overflow. Links use hover underlines in their text color and the composer's icon-to-number spacing.

Click a row to open the PR in T3; Cmd/Ctrl-click or middle-click opens the host. Keyboard users can Tab into the links. Preview subscriptions mount only while open.

Per review on #10651, the panel opens on press rather than hover. Hover shows only the label tooltip, Escape and outside press close it, and Base UI manages focus. Mobile drawer taps still navigate straight to the page.

Web and desktop. Validation: 6 focused tests, web typecheck, targeted lint and formatting passed. Headless browser pass on web for hover, press, and Escape in both color schemes.

## UI Changes

### Before

![Pull Requests button before: plain label tooltip](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260908/pr-before.png)

### After

![Pull Requests preview after press](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260909/pr-after-press.png)

![Light mode](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260909/pr-after-press-light.png)

Original implementation by Claude Fable 5.1 via Claude Code in T3 Code. Follow-up changes by GPT-6 via Codex in T3 Code. Press-to-open change, branch split, and this description by Claude Fable 5.1 via Claude Code in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add linked pull request preview popover to sidebar footer utility items
> - Introduces `SidebarUtilityPreviewItem` in [SidebarChrome.tsx](https://github.com/pingdotgg/t3code/pull/10650/files#diff-cbdc7d544762cec67fb7c23f9e66e80e1ca2158f0d100a878363a7ae01f77c11): a popover-backed footer item that opens on hover and keyboard focus, does not toggle when the button is pressed, and closes before preview links navigate.
> - Adds `collectPullRequestPreviewEntries` in [SidebarUtilityPreviews.logic.ts](https://github.com/pingdotgg/t3code/pull/10650/files#diff-8c25978c1ce51172602f91c4dbf106d9e3ddb1d749f9217a5d4fb68f6eeb9124) to gather one entry per tracked pull request, preferring linked references over branch references, deduplicating case-insensitively, and ordering active entries before snoozed ones by wake time.
> - Adds `SidebarPullRequestsPreview` in [SidebarUtilityPreviews.tsx](https://github.com/pingdotgg/t3code/pull/10650/files#diff-ba0307a0a3f3aaf07a5e6ac07df583a8308531801bc9ec424937a01cffd3f03a) which renders up to 8 pull-request rows with state icons, snooze indicators, and an empty state; activating a row opens the pull request link and navigates to its owning thread.
> - Adds fixture factories and a test suite in [SidebarUtilityPreviews.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10650/files#diff-119c5a77971f1b52be222be58f6baad0edb839477675610810ec70bdc67622f4) covering lifecycle filtering, linked-vs-branch precedence, ordering, settlement capability handling, and deduplication.
> - Behavioral Change: footer utility items with a `preview` prop now render an interactive popover instead of a plain tooltip; items without a preview keep the existing tooltip and click behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e99d440.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hoverable Pull Requests preview to the sidebar footer.
  - Displays up to eight relevant active and snoozed pull requests with status, references, titles, and snooze indicators.
  - Supports opening pull requests directly, including modified-click behavior.
  - Preserved tooltip behavior for sidebar items without previews.

- **Bug Fixes**
  - Improved keyboard focus handling when opening previews.
  - Previews now close when focus leaves the preview area or a link is selected.
  - Prevented duplicate pull request entries and improved preview ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

