### PR TITLE
fix(desktop): restore layout control hit targets

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1603,13 +1603,13 @@ code {
   -webkit-app-region: drag;
 }
 
-/* Electron 44 inherits app-region. A later header child can otherwise add a
-   drag rectangle over fixed controls that already opted out. `none` emits no
-   rectangle, preserving the parent's drag area; `no-drag` would subtract it.
-   Use the base layer so explicit drag/no-drag utilities still take precedence. */
+/* Electron 44 inherits app-region. Reset children to the initial value so they
+   do not add drag rectangles over fixed controls. Explicit `none` is treated
+   as `no-drag` and breaks titlebar dragging; `initial` emits no rectangle.
+   The base layer lets explicit drag/no-drag utilities take precedence. */
 @layer base {
   .drag-region > * {
-    -webkit-app-region: none;
+    -webkit-app-region: initial;
   }
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1604,8 +1604,9 @@ code {
 }
 
 /* Electron 44 inherits app-region. A later header child can otherwise add a
-   drag rectangle over fixed controls that already opted out. Reset children
-   in the base layer so explicit drag/no-drag utilities still take precedence. */
+   drag rectangle over fixed controls that already opted out. `none` emits no
+   rectangle, preserving the parent's drag area; `no-drag` would subtract it.
+   Use the base layer so explicit drag/no-drag utilities still take precedence. */
 @layer base {
   .drag-region > * {
     -webkit-app-region: none;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1603,6 +1603,15 @@ code {
   -webkit-app-region: drag;
 }
 
+/* Electron 44 inherits app-region. A later header child can otherwise add a
+   drag rectangle over fixed controls that already opted out. Reset children
+   in the base layer so explicit drag/no-drag utilities still take precedence. */
+@layer base {
+  .drag-region > * {
+    -webkit-app-region: none;
+  }
+}
+
 .drag-region button,
 .drag-region input,
 .drag-region textarea,

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1786,22 +1786,7 @@ function PullRequestsRouteView() {
           }
         />
       ),
-    titlebarControls:
-      // While the panel is closed the strip lives inside the header: a no-drag
-      // descendant beats the header's desktop drag-region, where a floating
-      // sibling loses (app-region hit-testing ignores z-index). While the
-      // floating strip crosses the header during motion, the narrow extension
-      // keeps that overlap non-draggable without moving the toggle.
-      pullRequestsSupported ? (
-        rightPanelPresent ? (
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-y-0 left-full w-7 [-webkit-app-region:no-drag]"
-          />
-        ) : (
-          openPanelControls
-        )
-      ) : null,
+    titlebarControls: pullRequestsSupported && !rightPanelPresent ? openPanelControls : null,
     rightPanelOpen: rightPanelState.isOpen,
     listBody,
     scrollRef,
@@ -1884,7 +1869,6 @@ function PullRequestsRouteView() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="relative flex min-h-0 flex-1">
-        {pullRequestsSupported && rightPanelPresent ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
         {rightPanelPresent && renderedPullRequestSurface && panelEnvironmentId !== null ? (
@@ -1955,6 +1939,10 @@ function PullRequestsRouteView() {
             />
           </RightPanelTabs>
         ) : null}
+        {/* Native drag regions follow layout-tree order, not z-index. Keep the
+            actual control's no-drag rectangle after both titlebars, including
+            while the panel closes, without putting it in the clipped panel. */}
+        {pullRequestsSupported && rightPanelPresent ? openPanelControls : null}
       </div>
     </SidebarInset>
   );
@@ -2213,19 +2201,14 @@ function PullRequestsColumn({
     // Painted flat like the chat column: the inset underneath carries the chrome grain, and a
     // content surface that lets it show reads as a different background than every thread.
     <div className="@container/pr-list flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-      {/* A closed right panel leaves this column full-width, so the shared header
-          reserves native window controls and hosts the controls strip itself: on
-          desktop the header is a drag-region, and only a no-drag descendant wins
-          clicks from it - a floating sibling loses to app-region hit-testing no
-          matter its z-index. While the panel is open, the strip mounts back at
-          the route level, whose box spans the panel too, so the toggle keeps one
-          fixed top-right anchor. */}
+      {/* Keep the closed-panel controls inside this titlebar. The open-panel
+          controls mount after both columns at the route level, preserving the
+          same top-right anchor while excluding both native drag regions. */}
       <WorkspacePageHeader
         electron={isElectron}
         reserveNativeControls={!rightPanelOpen}
         className="relative bg-background"
       >
-        {titlebarControls}
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope" className="overflow-hidden">
             {/* An expanded search owns the scarce horizontal space. The page title stays
@@ -2282,6 +2265,7 @@ function PullRequestsColumn({
           </div>
         ) : null}
         {rightPanelControl}
+        {titlebarControls}
       </WorkspacePageHeader>
 
       <div

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -1786,7 +1786,22 @@ function PullRequestsRouteView() {
           }
         />
       ),
-    titlebarControls: pullRequestsSupported && !rightPanelPresent ? openPanelControls : null,
+    titlebarControls:
+      // While the panel is closed the strip lives inside the header: a no-drag
+      // descendant beats the header's desktop drag-region, where a floating
+      // sibling loses (app-region hit-testing ignores z-index). While the
+      // floating strip crosses the header during motion, the narrow extension
+      // keeps that overlap non-draggable without moving the toggle.
+      pullRequestsSupported ? (
+        rightPanelPresent ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-full w-7 [-webkit-app-region:no-drag]"
+          />
+        ) : (
+          openPanelControls
+        )
+      ) : null,
     rightPanelOpen: rightPanelState.isOpen,
     listBody,
     scrollRef,
@@ -1869,6 +1884,7 @@ function PullRequestsRouteView() {
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="relative flex min-h-0 flex-1">
+        {pullRequestsSupported && rightPanelPresent ? openPanelControls : null}
         <PullRequestsColumn {...columnProps} />
 
         {rightPanelPresent && renderedPullRequestSurface && panelEnvironmentId !== null ? (
@@ -1939,10 +1955,6 @@ function PullRequestsRouteView() {
             />
           </RightPanelTabs>
         ) : null}
-        {/* Native drag regions follow layout-tree order, not z-index. Keep the
-            actual control's no-drag rectangle after both titlebars, including
-            while the panel closes, without putting it in the clipped panel. */}
-        {pullRequestsSupported && rightPanelPresent ? openPanelControls : null}
       </div>
     </SidebarInset>
   );
@@ -2201,14 +2213,19 @@ function PullRequestsColumn({
     // Painted flat like the chat column: the inset underneath carries the chrome grain, and a
     // content surface that lets it show reads as a different background than every thread.
     <div className="@container/pr-list flex min-h-0 min-w-0 flex-1 flex-col bg-background">
-      {/* Keep the closed-panel controls inside this titlebar. The open-panel
-          controls mount after both columns at the route level, preserving the
-          same top-right anchor while excluding both native drag regions. */}
+      {/* A closed right panel leaves this column full-width, so the shared header
+          reserves native window controls and hosts the controls strip itself: on
+          desktop the header is a drag-region, and only a no-drag descendant wins
+          clicks from it - a floating sibling loses to app-region hit-testing no
+          matter its z-index. While the panel is open, the strip mounts back at
+          the route level, whose box spans the panel too, so the toggle keeps one
+          fixed top-right anchor. */}
       <WorkspacePageHeader
         electron={isElectron}
         reserveNativeControls={!rightPanelOpen}
         className="relative bg-background"
       >
+        {titlebarControls}
         {condensed ? (
           <WorkspaceBreadcrumb ariaLabel="Pull request scope" className="overflow-hidden">
             {/* An expanded search owns the scarce horizontal space. The page title stays
@@ -2265,7 +2282,6 @@ function PullRequestsColumn({
           </div>
         ) : null}
         {rightPanelControl}
-        {titlebarControls}
       </WorkspacePageHeader>
 
       <div


### PR DESCRIPTION
Electron 44 makes `app-region` inherit into header children. Later header rectangles cover the fixed layout buttons, leaving only their thin edges clickable.

Reset direct children of each drag region with `-webkit-app-region: initial`. This stops inherited rectangles from covering controls while preserving the parent titlebar's drag area. Explicit `none` is unsuitable here: Chromium converts it to `no-drag`, which removes the children's area from the draggable titlebar. The base-layer rule preserves explicit drag/no-drag utilities.

Validation:

- An isolated Electron 44.1.0 fixture confirms explicit `none` computes to `no-drag`, while `initial` computes to the neutral `none` state. The header retains `drag` and its button retains `no-drag`.
- The actual stylesheet compiles with the repository's Tailwind version. Formatting and whitespace checks pass.
- Fresh source audit found no issues; the diff is limited to the shared CSS rule.
- All executed CI checks pass. Macroscope approved the current commit and CodeRabbit found no actionable issues. Bugbot remains unavailable due to the team spending limit.
- Julius verified that the controls remain clickable and dragging empty titlebar space moves the window again with the corrected CSS. Julius is handling the interaction recording.

Closes [#10661](https://github.com/pingdotgg/t3code/issues/10661)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix drag-region hit targets by resetting `-webkit-app-region` for direct children
> Adds a base-layer CSS rule in [index.css](https://github.com/pingdotgg/t3code/pull/10673/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) that resets `-webkit-app-region` to its initial value for direct children of `.drag-region`. Existing unlayered selectors for buttons, inputs, textareas, selects, and links still mark those controls as `no-drag` and take precedence over the layered reset. This restores correct click behavior for layout controls inside frameless titlebar drag regions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7862a3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title bar dragging behavior in the desktop app.
  * Interactive child elements now avoid unintentionally creating draggable areas while preserving explicit drag and no-drag controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Model: GPT-6. Harness: Codex.
