### PR TITLE
feat(usage): add an all-time period

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -313,8 +313,8 @@ export function UsageRouteScreen() {
                     days={chartDays}
                     daily={chartTotals}
                     metric={metric}
-                    sinceDay={days[0] ?? window.untilDay}
-                    untilDay={window.untilDay}
+                    sinceDay={chartDays[0] ?? window.untilDay}
+                    untilDay={chartDays[chartDays.length - 1] ?? window.untilDay}
                     isPast24Hours={isPast24Hours}
                     timeZone={window.timeZone}
                   />

--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -6,7 +6,7 @@ import {
   type MergedUsage,
 } from "@t3tools/shared/usageMerge";
 import {
-  enumerateDays,
+  enumerateChartDays,
   enumerateHourStarts,
   formatCount,
   formatDayShort,
@@ -14,7 +14,10 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  groupDailyByWeek,
   makeWindow,
+  MAX_DAILY_CHART_DAYS,
+  type UsageWindowSpan,
 } from "@t3tools/shared/usageFormat";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
@@ -49,7 +52,12 @@ const WINDOW_OPTIONS = [
   { value: 7, label: "7d", accessibilityLabel: "Past 7 days" },
   { value: 30, label: "30d", accessibilityLabel: "Past 30 days" },
   { value: 90, label: "90d", accessibilityLabel: "Past 90 days" },
-] as const;
+  { value: "all", label: "All", accessibilityLabel: "All time" },
+] as const satisfies readonly {
+  value: UsageWindowSpan;
+  label: string;
+  accessibilityLabel: string;
+}[];
 
 const METRIC_OPTIONS = [
   { value: "cost", label: "Cost" },
@@ -68,7 +76,7 @@ export function UsageRouteScreen() {
   const insets = useSafeAreaInsets();
   const [tab, setTab] = useState<UsageTab>("usage");
   const [windowSelection, setWindowSelection] = useState(() => ({
-    days: 30,
+    days: 30 as UsageWindowSpan,
     window: makeWindow(30),
   }));
   const [metric, setMetric] = useState<UsageChartMetric>("cost");
@@ -82,16 +90,21 @@ export function UsageRouteScreen() {
   );
   const limits = useRefreshLimits(selectedEnvironmentIds);
 
-  const days = useMemo(
-    () => enumerateDays(window.sinceDay, window.untilDay),
-    [window.sinceDay, window.untilDay],
+  const days = useMemo(() => enumerateChartDays(window, merged.daily), [window, merged.daily]);
+  // Long spans roll up into weeks: a bar per day would be thinner than a pixel.
+  const weekly = useMemo(
+    () =>
+      !isPast24Hours && days.length > MAX_DAILY_CHART_DAYS
+        ? groupDailyByWeek(days, merged.daily)
+        : null,
+    [days, isPast24Hours, merged.daily],
   );
   const chartDays = useMemo(
     () =>
       isPast24Hours && window.sinceTime !== undefined && window.untilTime !== undefined
         ? enumerateHourStarts(window.sinceTime, window.untilTime)
-        : days,
-    [days, isPast24Hours, window.sinceTime, window.untilTime],
+        : (weekly?.periods ?? days),
+    [days, isPast24Hours, weekly, window.sinceTime, window.untilTime],
   );
   const chartTotals = useMemo(
     (): readonly DailyTotals[] =>
@@ -102,14 +115,14 @@ export function UsageRouteScreen() {
             totalTokens: hour.totalTokens,
             byProvider: hour.byProvider,
           }))
-        : merged.daily,
-    [isPast24Hours, merged.daily, merged.hourly],
+        : (weekly?.totals ?? merged.daily),
+    [isPast24Hours, merged.daily, merged.hourly, weekly],
   );
 
   const [refreshingUsage, setRefreshingUsage] = useState(false);
   const refreshingRef = useRef(false);
   const showingLimits = tab === "limits";
-  const selectWindow = (days: number) => {
+  const selectWindow = (days: UsageWindowSpan) => {
     setWindowSelection({
       days,
       window: makeWindow(days, undefined, days === 1 ? "hour" : "day"),
@@ -300,7 +313,7 @@ export function UsageRouteScreen() {
                     days={chartDays}
                     daily={chartTotals}
                     metric={metric}
-                    sinceDay={window.sinceDay}
+                    sinceDay={days[0] ?? window.untilDay}
                     untilDay={window.untilDay}
                     isPast24Hours={isPast24Hours}
                     timeZone={window.timeZone}

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -23,7 +23,12 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
-import { decodeScanCache, encodeScanCache, type ScanCache } from "./usageScanCache.ts";
+import {
+  decodeScanCache,
+  decodeScanCacheRetainSince,
+  encodeScanCache,
+  type ScanCache,
+} from "./usageScanCache.ts";
 import * as UsageService from "./UsageService.ts";
 
 function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
@@ -291,6 +296,86 @@ describe("UsageService", () => {
       }).pipe(
         Effect.provide(
           serviceLayers({ prefix: "usage-service-concurrent-prune-test", home, settings }),
+        ),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("never lets an earlier, smaller snapshot land after a fuller one", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      // Only the all-time scan lists this one, so its snapshot is the only one
+      // carrying the entry and the retention marker.
+      const oldTranscript = NodePath.join(NodePath.dirname(transcript), "old.jsonl");
+      yield* Effect.promise(() => NodeFSP.writeFile(oldTranscript, claudeLine(2, 7)));
+      const nowMs = yield* Clock.currentTimeMillis;
+      const staleMtimeSeconds = (nowMs - 200 * 24 * 60 * 60 * 1000) / 1000;
+      yield* Effect.promise(() =>
+        NodeFSP.utimes(oldTranscript, staleMtimeSeconds, staleMtimeSeconds),
+      );
+      const allTime: UsageSummaryInput = { ...WINDOW, sinceDay: UsageDay.make("2020-01-01") };
+      const grokDir = NodePath.join(home, "grok", "sessions");
+
+      yield* Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cachePath = NodePath.join(config.stateDir, "usage-scan-cache.json");
+        const firstWriteStarted = yield* Deferred.make<void>();
+        const releaseFirstWrite = yield* Deferred.make<void>();
+        const allTimeWalked = yield* Deferred.make<void>();
+        // Cache writes land here in completion order rather than on disk, so
+        // the test sees exactly which snapshot won.
+        const landed: string[] = [];
+        let cacheWrites = 0;
+        let grokProbes = 0;
+        const service = yield* UsageService.make.pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fileSystem,
+            // Grok is walked last: its probe resolving means the walk is done.
+            exists: (path) =>
+              fileSystem.exists(path).pipe(
+                Effect.tap(() => {
+                  if (path !== grokDir) return Effect.void;
+                  grokProbes += 1;
+                  return grokProbes === 2
+                    ? Deferred.succeed(allTimeWalked, undefined)
+                    : Effect.void;
+                }),
+              ),
+            writeFileString: (path, data, options) => {
+              if (path !== cachePath) return fileSystem.writeFileString(path, data, options);
+              cacheWrites += 1;
+              const land = Effect.sync(() => {
+                landed.push(data);
+              });
+              if (cacheWrites !== 1) return land;
+              return Deferred.succeed(firstWriteStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseFirstWrite)),
+                Effect.andThen(land),
+              );
+            },
+          }),
+        );
+
+        const bounded = yield* service.readSummary(WINDOW).pipe(Effect.forkChild);
+        yield* Deferred.await(firstWriteStarted);
+        // The all-time scan adds the old transcript and lowers the horizon
+        // while the bounded snapshot, which has neither, is still being written.
+        const allTimeScan = yield* service.readSummary(allTime).pipe(Effect.forkChild);
+        yield* Deferred.await(allTimeWalked);
+        yield* Deferred.succeed(releaseFirstWrite, undefined);
+        assert.strictEqual(totalOutputTokens(yield* Fiber.join(bounded)), 5);
+        assert.strictEqual(totalOutputTokens(yield* Fiber.join(allTimeScan)), 12);
+
+        assert.strictEqual(landed.length, 2);
+        const final = decodeJsonDocument(landed[1]);
+        assert.isTrue(decodeScanCache(final).has(transcript));
+        assert.isTrue(decodeScanCache(final).has(oldTranscript));
+        assert.isNotNull(decodeScanCacheRetainSince(final));
+      }).pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-write-barrier-test", home, settings }),
         ),
       );
     }).pipe(Effect.scoped),

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -243,6 +243,59 @@ describe("UsageService", () => {
     }).pipe(Effect.scoped),
   );
 
