### PR TITLE
feat(web): preview spend and subscription limits from the sidebar footer

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -35,6 +35,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { readPullRequestListPreferences } from "../pullRequest/pullRequestListPreferences";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
 import { SidebarUpdateArchitectureWarning, SidebarUpdatePill } from "./SidebarUpdatePill";
+import { SidebarUsagePreview } from "./SidebarUsagePreview";
 
 export const SidebarChromeHeader = memo(function SidebarChromeHeader({
   isElectron,
@@ -297,6 +298,8 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
             icon={<ChartNoAxesColumnIcon />}
             label="Usage"
             onClick={handleUsageClick}
+            // A drawer tap goes straight to the page; the glance is for the docked sidebar.
+            preview={isMobile ? undefined : <SidebarUsagePreview />}
           />
         </>
       )}

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -1,11 +1,12 @@
 import {
   ArrowLeftIcon,
+  ArrowUpRightIcon,
   ChartNoAxesColumnIcon,
   GitPullRequestIcon,
   SettingsIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { memo, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 import { Link, useCanGoBack, useLocation, useNavigate } from "@tanstack/react-router";
 
 import { useEnvironmentIdentificationMode } from "../../hooks/useSettings";
@@ -29,6 +30,7 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "../ui/sidebar";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { readPullRequestListPreferences } from "../pullRequest/pullRequestListPreferences";
 import { SidebarProviderUpdatePill } from "./SidebarProviderUpdatePill";
@@ -106,27 +108,109 @@ function SidebarBrand({ onBackdrop }: { onBackdrop: boolean }) {
   );
 }
 
+/**
+ * A footer icon button. Without a `preview` a press navigates to the page and
+ * hover shows the label. With one, a press opens a glance at the page instead,
+ * whose heading leads on to the page; the preview only mounts while open, so
+ * its data subscriptions never run for an idle footer.
+ */
 function SidebarUtilityItem({
   icon,
   label,
   onClick,
+  preview,
 }: {
   icon: ReactNode;
   label: string;
   onClick: () => void;
+  preview?: ReactNode;
 }) {
+  if (!preview) {
+    return (
+      <SidebarMenuItem className="shrink-0">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <SidebarMenuButton aria-label={label} onClick={onClick} size="icon">
+                {icon}
+              </SidebarMenuButton>
+            }
+          />
+          <TooltipPopup side="top">{label}</TooltipPopup>
+        </Tooltip>
+      </SidebarMenuItem>
+    );
+  }
+  return (
+    <SidebarUtilityPreviewItem icon={icon} label={label} onClick={onClick}>
+      {preview}
+    </SidebarUtilityPreviewItem>
+  );
+}
+
+function SidebarUtilityPreviewItem({
+  icon,
+  label,
+  onClick,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  // Opens on press only, never on hover: a panel that appears by itself is easy to trigger by
+  // accident. Base UI moves focus in on open and back to the trigger on Escape or outside press.
+  const [open, setOpen] = useState(false);
   return (
     <SidebarMenuItem className="shrink-0">
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <SidebarMenuButton aria-label={label} onClick={onClick} size="icon">
-              {icon}
-            </SidebarMenuButton>
-          }
-        />
-        <TooltipPopup side="top">{label}</TooltipPopup>
-      </Tooltip>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Tooltip disabled={open}>
+          <TooltipTrigger
+            render={
+              <PopoverTrigger
+                render={
+                  <SidebarMenuButton aria-label={label} size="icon">
+                    {icon}
+                  </SidebarMenuButton>
+                }
+              />
+            }
+          />
+          <TooltipPopup side="top">{label}</TooltipPopup>
+        </Tooltip>
+        <PopoverPopup
+          align="center"
+          aria-label={label}
+          className="max-w-none shadow-xl shadow-black/25"
+          // Rows are links that navigate in place; close so the glance does not outlive the page
+          // it was about. Link handlers stop propagation, so this runs during capture.
+          onClickCapture={(event) => {
+            if (event.target instanceof Element && event.target.closest("a")) setOpen(false);
+          }}
+          side="top"
+          tooltipStyle
+          viewportClassName="not-data-transitioning:overflow-y-auto"
+        >
+          <div className="flex w-72 max-w-[calc(100vw-3rem)] flex-col gap-2 p-1 text-xs">
+            <button
+              aria-label={`Open ${label}`}
+              className="group/preview-heading -mx-1 flex w-fit items-center gap-1 rounded-sm px-1 text-sm leading-5 font-medium text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                setOpen(false);
+                onClick();
+              }}
+              type="button"
+            >
+              <span className="underline-offset-2 group-hover/preview-heading:underline">
+                {label}
+              </span>
+              <ArrowUpRightIcon aria-hidden className="size-3.5 text-muted-foreground" />
+            </button>
+            {children}
+          </div>
+        </PopoverPopup>
+      </Popover>
     </SidebarMenuItem>
   );
 }

