### PR TITLE
fix(providers): preserve harness update ownership and failures

### DIFF
--- a/apps/server/src/provider/Drivers/CursorDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.test.ts
@@ -55,7 +55,7 @@ it.layer(testLayer)("CursorDriver", (it) => {
           instanceId: ProviderInstanceId.make("cursor-copy-command"),
           displayName: "Cursor test",
           enabled: false,
-          environment: [],
+          environment: [{ name: "HOME", value: tempDir, sensitive: false }],
           config: { ...CursorDriver.defaultConfig(), binaryPath },
         });
 
@@ -64,6 +64,7 @@ it.layer(testLayer)("CursorDriver", (it) => {
           command: `'${binaryPath}' update`,
           executable: binaryPath,
           args: ["update"],
+          env: expect.objectContaining({ HOME: tempDir }),
         });
         expect((yield* instance.snapshot.refresh).status).toBe("disabled");
       }).pipe(

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -70,6 +70,7 @@ const UPDATE: ProviderMaintenanceCapabilitiesResolver = {
             updateArgs: ["update"],
             updateLockKey: "cursor-agent",
             platform: context.platform,
+            env: context.env,
           })
         : makeManualOnlyProviderMaintenanceCapabilities({
             provider: DRIVER_KIND,

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -277,6 +277,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
               "@example/package-tool@latest",
             ],
             lockKey: `npm-global:${normalizeCommandPath(tempDir)}`,
+            env: { PATH: "" },
           },
         });
       }),
@@ -310,6 +311,33 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       ),
     ).toBeNull();
   });
+
+  it.effect.skipIf(!symlinksSupported)(
+    "uses npm for a native-looking alias into an npm install",
+    () =>
+      Effect.gen(function* () {
+        const tempDir = yield* makeTempDir("t3-native-alias-npm");
+        const installed = linkIntoPackage(tempDir, "native-package-tool", [
+          "lib",
+          "node_modules",
+          "@example",
+          "native-package-tool",
+        ]);
+        const alias = NodePath.join(tempDir, ".local", "bin", "native-package-tool");
+        NodeFS.mkdirSync(NodePath.dirname(alias), { recursive: true });
+        NodeFS.symlinkSync(installed, alias);
+
+        const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
+          nativePackageToolUpdate,
+          { binaryPath: alias, env: { PATH: "" } },
+        ).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, noSpawn));
+
+        expect(capabilities.update).toMatchObject({
+          executable: "npm",
+          lockKey: `npm-global:${normalizeCommandPath(tempDir)}`,
+        });
+      }),
+  );
 
   // The Codex Windows installer exposes `%LOCALAPPDATA%\\Programs\\OpenAI\\Codex\\bin`
   // as a junction into `%CODEX_HOME%\\packages\\standalone\\current\\bin`. Node's
@@ -415,6 +443,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         expect(capabilities.update).toMatchObject({
           command: "pnpm add -g @example/package-tool@latest",
           lockKey: "pnpm-global",
+          env: { PATH: "" },
         });
       }),
   );
@@ -441,6 +470,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         expect(capabilities.update).toMatchObject({
           command: "bun i -g @example/package-tool@latest",
           lockKey: "bun-global",
+          env: { PATH: bunBinDir },
         });
       }),
   );
@@ -471,6 +501,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           executable: nativePath,
           args: ["update"],
           lockKey: "nativePackageTool-native",
+          env: { PATH: nativeBinDir },
         },
       });
     }),
@@ -591,10 +622,14 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
 
       const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(resolver, {
         binaryPath: nativePath,
-        env: { PATH: "" },
+        env: { PATH: "", TOOL_HOME: "other-home", HTTPS_PROXY: "http://instance-proxy:8080" },
       }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, noSpawn));
 
-      expect(capabilities.update?.env).toEqual({ TOOL_HOME: tempDir });
+      expect(capabilities.update?.env).toEqual({
+        PATH: "",
+        TOOL_HOME: tempDir,
+        HTTPS_PROXY: "http://instance-proxy:8080",
+      });
     }),
   );
 