+  it.live("protects an all-time scan's old entries from a bounded scan finishing mid-walk", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      const nowMs = yield* Clock.currentTimeMillis;
+      const staleMtimeSeconds = (nowMs - 200 * 24 * 60 * 60 * 1000) / 1000;
+      yield* Effect.promise(() => NodeFSP.utimes(transcript, staleMtimeSeconds, staleMtimeSeconds));
+      const allTime: UsageSummaryInput = { ...WINDOW, sinceDay: UsageDay.make("2020-01-01") };
+      // Walked last, so by the time the all-time scan probes it the old
+      // transcript is already in the cache and the prune has not run yet.
+      const grokDir = NodePath.join(home, "grok", "sessions");
+
+      yield* Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const allTimeReachedGrok = yield* Deferred.make<void>();
+        const releaseAllTime = yield* Deferred.make<void>();
+        let grokProbes = 0;
+        const service = yield* UsageService.make.pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fileSystem,
+            exists: (path) => {
+              if (path !== grokDir) return fileSystem.exists(path);
+              grokProbes += 1;
+              if (grokProbes !== 1) return fileSystem.exists(path);
+              return Deferred.succeed(allTimeReachedGrok, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseAllTime)),
+                Effect.andThen(fileSystem.exists(path)),
+              );
+            },
+          }),
+        );
+
+        const inFlight = yield* service.readSummary(allTime).pipe(Effect.forkChild);
+        yield* Deferred.await(allTimeReachedGrok);
+        // A bounded scan runs to completion, prune included, while the
+        // all-time scan is still walking.
+        assert.strictEqual(totalOutputTokens(yield* service.readSummary(WINDOW)), 0);
+        yield* Deferred.succeed(releaseAllTime, undefined);
+        assert.strictEqual(totalOutputTokens(yield* Fiber.join(inFlight)), 5);
+
+        const persisted = yield* fileSystem.readFileString(
+          NodePath.join(config.stateDir, "usage-scan-cache.json"),
+        );
+        assert.isTrue(decodeScanCache(decodeJsonDocument(persisted)).has(transcript));
+      }).pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-concurrent-prune-test", home, settings }),
+        ),
+      );
+    }).pipe(Effect.scoped),
+  );
+
   it.live("does not share an in-flight scan after custom prices change", () =>
     Effect.gen(function* () {
       const { transcript, settings, home } = yield* setup;

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -23,7 +23,7 @@ import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
-import { decodeScanCache } from "./usageScanCache.ts";
+import { decodeScanCache, encodeScanCache, type ScanCache } from "./usageScanCache.ts";
 import * as UsageService from "./UsageService.ts";
 
 function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
@@ -41,9 +41,9 @@ function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"):
 }
 
 /** The scan cache file is JSON of a shape `usageScanCache` narrows by hand. */
-const decodeJsonDocument = Schema.decodeUnknownSync(
-  Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>),
-);
+const JsonDocument = Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>);
+const decodeJsonDocument = Schema.decodeUnknownSync(JsonDocument);
+const encodeJsonDocument = Schema.encodeSync(JsonDocument);
 
 const WINDOW: UsageSummaryInput = {
   timeZone: "UTC",
@@ -201,6 +201,44 @@ describe("UsageService", () => {
         assert.isTrue(decodeScanCache(decodeJsonDocument(afterRestart)).has(transcript));
       }).pipe(
         Effect.provide(serviceLayers({ prefix: "usage-service-all-time-test", home, settings })),
+      );
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("still ages out old entries after a restart when no all-time scan ever ran", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      const nowMs = yield* Clock.currentTimeMillis;
+      // A cache left behind by bounded scans only: an entry that has since
+      // aged past the retention, and no all-time marker.
+      const aged: ScanCache = new Map([
+        [
+          transcript,
+          {
+            size: 1,
+            mtimeMs: nowMs - 200 * 24 * 60 * 60 * 1000,
+            provider: "claude",
+            records: [],
+            tailRecords: [],
+            position: { resumeOffset: 1, guardLength: 1, guardHash: 0, codexState: null },
+          },
+        ],
+      ]);
+
+      yield* Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const cachePath = NodePath.join(config.stateDir, "usage-scan-cache.json");
+        yield* fileSystem.writeFileString(cachePath, encodeJsonDocument(encodeScanCache(aged)));
+
+        const service = yield* UsageService.make;
+        yield* service.readSummary(WINDOW);
+        const persisted = yield* fileSystem.readFileString(cachePath);
+        assert.isFalse(decodeScanCache(decodeJsonDocument(persisted)).has(transcript));
+      }).pipe(
+        Effect.provide(
+          serviceLayers({ prefix: "usage-service-bounded-prune-test", home, settings }),
+        ),
       );
     }).pipe(Effect.scoped),
   );

