### PR TITLE
feat(codex): attach images to question answers

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -233,12 +233,20 @@ describe("OrchestrationEngine", () => {
           await system.dispose();
           system = await createOrchestrationSystem(databasePath);
         }
+        const answerImage = {
+          type: "image" as const,
+          id: "answer-image-1",
+          name: "screenshot.png",
+          mimeType: "image/png",
+          sizeBytes: 6,
+        };
         const response = {
           type: "thread.user-input.respond" as const,
           commandId: CommandId.make("async-response"),
           threadId,
           requestId,
           answers: { "0": "pnpm", "1": "Example" },
+          attachments: [answerImage],
           createdAt: "2026-01-01T00:00:02.000Z",
         };
         await expect(
@@ -259,6 +267,7 @@ describe("OrchestrationEngine", () => {
         expect(userMessages?.[0]?.text).toBe(
           "Which package manager?\npnpm\n\nWhat should it be named?\nExample",
         );
+        expect(userMessages?.[0]?.attachments).toEqual([answerImage]);
         expect(
           after.threads[0]?.activities.find((activity) => activity.kind === "user-input.resolved")
             ?.payload,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -3709,17 +3709,38 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
+    const answerImage = {
+      type: "image" as const,
+      id: "thread-1-00000000-0000-4000-8000-0000000000aa",
+      name: "screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: 6,
+    };
     await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.user-input.respond",
-        commandId: CommandId.make("cmd-user-input-respond"),
-        threadId: ThreadId.make("thread-1"),
-        requestId: asApprovalRequestId("user-input-request-1"),
-        answers: {
-          sandbox_mode: "workspace-write",
-        },
-        createdAt: now,
-      }),
+      harness.engine
+        .dispatch({
+          type: "thread.user-input.respond",
+          commandId: CommandId.make("cmd-user-input-respond"),
+          threadId: ThreadId.make("thread-1"),
+          requestId: asApprovalRequestId("user-input-request-1"),
+          answers: {
+            sandbox_mode: "workspace-write",
+          },
+          createdAt: now,
+        })
+        .pipe(
+          Effect.andThen(
+            harness.engine.dispatch({
+              type: "thread.user-input.respond",
+              commandId: CommandId.make("cmd-user-input-respond-attachments"),
+              threadId: ThreadId.make("thread-1"),
+              requestId: asApprovalRequestId("user-input-request-2"),
+              answers: { "0": "yes" },
+              attachments: [answerImage],
+              createdAt: now,
+            }),
+          ),
+        ),
     );
 
     await harness.drain();
@@ -3729,6 +3750,13 @@ describe("ProviderCommandReactor", () => {
       answers: {
         sandbox_mode: "workspace-write",
       },
+    });
+    // Attachments ride along untouched; the provider decides how to deliver them.
+    expect(harness.respondToUserInput.mock.calls[1]?.[0]).toEqual({
+      threadId: "thread-1",
+      requestId: "user-input-request-2",
+      answers: { "0": "yes" },
+      attachments: [answerImage],
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1609,6 +1609,7 @@ const make = Effect.gen(function* () {
           threadId: event.payload.threadId,
           requestId: event.payload.requestId,
           answers: event.payload.answers,
+          ...(event.payload.attachments ? { attachments: event.payload.attachments } : {}),
         })
         .pipe(
           Effect.catchCause((cause) =>

--- a/apps/server/src/orchestration/Normalizer.attachments.test.ts
+++ b/apps/server/src/orchestration/Normalizer.attachments.test.ts
@@ -5,6 +5,7 @@ import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import {
+  ApprovalRequestId,
   type ClientOrchestrationCommand,
   CommandId,
   MessageId,
@@ -48,6 +49,29 @@ function turnStartCommand(input: {
     },
     runtimeMode: "full-access",
     interactionMode: "default",
+    createdAt: "2026-08-01T00:00:00.000Z",
+  };
+}
+
+function userInputRespondCommand(input: {
+  readonly attachments?: ReadonlyArray<{ readonly id: string; readonly sizeBytes: number }>;
+}): ClientOrchestrationCommand {
+  return {
+    type: "thread.user-input.respond",
+    commandId: CommandId.make("command-2"),
+    threadId: ThreadId.make("thread-1"),
+    requestId: ApprovalRequestId.make("request-1"),
+    answers: { "0": "yes" },
+    ...(input.attachments
+      ? {
+          attachments: input.attachments.map((attachment) => ({
+            type: "image" as const,
+            name: "screenshot.png",
+            mimeType: "image/png",
+            ...attachment,
+          })),
+        }
+      : {}),
     createdAt: "2026-08-01T00:00:00.000Z",
   };
 }
@@ -355,6 +379,66 @@ describe("normalizeDispatchCommand attachments", () => {
         },
       }).pipe(Effect.flip);
       expect(mismatchedType.message).toContain("attachment type");
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("claims uploaded images for a question answer", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const bytes = Buffer.from("pixels");
+      const pendingPath = NodePath.join(config.attachmentsDir, `pending-${attachmentUuid}.png`);
+      NodeFS.writeFileSync(pendingPath, bytes);
+
+      const normalized = yield* normalizeDispatchCommand(
+        userInputRespondCommand({
+          attachments: [{ id: `pending-${attachmentUuid}`, sizeBytes: bytes.byteLength }],
+        }),
+      );
+      if (normalized.type !== "thread.user-input.respond") {
+        throw new Error("Expected a thread.user-input.respond command.");
+      }
+
+      const attachment = normalized.attachments?.[0];
+      expect(attachment?.id.startsWith("thread-1-")).toBe(true);
+      expect(
+        NodeFS.readFileSync(NodePath.join(config.attachmentsDir, `${attachment!.id}.png`)),
+      ).toEqual(bytes);
+      expect(NodeFS.existsSync(pendingPath)).toBe(true);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("leaves an answer without attachments untouched", () =>
+    Effect.gen(function* () {
+      const normalized = yield* normalizeDispatchCommand(userInputRespondCommand({}));
+      if (normalized.type !== "thread.user-input.respond") {
+        throw new Error("Expected a thread.user-input.respond command.");
+      }
+      expect("attachments" in normalized).toBe(false);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("removes a claimed answer copy when the answer fails to dispatch", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const pendingPath = NodePath.join(config.attachmentsDir, `pending-${attachmentUuid}.png`);
+      NodeFS.writeFileSync(pendingPath, Buffer.from("pixels"));
+      const command = userInputRespondCommand({
+        attachments: [{ id: `pending-${attachmentUuid}`, sizeBytes: 6 }],
+      });
+      const normalized = yield* normalizeDispatchCommand(command);
+      if (normalized.type !== "thread.user-input.respond") {
+        throw new Error("Expected a thread.user-input.respond command.");
+      }
+      const claimedPath = NodePath.join(
+        config.attachmentsDir,
+        `${normalized.attachments![0]!.id}.png`,
+      );
+      expect(NodeFS.existsSync(claimedPath)).toBe(true);
+
+      yield* cleanupFailedUploadedAttachments(command, normalized);
+
+      expect(NodeFS.existsSync(claimedPath)).toBe(false);
+      expect(NodeFS.existsSync(pendingPath)).toBe(true);
     }).pipe(Effect.provide(testLayer)),
   );
 });

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -3,11 +3,14 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import {
+  type ChatAttachment,
   type ClientOrchestrationCommand,
   type IsoDateTime,
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  type ThreadId,
+  type UploadChatAttachment,
 } from "@t3tools/contracts";
 
 import {
@@ -76,9 +79,6 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
   Effect.gen(function* () {
     const receivedAt = DateTime.formatIso(yield* DateTime.now);
     const canonicalCommand = canonicalizeClientCommandTimestamps(command, receivedAt);
-    const fileSystem = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const serverConfig = yield* ServerConfig;
     const workspacePaths = yield* WorkspacePaths.WorkspacePaths;
 
     const normalizeProjectWorkspaceRoot = (workspaceRoot: string) =>
@@ -129,19 +129,62 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       } satisfies OrchestrationCommand;
     }
 
-    if (canonicalCommand.type !== "thread.turn.start") {
-      return canonicalCommand as OrchestrationCommand;
+    if (canonicalCommand.type === "thread.turn.start") {
+      return {
+        ...canonicalCommand,
+        message: {
+          ...canonicalCommand.message,
+          attachments: yield* normalizeCommandAttachments({
+            threadId: canonicalCommand.threadId,
+            attachments: canonicalCommand.message.attachments,
+          }),
+        },
+      } satisfies OrchestrationCommand;
     }
 
+    if (canonicalCommand.type === "thread.user-input.respond") {
+      const { attachments, ...rest } = canonicalCommand;
+      const normalized: OrchestrationCommand =
+        attachments === undefined || attachments.length === 0
+          ? rest
+          : {
+              ...rest,
+              attachments: yield* normalizeCommandAttachments({
+                threadId: canonicalCommand.threadId,
+                attachments,
+              }),
+            };
+      return normalized;
+    }
+
+    return canonicalCommand as OrchestrationCommand;
+  });
+
+/**
+ * Turns client attachments into thread-owned files: pending uploads are
+ * claimed under a thread-scoped id, inline data URLs are persisted. Anything
+ * claimed is removed again when a later attachment in the batch fails.
+ */
+const normalizeCommandAttachments = Effect.fn("Normalizer.normalizeCommandAttachments")(
+  function* (input: {
+    readonly threadId: ThreadId;
+    readonly attachments: ReadonlyArray<UploadChatAttachment | ChatAttachment>;
+  }) {
+    if (input.attachments.length === 0) {
+      return [];
+    }
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const serverConfig = yield* ServerConfig;
     const claimedAttachmentPaths: string[] = [];
-    const normalizedAttachments = yield* Effect.forEach(
-      canonicalCommand.message.attachments,
+    return yield* Effect.forEach(
+      input.attachments,
       (attachment) =>
         Effect.gen(function* () {
           if (!("dataUrl" in attachment)) {
             const claim = planAttachmentClaim({
               attachmentsDir: serverConfig.attachmentsDir,
-              threadId: canonicalCommand.threadId,
+              threadId: input.threadId,
               attachmentId: attachment.id,
             });
             if (!claim.ok) {
@@ -180,7 +223,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
               });
             }
 
-            // Keep the pending copy until the turn succeeds. A failed thread
+            // Keep the pending copy until the command succeeds. A failed thread
             // bootstrap can then retry with a fresh thread id. A copy, not a
             // hard link: an agent editing the delivered file in place must not
             // mutate the retry source.
@@ -212,7 +255,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
             });
           }
 
-          const attachmentId = createAttachmentId(canonicalCommand.threadId);
+          const attachmentId = createAttachmentId(input.threadId);
           if (!attachmentId) {
             return yield* new OrchestrationDispatchCommandError({
               message: "Failed to create a safe attachment id.",
@@ -259,30 +302,42 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
         }),
       { concurrency: 1 },
     ).pipe(Effect.tapError(() => removeClaimedAttachmentPaths(claimedAttachmentPaths)));
+  },
+);
 
-    return {
-      ...canonicalCommand,
-      message: {
-        ...canonicalCommand.message,
-        attachments: normalizedAttachments,
-      },
-    } satisfies OrchestrationCommand;
-  });
+function commandAttachments(
+  command: ClientOrchestrationCommand | OrchestrationCommand,
+): ReadonlyArray<UploadChatAttachment | ChatAttachment> {
+  switch (command.type) {
+    case "thread.turn.start":
+      return command.message.attachments;
+    case "thread.user-input.respond":
+      return command.attachments ?? [];
+    default:
+      return [];
+  }
+}
 
 export const cleanupFailedUploadedAttachments = Effect.fn(
   "Normalizer.cleanupFailedUploadedAttachments",
 )(function* (command: ClientOrchestrationCommand, normalizedCommand: OrchestrationCommand) {
-  if (command.type !== "thread.turn.start" || normalizedCommand.type !== "thread.turn.start") {
+  if (command.type !== normalizedCommand.type) {
+    return;
+  }
+  const originalAttachments = commandAttachments(command);
+  const normalizedAttachments = commandAttachments(normalizedCommand);
+  if (normalizedAttachments.length === 0) {
     return;
   }
 
   const serverConfig = yield* ServerConfig;
   const claimedPaths: string[] = [];
-  for (const [index, attachment] of normalizedCommand.message.attachments.entries()) {
-    const original = command.message.attachments[index];
+  for (const [index, attachment] of normalizedAttachments.entries()) {
+    const original = originalAttachments[index];
     if (
       !original ||
       "dataUrl" in original ||
+      "dataUrl" in attachment ||
       parseThreadSegmentFromAttachmentId(original.id) !== PENDING_ATTACHMENT_THREAD_SEGMENT
     ) {
       continue;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1280,7 +1280,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
                 messageId: MessageId.make(`async-answer:${command.requestId}`),
                 role: "user",
                 text: replies.join("\n\n"),
-                attachments: [],
+                attachments: command.attachments ?? [],
               },
             },
           ],
@@ -1301,6 +1301,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           requestId: command.requestId,
           answers: command.answers,
+          ...(command.attachments && command.attachments.length > 0
+            ? { attachments: command.attachments }
+            : {}),
           createdAt: command.createdAt,
         },
       };

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -41,6 +41,7 @@ import { ProviderAdapterValidationError } from "../Errors.ts";
 import type { CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
+  type CodexUserInputAttachment,
   type CodexSessionRuntimeOptions,
   type CodexSessionRuntimeSendTurnInput,
   type CodexSessionRuntimeShape,
@@ -114,8 +115,11 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
   );
 
   public readonly respondToUserInputImpl = vi.fn(
-    (_requestId: ApprovalRequestId, _answers: ProviderUserInputAnswers): Promise<void> =>
-      Promise.resolve(undefined),
+    (
+      _requestId: ApprovalRequestId,
+      _answers: ProviderUserInputAnswers,
+      _attachments?: ReadonlyArray<CodexUserInputAttachment>,
+    ): Promise<void> => Promise.resolve(undefined),
   );
 
   public readonly closeImpl = vi.fn(() => Promise.resolve(undefined));
@@ -154,8 +158,16 @@ class FakeCodexRuntime implements CodexSessionRuntimeShape {
     return Effect.promise(() => this.respondToRequestImpl(requestId, decision));
   }
 
-  respondToUserInput(requestId: ApprovalRequestId, answers: ProviderUserInputAnswers) {
-    return Effect.promise(() => this.respondToUserInputImpl(requestId, answers));
+  respondToUserInput(
+    requestId: ApprovalRequestId,
+    answers: ProviderUserInputAnswers,
+    attachments?: ReadonlyArray<CodexUserInputAttachment>,
+  ) {
+    return Effect.promise(() =>
+      attachments
+        ? this.respondToUserInputImpl(requestId, answers, attachments)
+        : this.respondToUserInputImpl(requestId, answers),
+    );
   }
 
   get events() {
@@ -412,6 +424,73 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
 
       NodeAssert.equal(result._tag, "Failure");
       NodeAssert.equal(result.failure._tag, "ProviderAdapterSessionNotFoundError");
+    }),
+  );
+
+  it.effect("steers answer images to the runtime as local image paths", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const config = yield* ServerConfig;
+      const threadId = asThreadId("thread-answer-images");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const runtime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      const attachment = {
+        type: "image" as const,
+        id: "thread-answer-images-00000000-0000-4000-8000-0000000000aa",
+        name: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 6,
+      };
+      const attachmentPath = NodePath.join(config.attachmentsDir, `${attachment.id}.png`);
+      NodeFS.writeFileSync(attachmentPath, Buffer.from("pixels"));
+
+      yield* adapter
+        .respondToUserInput(threadId, ApprovalRequestId.make("user-input-1"), { "0": "yes" }, [
+          attachment,
+        ])
+        .pipe(Effect.ensuring(Effect.sync(() => NodeFS.rmSync(attachmentPath, { force: true }))));
+
+      NodeAssert.deepStrictEqual(runtime.respondToUserInputImpl.mock.calls[0], [
+        "user-input-1",
+        { "0": "yes" },
+        [{ input: { type: "localImage", path: attachmentPath }, attachment }],
+      ]);
+    }),
+  );
+
+  it.effect("keeps the question open when an answer image is missing on disk", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const threadId = asThreadId("thread-answer-missing-image");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const runtime = sessionRuntimeFactory.lastRuntime;
+      NodeAssert.ok(runtime);
+      runtime.respondToUserInputImpl.mockClear();
+
+      const result = yield* adapter
+        .respondToUserInput(threadId, ApprovalRequestId.make("user-input-2"), { "0": "yes" }, [
+          {
+            type: "image",
+            id: "thread-answer-missing-image-00000000-0000-4000-8000-0000000000ab",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 6,
+          },
+        ])
+        .pipe(Effect.result);
+
+      NodeAssert.equal(result._tag, "Failure");
+      NodeAssert.equal(result.failure._tag, "ProviderAdapterRequestError");
+      NodeAssert.equal(runtime.respondToUserInputImpl.mock.calls.length, 0);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2487,7 +2487,10 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         detail: `Invalid attachment id '${attachment.id}'.`,
       });
     }
