### PR TITLE
fix(clients): hide redundant Auto mode for OpenCode

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -475,6 +475,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       ownerId: settingsOwnerId,
       environmentId: props.environmentId,
       providerInstanceId: currentModelSelection.instanceId,
+      providerDriver: selectedProviderStatus?.driver,
       providerGroups: threadProviderGroups,
       selectedModel: currentModelSelection,
       onSelectModel: (option) => props.onUpdateModelSelection(option.selection),
@@ -487,6 +488,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     [
       currentModelSelection,
       currentRuntimeMode,
+      selectedProviderStatus?.driver,
       props.onUpdateModelSelection,
       props.onUpdateRuntimeMode,
       providerOptionDescriptors,

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -14,6 +14,10 @@ import {
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
+import {
+  runtimeModesForProvider,
+  visibleRuntimeModeForProvider,
+} from "@t3tools/shared/runtimeMode";
 import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import {
   createNativeStackNavigator,
@@ -315,6 +319,7 @@ type ThreadSettingsSubmenuPage =
 type ThreadSettingsSessionProps = {
   readonly environmentId: EnvironmentId | null;
   readonly providerInstanceId?: ProviderInstanceId;
+  readonly providerDriver?: string;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly selectedModel: ModelSelection | null;
   readonly onSelectModel: (option: ModelOption) => void;
@@ -369,6 +374,7 @@ type ThreadSettingsSessionValue = {
   readonly environmentId: EnvironmentId | null;
   readonly providerInstanceId?: ProviderInstanceId;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
+  readonly availableRuntimeModes: ReadonlyArray<RuntimeMode>;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
   readonly displayedDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
@@ -402,6 +408,8 @@ function ThreadSettingsSessionProvider(
     () => new Set(),
   );
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
+  const availableRuntimeModes = runtimeModesForProvider(props.providerDriver);
+  const visibleRuntimeMode = visibleRuntimeModeForProvider(props.runtimeMode, props.providerDriver);
 
   const isApplied = useCallback(
     (option: ModelOption) =>
@@ -497,7 +505,8 @@ function ThreadSettingsSessionProvider(
       environmentId: props.environmentId,
       providerInstanceId: props.providerInstanceId,
       providerGroups: props.providerGroups,
-      runtimeMode: props.runtimeMode,
+      availableRuntimeModes,
+      runtimeMode: visibleRuntimeMode,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
       displayedDescriptors,
       providerExpansionOverrides,
@@ -531,10 +540,11 @@ function ThreadSettingsSessionProvider(
       providerFilter,
       props.onUpdateRuntimeMode,
       props.providerGroups,
-      props.runtimeMode,
       searchQuery,
       showLegacyToggle,
       toggleProvider,
+      availableRuntimeModes,
+      visibleRuntimeMode,
     ],
   );
 
@@ -906,7 +916,9 @@ function ThreadSettingsChoiceContent(props: {
   const submenuContent =
     props.submenu.kind === "runtime"
       ? {
-          rows: RUNTIME_MODE_CHOICES.map((choice) => ({
+          rows: RUNTIME_MODE_CHOICES.filter((choice) =>
+            session.availableRuntimeModes.includes(choice.mode),
+          ).map((choice) => ({
             id: choice.mode,
             label: choice.label,
             description: choice.description,
@@ -1297,6 +1309,7 @@ export function NewTaskThreadSettingsRouteScreen() {
   return (
     <ThreadSettingsSessionProvider
       environmentId={flow.selectedEnvironmentId}
+      providerDriver={flow.selectedModelOption?.providerDriver}
       providerGroups={flow.providerGroups}
       selectedModel={flow.selectedModel}
       onSelectModel={(option) => flow.setSelectedModelKey(option.key, option.selection.options)}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -26,6 +26,10 @@ import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import { USAGE_LIMITS_COMMAND } from "@t3tools/shared/usageLimits";
 import {
+  runtimeModesForProvider,
+  visibleRuntimeModeForProvider,
+} from "@t3tools/shared/runtimeMode";
+import {
   Fragment,
   memo,
   type ComponentProps,
@@ -911,7 +915,6 @@ const runtimeModeConfig: Record<
   },
 };
 
-const runtimeModeOptions = Object.keys(runtimeModeConfig) as RuntimeMode[];
 const extendReplacementRangeForTrailingSpace = (
   text: string,
   rangeEnd: number,
@@ -988,6 +991,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   showInteractionModeToggle: boolean;
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  runtimeModes: ReadonlyArray<RuntimeMode>;
   size?: "sm" | "xs";
   hidden?: boolean;
   onToggleInteractionMode: () => void;
@@ -1070,7 +1074,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
             <SelectValue>{runtimeModeOption.label}</SelectValue>
           </TooltipTrigger>
           <SelectPopup alignItemWithTrigger={false} {...composerFloatingLayerProps}>
-            {runtimeModeOptions.map((mode) => {
+            {props.runtimeModes.map((mode) => {
               const option = runtimeModeConfig[mode];
               const OptionIcon = option.icon;
               return (
@@ -1697,6 +1701,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // disabled.
   const selectedProvider: ProviderDriverKind =
     selectedProviderEntry?.driverKind ?? requestedDriverKind;
+  const availableRuntimeModes = runtimeModesForProvider(selectedProvider);
+  const visibleRuntimeMode = visibleRuntimeModeForProvider(runtimeMode, selectedProvider);
 
   const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
     threadRef: composerDraftTarget,
@@ -4015,7 +4021,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         <ComposerFooterModeControls
           showInteractionModeToggle={planModeUiEnabled}
           interactionMode={interactionMode}
-          runtimeMode={runtimeMode}
+          runtimeMode={visibleRuntimeMode}
+          runtimeModes={availableRuntimeModes}
           size={composerControlsInStrip ? "xs" : "sm"}
           hidden={composerControlsHidden || restingHiddenBlockCount > 0}
           onToggleInteractionMode={toggleInteractionMode}
@@ -4094,7 +4101,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       {composerControlsCompact ? (
         <CompactComposerControlsMenu
           interactionMode={interactionMode}
-          runtimeMode={runtimeMode}
+          runtimeMode={visibleRuntimeMode}
+          runtimeModes={availableRuntimeModes}
           showInteractionModeToggle={planModeUiEnabled}
           traitsMenuContent={providerTraitsMenuContent}
           onToggleInteractionMode={toggleInteractionMode}
@@ -4134,7 +4142,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
             >
               <CompactComposerControlsMenu
                 interactionMode={interactionMode}
-                runtimeMode={runtimeMode}
+                runtimeMode={visibleRuntimeMode}
+                runtimeModes={availableRuntimeModes}
                 size="xs"
                 hidden={composerControlsHidden || hiddenRestingBlockIds.length === 0}
                 showInteractionModeToggle={

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -16,6 +16,7 @@ import { useComposerMenuState } from "./useComposerMenuState";
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  runtimeModes: ReadonlyArray<RuntimeMode>;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
   size?: "sm" | "xs";
@@ -76,10 +77,17 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onRuntimeModeChange(value as RuntimeMode);
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="auto">Auto</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          {props.runtimeModes.map((mode) => (
+            <MenuRadioItem key={mode} value={mode}>
+              {mode === "approval-required"
+                ? "Supervised"
+                : mode === "auto-accept-edits"
+                  ? "Auto-accept edits"
+                  : mode === "auto"
+                    ? "Auto"
+                    : "Full access"}
+            </MenuRadioItem>
+          ))}
         </MenuRadioGroup>
       </MenuPopup>
     </Menu>

--- a/docs/user/permission-modes.md
+++ b/docs/user/permission-modes.md
@@ -28,4 +28,8 @@ actions still require approval.
 Antigravity can still send native approval requests in **Full access**. It only offers remembered
 approvals for actions that support them.
 
+OpenCode's picker offers **Supervised**, **Auto-accept edits**, and **Full access** on web,
+desktop, and mobile. Existing OpenCode **Auto** threads display **Supervised**, matching
+their approval behavior.
+
 See the [provider guides](./install.md#providers) for setup and provider-specific limits.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -191,6 +191,10 @@
       "types": "./src/terminalLabels.ts",
       "import": "./src/terminalLabels.ts"
     },
+    "./runtimeMode": {
+      "types": "./src/runtimeMode.ts",
+      "import": "./src/runtimeMode.ts"
+    },
     "./relayClient": {
       "types": "./src/relayClient.ts",
       "import": "./src/relayClient.ts"

--- a/packages/shared/src/runtimeMode.test.ts
+++ b/packages/shared/src/runtimeMode.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { runtimeModesForProvider, visibleRuntimeModeForProvider } from "./runtimeMode.ts";
+
+describe("runtimeModesForProvider", () => {
+  it("omits redundant Auto but retains automatic edits for OpenCode", () => {
+    expect(runtimeModesForProvider("opencode")).toEqual([
+      "approval-required",
+      "auto-accept-edits",
+      "full-access",
+    ]);
+  });
+
+  it("keeps every runtime mode for other providers", () => {
+    expect(runtimeModesForProvider("codex")).toEqual([
+      "approval-required",
+      "auto-accept-edits",
+      "auto",
+      "full-access",
+    ]);
+  });
+});
+
+describe("visibleRuntimeModeForProvider", () => {
+  it("renders OpenCode auto as supervised without mislabeling automatic edits", () => {
+    expect(visibleRuntimeModeForProvider("auto", "opencode")).toBe("approval-required");
+    expect(visibleRuntimeModeForProvider("auto-accept-edits", "opencode")).toBe(
+      "auto-accept-edits",
+    );
+  });
+
+  it("preserves supported modes", () => {
+    expect(visibleRuntimeModeForProvider("full-access", "opencode")).toBe("full-access");
+    expect(visibleRuntimeModeForProvider("auto", "codex")).toBe("auto");
+  });
+});

--- a/packages/shared/src/runtimeMode.ts
+++ b/packages/shared/src/runtimeMode.ts
@@ -1,0 +1,34 @@
+import type { RuntimeMode } from "@t3tools/contracts";
+
+const ALL_RUNTIME_MODES = [
+  "approval-required",
+  "auto-accept-edits",
+  "auto",
+  "full-access",
+] as const satisfies ReadonlyArray<RuntimeMode>;
+
+const OPENCODE_RUNTIME_MODES = [
+  "approval-required",
+  "auto-accept-edits",
+  "full-access",
+] as const satisfies ReadonlyArray<RuntimeMode>;
+
+/** OpenCode has no automatic reviewer, so its picker omits Auto. */
+export function runtimeModesForProvider(
+  providerDriver: string | null | undefined,
+): ReadonlyArray<RuntimeMode> {
+  return providerDriver === "opencode" ? OPENCODE_RUNTIME_MODES : ALL_RUNTIME_MODES;
+}
+
+/**
+ * Older OpenCode threads can retain a mode that is not available in its picker.
+ * Auto behaves like supervised; auto-accept edits must retain its accurate label.
+ */
+export function visibleRuntimeModeForProvider(
+  runtimeMode: RuntimeMode,
+  providerDriver: string | null | undefined,
+): RuntimeMode {
+  return providerDriver === "opencode" && runtimeMode === "auto"
+    ? "approval-required"
+    : runtimeMode;
+}


### PR DESCRIPTION
OpenCode's Auto mode still asks for approval like Supervised, so selecting Auto suggests behavior the provider does not implement.

Offer Supervised, Auto-accept edits, and Full access in the OpenCode composer controls on web and desktop and in the mobile thread settings sheet. Existing Auto threads display Supervised, matching their existing approval behavior. Other providers keep their current options.

Validation: all four focused runtime-mode tests pass, web and mobile type checks pass, and formatting checks pass. The maintainer verified the web UI: Codex keeps all four modes and OpenCode offers the three supported choices. Mobile UI was not tested in an emulator.

UI evidence: maintainer-provided screenshots are awaiting attachment. They compare Codex and OpenCode after the change; they are not a before/after pair. Kept as a draft until image evidence is attached.

Created with GPT-6 in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide redundant OpenCode Auto runtime mode and show it as Supervised
> - Adds `runtimeModesForProvider` and `visibleRuntimeModeForProvider` helpers in [runtimeMode.ts](https://github.com/pingdotgg/t3code/pull/10672/files#diff-af499977252c7f1c6dc2715b4fc92a12257c9b85445b84c2d635ff66362eab9b) that return three modes for OpenCode (excluding Auto) and map OpenCode Auto to the Supervised display mode.
> - Exports the new shared module via the `runtimeMode` subpath in [package.json](https://github.com/pingdotgg/t3code/pull/10672/files#diff-3752b1e4e3e2032593e21e9268ec0379680a59e4e7b8517d0d5492a71530d3e8).
> - Web `ChatComposer` and mobile `ThreadSettingsSheet` derive available and visible runtime modes from the selected provider's driver, so provider-incompatible modes no longer render.
> - `CompactComposerControlsMenu` and `ComposerFooterModeControls` now render runtime modes from a `runtimeModes` prop instead of a fixed four-item list.
> - Risk: OpenCode providers no longer expose Auto as a selectable mode; existing OpenCode Auto threads display as Supervised per [permission-modes.md](https://github.com/pingdotgg/t3code/pull/10672/files#diff-b0382a5d0d5541b3ad51c034e0ca7174f4481834d6b5547430d14f8d89c9778e).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 696ec3d. 6 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->