### PR TITLE
fix(desktop): stop generating declarations during bundling

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       define: publicConfigDefine,
@@ -61,6 +62,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       define: publicConfigDefine,
@@ -75,6 +77,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       entry: ["src/preview-pick-preload.ts"],
@@ -85,6 +88,7 @@ export default defineConfig({
     {
       format: "cjs",
       outDir: "dist-electron",
+      dts: false,
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
       entry: ["src/preview-pip-preload.ts"],


### PR DESCRIPTION
Desktop builds enable declaration output implicitly through the composite tsconfig. The declaration compiler also includes `scripts/lib`, which sits outside the desktop root, so `vp pack` leaves 15 generated `.d.ts` files beside those sources. They can then be picked up by an unrelated commit.

Disable declaration generation in all four desktop pack configurations. These bundles are executables and preloads with no declaration consumers.

Validation in an isolated worktree:

- `T3CODE_DESKTOP_DEV=0 vp pack` completed all four builds and produced the main process and three preload entry points.
- Confirmed zero `.d.ts`, `.d.cts`, or `.d.mts` files under `scripts/lib` and `apps/desktop` afterward.
- `vp pack --no-write`, targeted lint, and `git diff --check` passed.

Before: 15 source declarations appeared during desktop bundling. After: runtime bundles build without declaration output. This is a build configuration change, so screenshots are not applicable.

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop generating declaration for desktop Electron bundles
> Sets `dts: false` on all four CommonJS pack configurations in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/10679/files#diff-5fc8c830ebf6102f62b066b8a0120f2bb98d8ab83abe63719f30a03c5dc16b2c): the main Electron bundle, the preload bundle, and the two preview preload bundles. JavaScript output and source maps are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb928c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted desktop application packaging configuration to prevent declaration files from being generated for Electron bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->