--- a/apps/web/src/components/sidebar/SidebarUsagePreview.tsx
+++ b/apps/web/src/components/sidebar/SidebarUsagePreview.tsx
@@ -1,0 +1,132 @@
+import { useAtomValue } from "@effect/atom-react";
+import {
+  collectLimitAccounts,
+  collectLimitNotices,
+  collectLimitPools,
+  formatDuration,
+  type LimitPool,
+  type LimitPoolWindow,
+} from "@t3tools/shared/usageLimits";
+import { formatUsd, makeWindow } from "@t3tools/shared/usageFormat";
+import { useMemo, useState } from "react";
+
+import { environmentPresentations } from "../../state/presentation";
+import { useUsage } from "../../state/usage";
+import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
+import { getDriverOption } from "../settings/providerDriverMeta";
+import { barColor } from "../usage/UsageLimits";
+
+function PoolWindowRow({
+  window,
+  color,
+  now,
+}: {
+  readonly window: LimitPoolWindow;
+  readonly color: string;
+  readonly now: number;
+}) {
+  // The soonest reset that hands anything back, as the Usage page picks it.
+  const nextReset = window.resets.find((reset) => reset.restoresPercent > 0);
+  return (
+    <div className="grid grid-cols-[6rem_minmax(0,1fr)_auto] items-center gap-x-2 leading-5">
+      <span className="truncate text-muted-foreground">{window.label}</span>
+      {/* Pooled across the provider's accounts, like the Usage page headline. */}
+      <span aria-hidden className="relative h-1.5 overflow-hidden rounded-full bg-muted">
+        <span
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{ width: `${window.remainingPercent}%`, backgroundColor: color }}
+        />
+      </span>
+      <span className="shrink-0 text-end tabular-nums">
+        <span className="font-medium text-foreground">{window.remainingPercent}%</span>
+        {nextReset ? (
+          <span className="text-muted-foreground">
+            {" "}
+            · {nextReset.at <= now ? "now" : formatDuration(nextReset.at - now)}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function PoolRows({ pool, now }: { readonly pool: LimitPool; readonly now: number }) {
+  const label = getDriverOption(pool.driver)?.label ?? String(pool.driver);
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="flex items-center gap-1.5 leading-5 font-medium text-foreground">
+        <ProviderInstanceIcon
+          driverKind={pool.driver}
+          displayName={label}
+          indicatorBackground="var(--popover)"
+          className="size-4"
+          iconClassName="size-3 text-foreground/80"
+        />
+        {label}
+        {pool.accounts.length > 1 ? (
+          <span className="font-normal text-muted-foreground">
+            {" "}
+            · {pool.accounts.length} accounts
+          </span>
+        ) : null}
+      </span>
+      {pool.windows.map((window) => (
+        <PoolWindowRow
+          key={`${window.kind}:${window.id}`}
+          window={window}
+          color={barColor(pool.driver)}
+          now={now}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Spend over the past day and what is left on each subscription window, read
+ * from the same query and provider snapshots the Usage page uses. The footer
+ * item supplies the frame and heading. Mounted only while the popover is open.
+ */
+export function SidebarUsagePreview() {
+  // Anchored once per open: countdowns must not tick, and a fixed window keeps
+  // the query key stable so it is not re-issued on every render.
+  const [now] = useState(() => Date.now());
+  const [window] = useState(() => makeWindow(1, new Date(now), "hour"));
+  const { merged, selectedEnvironments, isPending, isPartial } = useUsage(window);
+  const answered = selectedEnvironments.some((environment) => environment.summary !== null);
+  const failed = selectedEnvironments.some((environment) => environment.error !== null);
+  const presentations = useAtomValue(environmentPresentations.presentationsAtom);
+  const pools = useMemo(
+    () => collectLimitPools(collectLimitAccounts(presentations), now),
+    [now, presentations],
+  );
+  const notices = useMemo(() => collectLimitNotices(presentations), [presentations]);
+
+  return (
+    <>
+      <div className="flex items-baseline justify-between gap-3 leading-5">
+        <span className="text-muted-foreground">Spend, past 24h</span>
+        <span className="font-medium text-foreground tabular-nums">
+          {isPending ? "…" : answered ? formatUsd(merged.costUsd) : failed ? "Failed" : "—"}
+          {answered && (isPartial || failed) ? (
+            <span className="font-normal text-muted-foreground"> · partial</span>
+          ) : null}
+        </span>
+      </div>
+      {pools.length > 0 || notices.length > 0 ? (
+        <div className="flex flex-col gap-2 border-t border-border/60 pt-2">
+          {pools.map((pool) => (
+            <PoolRows key={pool.driver} pool={pool} now={now} />
+          ))}
+          {notices.length > 0 ? (
+            <ul className="flex flex-col gap-1 text-muted-foreground">
+              {notices.map((notice) => (
+                <li key={notice}>{notice}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Claude Fable 5.1 on behalf of Oliver**

## ELI5

Press the Usage button to see spend over the past 24 hours and remaining subscription limits. The panel's heading leads on to the full Usage page.

## Problem

Checking spend and remaining quota requires leaving the thread for the Usage page.

## Implementation

Independent of #10650. Both PRs start with the same commit that lets a footer item open a preview on press, so either can merge first. The second one rebases and that commit drops out of its diff.

Reuse the Usage page's query and pooled limit helpers. Each provider gets one bar per subscription window, with an account count when several accounts contribute. The time window stays fixed while the popover is open, and data subscriptions mount only while open.

Incomplete spend totals are marked partial, fully failed reads show “Failed”, and quota-probe failures remain visible even when no bars can be drawn.

Per review, the panel opens on press rather than hover. Hover shows only the label tooltip, Escape and outside press close it, and Base UI manages focus. Mobile drawer taps still navigate straight to the page.

Web and desktop. Validation: web typecheck, targeted lint and formatting passed. Headless browser pass on web for hover, press, and Escape in both color schemes.

## UI Changes

### Before

![Usage button before: plain label tooltip](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260908/usage-before.png)

### After

Hover shows only the label:

![Usage button on hover: label tooltip only](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260909/usage-hover-label.png)

Press opens the preview, with three Claude accounts pooled into one bar per window (simulated accounts for the capture):

![Usage preview after press: spend past 24h and pooled subscription windows](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260909/usage-after-press-pooled.png)

![Light mode](https://github.com/flamboh/t3code/releases/download/sidebar-previews-evidence-20260909/usage-after-press-pooled-light.png)

Original implementation by Claude Fable 5.1 via Claude Code in T3 Code. Follow-up fixes by GPT-6 via Codex in T3 Code. Press-to-open change, branch split, and this description by Claude Fable 5.1 via Claude Code in T3 Code.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spend and pull-request preview popovers to sidebar footer
> - Adds hover/focus-triggered preview popovers to the Usage and Pull Requests sidebar utility items via `SidebarUtilityPreviewItem`; items without a preview keep their existing tooltip.
> - The Usage preview shows past-24-hour spend status (pending, failed, unavailable, partial, or formatted) and provider limit windows with remaining capacity and reset times in `SidebarUsagePreview`.
> - The Pull Requests preview collects unarchived, unsettled threads into up to eight rows using `collectPullRequestPreviewEntries`, preferring linked pull requests over branch matches, de-duplicating case-insensitively, and ordering active entries before snoozed ones sorted by wake time.
> - Trigger presses cancel popover state so navigation still runs; focus suppression prevents the popover from reopening after link activation or Escape.
> - Adds fixture helpers and a full test suite for `collectPullRequestPreviewEntries` covering lifecycle filtering, ordering, capability handling, and de-duplication.
> - Behavioral Change: `SidebarUtilityItem` now delegates rendering to `SidebarUtilityPreviewItem` when a `preview` prop is supplied, changing hover/focus behavior for those footer items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c8c60a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a usage preview to the docked sidebar, showing recent spend, remaining limits, progress indicators, reset times, and relevant notices.
  * The preview opens when the usage item is pressed and includes navigation to the full Usage page.
  * On mobile, the usage item retains its existing navigation behavior without displaying the preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


