### PR TITLE
fix(web): save PR body edits with Cmd/Ctrl+Enter

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx
@@ -55,11 +55,24 @@ export function PullRequestMarkdownEditor({
     setDraft(value);
   }
   const empty = draft.trim().length === 0;
+  const saveDisabled = saving || (empty && !allowEmpty);
 
   return (
     <div
       className={cn("space-y-2", className)}
       onKeyDown={(event) => {
+        if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+        if (
+          event.key === "Enter" &&
+          (event.metaKey || event.ctrlKey) &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!saveDisabled && !event.repeat) onSave(draft);
+          return;
+        }
         if (event.key !== "Escape" || saving) return;
         event.preventDefault();
         onCancel();
@@ -106,12 +119,7 @@ export function PullRequestMarkdownEditor({
         <Button size="xs" variant="ghost" disabled={saving} onClick={onCancel}>
           Cancel
         </Button>
-        <Button
-          size="xs"
-          variant="outline"
-          disabled={saving || (empty && !allowEmpty)}
-          onClick={() => onSave(draft)}
-        >
+        <Button size="xs" variant="outline" disabled={saveDisabled} onClick={() => onSave(draft)}>
           {saving ? "Saving..." : "Save"}
         </Button>
       </div>


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

### ELI5
Save an edited PR description with Cmd+Enter on macOS or Ctrl+Enter on Windows/Linux.

### Problem
The in-app PR body editor only supported Escape to cancel, so saving required clicking Save.

### Fix
Handle Cmd/Ctrl+Enter in the shared markdown editor, including existing comment edits. Reuse the Save button's validation and saving state. Ignore composition and repeated key presses; plain Enter still inserts a newline.

### UI Changes
**Before:** Cmd/Ctrl+Enter did not save edits.

**After:** Cmd/Ctrl+Enter saves the draft. Appearance is unchanged; visual evidence omitted at Oliver's request.

Validation: web typecheck, focused lint, formatting, and diff checks passed. Code review found no actionable issues. Browser verification was not run.

Made with GPT-6 in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cmd/Ctrl+Enter shortcut to save PR body edits in `PullRequestMarkdownEditor`
> - Adds a `Cmd/Ctrl+Enter` shortcut to save drafts in [PullRequestMarkdownEditor.tsx](apps/web/src/components/pullRequest/PullRequestMarkdownEditor.tsx), triggering only when Shift or Alt are not pressed.
> - Uses a shared condition to disable the Save button and shortcut while saving is in progress or when the draft is empty and empty values are not allowed.
> - Ignores IME composition events and repeated keydown events to prevent duplicate or accidental saves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a900d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cmd/Ctrl+Enter keyboard shortcut for saving pull request comments and drafts.
  * The shortcut avoids triggering during text composition, repeated key events, or when modifier combinations make it unavailable.
  * Save controls are now consistently disabled when saving is unavailable, including during active saves or with disallowed empty drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->