--- a/apps/server/src/usage/UsageService.test.ts
+++ b/apps/server/src/usage/UsageService.test.ts
@@ -8,6 +8,7 @@ import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { HostProcessEnvironment } from "@t3tools/shared/hostProcess";
 import { UsageDay, type UsageSummaryInput } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
 import * as Duration from "effect/Duration";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
@@ -16,11 +17,13 @@ import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Scheduler from "effect/Scheduler";
+import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerSettings from "../serverSettings.ts";
+import { decodeScanCache } from "./usageScanCache.ts";
 import * as UsageService from "./UsageService.ts";
 
 function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"): string {
@@ -36,6 +39,11 @@ function claudeLine(id: number, outputTokens: number, model = "claude-fable-5"):
     },
   })}\n`;
 }
+
+/** The scan cache file is JSON of a shape `usageScanCache` narrows by hand. */
+const decodeJsonDocument = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Unknown as unknown as Schema.Codec<unknown>),
+);
 
 const WINDOW: UsageSummaryInput = {
   timeZone: "UTC",
@@ -156,6 +164,44 @@ describe("UsageService", () => {
       yield* Effect.promise(() => NodeFSP.appendFile(transcript, claudeLine(2, 7)));
       const second = yield* service.readSummary(WINDOW);
       assert.strictEqual(totalOutputTokens(second), 12);
+    }).pipe(Effect.scoped),
+  );
+
+  it.live("keeps transcripts older than the bounded retention cached after an all-time scan", () =>
+    Effect.gen(function* () {
+      const { transcript, settings, home } = yield* setup;
+      yield* Effect.promise(() => NodeFSP.writeFile(transcript, claudeLine(1, 5)));
+      // Well past the 90-day retention that bounded windows prune to.
+      const nowMs = yield* Clock.currentTimeMillis;
+      const staleMtimeSeconds = (nowMs - 200 * 24 * 60 * 60 * 1000) / 1000;
+      yield* Effect.promise(() => NodeFSP.utimes(transcript, staleMtimeSeconds, staleMtimeSeconds));
+      const allTime: UsageSummaryInput = { ...WINDOW, sinceDay: UsageDay.make("2020-01-01") };
+
+      yield* Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const service = yield* UsageService.make;
+
+        const first = yield* service.readSummary(allTime);
+        assert.strictEqual(totalOutputTokens(first), 5);
+
+        // The bounded window skips the file by mtime; it used to evict the
+        // entry too, turning the next all-time view into a cold re-parse.
+        const bounded = yield* service.readSummary(WINDOW);
+        assert.strictEqual(totalOutputTokens(bounded), 0);
+        const cachePath = NodePath.join(config.stateDir, "usage-scan-cache.json");
+        const persisted = yield* fileSystem.readFileString(cachePath);
+        assert.isTrue(decodeScanCache(decodeJsonDocument(persisted)).has(transcript));
+
+        // A restarted server learns the horizon from what it loads, so its
+        // first bounded scan keeps the entry as well.
+        const restarted = yield* UsageService.make;
+        assert.strictEqual(totalOutputTokens(yield* restarted.readSummary(WINDOW)), 0);
+        const afterRestart = yield* fileSystem.readFileString(cachePath);
+        assert.isTrue(decodeScanCache(decodeJsonDocument(afterRestart)).has(transcript));
+      }).pipe(
+        Effect.provide(serviceLayers({ prefix: "usage-service-all-time-test", home, settings })),
+      );
     }).pipe(Effect.scoped),
   );
 

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -153,6 +153,11 @@ export const make = Effect.gen(function* () {
   // whatever entries happen to be cached would pin itself to the oldest one
   // and stop age pruning altogether.
   let retentionHorizonMs = Number.POSITIVE_INFINITY;
+  // Scans for different windows run concurrently and each persists when it
+  // finishes. Snapshot and write hold this so a later, fuller snapshot cannot
+  // start writing until the earlier one has landed, which is what makes the
+  // last write to disk the newest cache state.
+  const scanCacheLock = yield* Semaphore.make(1);
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
   const scanCachePath = path.join(config.stateDir, "usage-scan-cache.json");
@@ -301,21 +306,30 @@ export const make = Effect.gen(function* () {
     }),
   );
 
-  const persistScanCache = Effect.fn("UsageService.persistScanCache")(function* () {
-    if (!cacheDirty) return;
-    // Cleared only after the write lands, so a failed persist is retried on
-    // the next scan instead of leaving disk permanently stale.
-    yield* encodeScanCacheFile(
-      encodeScanCache(fileCache, { retainSinceMs: retentionHorizonMs }),
-    ).pipe(
-      Effect.flatMap((serialized) => fileSystem.writeFileString(scanCachePath, serialized)),
-      Effect.map(() => {
+  const persistScanCache = scanCacheLock
+    .withPermit(
+      Effect.gen(function* () {
+        if (!cacheDirty) return;
+        // Cleared before the write, not after: a scan still walking while this
+        // write is in flight dirties the cache again, and clearing afterwards
+        // would swallow that and leave its entries unpersisted. A failed write
+        // restores the flag so the next scan retries instead of leaving disk
+        // permanently stale.
         cacheDirty = false;
+        yield* encodeScanCacheFile(
+          encodeScanCache(fileCache, { retainSinceMs: retentionHorizonMs }),
+        ).pipe(
+          Effect.flatMap((serialized) => fileSystem.writeFileString(scanCachePath, serialized)),
+          // A cache we cannot write is a slower next start, not a failed read.
+          Effect.catchCause(() =>
+            Effect.sync(() => {
+              cacheDirty = true;
+            }),
+          ),
+        );
       }),
-      // A cache we cannot write is a slower next start, not a failed read.
-      Effect.catchCause(() => Effect.void),
-    );
-  });
+    )
+    .pipe(Effect.withSpan("UsageService.persistScanCache"));
 
   /**
    * Parses one transcript, reusing the cached result when it is unchanged.
@@ -560,7 +574,7 @@ export const make = Effect.gen(function* () {
       retentionCutoffMs: Math.min(boundedRetentionMs, retentionHorizonMs),
     });
     if (pruned > 0) cacheDirty = true;
-    yield* persistScanCache();
+    yield* persistScanCache;
 
     const aggregated = aggregator.finish();
     const readAt = yield* DateTime.now;

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -472,6 +472,16 @@ export const make = Effect.gen(function* () {
     }
     const windowStartMs =
       (hourlyWindow?.sinceTimeMs ?? DateTime.toEpochMillis(windowStart.value)) - MTIME_SLACK_MS;
+    const boundedRetentionMs = startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    // Only a scan reaching past the bounded retention moves the horizon. It
+    // moves before the walk, not after: scans for different windows run
+    // concurrently, and a bounded scan finishing mid-walk prunes with whatever
+    // horizon it sees, so the old entries this walk adds must already be
+    // protected. The marker must reach disk even when no file changed.
+    if (windowStartMs < boundedRetentionMs && windowStartMs < retentionHorizonMs) {
+      retentionHorizonMs = windowStartMs;
+      cacheDirty = true;
+    }
 
     // Pricing only matters once records are aggregated, so the rate table
     // loads while transcripts stream instead of gating them: a cold rates
@@ -543,13 +553,6 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    const boundedRetentionMs = startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
-    // Only a scan reaching past the bounded retention moves the horizon, and
-    // the marker must reach disk even when no file changed.
-    if (windowStartMs < boundedRetentionMs && windowStartMs < retentionHorizonMs) {
-      retentionHorizonMs = windowStartMs;
-      cacheDirty = true;
-    }
     const pruned = pruneScanCache(fileCache, {
       livePaths,
       walkedRoots,

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -76,7 +76,12 @@ const RATES_REFRESH_FLOOR_MS = 60 * 1000;
 const MTIME_SLACK_MS = 36 * 60 * 60 * 1000;
 const MAX_HOURLY_WINDOW_MS = 24 * 60 * 60 * 1000;
 
-/** Longest window the UI offers, plus slack. Older entries are pruned. */
+/**
+ * Longest bounded window the UI offers, plus slack. Older entries are pruned
+ * until an all-time scan runs; from then on everything it walked is kept, so
+ * switching between periods never re-parses years of transcripts. See
+ * `retentionHorizonMs`.
+ */
 const CACHE_RETENTION_DAYS = 90;
 
 /** On-disk shape of the rate snapshot. */
@@ -142,6 +147,11 @@ export const make = Effect.gen(function* () {
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
+  // Oldest window start any scan asked for. Survives restarts without being
+  // stored: an entry older than the bounded retention can only be in the
+  // loaded cache because an all-time scan put it there, so the oldest loaded
+  // entry is the horizon.
+  let retentionHorizonMs = Number.POSITIVE_INFINITY;
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
   const scanCachePath = path.join(config.stateDir, "usage-scan-cache.json");
@@ -285,7 +295,10 @@ export const make = Effect.gen(function* () {
         Effect.catchCause(() => Effect.succeed(null)),
       );
       if (document === null) return;
-      for (const [path, entry] of decodeScanCache(document)) fileCache.set(path, entry);
+      for (const [path, entry] of decodeScanCache(document)) {
+        fileCache.set(path, entry);
+        retentionHorizonMs = Math.min(retentionHorizonMs, entry.mtimeMs);
+      }
     }),
   );
 
@@ -529,11 +542,15 @@ export const make = Effect.gen(function* () {
       });
     }
 
+    retentionHorizonMs = Math.min(retentionHorizonMs, windowStartMs);
     const pruned = pruneScanCache(fileCache, {
       livePaths,
       walkedRoots,
       windowStartMs,
-      retentionCutoffMs: startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      retentionCutoffMs: Math.min(
+        startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+        retentionHorizonMs,
+      ),
     });
     if (pruned > 0) cacheDirty = true;
     yield* persistScanCache();

--- a/apps/server/src/usage/UsageService.ts
+++ b/apps/server/src/usage/UsageService.ts
@@ -53,6 +53,7 @@ import {
 } from "./usageTranscriptReader.ts";
 import {
   decodeScanCache,
+  decodeScanCacheRetainSince,
   dedupeWithinFile,
   encodeScanCache,
   pruneScanCache,
@@ -147,10 +148,10 @@ export const make = Effect.gen(function* () {
 
   const fileCache: ScanCache = new Map();
   let cacheDirty = false;
-  // Oldest window start any scan asked for. Survives restarts without being
-  // stored: an entry older than the bounded retention can only be in the
-  // loaded cache because an all-time scan put it there, so the oldest loaded
-  // entry is the horizon.
+  // Oldest window start an all-time scan asked for, persisted with the cache
+  // as an explicit marker. Bounded scans never set it: a horizon inferred from
+  // whatever entries happen to be cached would pin itself to the oldest one
+  // and stop age pruning altogether.
   let retentionHorizonMs = Number.POSITIVE_INFINITY;
 
   const ratesCachePath = path.join(config.stateDir, "usage-model-rates.json");
@@ -295,10 +296,8 @@ export const make = Effect.gen(function* () {
         Effect.catchCause(() => Effect.succeed(null)),
       );
       if (document === null) return;
-      for (const [path, entry] of decodeScanCache(document)) {
-        fileCache.set(path, entry);
-        retentionHorizonMs = Math.min(retentionHorizonMs, entry.mtimeMs);
-      }
+      for (const [path, entry] of decodeScanCache(document)) fileCache.set(path, entry);
+      retentionHorizonMs = decodeScanCacheRetainSince(document) ?? Number.POSITIVE_INFINITY;
     }),
   );
 
@@ -306,7 +305,9 @@ export const make = Effect.gen(function* () {
     if (!cacheDirty) return;
     // Cleared only after the write lands, so a failed persist is retried on
     // the next scan instead of leaving disk permanently stale.
-    yield* encodeScanCacheFile(encodeScanCache(fileCache)).pipe(
+    yield* encodeScanCacheFile(
+      encodeScanCache(fileCache, { retainSinceMs: retentionHorizonMs }),
+    ).pipe(
       Effect.flatMap((serialized) => fileSystem.writeFileString(scanCachePath, serialized)),
       Effect.map(() => {
         cacheDirty = false;
@@ -542,15 +543,18 @@ export const make = Effect.gen(function* () {
       });
     }
 
-    retentionHorizonMs = Math.min(retentionHorizonMs, windowStartMs);
+    const boundedRetentionMs = startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+    // Only a scan reaching past the bounded retention moves the horizon, and
+    // the marker must reach disk even when no file changed.
+    if (windowStartMs < boundedRetentionMs && windowStartMs < retentionHorizonMs) {
+      retentionHorizonMs = windowStartMs;
+      cacheDirty = true;
+    }
     const pruned = pruneScanCache(fileCache, {
       livePaths,
       walkedRoots,
       windowStartMs,
-      retentionCutoffMs: Math.min(
-        startedAtMs - CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
-        retentionHorizonMs,
-      ),
+      retentionCutoffMs: Math.min(boundedRetentionMs, retentionHorizonMs),
     });
     if (pruned > 0) cacheDirty = true;
     yield* persistScanCache();

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 
 import {
   decodeScanCache,
+  decodeScanCacheRetainSince,
   dedupeWithinFile,
   encodeScanCache,
   pruneScanCache,
@@ -53,6 +54,25 @@ function cacheWith(entries: readonly [string, number, readonly UsageRecord[]][])
   }
   return cache;
 }
+
+describe("all-time retention marker", () => {
+  it("is carried only when an all-time scan recorded it", () => {
+    const cache = cacheWith([["/a.jsonl", 100, [record()]]]);
+
+    expect(decodeScanCacheRetainSince(encodeScanCache(cache))).toBeNull();
+    expect(decodeScanCacheRetainSince(encodeScanCache(cache, { retainSinceMs: 1_500 }))).toBe(
+      1_500,
+    );
+    // An unset horizon is +Infinity in memory and must not be written as one.
+    expect(
+      decodeScanCacheRetainSince(
+        encodeScanCache(cache, { retainSinceMs: Number.POSITIVE_INFINITY }),
+      ),
+    ).toBeNull();
+    // Old cached entries are not a marker; only the explicit field is.
+    expect(decodeScanCacheRetainSince({ ...encodeScanCache(cache), version: 1 })).toBeNull();
+  });
+});
 
 describe("scan cache round trip", () => {
   it("restores records unchanged", () => {

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -83,10 +83,19 @@ interface SerializedCache {
   readonly models: readonly string[];
   readonly sessions: readonly string[];
   readonly files: Readonly<Record<string, SerializedFile>>;
+  /**
+   * Oldest window start an all-time scan asked for, when one has run. Present
+   * only then: it is what tells a later bounded scan to keep entries older
+   * than its own retention instead of pruning them.
+   */
+  readonly retainSinceMs?: number;
 }
 
 /** Serialises the cache, interning the repeated model and session strings. */
-export function encodeScanCache(cache: ScanCache): SerializedCache {
+export function encodeScanCache(
+  cache: ScanCache,
+  options: { readonly retainSinceMs?: number } = {},
+): SerializedCache {
   const models: string[] = [];
   const sessions: string[] = [];
   const modelIndex = new Map<string, number>();
@@ -129,11 +138,32 @@ export function encodeScanCache(cache: ScanCache): SerializedCache {
     };
   }
 
-  return { version: USAGE_SCAN_CACHE_VERSION, models, sessions, files };
+  const retainSinceMs = options.retainSinceMs;
+  return {
+    version: USAGE_SCAN_CACHE_VERSION,
+    models,
+    sessions,
+    files,
+    ...(retainSinceMs !== undefined && Number.isFinite(retainSinceMs) ? { retainSinceMs } : {}),
+  };
 }
 
 function isRecordArray(value: unknown): value is readonly unknown[] {
   return Array.isArray(value);
+}
+
+/**
+ * The all-time retention marker of a parsed document, or `null` when no
+ * all-time scan has been recorded. Kept apart from the file entries so the
+ * marker is never inferred from what happens to be cached.
+ */
+export function decodeScanCacheRetainSince(document: unknown): number | null {
+  if (typeof document !== "object" || document === null) return null;
+  const root = document as Partial<SerializedCache>;
+  if (root.version !== USAGE_SCAN_CACHE_VERSION) return null;
+  return typeof root.retainSinceMs === "number" && Number.isFinite(root.retainSinceMs)
+    ? root.retainSinceMs
+    : null;
 }
 
 /**

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -26,7 +26,7 @@ import { serverEnvironment } from "../../state/server";
 import { useUsage, type EnvironmentUsageStatus } from "../../state/usage";
 import { useAtomCommand } from "../../state/use-atom-command";
 import {
-  enumerateDays,
+  enumerateChartDays,
   enumerateHourStarts,
   formatCount,
   formatDateTimeShort,
@@ -35,7 +35,10 @@ import {
   formatPercent,
   formatTokens,
   formatUsd,
+  groupDailyByWeek,
   makeWindow,
+  MAX_DAILY_CHART_DAYS,
+  type UsageWindowSpan,
 } from "@t3tools/shared/usageFormat";
 import { Button } from "../ui/button";
 import {
@@ -84,10 +87,13 @@ const WINDOW_OPTIONS = [
   { days: 7, label: "7 days" },
   { days: 30, label: "30 days" },
   { days: 90, label: "90 days" },
-] as const;
+  { days: "all", label: "All time" },
+] as const satisfies readonly { days: UsagePagePreferences["windowDays"]; label: string }[];
 
-function isUsageWindowDays(value: number): value is UsagePagePreferences["windowDays"] {
-  return WINDOW_OPTIONS.some((option) => option.days === value);
+function parseUsageWindow(value: string): UsagePagePreferences["windowDays"] | null {
+  const span: UsageWindowSpan = value === "all" ? "all" : Number(value);
+  const option = WINDOW_OPTIONS.find((candidate) => candidate.days === span);
+  return option === undefined ? null : option.days;
 }
 
 export function UsagePage() {
@@ -118,9 +124,15 @@ export function UsagePage() {
     reportFailure: false,
   });
 
-  const days = useMemo(
-    () => enumerateDays(window.sinceDay, window.untilDay),
-    [window.sinceDay, window.untilDay],
+  const days = useMemo(() => enumerateChartDays(window, merged.daily), [window, merged.daily]);
+  // Long spans roll up into weeks so the chart stays legible; the breakdown
+  // table below keeps its per-day rows.
+  const weekly = useMemo(
+    () =>
+      !isPast24Hours && days.length > MAX_DAILY_CHART_DAYS
+        ? groupDailyByWeek(days, merged.daily)
+        : null,
+    [days, isPast24Hours, merged.daily],
   );
   const hours = useMemo(
     () =>
@@ -147,8 +159,9 @@ export function UsagePage() {
   const activeProviders = useMemo(() => providersWithUsage(merged.providers), [merged.providers]);
   const timeValueColumnWidth = `${60 / (activeProviders.length + 2)}%`;
 
-  const selectWindow = (days: number) => {
-    if (!isUsageWindowDays(days)) return;
+  const selectWindow = (value: string) => {
+    const days = parseUsageWindow(value);
+    if (days === null) return;
     const nextPreferences = { metric, windowDays: days };
     setPreferences(nextPreferences);
     saveUsagePagePreferences(nextPreferences);
@@ -197,10 +210,11 @@ export function UsagePage() {
       setIsRefreshing(false);
     });
   };
+  // All time starts at the first active day rather than the request floor.
   const windowLabel =
     isPast24Hours && window.sinceTime !== undefined && window.untilTime !== undefined
       ? `${formatDateTimeShort(window.sinceTime, window.timeZone)} to ${formatDateTimeShort(window.untilTime, window.timeZone)}`
-      : `${formatDayShort(window.sinceDay)} to ${formatDayShort(window.untilDay)}`;
+      : `${formatDayShort(days[0] ?? window.untilDay)} to ${formatDayShort(window.untilDay)}`;
   const topbarContent = (
     <div className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-2 py-2 xl:flex">
       <WorkspaceBreadcrumb ariaLabel="Usage breadcrumb" className="col-span-2 min-w-0">
@@ -251,7 +265,7 @@ export function UsagePage() {
           disabled={showingLimits}
           onValueChange={(next) => {
             const value = next[0];
-            if (value) selectWindow(Number(value));
+            if (value) selectWindow(value);
           }}
         >
           {WINDOW_OPTIONS.map((option) => (
@@ -299,7 +313,9 @@ export function UsagePage() {
         <Select
           value={String(windowDays)}
           disabled={showingLimits}
-          onValueChange={(value) => selectWindow(Number(value))}
+          onValueChange={(value) => {
+            if (value !== null) selectWindow(value);
+          }}
         >
           <SelectTrigger
             aria-label="Usage period"
@@ -416,18 +432,18 @@ export function UsagePage() {
 
                   <div className="flex min-w-0 flex-col gap-3">
                     <h2 className="text-sm font-medium text-foreground">
-                      {isPast24Hours ? "Hourly" : "Daily"}{" "}
+                      {isPast24Hours ? "Hourly" : weekly === null ? "Daily" : "Weekly"}{" "}
                       {metric === "tokens" ? "processed tokens" : "cost"}
                     </h2>
                     <UsageProviderChart
                       providers={activeProviders}
-                      days={days}
-                      daily={merged.daily}
+                      days={weekly?.periods ?? days}
+                      daily={weekly?.totals ?? merged.daily}
                       hours={hours}
                       hourly={merged.hourly}
                       metric={metric}
                       referenceTime={window.untilTime}
-                      resolution={isPast24Hours ? "hour" : "day"}
+                      resolution={isPast24Hours ? "hour" : weekly === null ? "day" : "week"}
                       timeZone={window.timeZone}
                     />
                   </div>

--- a/apps/web/src/components/usage/UsageProviderChart.tsx
+++ b/apps/web/src/components/usage/UsageProviderChart.tsx
@@ -26,7 +26,8 @@ interface UsageProviderChartProps {
   readonly hourly: readonly HourlyTotals[];
   readonly metric: UsageChartMetric;
   readonly referenceTime: string | undefined;
-  readonly resolution: "day" | "hour";
+  /** Weeks arrive through `days`/`daily`, keyed by their start day. */
+  readonly resolution: "day" | "week" | "hour";
   readonly timeZone: string;
 }
 
@@ -308,7 +309,11 @@ export function UsageProviderChart({
   const hoveredPeriod = hoverIndex === null ? undefined : periods[hoverIndex];
   const hoveredColumn = hoverIndex === null ? undefined : series[hoverIndex];
   const formatPeriod = (period: string) =>
-    resolution === "hour" ? formatHourShort(period, timeZone) : formatDayShort(period);
+    resolution === "hour"
+      ? formatHourShort(period, timeZone)
+      : resolution === "week"
+        ? `Week of ${formatDayShort(period)}`
+        : formatDayShort(period);
   const formatTooltipPeriod = (period: string) =>
     resolution === "hour" && referenceTime !== undefined
       ? formatRelativeHourShort(period, referenceTime, timeZone)
@@ -344,7 +349,7 @@ export function UsageProviderChart({
             viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
             preserveAspectRatio="none"
             role="img"
-            aria-label={`${resolution === "hour" ? "Hourly" : "Daily"} ${metric === "tokens" ? "processed tokens" : "cost"} by provider`}
+            aria-label={`${resolution === "hour" ? "Hourly" : resolution === "week" ? "Weekly" : "Daily"} ${metric === "tokens" ? "processed tokens" : "cost"} by provider`}
           >
             {ticks.map((tick) => {
               const y = toY(tick);

--- a/apps/web/src/components/usage/usagePagePreferences.test.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.test.ts
@@ -28,12 +28,15 @@ describe("Usage page preferences", () => {
     expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
   });
 
-  it.each([1, 7, 30, 90] as const)("round-trips every metric with a %i-day range", (windowDays) => {
-    for (const metric of ["cost", "tokens", "limits"] as const) {
-      saveUsagePagePreferences({ metric, windowDays });
-      expect(readUsagePagePreferences()).toEqual({ metric, windowDays });
-    }
-  });
+  it.each([1, 7, 30, 90, "all"] as const)(
+    "round-trips every metric with a %s range",
+    (windowDays) => {
+      for (const metric of ["cost", "tokens", "limits"] as const) {
+        saveUsagePagePreferences({ metric, windowDays });
+        expect(readUsagePagePreferences()).toEqual({ metric, windowDays });
+      }
+    },
+  );
 
   it.each([
     "not-json",

--- a/apps/web/src/components/usage/usagePagePreferences.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.ts
@@ -5,7 +5,7 @@ import { getLocalStorageItem, setLocalStorageItem } from "../../hooks/useLocalSt
 const STORAGE_KEY = "t3code:usage-page-preferences:v1";
 const UsagePagePreferencesSchema = Schema.Struct({
   metric: Schema.Literals(["cost", "tokens", "limits"]),
-  windowDays: Schema.Literals([1, 7, 30, 90]),
+  windowDays: Schema.Literals([1, 7, 30, 90, "all"]),
 });
 export type UsagePagePreferences = typeof UsagePagePreferencesSchema.Type;
 

--- a/packages/shared/src/usageFormat.test.ts
+++ b/packages/shared/src/usageFormat.test.ts
@@ -1,13 +1,78 @@
 // @effect-diagnostics globalDate:off -- A fixed instant keeps calendar-window assertions deterministic.
 import { describe, expect, it, vi } from "vite-plus/test";
 
+import type { DailyTotals } from "./usageMerge.ts";
 import {
+  enumerateChartDays,
   enumerateHourStarts,
   formatDateTimeShort,
   formatHourShort,
   formatRelativeHourShort,
+  groupDailyByWeek,
   makeWindow,
+  USAGE_ALL_TIME_SINCE_DAY,
+  weekStart,
 } from "./usageFormat.ts";
+
+function dayTotals(day: string, codex: number, claude = 0): DailyTotals {
+  return {
+    day,
+    costUsd: codex + claude,
+    totalTokens: (codex + claude) * 10,
+    byProvider: new Map([
+      ["codex", { costUsd: codex, totalTokens: codex * 10 }],
+      ...(claude === 0 ? [] : [["claude", { costUsd: claude, totalTokens: claude * 10 }] as const]),
+    ]),
+  };
+}
+
+describe("all-time usage windows", () => {
+  it("requests everything from the fixed floor day", () => {
+    const window = makeWindow("all", new Date("2026-08-11T12:37:42.123Z"));
+
+    expect(window.sinceDay).toBe(USAGE_ALL_TIME_SINCE_DAY);
+    expect(window.untilDay).toBe("2026-08-11");
+    expect(window.resolution).toBe("day");
+  });
+
+  it("charts an all-time window from its first active day, and a bounded one in full", () => {
+    const window = makeWindow("all", new Date("2026-08-11T12:37:42.123Z"));
+    const daily = [dayTotals("2026-08-09", 1), dayTotals("2026-08-10", 2)];
+
+    expect(enumerateChartDays(window, daily)).toEqual(["2026-08-09", "2026-08-10", "2026-08-11"]);
+    expect(enumerateChartDays(window, [])).toEqual(["2026-08-11"]);
+    expect(enumerateChartDays(makeWindow(3, new Date("2026-08-11T12:37:42.123Z")), [])).toEqual([
+      "2026-08-09",
+      "2026-08-10",
+      "2026-08-11",
+    ]);
+  });
+});
+
+describe("weekly chart buckets", () => {
+  it("starts weeks on Monday", () => {
+    expect(weekStart("2026-08-10")).toBe("2026-08-10");
+    expect(weekStart("2026-08-16")).toBe("2026-08-10");
+    expect(weekStart("2026-08-09")).toBe("2026-08-03");
+  });
+
+  it("sums days into their week and zero-fills quiet weeks between", () => {
+    const days = ["2026-08-05", "2026-08-06", "2026-08-07", "2026-08-25"];
+    const { periods, totals } = groupDailyByWeek(days, [
+      dayTotals("2026-08-05", 1, 2),
+      dayTotals("2026-08-07", 3),
+      dayTotals("2026-08-25", 5),
+    ]);
+
+    expect(periods).toEqual(["2026-08-03", "2026-08-10", "2026-08-17", "2026-08-24"]);
+    expect(totals.map((week) => [week.day, week.costUsd])).toEqual([
+      ["2026-08-03", 6],
+      ["2026-08-24", 5],
+    ]);
+    expect(totals[0]?.byProvider.get("codex")).toEqual({ costUsd: 4, totalTokens: 40 });
+    expect(totals[0]?.byProvider.get("claude")).toEqual({ costUsd: 2, totalTokens: 20 });
+  });
+});
 
 describe("hourly usage formatting", () => {
   it("enumerates 24 fixed buckets across a rolling window", () => {

--- a/packages/shared/src/usageFormat.ts
+++ b/packages/shared/src/usageFormat.ts
@@ -4,7 +4,24 @@
  *
  * @module usageFormat
  */
-import { UsageDay, type UsageResolution, type UsageSummaryInput } from "@t3tools/contracts";
+import {
+  UsageDay,
+  type UsageProviderKind,
+  type UsageResolution,
+  type UsageSummaryInput,
+} from "@t3tools/contracts";
+
+import type { DailyTotals } from "./usageMerge.ts";
+
+/**
+ * Span the page can request: a count of days ending today, or everything.
+ *
+ * "All time" is sent as a fixed floor day rather than an open-ended window so
+ * the request stays valid for every server version. The floor predates the
+ * first release of every provider CLI, so nothing can fall before it.
+ */
+export type UsageWindowSpan = number | "all";
+export const USAGE_ALL_TIME_SINCE_DAY = UsageDay.make("2020-01-01");
 
 const CURRENCY = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -81,6 +98,75 @@ export function enumerateDays(sinceDay: string, untilDay: string): readonly stri
 }
 
 const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Charts draw one point per day up to this many days. Beyond it the page rolls
+ * days up into weeks: an all-time span can run for years, and a bar per day
+ * would be narrower than a pixel on a phone.
+ */
+export const MAX_DAILY_CHART_DAYS = 120;
+
+/** The Monday on or before `day`, as `YYYY-MM-DD`. */
+export function weekStart(day: string): string {
+  const parsed = Date.parse(`${day}T00:00:00Z`);
+  if (Number.isNaN(parsed)) return day;
+  const date = new Date(parsed);
+  // getUTCDay: Sunday is 0, so Monday-based weeks shift Sunday to the end.
+  const offset = (date.getUTCDay() + 6) % 7;
+  return new Date(parsed - offset * DAY_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * Rolls daily totals up into Monday-based weeks, keyed by week start day.
+ *
+ * Returns every week between the first and last of `days` so the chart still
+ * zero-fills quiet stretches, exactly as it does per day for short windows.
+ */
+export function groupDailyByWeek(
+  days: readonly string[],
+  daily: readonly DailyTotals[],
+): { readonly periods: readonly string[]; readonly totals: readonly DailyTotals[] } {
+  const first = days[0];
+  const last = days[days.length - 1];
+  if (first === undefined || last === undefined) return { periods: [], totals: [] };
+
+  const periods: string[] = [];
+  const start = Date.parse(`${weekStart(first)}T00:00:00Z`);
+  const end = Date.parse(`${weekStart(last)}T00:00:00Z`);
+  for (let cursor = start; cursor <= end; cursor += 7 * DAY_MS) {
+    periods.push(new Date(cursor).toISOString().slice(0, 10));
+  }
+
+  const byWeek = new Map<
+    string,
+    {
+      costUsd: number;
+      totalTokens: number;
+      byProvider: Map<UsageProviderKind, { costUsd: number; totalTokens: number }>;
+    }
+  >();
+  for (const totals of daily) {
+    const week = weekStart(totals.day);
+    const entry = byWeek.get(week) ?? { costUsd: 0, totalTokens: 0, byProvider: new Map() };
+    entry.costUsd += totals.costUsd;
+    entry.totalTokens += totals.totalTokens;
+    for (const [provider, value] of totals.byProvider) {
+      const current = entry.byProvider.get(provider) ?? { costUsd: 0, totalTokens: 0 };
+      current.costUsd += value.costUsd;
+      current.totalTokens += value.totalTokens;
+      entry.byProvider.set(provider, current);
+    }
+    byWeek.set(week, entry);
+  }
+
+  return {
+    periods,
+    totals: [...byWeek.entries()]
+      .map(([day, entry]) => ({ day, ...entry }))
+      .sort((a, b) => a.day.localeCompare(b.day)),
+  };
+}
 
 /** Every fixed-duration bucket start in an hourly rolling window. */
 export function enumerateHourStarts(sinceTime: string, untilTime: string): readonly string[] {
@@ -175,7 +261,7 @@ export function formatRelativeHourShort(
  * line up with what they actually experienced.
  */
 export function makeWindow(
-  days: number,
+  span: UsageWindowSpan,
   now = new Date(),
   resolution: UsageResolution = "day",
 ): UsageSummaryInput {
@@ -216,17 +302,44 @@ export function makeWindow(
       untilTime: untilTime.toISOString(),
     };
   }
+  if (span === "all") {
+    return {
+      sinceDay: USAGE_ALL_TIME_SINCE_DAY,
+      untilDay: UsageDay.make(untilDay),
+      timeZone,
+      resolution,
+    };
+  }
   // Subtracting fixed milliseconds from `now` lands on the wrong calendar day
   // around a DST transition. The window start is pure calendar arithmetic on
   // the local end day, done in UTC where days are uniform.
   const [year = 0, month = 1, dayOfMonth = 1] = untilDay
     .split("-")
     .map((part) => Number.parseInt(part, 10));
-  const start = new Date(Date.UTC(year, month - 1, dayOfMonth - (days - 1)));
+  const start = new Date(Date.UTC(year, month - 1, dayOfMonth - (span - 1)));
   return {
     sinceDay: UsageDay.make(start.toISOString().slice(0, 10)),
     untilDay: UsageDay.make(untilDay),
     timeZone,
     resolution,
   };
+}
+
+/**
+ * The days a chart should draw for a window.
+ *
+ * An all-time window starts at a floor years before any transcript exists, so
+ * it is clipped to the first day that saw activity; every other window draws
+ * its full span, quiet days included.
+ */
+export function enumerateChartDays(
+  window: Pick<UsageSummaryInput, "sinceDay" | "untilDay">,
+  daily: readonly DailyTotals[],
+): readonly string[] {
+  const firstActive = daily[0]?.day;
+  const sinceDay =
+    window.sinceDay === USAGE_ALL_TIME_SINCE_DAY
+      ? (firstActive ?? window.untilDay)
+      : window.sinceDay;
+  return enumerateDays(sinceDay, window.untilDay);
 }


### PR DESCRIPTION
## What Changed

Add "All time" to the period picker on web and mobile. 

The request keeps the existing contract by sending a fixed floor day, and the chart starts at the first active day instead. Spans longer than 120 days draw one point per week so a year of history stays legible, especially on a phone. 

The server keeps everything an all-time scan walked in its cache instead of pruning to 90 days, so the next all-time view is warm rather than a cold re-parse of years of transcripts.

## Why

The usage page stopped at 90 days, so there was no way to see what a provider has cost since you started using it.

## UI Changes

Selection changes
<img width="611" height="49" alt="image" src="https://github.com/user-attachments/assets/48cc3567-c6d5-4517-a93c-2566b73b6ca8" />  
  
<img width="232" height="222" alt="image" src="https://github.com/user-attachments/assets/383c69e3-6dd0-42d0-91be-a339bde62e21" />  


90 Days (gives the exact 90 days prior):   
<img width="522" height="360" alt="image" src="https://github.com/user-attachments/assets/a75d57eb-cba0-4759-a9f5-30d9cbc4dcd5" />  

All Time (finds the earliest day):
<img width="510" height="372" alt="image" src="https://github.com/user-attachments/assets/5bb9045f-1eb4-4824-a1d7-afda88ec378c" />  


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **All time** usage window across web and mobile.
  - Long usage ranges now automatically display weekly chart data for easier viewing.
  - Weekly chart labels, tooltips, and accessibility text identify the represented week.
  - All-time charts begin at the first available usage data.

- **Bug Fixes**
  - Improved usage scan caching to preserve historical data across scans and restarts.
  - Prevented concurrent scans from overwriting more complete cached usage results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->