-    const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+    // Codex reads the file itself when the turn starts, so only the path
+    // crosses the JSON-RPC boundary. Stat first: a missing file would otherwise
+    // degrade into a silent placeholder on the Codex side instead of an error.
+    const fileInfo = yield* fileSystem.stat(attachmentPath).pipe(
       Effect.mapError(
         (cause) =>
           new ProviderAdapterRequestError({
@@ -2498,15 +2501,22 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           }),
       ),
     );
+    if (fileInfo.type !== "File") {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "turn/start",
+        detail: `Attachment '${attachment.id}' is not a regular file.`,
+      });
+    }
     return {
-      type: "image" as const,
-      url: `data:${attachment.mimeType};base64,${Buffer.from(bytes).toString("base64")}`,
+      type: "localImage" as const,
+      path: attachmentPath,
     };
   });
 
   const sendTurn: CodexAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
-    // Codex ingests images only. Anything else would be base64-encoded as an
-    // image and rejected or misread; generic files reach the agent through the
+    // Codex ingests images only. Anything else would be passed as an image
+    // path and rejected or misread; generic files reach the agent through the
     // path line ProviderService puts in the prompt.
     const codexAttachments = yield* Effect.forEach(
       (input.attachments ?? []).filter((attachment) => attachment.type === "image"),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -8,6 +8,7 @@
  * @module CodexAdapterLive
  */
 import {
+  ChatAttachment,
   EventId,
   type CanonicalItemType,
   type CanonicalRequestType,
@@ -181,6 +182,11 @@ function readPayload<A>(
   const isPayload = Schema.is(schema);
   return isPayload(payload) ? payload : undefined;
 }
+
+/** Attachments the runtime adds to the answered notification alongside the Codex answers. */
+const UserInputAnsweredAttachments = Schema.Struct({
+  attachments: Schema.Array(ChatAttachment),
+});
 
 function trimText(value: string | undefined | null): string | undefined {
   const trimmed = value?.trim();
@@ -1899,12 +1905,14 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
+    const attachments = readPayload(UserInputAnsweredAttachments, event.payload)?.attachments;
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),
         type: "user-input.resolved",
         payload: {
           answers: toCanonicalUserInputAnswers(payload.answers),
+          ...(attachments && attachments.length > 0 ? { attachments } : {}),
         },
       },
     ];