@@ -637,7 +672,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     { directory: "Cellar", name: "package-tool", kind: "formula" },
     { directory: "Cellar", name: "package-tool@latest", kind: "formula" },
   ] as const)(
-    "upgrades the owning Homebrew $kind $name through an executable alias",
+    "upgrades the owning Homebrew $kind $name through a native-looking alias",
     (fixture) =>
       Effect.gen(function* () {
         const tempDir = yield* makeTempDir("t3-homebrew-capabilities");
@@ -652,13 +687,20 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           "package-tool-0.148.0",
         );
         writeExecutable(ownedBinary);
-        const link = NodePath.join(tempDir, "bin", "custom-package-tool");
+        const link = NodePath.join(tempDir, ".local", "bin", "native-package-tool");
         NodeFS.mkdirSync(NodePath.dirname(link), { recursive: true });
         NodeFS.symlinkSync(ownedBinary, link);
         const spawned: Array<ReadonlyArray<string>> = [];
 
         const capabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(
-          packageToolUpdate,
+          makePackageManagedProviderMaintenanceResolver({
+            provider: driver("packageTool"),
+            npmPackageName: "@example/package-tool",
+            nativeUpdate: {
+              args: ["update"],
+              isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
+            },
+          }),
           {
             binaryPath: link,
             env: { PATH: brewBinDir },
@@ -699,6 +741,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
                 ? ["upgrade", "--cask", fixture.name]
                 : ["upgrade", fixture.name],
             lockKey: "homebrew",
+            env: { PATH: brewBinDir },
           },
         });
       }),

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -365,7 +365,8 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
   const packageName = definition.npmPackageName;
 
   const nativeUpdate = definition.nativeUpdate;
-  if (nativeUpdate && commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))) {
+  // A familiar launcher path can be a symlink into a package manager's install.
+  if (nativeUpdate && nativeUpdate.isCommandPath(context.realCommandPath)) {
     return makeProviderMaintenanceCapabilities({
       provider: definition.provider,
       packageName,
@@ -373,7 +374,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
       updateArgs: nativeUpdate.args,
       updateLockKey: `${definition.provider}-native`,
       platform: context.platform,
-      ...(nativeUpdate.env ? { env: nativeUpdate.env } : {}),
+      env: { ...context.env, ...nativeUpdate.env },
     });
   }
   if (commandPaths.some(isVitePlusGlobalCommandPath)) {
@@ -383,6 +384,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
       updateExecutable: "vp",
       updateArgs: ["i", "-g", packageName],
       updateLockKey: "vite-plus-global",
+      env: context.env,
     });
   }
   if (commandPaths.some(isBunGlobalCommandPath)) {
@@ -392,6 +394,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
       updateExecutable: "bun",
       updateArgs: ["i", "-g", `${packageName}@latest`],
       updateLockKey: "bun-global",
+      env: context.env,
     });
   }
   if (commandPaths.some(isPnpmGlobalCommandPath)) {
@@ -401,6 +404,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
       updateExecutable: "pnpm",
       updateArgs: ["add", "-g", `${packageName}@latest`],
       updateLockKey: "pnpm-global",
+      env: context.env,
     });
   }
 
@@ -427,6 +431,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
         `${packageName}@latest`,
       ],
       updateLockKey: `npm-global:${normalizeCommandPath(npmPrefix)}`,
+      env: context.env,
     });
   }
 
@@ -466,6 +471,7 @@ export const resolvePackageManagedProviderMaintenance = Effect.fn(
       updateExecutable: brewPath,
       updateArgs: args,
       updateLockKey: "homebrew",
+      env: context.env,
       updateCommand: ["brew", ...args].join(" "),
       latestVersion: info ? parseHomebrewLatestVersion(info, homebrew) : null,
     });

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -7,6 +7,8 @@ import {
 } from "@t3tools/contracts";
 import { ServerProviderUpdateError } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -209,18 +211,16 @@ function makeRegistry(
 }
 
 const makeTestRunner = (registry: ProviderRegistryShape) =>
