### PR TITLE
fix(desktop): keep sidebar artwork out of the drag region

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -403,6 +403,8 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
 /* Stage-channel art needs a mask and pseudo-element gradient, so keep the
    behavior composable without tying it to the global components layer. */
 @utility sidebar-stage-backdrop {
+  /* The art extends below the titlebar; do not inherit its native drag region. */
+  -webkit-app-region: initial;
   --stage-fade: var(--sidebar-stage-fade, var(--app-chrome-background));
   mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 92%);
   -webkit-mask-image: linear-gradient(to bottom, black 0%, black 55%, transparent 92%);


### PR DESCRIPTION
## What Changed

Reset `-webkit-app-region` to `initial` on the shared sidebar artwork. This prevents the artwork from inheriting the header's native drag region.

## Why

The 80px artwork extends below the 52px header and covers Search and New thread. Electron inherits `app-region: drag` through the artwork, so native pointer events never reach those controls, while the keyboard shortcut still works. `pointer-events: none` does not exclude a native drag region.

Use `initial` because Electron maps an explicit `none` to `no-drag`, which would cancel dragging across the overlapping header. The reset keeps the header at `drag` and the artwork at the initial `none` value. Development and nightly artwork share this fix.

Fixes #10661.

Verified with Electron 44.1.0 on macOS using isolated state copied from an existing profile: native pen clicks open the project picker, Search accepts typing, and repeated clicks work after dismissal. Restoring the original inherited style reproduces the blocked pen with no pointer events; Cmd+N still opens the picker. Linux/Hyprland and Shift-click were not exercised. Web build, scoped formatting, and `git diff --check` pass. No JavaScript, provider, or contract changes.

## UI Changes

Cropped to omit project paths and thread content. Before restores the original inherited style; after uses the compiled fix.

| Before: native click ignored | After: native click opens picker |
| --- | --- |
| ![Before](https://github.com/Gigioxx/t3code/releases/download/issue-10661-evidence/t3-10661-before.png) | ![After](https://github.com/Gigioxx/t3code/releases/download/issue-10661-evidence/t3-10661-after.png) |

[Native click interaction recording](https://github.com/Gigioxx/t3code/releases/download/issue-10661-evidence/t3-10661-click.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset `-webkit-app-region` on `sidebar-stage-backdrop` utility
> The sidebar stage artwork was inheriting the titlebar's native drag region, making it uninteractable. Adds a WebKit app-region reset to the `sidebar-stage-backdrop` CSS utility in [index.css](https://github.com/pingdotgg/t3code/pull/10680/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) so those elements use the initial app-region value instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 994a6cd. 1 file reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/index.css — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 407](https://github.com/pingdotgg/t3code/blob/994a6cdd7dad0ff0713913f4f19644a6aa26579d/apps/web/src/index.css#L407): `-webkit-app-region: initial` only resets the artwork to the property's initial value; it does not create the `no-drag` exclusion Electron requires. The backdrop is a child of the `.drag-region` header and overlaps controls below the 52px header, so the ancestor's rectangular draggable region still covers that area and native pointer events remain suppressed. Electron documents `app-region: no-drag` as the operation that excludes an overlapping rectangle and reenables pointer events. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stage-channel artwork extending below the title bar from being treated as a window drag area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->