@@ -2473,8 +2481,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
 
   const resolveAttachment = Effect.fn("resolveAttachment")(function* (
-    input: ProviderSendTurnInput,
-    attachment: NonNullable<ProviderSendTurnInput["attachments"]>[number],
+    attachment: ChatAttachment,
+    method: "turn/start" | "turn/steer" = "turn/start",
   ) {
     const attachmentPath = resolveAttachmentPath({
       attachmentsDir: serverConfig.attachmentsDir,
@@ -2483,7 +2491,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     if (!attachmentPath) {
       return yield* new ProviderAdapterRequestError({
         provider: PROVIDER,
-        method: "turn/start",
+        method,
         detail: `Invalid attachment id '${attachment.id}'.`,
       });
     }
@@ -2495,7 +2503,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         (cause) =>
           new ProviderAdapterRequestError({
             provider: PROVIDER,
-            method: "turn/start",
+            method,
             detail: `Failed to read attachment file: ${cause.message}.`,
             cause,
           }),
@@ -2504,7 +2512,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     if (fileInfo.type !== "File") {
       return yield* new ProviderAdapterRequestError({
         provider: PROVIDER,
-        method: "turn/start",
+        method,
         detail: `Attachment '${attachment.id}' is not a regular file.`,
       });
     }
@@ -2520,7 +2528,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     // path line ProviderService puts in the prompt.
     const codexAttachments = yield* Effect.forEach(
       (input.attachments ?? []).filter((attachment) => attachment.type === "image"),
-      (attachment) => resolveAttachment(input, attachment),
+      (attachment) => resolveAttachment(attachment),
       { concurrency: 1 },
     );
 
@@ -2649,19 +2657,32 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       ),
     );
 
-  const respondToUserInput: CodexAdapterShape["respondToUserInput"] = (
-    threadId,
-    requestId,
-    answers,
-  ) =>
-    requireSession(threadId).pipe(
-      Effect.flatMap((session) => session.runtime.respondToUserInput(requestId, answers)),
-      Effect.mapError((cause) =>
-        cause._tag === "ProviderAdapterSessionNotFoundError"
-          ? cause
-          : mapCodexRuntimeError(threadId, "item/tool/requestUserInput", cause),
-      ),
+  const respondToUserInput: CodexAdapterShape["respondToUserInput"] = Effect.fn(
+    "respondToUserInput",
+  )(function* (threadId, requestId, answers, attachments) {
+    const session = yield* requireSession(threadId);
+    // Images only, as in sendTurn: the runtime steers them into the turn as
+    // local image inputs, which is not a channel for arbitrary files.
+    const codexAttachments = yield* Effect.forEach(
+      (attachments ?? []).filter((attachment) => attachment.type === "image"),
+      (attachment) =>
+        resolveAttachment(attachment, "turn/steer").pipe(
+          Effect.map((input) => ({ input, attachment })),
+        ),
+      { concurrency: 1 },
     );
+    yield* session.runtime
+      .respondToUserInput(
+        requestId,
+        answers,
+        codexAttachments.length > 0 ? codexAttachments : undefined,
+      )
+      .pipe(
+        Effect.mapError((cause) =>
+          mapCodexRuntimeError(threadId, "item/tool/requestUserInput", cause),
+        ),
+      );
+  });
 
   const writeNativeEvent = Effect.fnUntraced(function* (event: ProviderEvent) {
     if (!nativeEventLogger) {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -71,8 +71,8 @@ describe("buildTurnStartParams", () => {
         runtimeMode: "full-access",
         attachments: [
           {
-            type: "image",
-            url: { secret } as unknown as string,
+            type: "localImage",
+            path: { secret } as unknown as string,
           },
         ],
       }).pipe(Effect.flip),
@@ -140,8 +140,8 @@ describe("buildTurnStartParams", () => {
         interactionMode: "default",
         attachments: [
           {
-            type: "image",
-            url: "data:image/png;base64,abc",
+            type: "localImage",
+            path: "/tmp/attachments/thread-1-image.png",
           },
         ],
       }),
@@ -160,8 +160,8 @@ describe("buildTurnStartParams", () => {
           text: "Implement it",
         },
         {
-          type: "image",
-          url: "data:image/png;base64,abc",
+          type: "localImage",
+          path: "/tmp/attachments/thread-1-image.png",
         },
       ],
       model: "gpt-5.3-codex",

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -171,8 +171,8 @@ export interface CodexSessionRuntimeOptions {
 export interface CodexSessionRuntimeSendTurnInput {
   readonly input?: string;
   readonly attachments?: ReadonlyArray<{
-    readonly type: "image";
-    readonly url: string;
+    readonly type: "localImage";
+    readonly path: string;
   }>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier | undefined;
@@ -595,8 +595,8 @@ export function buildTurnStartParams(input: {
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
   readonly attachments?: ReadonlyArray<{
-    readonly type: "image";
-    readonly url: string;
+    readonly type: "localImage";
+    readonly path: string;
   }>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1,4 +1,5 @@
 import {
+  type ChatAttachment,
   ApprovalRequestId,
   DEFAULT_MODEL,
   EventId,
@@ -168,12 +169,30 @@ export interface CodexSessionRuntimeOptions {
   readonly appServerArgs?: ReadonlyArray<string>;
 }
 
+/** Image the app server reads from disk when the turn or steer is submitted. */
+export interface CodexSessionRuntimeImageInput {
+  readonly type: "localImage";
+  readonly path: string;
+}
+
+/** Image attached to a request_user_input answer. */
+export interface CodexUserInputAttachment {
+  /** Steered into the running turn so the model sees it with the answer. */
+  readonly input: CodexSessionRuntimeImageInput;
+  /** Echoed on the answered event so the timeline can show what was sent. */
+  readonly attachment: ChatAttachment;
+}
+
+/**
+ * Leads the steered message that carries answer images. The model reads it
+ * right after the request_user_input tool result, so it ties the images to
+ * the answer it just received.
+ */
+const USER_INPUT_ATTACHMENT_STEER_TEXT = "Attached with my answer to your question:";
+
 export interface CodexSessionRuntimeSendTurnInput {
   readonly input?: string;
-  readonly attachments?: ReadonlyArray<{
-    readonly type: "localImage";
-    readonly path: string;
-  }>;
+  readonly attachments?: ReadonlyArray<CodexSessionRuntimeImageInput>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort | undefined;
@@ -212,6 +231,7 @@ export interface CodexSessionRuntimeShape {
   readonly respondToUserInput: (
     requestId: ApprovalRequestId,
     answers: ProviderUserInputAnswers,
+    attachments?: ReadonlyArray<CodexUserInputAttachment>,
   ) => Effect.Effect<void, CodexSessionRuntimeError>;
   readonly events: Stream.Stream<ProviderEvent, never>;
   readonly close: Effect.Effect<void>;
@@ -594,10 +614,7 @@ export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
-  readonly attachments?: ReadonlyArray<{
-    readonly type: "localImage";
-    readonly path: string;
-  }>;
+  readonly attachments?: ReadonlyArray<CodexSessionRuntimeImageInput>;
   readonly model?: string;
   readonly serviceTier?: CodexServiceTier;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort;
@@ -2475,7 +2492,7 @@ export const makeCodexSessionRuntime = (
             },
           });
         }),
-      respondToUserInput: (requestId, answers) =>
+      respondToUserInput: (requestId, answers, attachments) =>
         Effect.gen(function* () {
           const pending = (yield* Ref.get(pendingUserInputsRef)).get(requestId);
           if (!pending) {
@@ -2484,6 +2501,28 @@ export const makeCodexSessionRuntime = (
             });
           }
           const codexAnswers = yield* toCodexUserInputAnswers(answers);
+          if (attachments && attachments.length > 0) {
+            // The answer itself can only carry text, so the images travel as
+            // steered input on the turn that is blocked on this question. Codex
+            // drains steered input at the top of its next model request, the
+            // same request that carries the tool result, so the model sees the
+            // images together with the answers. Steering before releasing the
+            // answer keeps the question open if the app server rejects it.
+            if (!pending.turnId) {
+              return yield* CodexErrors.CodexAppServerRequestError.invalidParams(
+                "This question is not bound to an active turn, so images cannot be attached to the answer.",
+              );
+            }
+            const providerThreadId = yield* readProviderThreadId;
+            yield* client.request("turn/steer", {
+              threadId: providerThreadId,
+              expectedTurnId: pending.turnId,
+              input: [
+                { type: "text", text: USER_INPUT_ATTACHMENT_STEER_TEXT },
+                ...attachments.map((entry) => entry.input),
+              ],
+            });
+          }
           yield* Ref.update(pendingUserInputsRef, (current) => {
             const next = new Map(current);
             next.delete(requestId);
@@ -2499,6 +2538,9 @@ export const makeCodexSessionRuntime = (
             ...(pending.itemId ? { itemId: pending.itemId } : {}),
             payload: {
               answers: codexAnswers,
+              ...(attachments && attachments.length > 0
+                ? { attachments: attachments.map((entry) => entry.attachment) }
+                : {}),
             },
           });
         }),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -13,6 +13,7 @@ import type {
   ProviderUploadFeedbackResult,
 } from "@t3tools/contracts";
 import {
+  type ChatAttachment,
   ASSISTANT_CITATION_MAX_TEXT_LENGTH,
   AssistantCitation,
   ApprovalRequestId,
@@ -216,6 +217,7 @@ function makeFakeCodexAdapter(
       _threadId: ThreadId,
       _requestId: string,
       _answers: Record<string, unknown>,
+      _attachments?: ReadonlyArray<ChatAttachment>,
     ): Effect.Effect<void, ProviderAdapterError> => Effect.void,
   );
 
@@ -1651,6 +1653,43 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("rejects answer images for providers that cannot steer them", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-claude-answer-images");
+      yield* provider.startSession(threadId, {
+        provider: ProviderDriverKind.make("claudeAgent"),
+        providerInstanceId: claudeAgentInstanceId,
+        threadId,
+        cwd: fixtureCwd("project"),
+        runtimeMode: "full-access",
+      });
+      routing.claude.respondToUserInput.mockClear();
+
+      const failure = yield* Effect.flip(
+        provider.respondToUserInput({
+          threadId,
+          requestId: asRequestId("req-user-input-claude"),
+          answers: { "0": "yes" },
+          attachments: [
+            {
+              type: "image",
+              id: "thread-claude-answer-images-00000000-0000-4000-8000-0000000000aa",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 6,
+            },
+          ],
+        }),
+      );
+
+      assert.instanceOf(failure, ProviderAdapterRequestError);
+      assert.include(failure.detail, "cannot take images");
+      assert.equal(routing.claude.respondToUserInput.mock.calls.length, 0);
+      yield* provider.stopSession({ threadId });
+    }),
+  );
+
   it.effect("routes provider operations and rollback conversation", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService.ProviderService;
@@ -1701,6 +1740,24 @@ routing.layer("ProviderServiceLive routing", (it) => {
             sandbox_mode: "workspace-write",
           },
         ],
+      ]);
+
+      const answerImage = {
+        type: "image" as const,
+        id: "thread-1-00000000-0000-4000-8000-0000000000aa",
+        name: "screenshot.png",
+        mimeType: "image/png",
+        sizeBytes: 6,
+      };
+      routing.codex.respondToUserInput.mockClear();
+      yield* provider.respondToUserInput({
+        threadId: session.threadId,
+        requestId: asRequestId("req-user-input-2"),
+        answers: { "0": "yes" },
+        attachments: [answerImage],
+      });
+      assert.deepEqual(routing.codex.respondToUserInput.mock.calls, [
+        [session.threadId, asRequestId("req-user-input-2"), { "0": "yes" }, [answerImage]],
       ]);
 
       yield* provider.rollbackConversation({

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1919,7 +1919,26 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         "provider.thread_id": input.threadId,
         "provider.request_id": input.requestId,
       });
-      yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
+      const attachments = input.attachments ?? [];
+      // Only Codex can steer images into the turn that is waiting on the
+      // answer. Failing here keeps the question open so the user can drop the
+      // images instead of having them vanish.
+      if (attachments.length > 0 && routed.adapter.provider !== "codex") {
+        return yield* new ProviderAdapterRequestError({
+          provider: routed.adapter.provider,
+          method: "item/tool/requestUserInput",
+          detail:
+            "This provider cannot take images with an answer yet. Answer in text and send the images as a follow-up message.",
+        });
+      }
+      yield* attachments.length > 0
+        ? routed.adapter.respondToUserInput(
+            routed.threadId,
+            input.requestId,
+            input.answers,
+            attachments,
+          )
+        : routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
     }).pipe(
       withMetrics({
         counter: providerTurnsTotal,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -8,6 +8,7 @@
  * @module ProviderAdapter
  */
 import type {
+  ChatAttachment,
   ApprovalRequestId,
   ProviderApprovalDecision,
   ProviderDriverKind,
@@ -103,12 +104,15 @@ export interface ProviderAdapterShape<TError> {
   ) => Effect.Effect<void, TError>;
 
   /**
-   * Respond to a structured user-input request.
+   * Respond to a structured user-input request. Attachments accompany the
+   * answers; an adapter that cannot deliver them to a running turn must fail
+   * rather than drop them silently.
    */
   readonly respondToUserInput: (
     threadId: ThreadId,
     requestId: ApprovalRequestId,
     answers: ProviderUserInputAnswers,
+    attachments?: ReadonlyArray<ChatAttachment>,
   ) => Effect.Effect<void, TError>;
 
   /**

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -30,6 +30,8 @@ import {
   type KeybindingCommand,
   OrchestrationThreadActivity,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  type ChatAttachment,
+  type UploadChatAttachment,
   ProviderInteractionMode,
   ProviderDriverKind,
   resolveEnvironmentMachineKind,
@@ -1526,6 +1528,7 @@ export default function ChatView(props: ChatViewProps) {
   });
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
   const addComposerDraftFiles = useComposerDraftStore((store) => store.addFiles);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.setTerminalContexts,
@@ -2659,6 +2662,12 @@ export default function ChatView(props: ChatViewProps) {
   const activePendingIsResponding = activePendingUserInput
     ? respondingUserInputRequestIds.includes(activePendingUserInput.requestId)
     : false;
+  // Async questions become a normal message, which every provider takes
+  // attachments on. Native callbacks can only carry images when the provider
+  // steers them into the running turn, which Codex does.
+  const activePendingUserInputAcceptsImages =
+    activePendingUserInput !== null &&
+    (activePendingUserInput.dismissible || selectedProvider === "codex");
   const activeProposedPlan = useMemo(() => {
     if (!latestTurnSettled) {
       return null;
@@ -7038,32 +7047,113 @@ export default function ChatView(props: ChatViewProps) {
     [activeThreadId, environmentId, respondToThreadApproval, setThreadError],
   );
 
+  // The image half of the send path: uploads when the server takes them,
+  // inline data URLs for servers that predate uploads.
+  const prepareAnswerImages = useCallback(
+    async (
+      images: ReadonlyArray<ComposerImageAttachment>,
+    ): Promise<
+      | {
+          readonly ok: true;
+          readonly attachments: ReadonlyArray<UploadChatAttachment | ChatAttachment>;
+        }
+      | { readonly ok: false; readonly reason: string }
+    > => {
+      if (supportsAttachmentUploads) {
+        for (const image of images) {
+          startAttachmentUpload({ environmentId, image, draftTarget: composerDraftTarget });
+        }
+        await awaitAttachmentUploads(images.map((image) => image.id));
+        const uploaded = getUploadedAttachments({ environmentId, images });
+        return uploaded === null
+          ? { ok: false, reason: "Retry or remove failed uploads before sending." }
+          : { ok: true, attachments: uploaded };
+      }
+      return {
+        ok: true,
+        attachments: await Promise.all(
+          images.map(async (image) => ({
+            type: "image" as const,
+            name: image.name,
+            mimeType: image.mimeType,
+            sizeBytes: image.sizeBytes,
+            dataUrl: await readFileAsDataUrl(image.file),
+            ...(image.source ? { source: image.source } : {}),
+          })),
+        ),
+      };
+    },
+    [composerDraftTarget, environmentId, supportsAttachmentUploads],
+  );
+
   const onRespondToUserInput = useCallback(
     async (requestId: ApprovalRequestId, answers: Record<string, unknown>) => {
       if (!activeThreadId) return;
 
+      // Read the staged images up front so a paste that lands while the
+      // reply is in flight stays in the draft for the next message.
+      const answerImages = activePendingUserInputAcceptsImages
+        ? [...(composerRef.current?.getSendContext().images ?? [])]
+        : [];
       setRespondingUserInputRequestIds((existing) =>
         existing.includes(requestId) ? existing : [...existing, requestId],
       );
+      const finishResponding = () =>
+        setRespondingUserInputRequestIds((existing) => existing.filter((id) => id !== requestId));
+
+      let attachments: ReadonlyArray<UploadChatAttachment | ChatAttachment> = [];
+      if (answerImages.length > 0) {
+        const prepared = await prepareAnswerImages(answerImages);
+        if (!prepared.ok) {
+          setThreadError(activeThreadId, prepared.reason);
+          finishResponding();
+          return;
+        }
+        attachments = prepared.attachments;
+      }
+
       const result = await respondToThreadUserInput({
         environmentId,
         input: {
           threadId: activeThreadId,
           requestId,
           answers,
+          ...(attachments.length > 0 ? { attachments } : {}),
         },
       });
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        setThreadError(
-          activeThreadId,
-          error instanceof Error ? error.message : "Failed to submit user input.",
-        );
+      if (result._tag === "Failure") {
+        if (!isAtomCommandInterrupted(result)) {
+          const error = squashAtomCommandFailure(result);
+          setThreadError(
+            activeThreadId,
+            error instanceof Error ? error.message : "Failed to submit user input.",
+          );
+        }
+      } else if (answerImages.length > 0) {
+        // The server now owns thread-scoped copies; drop the pending uploads
+        // and the composer previews.
+        if (supportsAttachmentUploads) {
+          releaseDraftAttachments(answerImages);
+        }
+        for (const image of answerImages) {
+          removeComposerDraftImage(composerDraftTarget, image.id);
+        }
       }
-      setRespondingUserInputRequestIds((existing) => existing.filter((id) => id !== requestId));
+      finishResponding();
       return result;
     },
-    [activeThreadId, environmentId, respondToThreadUserInput, setThreadError],
+    [
+      activePendingUserInputAcceptsImages,
+      activeThreadId,
+      composerDraftTarget,
+      composerRef,
+      environmentId,
+      prepareAnswerImages,
+      removeComposerDraftImage,
+      respondToThreadUserInput,
+      setThreadError,
+      supportsAttachmentUploads,
+    ],
   );
 
   // Closes an async question without messaging the agent. The server records
@@ -8141,6 +8231,7 @@ export default function ChatView(props: ChatViewProps) {
                             activePendingDraftAnswers={activePendingDraftAnswers}
                             activePendingQuestionIndex={activePendingQuestionIndex}
                             respondingRequestIds={respondingRequestIds}
+                            pendingUserInputAcceptsImages={activePendingUserInputAcceptsImages}
                             showPlanFollowUpPrompt={showPlanFollowUpPrompt}
                             activeProposedPlan={activeProposedPlan}
                             activeTasksProgress={activeComposerTasksProgress}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1277,6 +1277,8 @@ export interface ChatComposerProps {
   activePendingDraftAnswers: Record<string, PendingUserInputDraftAnswer>;
   activePendingQuestionIndex: number;
   respondingRequestIds: ApprovalRequestId[];
+  /** Images staged in the composer go out with the answer to the active question. */
+  pendingUserInputAcceptsImages: boolean;
 
   // Plan
   showPlanFollowUpPrompt: boolean;
@@ -1397,6 +1399,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activePendingApproval,
     pendingApprovals,
     pendingUserInputs,
+    pendingUserInputAcceptsImages,
     activePendingProgress,
     activePendingResolvedAnswers,
     activePendingIsResponding,
@@ -2127,7 +2130,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     (!isComposerCollapsedMobile && showPlanFollowUpPrompt && activeProposedPlan !== null);
   const showCollapsedMobilePromptRow =
     isComposerCollapsedMobile && !isComposerApprovalState && pendingUserInputs.length === 0;
-  const showComposerAttachAction = fileStagingLimit !== null && pendingUserInputs.length === 0;
+  const showComposerAttachAction =
+    fileStagingLimit !== null && (pendingUserInputs.length === 0 || pendingUserInputAcceptsImages);
+  const attachActionLabel = pendingUserInputs.length > 0 ? "Attach images" : "Attach files";
   const composerFooterHasWideActions = showPlanFollowUpPrompt || activePendingProgress !== null;
   const composerFooterActionLayoutKey = useMemo(() => {
     if (activePendingProgress) {
@@ -4255,7 +4260,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // ------------------------------------------------------------------
   const addComposerAttachments = async (files: File[]) => {
     if (!activeThreadId || files.length === 0) return;
-    if (pendingUserInputs.length > 0) {
+    const attachingToAnswer = pendingUserInputs.length > 0;
+    if (attachingToAnswer && !pendingUserInputAcceptsImages) {
       toastManager.add({
         type: "error",
         title: "Attach files after answering pending questions.",
@@ -4316,6 +4322,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       if (attachmentKind === "image") {
         acceptedImages.push(normalizeComposerImageFileMimeType(file));
       } else {
+        if (attachingToAnswer) {
+          error = "Only images can go with an answer. Attach other files after answering.";
+          continue;
+        }
         if (fileStagingLimit === null) {
           error = "This server does not support file attachments.";
           continue;
@@ -5684,13 +5694,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                               size="icon-sm"
                               onPointerDown={(event) => event.preventDefault()}
                               onClick={() => attachmentInputRef.current?.click()}
-                              aria-label="Attach files"
+                              aria-label={attachActionLabel}
                             />
                           }
                         >
                           <PaperclipIcon />
                         </TooltipTrigger>
-                        <TooltipPopup>Attach files</TooltipPopup>
+                        <TooltipPopup>{attachActionLabel}</TooltipPopup>
                       </Tooltip>
                     </>
                   ) : null}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3217,6 +3217,14 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
       ? undefined
       : (workEntry.toolIcon ?? workEntry.toolSource?.icon);
   const previewText = displayLabel ?? workEntryDisplayLabel(workEntry, workspaceRoot);
+  const answerImages = useMemo(
+    () =>
+      (workEntry.attachments ?? []).filter(isImageAttachment).map((image) => ({
+        image,
+        resource: { _tag: "attachment", attachmentId: image.id } as const,
+      })),
+    [workEntry.attachments],
+  );
   const viewedImagePath = workEntryViewedImagePath(workEntry);
   const viewedImage =
     viewedImagePath && threadRef
@@ -3345,6 +3353,25 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           </span>
         </div>
       </div>
+      {answerImages.length > 0 && threadRef ? (
+        <div
+          className="mt-1 ms-7 flex cursor-default flex-wrap gap-1.5"
+          onClick={stopRowToggle}
+          onPointerDown={stopRowToggle}
+        >
+          {answerImages.map(({ image, resource }) => (
+            <ChatMarkdownAssetImage
+              key={image.id}
+              environmentId={threadRef.environmentId}
+              resource={resource}
+              alt={image.name}
+              maxHeightRem={6}
+              workspaceRoot={workspaceRoot}
+              onImageExpand={onImageExpand}
+            />
+          ))}
+        </div>
+      ) : null}
       {expanded && viewedImage && threadRef ? (
         <div
           className="mt-1 ms-7 cursor-default"

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -477,6 +477,30 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("keeps answer images on resolved user input entries", () => {
+    const attachment = {
+      type: "image",
+      id: "thread-1-image",
+      name: "screenshot.png",
+      mimeType: "image/png",
+      sizeBytes: 6,
+    };
+    const entries = deriveWorkLogEntries([
+      makeActivity({
+        id: "answered",
+        kind: "user-input.resolved",
+        summary: "User input submitted",
+        tone: "info",
+        payload: {
+          requestId: "request-1",
+          answers: { "0": "yes" },
+          attachments: [attachment, { bogus: true }],
+        },
+      }),
+    ]);
+    expect(entries[0]?.attachments).toEqual([attachment]);
+  });
+
   it("omits tool started entries and keeps completed entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -4,6 +4,7 @@ import {
 } from "@t3tools/client-runtime/pending-requests";
 import * as Option from "effect/Option";
 import * as Arr from "effect/Array";
+import * as Schema from "effect/Schema";
 import { shallow } from "zustand/vanilla/shallow";
 import { isBackgroundTaskActivity } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
@@ -18,6 +19,7 @@ import {
 } from "@t3tools/client-runtime/work-log/presentation";
 import { extractToolActivityPresentation } from "@t3tools/client-runtime/work-log/tool-presentation";
 import {
+  ChatAttachment as ChatAttachmentSchema,
   isToolLifecycleItemType,
   type AssetResource,
   type OrchestrationLatestTurn,
@@ -59,6 +61,8 @@ export interface WorkLogEntry {
   label: string;
   detail?: string;
   viewedImagePath?: string;
+  /** Images sent with a question answer, shown under the resolved row. */
+  attachments?: ReadonlyArray<ChatAttachment>;
   command?: string;
   rawCommand?: string;
   changedFiles?: ReadonlyArray<string>;
@@ -92,6 +96,13 @@ export interface WorkLogEntry {
 }
 
 const workLogCollapseKey = Symbol();
+
+const isChatAttachment = Schema.is(ChatAttachmentSchema);
+
+/** The provider echoes answer attachments on the resolved activity. */
+function extractAnsweredAttachments(value: unknown): ReadonlyArray<ChatAttachment> {
+  return Array.isArray(value) ? value.filter(isChatAttachment) : [];
+}
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
   sourceActivityKind: OrchestrationThreadActivity["kind"];
@@ -559,6 +570,12 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (viewedImagePath) {
     entry.viewedImagePath = viewedImagePath;
+  }
+  if (activity.kind === "user-input.resolved") {
+    const attachments = extractAnsweredAttachments(payload?.attachments);
+    if (attachments.length > 0) {
+      entry.attachments = attachments;
+    }
   }
   if (commandPreview.command) {
     entry.command = commandPreview.command;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1133,12 +1133,26 @@ const ThreadApprovalRespondCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+// Attachments ride alongside the text answers. Native callback questions
+// steer them into the running turn; async questions carry them on the
+// follow-up message the answer becomes.
 const ThreadUserInputRespondCommand = Schema.Struct({
   type: Schema.Literal("thread.user-input.respond"),
   commandId: CommandId,
   threadId: ThreadId,
   requestId: ApprovalRequestId,
   answers: ProviderUserInputAnswers,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  createdAt: IsoDateTime,
+});
+
+const ClientThreadUserInputRespondCommand = Schema.Struct({
+  type: Schema.Literal("thread.user-input.respond"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  requestId: ApprovalRequestId,
+  answers: ProviderUserInputAnswers,
+  attachments: Schema.optional(Schema.Array(Schema.Union([UploadChatAttachment, ChatAttachment]))),
   createdAt: IsoDateTime,
 });
 
@@ -1226,7 +1240,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ClientThreadTurnStartCommand,
   ThreadTurnInterruptCommand,
   ThreadApprovalRespondCommand,
-  ThreadUserInputRespondCommand,
+  ClientThreadUserInputRespondCommand,
   ThreadUserInputDismissCommand,
   ThreadCheckpointRevertCommand,
   ThreadSessionStopCommand,
@@ -1585,6 +1599,7 @@ const ThreadUserInputResponseRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   requestId: ApprovalRequestId,
   answers: ProviderUserInputAnswers,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -110,6 +110,7 @@ export const ProviderRespondToUserInputInput = Schema.Struct({
   threadId: ThreadId,
   requestId: ApprovalRequestId,
   answers: ProviderUserInputAnswers,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
 });
 export type ProviderRespondToUserInputInput = typeof ProviderRespondToUserInputInput.Type;
 

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -15,7 +15,7 @@ import {
 } from "./baseSchemas.ts";
 import { ProviderInstanceId, ProviderDriverKind } from "./providerInstance.ts";
 import { ProviderUsageLimitsUpdate } from "./providerUsageLimits.ts";
-import { ProviderApprovalOption } from "./orchestration.ts";
+import { ChatAttachment, ProviderApprovalOption } from "./orchestration.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const UnknownRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
@@ -551,6 +551,7 @@ export type UserInputRequestedPayload = typeof UserInputRequestedPayload.Type;
 
 const UserInputResolvedPayload = Schema.Struct({
   answers: UnknownRecordSchema,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
 });
 export type UserInputResolvedPayload = typeof UserInputResolvedPayload.Type;
 


### PR DESCRIPTION
## Summary

Codex's `request_user_input` answer is text-only at the protocol level (`answers: Record<string, string[]>`), so until now the composer blocked attachments while a question was pending. This lets the user drop images into the answer.

**How the images reach the model.** The Codex runtime calls `turn/steer` on the turn that is blocked on the question, with the images as `localImage` inputs, right before releasing the answer. Codex drains steered input at the top of its next model request, which is the same request that carries the tool result, so the model sees the answer and the images together. Steering first means a rejected steer leaves the question open for a retry. The steered message leads with a short line tying the images to the answer.

**Other paths.**
- Async questions (`responseMode: "message"`) already become a normal turn; their attachments now ride on that message, which every provider supports.
- Native callbacks for non-Codex providers reject attachments with an explicit error rather than dropping them silently.

**Plumbing.**
- `thread.user-input.respond` accepts `attachments` (pending uploads or inline data URLs). The normalizer claims them onto the thread with the same logic as `thread.turn.start`, now shared in one helper. Failed dispatches clean up claimed copies.
- Attachments flow through the response-requested event, the reactor, `ProviderService`, and the adapter contract (`respondToUserInput` gains an optional attachments parameter).
- The answered notification echoes the attachments so the timeline's "User input submitted" row shows thumbnails.

**Web.**
- The attach button, paste, and drop stay active while a question is pending when the thread's provider can take images with an answer. Only images are accepted there; the button reads "Attach images".
- Answer images upload through the existing attachment queue and are released from the draft after the answer succeeds.

Also included from the first commit: Codex turn images are sent as `localImage` paths instead of base64 data URLs.

## Test plan

- [x] Normalizer: claims uploads for answers, leaves attachment-less answers untouched, cleans up on failed dispatch
- [x] Codex adapter: resolves answer images to local paths, fails loudly when a file is missing
- [x] ProviderService: forwards attachments to Codex, rejects them for Claude
- [x] Reactor and engine: attachments travel with the answer / land on the async-answer message
- [x] Web: resolved user-input rows keep answer images
- [x] `pnpm fmt`, `pnpm lint`, `pnpm typecheck`
- [ ] Manual: ask Codex a question, drop a screenshot into the answer, confirm the model references it

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image attachments to Codex question answers
> - Extends contracts in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/10669/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af), [provider.ts](https://github.com/pingdotgg/t3code/pull/10669/files#diff-6aa0be5ddcd97c0010b09b87bf387c0149973771b760df0565e908f262a4a95f), and [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/10669/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) with optional `ChatAttachment` arrays for user-input responses.
> - [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/10669/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) resolves image attachments to local filesystem paths and forwards them to the Codex runtime via `respondToUserInput`, replacing the previous base64 data URI approach.
> - [Normalizer.ts](https://github.com/pingdotgg/t3code/pull/10669/files#diff-751e99c6b2a5986d684c4717507023bfb24d6250386e071d6b48dd195e10c5ea) extracts shared attachment claiming and cleanup logic for both turn-start and user-input response commands.
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/10669/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/10669/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) enable image staging for eligible pending questions, uploading them to the server or converting to inline data URLs before submission.
> - Behavioral Change: `ProviderService.respondToUserInput` rejects image-bearing answers for non-Codex providers; `CodexAdapter.resolveAttachment` rejects missing, invalid, or non-regular files before the answer is sent.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d9dd553. 14 files reviewed, 10 issues evaluated, 4 issues filtered, 6 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/CodexSessionRuntime.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 2541](https://github.com/pingdotgg/t3code/blob/d9dd5530cd5c4742abe6463a4b5346bd1378624e/apps/server/src/provider/Layers/CodexSessionRuntime.ts#L2541): The new `attachments` payload is emitted here, but `ProviderRuntimeIngestion`'s `user-input.resolved` handler copies only `answers` into the persisted activity and drops `event.payload.attachments`. Consequently `workEntry.attachments` is never populated, so the newly added timeline image rendering cannot display images sent with a Codex question answer. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 7095](https://github.com/pingdotgg/t3code/blob/d9dd5530cd5c4742abe6463a4b5346bd1378624e/apps/web/src/components/ChatView.tsx#L7095): `activePendingUserInputAcceptsImages` permits images whenever the pending question is `dismissible`, even if its routed provider is not Codex. `onRespondToUserInput` then uploads and sends those attachments in `respondToThreadUserInput`; the server explicitly rejects any non-Codex attachment response, leaving the question unanswered and forcing the user to remove the image and retry. Gate this path on the provider that actually owns the pending session (Codex), rather than `dismissible`. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/session-logic.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 65](https://github.com/pingdotgg/t3code/blob/d9dd5530cd5c4742abe6463a4b5346bd1378624e/apps/web/src/session-logic.ts#L65): `attachments` is only added to the `WorkLogEntry` model here, but no `WorkLogEntry` renderer in `apps/web/src` reads this property (the timeline renders the rows without any attachment UI). Thus resolved question activities can retain their attachments but the screenshots are never displayed under the resolved row, so the new answer-image feature remains invisible. <b>[ Out of scope (triage) ]</b>
> - [line 575](https://github.com/pingdotgg/t3code/blob/d9dd5530cd5c4742abe6463a4b5346bd1378624e/apps/web/src/session-logic.ts#L575): `toDerivedWorkLogEntry` reads attachments only from the persisted `user-input.resolved` activity payload, but provider-runtime ingestion reconstructs that payload with only `requestId` and `answers`, dropping the `attachments` that `CodexSessionRuntime` includes in its resolved provider event. Consequently, a Codex answer containing an image is sent to the model but its resolved work-log row never displays the image. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attach images when responding to supported asynchronous questions.
  - Codex-powered conversations now accept image attachments with answers.
  - Submitted answer images appear as thumbnails in the conversation timeline.

- **Bug Fixes**
  - Unsupported providers now reject image attachments instead of silently dropping them.
  - Invalid or missing image files keep the question open and provide an error.
  - Attachment uploads are cleaned up appropriately when answer submission fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->