### PR TITLE
fix: hide email-bearing account labels in usage limits

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -97,6 +97,29 @@ function WindowRow(props: {
   );
 }
 
+function AccountInstanceLabel({ value }: { readonly value: string }) {
+  const [revealed, setRevealed] = useState(false);
+  if (!value.includes("@")) {
+    return (
+      <Text className="shrink text-xs text-foreground-tertiary" numberOfLines={1}>
+        · {value}
+      </Text>
+    );
+  }
+  return (
+    <Pressable
+      className="shrink active:opacity-60"
+      accessibilityRole="button"
+      accessibilityLabel={revealed ? "Hide account label" : "Reveal account label"}
+      onPress={() => setRevealed((current) => !current)}
+    >
+      <Text className="text-xs text-foreground-tertiary" numberOfLines={1}>
+        · {revealed ? value : "••••••@••••••"}
+      </Text>
+    </Pressable>
+  );
+}
+
 /** One account: icon, name and plan on a single line, then its windows. */
 export function AccountLimits(props: {
   readonly driver: Driver;
@@ -128,9 +151,7 @@ export function AccountLimits(props: {
         <View className="min-w-0 flex-1 flex-row items-baseline gap-2">
           <Text className="text-base font-t3-medium text-foreground">{props.label}</Text>
           {props.instanceLabel !== props.label ? (
-            <Text className="shrink text-xs text-foreground-tertiary" numberOfLines={1}>
-              · {props.instanceLabel}
-            </Text>
+            <AccountInstanceLabel key={props.instanceLabel} value={props.instanceLabel} />
           ) : null}
           {props.detail ? (
             <Text className="shrink text-sm text-foreground-muted" numberOfLines={1}>

--- a/apps/web/src/components/chat/ComposerUsageLimits.tsx
+++ b/apps/web/src/components/chat/ComposerUsageLimits.tsx
@@ -3,6 +3,7 @@ import { limitsNotice } from "@t3tools/shared/usageLimits";
 import { GaugeIcon } from "lucide-react";
 
 import { getDriverOption } from "../settings/providerDriverMeta";
+import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
 import { LimitWindows, ResetCredits } from "../usage/UsageLimits";
 import { ComposerBanner } from "./ComposerBanner";
 import type { ComposerBannerStackItem } from "./ComposerBannerStack";
@@ -20,6 +21,27 @@ function accountLabel(account: UsageLimitsReport["accounts"][number]): string {
     : driver;
 }
 
+function AccountSummary({ account }: { readonly account: UsageLimitsReport["accounts"][number] }) {
+  const label = accountLabel(account);
+  return (
+    <>
+      {label.includes("@") ? (
+        <RedactedSensitiveText
+          key={label}
+          value={label}
+          ariaLabel="Toggle account label visibility"
+          revealTooltip="Click to reveal account"
+          hideTooltip="Click to hide account"
+          className="max-w-full truncate align-bottom font-sans text-xs leading-normal"
+        />
+      ) : (
+        label
+      )}
+      {account.plan ? ` · ${account.plan}` : null}
+    </>
+  );
+}
+
 /** The /usage-limits result as a composer notice: it stacks under warnings and dismisses like one. */
 export function usageLimitsBannerItem(
   id: string,
@@ -29,9 +51,11 @@ export function usageLimitsBannerItem(
 ): ComposerBannerStackItem {
   const [first] = report.accounts;
   const single = report.accounts.length === 1 && first ? first : null;
-  const summary = single
-    ? [accountLabel(single), single.plan].filter(Boolean).join(" · ")
-    : `${report.accounts.length} accounts`;
+  const summary = single ? (
+    <AccountSummary account={single} />
+  ) : (
+    `${report.accounts.length} accounts`
+  );
   return {
     id,
     variant: "info",
@@ -65,7 +89,7 @@ function UsageLimitsBannerBody({
             <div key={account.id} className="flex min-w-0 flex-col gap-1">
               {report.accounts.length > 1 ? (
                 <span className="truncate text-xs text-muted-foreground">
-                  {[accountLabel(account), account.plan].filter(Boolean).join(" · ")}
+                  <AccountSummary account={account} />
                 </span>
               ) : null}
               {notice ? (


### PR DESCRIPTION
`/usage-limits` renders account labels verbatim, including proxy account filenames containing email addresses. This exposes emails during screen sharing.

Hide labels containing `@` until clicked or tapped, and allow hiding them again. Web and desktop reuse the existing blurred placeholder component in both the single-account heading and multi-account rows. Mobile uses its existing masked-text treatment. Changing the label resets its reveal state; plan names and quota bars stay readable.

Verification:

- Web and mobile typechecks, targeted lint, and formatting passed.
- Exercised the actual web composer with synthetic account data: single and multiple accounts, click to reveal/hide, reopening hidden, keyboard Enter/Space, and the narrow-screen details popover.
- Native runtime verification was unavailable on this Linux host because no Android SDK/emulator is installed.
- No contracts or provider adapters changed; the rendering fix applies to local and remote reports. Existing Settings email redaction remains in place. No documentation change is needed.

Before, from the PR merge base, with synthetic data:

![Before: proxy account email displayed in usage limits](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ca11a85fa372f1d7/before.png)

After, with the same data and viewport:

![After: email-bearing account label blurred by default](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9fc162a9cffcc1ab/after.png)

Click to reveal and hide, cropped from the actual browser recording and played at 2× speed:

![Clicking reveals the account label, and clicking again hides it](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5f94f5a527eb9a6d/reveal-hide.gif)

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide email-bearing account labels in usage limits
> - Adds `AccountInstanceLabel` to mobile usage-limit rows and `AccountSummary` to web composer usage limits; both render labels containing `@` through a masked, pressable reveal/hide control.
> - Labels without `@` and plan text remain directly visible.
> - Risk: any caller relying on the raw inline account-label text in [UsageLimitsSection.tsx](https://github.com/pingdotgg/t3code/pull/10668/files#diff-bab86b129cd45326c61da757d57d1cd8ba687238c357ff7c80f3056789a41494) or [ComposerUsageLimits.tsx](https://github.com/pingdotgg/t3code/pull/10668/files#diff-2c1bbeeb8fc657f2d4c9c5a20a12b69f0da06200da8dc236e09227a5bf82c770) will now receive a component element instead of a plain string for `@`-bearing labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58cf83b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensitive account labels are now masked by default in usage-limit displays.
  * Added controls to reveal or hide masked account labels.
  * Account summaries now consistently include the account plan where available.
  * Non-account labels continue to display normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->