-  Effect.service(ProviderMaintenanceRunner.ProviderMaintenanceRunner).pipe(
-    Effect.provide(
-      ProviderMaintenanceRunner.layer.pipe(
-        Layer.provide(
-          Layer.mergeAll(
-            Layer.succeed(ProviderRegistry, registry),
-            // Fresh per runner so a version cached by one test cannot leak into another.
-            Layer.sync(ProviderVersionCache, () => new Map()),
-          ),
-        ),
+  ProviderMaintenanceRunner.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.succeed(ProviderRegistry, registry),
+        // Fresh per runner so a version cached by one test cannot leak into another.
+        Layer.sync(ProviderVersionCache, () => new Map()),
       ),
     ),
+    Layer.build,
+    Effect.map(Context.get(ProviderMaintenanceRunner.ProviderMaintenanceRunner)),
   );
 
 describe("providerMaintenanceRunner", () => {
@@ -797,56 +797,54 @@ describe("providerMaintenanceRunner", () => {
     );
   });
 
-  it.effect(
-    "releases the running-provider marker when interrupted after queuing but before the lock run starts",
-    () =>
-      Effect.gen(function* () {
-        const { registry } = yield* makeRegistry(baseProvider);
-        let blockQueuedState = true;
-        const queuedStateWrittenLatch: { resolve: () => void } = { resolve: () => {} };
-        const releaseQueuedStateLatch: { resolve: () => void } = { resolve: () => {} };
-        const queuedStateWritten = new Promise<void>((resolve) => {
-          queuedStateWrittenLatch.resolve = resolve;
-        });
-        const releaseQueuedState = new Promise<void>((resolve) => {
-          releaseQueuedStateLatch.resolve = resolve;
-        });
+  it.effect("keeps an update and its lock alive when the requesting client disconnects", () =>
+    Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const running = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const completed = yield* Deferred.make<void>();
 
-        const updater = yield* makeTestRunner({
-          ...registry,
-          setProviderMaintenanceActionState: Effect.fn(
-            "providerMaintenanceRunner.test.blockQueuedState",
-          )(function* (input) {
-            const providers = yield* registry.setProviderMaintenanceActionState(input);
-            if (input.state?.status === "queued" && blockQueuedState) {
-              queuedStateWrittenLatch.resolve();
-              yield* Effect.promise(() => releaseQueuedState);
-            }
-            return providers;
-          }),
-        });
+      const updater = yield* makeTestRunner({
+        ...registry,
+        setProviderMaintenanceActionState: Effect.fn(
+          "providerMaintenanceRunner.test.blockRunningState",
+        )(function* (input) {
+          const providers = yield* registry.setProviderMaintenanceActionState(input);
+          if (input.state?.status === "running") {
+            yield* Deferred.succeed(running, undefined);
+            yield* Deferred.await(release);
+          }
+          if (input.state?.status === "succeeded") {
+            yield* Deferred.succeed(completed, undefined);
+          }
+          return providers;
+        }),
+      });
 
-        const first = yield* updater.updateProvider(CODEX_DRIVER).pipe(Effect.forkScoped);
-        yield* Effect.promise(() => queuedStateWritten);
-        blockQueuedState = false;
-
-        yield* Fiber.interrupt(first);
-        releaseQueuedStateLatch.resolve();
-
-        const second = yield* updater.updateProvider(CODEX_DRIVER).pipe(Effect.exit);
-        assert.strictEqual(Exit.isSuccess(second), true);
-        if (Exit.isSuccess(second)) {
-          assert.strictEqual(second.value.providers[0]?.updateState?.status, "succeeded");
+      const first = yield* updater.updateProvider(CODEX_DRIVER).pipe(Effect.forkScoped);
+      yield* Deferred.await(running);
+      yield* Fiber.interrupt(first);
+      const second = yield* updater.updateProvider(CODEX_DRIVER).pipe(Effect.exit);
+      assert.strictEqual(Exit.isFailure(second), true);
+      if (Exit.isFailure(second)) {
+        const error = Cause.squash(second.cause);
+        assert.isTrue(isServerProviderUpdateError(error));
+        if (isServerProviderUpdateError(error)) {
+          assert.strictEqual(error.reason, "An update is already running for this provider.");
         }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            NonWindowsPlatform,
-            latestVersionHttpClient("0.0.0"),
-            mockSpawnerLayer(() => ({ stdout: "updated" })),
-          ),
+      }
+      yield* Deferred.succeed(release, undefined);
+      yield* Deferred.await(completed);
+      assert.strictEqual((yield* registry.getProviders)[0]?.updateState?.status, "succeeded");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer(() => ({ stdout: "updated" })),
         ),
       ),
+    ),
   );
 
   it.effect("resolves npm to a .cmd shim and routes through the shell on win32", () => {

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -14,6 +14,7 @@ import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -86,7 +87,10 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
         // which a bare ChildProcess.spawn cannot launch (spawn npm ENOENT);
         // resolveSpawnCommand finds the real `.cmd` and routes it through the
         // shell. On Linux/macOS (incl. the WSL backend) this is a no-op.
-        const resolved = yield* resolveSpawnCommand(input.command, input.args);
+        const resolved = yield* resolveSpawnCommand(input.command, input.args, {
+          ...(input.env ? { env: input.env } : {}),
+          extendEnv: true,
+        });
         const child = yield* input.spawner
           .spawn(
             ChildProcess.make(resolved.command, resolved.args, {
@@ -212,6 +216,7 @@ function makeUpdateState(input: {
 }
 
 export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
+  const scope = yield* Effect.scope;
   const providerRegistry = yield* ProviderRegistry;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
@@ -462,6 +467,10 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               })
             : error,
         ),
+        // Reloading or disconnecting a client must not interrupt its installer.
+        // The server's service scope still cancels updates during shutdown.
+        Effect.forkIn(scope),
+        Effect.flatMap(Fiber.join),
       );
   });
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2904,6 +2904,7 @@ const makeWsRpcLayer = (
 
 export const websocketRpcRouteLayer = Layer.unwrap(
   Effect.gen(function* () {
+    const providerMaintenanceRunner = yield* ProviderMaintenanceRunner.make();
     const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
     const baseServerSelfUpdate = yield* ServerSelfUpdate.ServerSelfUpdate;
     const config = yield* ServerConfig.ServerConfig;
@@ -2967,7 +2968,12 @@ export const websocketRpcRouteLayer = Layer.unwrap(
             ).pipe(
               Layer.provideMerge(RpcSerialization.layerJson),
               Layer.provide(AgentSessionScanner.layer),
-              Layer.provide(ProviderMaintenanceRunner.layer),
+              Layer.provide(
+                Layer.succeed(
+                  ProviderMaintenanceRunner.ProviderMaintenanceRunner,
+                  providerMaintenanceRunner,
+                ),
+              ),
               Layer.provide(Layer.succeed(ServerSelfUpdate.ServerSelfUpdate, serverSelfUpdate)),
               // One server-lifetime service means clients share the same PR caches, and a WS
               // mutation invalidates the HTTP diff cache that every client reads from.

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -438,6 +438,7 @@ export function ProviderInstanceCard({
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
   const updateCommand = versionAdvisory?.updateCommand ?? null;
+  const updateState = liveProvider?.updateState;
   const FallbackIconComponent = driverOption?.icon;
   const displayName =
     instance.displayName?.trim() || driverOption?.label || String(instance.driver);
@@ -836,6 +837,24 @@ export function ProviderInstanceCard({
           }
         />
       </SettingsSection>
+
+      {updateState?.status === "failed" || updateState?.status === "unchanged" ? (
+        <SettingsSection
+          title={updateState.status === "failed" ? "Update failed" : "Update not verified"}
+        >
+          <div role="status" className="grid gap-2 px-3 py-3 text-xs sm:px-4">
+            <p className="text-warning">{updateState.message}</p>
+            {updateState.output ? (
+              <details className="min-w-0 text-muted-foreground">
+                <summary className="cursor-pointer">View update output</summary>
+                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted/50 p-3 text-[11px]">
+                  {updateState.output}
+                </pre>
+              </details>
+            ) : null}
+          </div>
+        </SettingsSection>
+      ) : null}
 
       {setup ? (
         <SettingsSection title="Setup">


### PR DESCRIPTION
Harness updates could lose instance environment variables, choose a native updater for a package-managed symlink, or be cancelled when the requesting client disconnected. Updates now use the instance environment and real executable ownership, share server-lifetime locks across clients, survive client disconnects, and expose failed installer output in provider settings.

Verified with 58 focused tests, server/web typechecks, scoped lint, a real npm failure, and a Codex 0.153.3 → 0.153.4 update while reloading the client; inspected settings at 1280×800 dark and 800×900 light. Recording export remains blocked: the preview tool saved the MP4 on the remote desktop, which this environment cannot retrieve, so interaction video evidence is unverified.

Related reports: #5629, #6115. Implemented with `gpt-6` in Codex.

![before: failed npm update leaves provider settings without an error](https://uploads-production-47e4.up.railway.app/files/3a62805c-3ad4-40cb-97bf-d1a1fd1cf409/before.png)

![after: provider settings shows the failed update and npm connection error](https://uploads-production-47e4.up.railway.app/files/994354d4-d22d-42c8-9dec-4dbd7c8ebd29/after.png)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve provider update ownership and environment across client disconnects
> - Provider update effects are forked into the service scope in `make` so they continue after the requesting client fiber is interrupted, while the server scope can still cancel them during shutdown ([providerMaintenanceRunner.ts](apps/server/src/provider/providerMaintenanceRunner.ts)).
> - Native updater detection in `resolvePackageManagedProviderMaintenance` now checks the real executable path, so a symlink whose visible path looks native but points into another installation is routed to the correct package manager (npm/pnpm/bun/Homebrew) instead ([providerMaintenance.ts](apps/server/src/provider/providerMaintenance.ts)).
> - All package-manager and Homebrew update actions now carry the resolved provider environment (PATH, HOME, TOOL_HOME, HTTPS_PROXY), with native-specific values overriding matching context keys.
> - WebSocket route layer creates one shared `ProviderMaintenanceRunner` instance for all connections, including its coordination state and server-lifetime scope ([ws.ts](apps/server/src/ws.ts)).
> - `ProviderInstanceCard` now renders update message and optional output when `liveProvider.updateState` is failed or unchanged ([ProviderInstanceCard.tsx](apps/web/src/components/settings/ProviderInstanceCard.tsx)).
> - Risk: the update lock and running update no longer release when the requesting client disconnects; a second concurrent update for the same provider is rejected while the first runs to completion.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5967474. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer provider update status messaging for failed or unverified updates, including expandable update output when available.
  * Provider update commands now consistently use the resolved environment settings.

* **Bug Fixes**
  * Updates now continue running when a client disconnects or reloads, while preventing conflicting updates from running simultaneously.
  * Improved handling and verification of native provider update commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->