### PR TITLE
fix(server): build native dependencies before activating updates

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -211,6 +211,27 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
 });
 
 it.layer(NodeServices.layer)("boot service install", (it) => {
+  it.effect("preserves the running service when a cached runtime cannot load node-pty", () =>
+    Effect.gen(function* () {
+      const { service, fs, statePath, commands, control, runtime } = yield* makeHarness();
+      const plan = yield* service.install();
+      const stateBefore = yield* fs.readFileString(statePath);
+      const unitBefore = yield* fs.readFileString(plan.unitPath);
+      control.failCommand = commands.find((command) => command.includes("--input-type=commonjs"));
+      expect(control.failCommand).toBeDefined();
+      commands.length = 0;
+
+      const error = yield* service.install().pipe(Effect.flip);
+
+      expect(error.message).toContain("loading node-pty");
+      expect(yield* fs.readFileString(statePath)).toBe(stateBefore);
+      expect(yield* fs.readFileString(plan.unitPath)).toBe(unitBefore);
+      expect(yield* fs.exists(runtime.sentinelPath)).toBe(true);
+      expect(commands).not.toContain("systemctl --user stop t3code.service");
+      expect(commands).not.toContain("systemctl --user restart t3code.service");
+    }),
+  );
+
   it.effect(
     "fails before installing files or validating a runtime when lingering needs an administrator",
     () =>

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -705,6 +705,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
     yield* ensurePinnedRuntimeInstalled({
       baseDir: input.baseDir,
       version: input.cliVersion,
+      execPath: host.execPath,
       fs,
       path,
       runner,

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -6,6 +6,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessRunner from "../processRunner.ts";
@@ -15,13 +16,33 @@ import {
   PinnedRuntimeInstallError,
 } from "./pinnedRuntime.ts";
 
+const decodeManifest = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
+
 const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
   ProcessRunner.ProcessRunner.of({
     run: (input) =>
       Effect.gen(function* () {
+        if (input.args[0] === "--input-type=commonjs") {
+          return {
+            stdout: "",
+            stderr: "",
+            code: ChildProcessSpawner.ExitCode(0),
+            timedOut: false,
+            stdoutTruncated: false,
+            stderrTruncated: false,
+            stdoutInvalidUtf8: false,
+            stderrInvalidUtf8: false,
+          };
+        }
         const prefixIndex = input.args.indexOf("--prefix");
         const stagingDir = input.args[prefixIndex + 1];
         if (stagingDir === undefined) return yield* Effect.die("missing npm --prefix");
+        assert.deepEqual(
+          yield* decodeManifest(
+            yield* fs.readFileString(path.join(stagingDir, "package.json")).pipe(Effect.orDie),
+          ).pipe(Effect.orDie),
+          { private: true, allowScripts: { "node-pty": true, "msgpackr-extract": true } },
+        );
         const entry = path.join(stagingDir, "node_modules", "t3", "dist", "bin.mjs");
         yield* fs.makeDirectory(path.dirname(entry), { recursive: true }).pipe(Effect.orDie);
         yield* fs.writeFileString(entry, "export {};\n").pipe(Effect.orDie);
@@ -39,6 +60,72 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
   });
 
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
+  for (const nativeModuleAvailable of [true, false]) {
+    it.effect(
+      nativeModuleAvailable
+        ? "loads node-pty from the candidate before publishing it"
+        : "rejects a successful install with a missing node-pty native binary",
+      () =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-native-" });
+          const finalPaths = pinnedRuntimePaths(path, baseDir, "1.2.3");
+          const nodeRunner = yield* ProcessRunner.make();
+          const install = successfulRunner(fs, path);
+          let validated = false;
+          const result = yield* ensurePinnedRuntimeInstalled({
+            baseDir,
+            version: "1.2.3",
+            execPath: process.execPath,
+            fs,
+            path,
+            runner: ProcessRunner.ProcessRunner.of({
+              run: (input) =>
+                input.command !== "npm"
+                  ? nodeRunner.run(input)
+                  : Effect.gen(function* () {
+                      const result = yield* install.run(input);
+                      const prefix = input.args[input.args.indexOf("--prefix") + 1]!;
+                      const moduleDir = path.join(prefix, "node_modules", "node-pty");
+                      yield* fs.makeDirectory(moduleDir, { recursive: true }).pipe(Effect.orDie);
+                      yield* fs
+                        .writeFileString(
+                          path.join(moduleDir, "index.js"),
+                          nativeModuleAvailable
+                            ? "require('node:fs').writeFileSync(__dirname + '/loaded', 'yes');"
+                            : "require('./build/Release/pty.node');",
+                        )
+                        .pipe(Effect.orDie);
+                      return result;
+                    }),
+            }),
+            validate: (runtime) =>
+              Effect.gen(function* () {
+                validated = true;
+                assert.isFalse(yield* fs.exists(runtime.sentinelPath));
+                assert.isTrue(
+                  yield* fs.exists(path.join(runtime.versionDir, "node_modules/node-pty/loaded")),
+                );
+              }).pipe(Effect.orDie),
+          }).pipe(Effect.result);
+
+          assert.equal(validated, nativeModuleAvailable);
+          assert.equal(yield* fs.exists(finalPaths.sentinelPath), nativeModuleAvailable);
+          if (nativeModuleAvailable) {
+            assert.equal(result._tag, "Success");
+          } else {
+            assert.equal(result._tag, "Failure");
+            if (result._tag === "Failure") {
+              assert.instanceOf(result.failure, PinnedRuntimeInstallError);
+              assert.include(result.failure.message, "loading node-pty");
+            }
+            assert.deepEqual(yield* fs.readDirectory(path.dirname(finalPaths.versionDir)), []);
+          }
+        }),
+    );
+  }
+
   it.effect("installs through pnpm when its Node runtime has no npm executable", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -49,6 +136,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       const paths = yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: ProcessRunner.ProcessRunner.of({
@@ -77,7 +165,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       });
       assert.deepEqual(
         commands.map((command) => command.command),
-        ["npm", "pnpm"],
+        ["npm", "pnpm", process.execPath],
       );
       assert.deepEqual(commands[1]!.args, ["--package=npm@11", "dlx", "npm", ...commands[0]!.args]);
       assert.equal(yield* fs.readFileString(paths.sentinelPath), "1.2.3\n");
@@ -93,6 +181,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: ProcessRunner.ProcessRunner.of({
@@ -128,6 +217,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       const installed = yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: successfulRunner(fs, path),
@@ -156,6 +246,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: successfulRunner(fs, path),
@@ -185,6 +276,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: successfulRunner(fs, path),
@@ -210,6 +302,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner: successfulRunner(fs, path),
@@ -240,6 +333,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       const install = yield* ensurePinnedRuntimeInstalled({
         baseDir,
         version: "1.2.3",
+        execPath: process.execPath,
         fs,
         path,
         runner,

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -74,13 +74,14 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedError<Pinne
 /**
  * Installs `t3@<version>` into the pinned runtime directory unless a complete
  * install is already there, and returns its paths. The sentinel is written
- * only after npm exits 0; checking the entry file alone is not enough. npm
- * extracts files before running native builds (node-pty), so a killed
- * install leaves a plausible-looking but broken tree behind.
+ * only after npm succeeds and validation passes. npm can skip native builds
+ * (node-pty) or be killed after extracting files, leaving a plausible-looking
+ * but broken tree behind.
  */
 interface PinnedRuntimeInstallInput {
   readonly baseDir: string;
   readonly version: string;
+  readonly execPath: string;
   readonly fs: FileSystem.FileSystem;
   readonly path: Path.Path;
   readonly runner: ProcessRunner.ProcessRunner["Service"];
@@ -88,6 +89,40 @@ interface PinnedRuntimeInstallInput {
     paths: PinnedRuntimePaths,
   ) => Effect.Effect<void, PinnedRuntimeInstallError | PinnedRuntimePreflightBlockedError>;
 }
+
+const validatePinnedRuntime = Effect.fn("cloud.pinned_runtime.validate")(function* (
+  input: PinnedRuntimeInstallInput,
+  paths: PinnedRuntimePaths,
+) {
+  // Resolve from the candidate, using the Node executable that will run it.
+  // npm can exit successfully even when it skips node-pty's native build.
+  const step = "loading node-pty in the pinned t3 runtime";
+  yield* input.runner
+    .run({
+      command: input.execPath,
+      args: [
+        "--input-type=commonjs",
+        "--eval",
+        "require('node:module').createRequire(process.argv[1])('node-pty');",
+        paths.entryPath,
+      ],
+      timeout: Duration.seconds(30),
+    })
+    .pipe(
+      Effect.mapError((cause) => new PinnedRuntimeInstallError({ step, cause })),
+      Effect.filterOrFail(
+        (result) => result.code === 0,
+        (result) =>
+          new PinnedRuntimeInstallError({
+            step,
+            exitCode: Number(result.code),
+            stdoutLength: result.stdout.length,
+            stderrLength: result.stderr.length,
+          }),
+      ),
+    );
+  yield* input.validate(paths);
+});
 
 const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(function* (
   input: PinnedRuntimeInstallInput,
@@ -106,7 +141,7 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
   const alreadyPinned =
     entryExists && Option.isSome(sentinel) && sentinel.value.trim() === input.version;
   if (alreadyPinned) {
-    yield* input.validate(paths);
+    yield* validatePinnedRuntime(input, paths);
     return paths;
   }
   if (versionDirExists) {
@@ -152,6 +187,19 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
   };
 
   return yield* Effect.gen(function* () {
+    // npm 12 requires project-scoped build approvals in the root manifest.
+    // Its CLI allow-scripts flag only applies to global installs and npm exec.
+    yield* fs
+      .writeFileString(
+        input.path.join(stagingDir, "package.json"),
+        '{"private":true,"allowScripts":{"node-pty":true,"msgpackr-extract":true}}\n',
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new PinnedRuntimeInstallError({ step: "preparing native build approvals", cause }),
+        ),
+      );
     const installStep = "installing the pinned t3 runtime (this can take a few minutes)";
     const installArgs = [
       "install",
@@ -195,7 +243,7 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
         ),
       );
 
-    yield* input.validate(stagingPaths);
+    yield* validatePinnedRuntime(input, stagingPaths);
     yield* fs
       .writeFileString(stagingPaths.sentinelPath, `${input.version}\n`)
       .pipe(
@@ -233,7 +281,7 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
         ),
       ),
     );
-    if (!published) yield* input.validate(paths);
+    if (!published) yield* validatePinnedRuntime(input, paths);
     return paths;
   }).pipe(
     Effect.ensuring(fs.remove(stagingDir, { recursive: true, force: true }).pipe(Effect.ignore)),

--- a/apps/server/src/cloud/selfUpdate.test.ts
+++ b/apps/server/src/cloud/selfUpdate.test.ts
@@ -21,6 +21,7 @@ interface HarnessOptions {
   readonly mode?: "web" | "desktop";
   readonly managed?: boolean;
   readonly preflight?: "ready" | "blocked";
+  readonly nativeModuleAvailable?: boolean;
   readonly requestUpdate?: ServiceLauncherClient.ServiceLauncherClient["Service"]["requestUpdate"];
   readonly desktopAppUpdate?: DesktopAppUpdate.DesktopAppUpdate["Service"];
 }
@@ -46,6 +47,19 @@ const makeHarness = Effect.fn("test.make_self_update_harness")(function* (
             stdout: "",
             stderr: "",
             code: ChildProcessSpawner.ExitCode(0),
+            timedOut: false,
+            stdoutTruncated: false,
+            stderrTruncated: false,
+            stdoutInvalidUtf8: false,
+            stderrInvalidUtf8: false,
+          };
+        }
+        if (input.args[0] === "--input-type=commonjs") {
+          order.push("native-module");
+          return {
+            stdout: "",
+            stderr: options.nativeModuleAvailable === false ? "Cannot find module pty.node" : "",
+            code: ChildProcessSpawner.ExitCode(options.nativeModuleAvailable === false ? 1 : 0),
             timedOut: false,
             stdoutTruncated: false,
             stderrTruncated: false,
@@ -329,7 +343,7 @@ it.layer(NodeServices.layer)("server self update", (it) => {
         method: "boot-service",
         updateId: "launcher-id",
       });
-      expect(order).toEqual(["install", "preflight", "accept"]);
+      expect(order).toEqual(["install", "native-module", "preflight", "accept"]);
     }),
   );
 
@@ -344,6 +358,15 @@ it.layer(NodeServices.layer)("server self update", (it) => {
         (yield* desktop.selfUpdate.update({ targetVersion: "1.1.0" }).pipe(Effect.flip)).reason,
       ).toContain("desktop app");
       expect([...web.order, ...desktop.order]).toEqual([]);
+    }),
+  );
+
+  it.effect("does not hand off an update when npm succeeds without a working native module", () =>
+    Effect.gen(function* () {
+      const { selfUpdate, order } = yield* makeHarness({ nativeModuleAvailable: false });
+      const error = yield* selfUpdate.update({ targetVersion: "1.1.0" }).pipe(Effect.flip);
+      expect(error.reason).toBe("Could not prepare t3@1.1.0.");
+      expect(order).toEqual(["install", "native-module"]);
     }),
   );
 

--- a/apps/server/src/cloud/selfUpdate.ts
+++ b/apps/server/src/cloud/selfUpdate.ts
@@ -213,6 +213,7 @@ export const make = Effect.fn("cloud.server_self_update.make")(function* () {
       const paths = yield* ensurePinnedRuntimeInstalled({
         baseDir: serverConfig.baseDir,
         version: targetVersion,
+        execPath,
         fs,
         path,
         runner,


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

### ELI5
Check that an update's terminal dependency works before switching to it.

### Problem
npm 12 can exit successfully while skipping unapproved native builds. T3 then marks the runtime complete, but the new server fails to start because `node-pty` is missing its native binary.

### Fix
Write staging-local build approvals for `node-pty` and `msgpackr-extract`. Load the candidate's `node-pty` with the service's Node executable before publishing or reusing the runtime. This covers local service installation and remote updates, preserving the running service on failure.

Validation: 54 focused tests, targeted lint, and server typecheck pass. Isolated npm 12 fixtures confirmed approved scripts run while unrelated scripts stay blocked; npm 11 accepts the manifest. Independent review found no actionable issues.

### UI Changes
Before: no visual changes.

After: no visual changes.

Made with GPT-6 in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Probe `node-pty` with host Node executable before activating pinned runtime updates
> - Pinned-runtime installation now requires the candidate runtime to successfully load `node-pty` via the host Node `execPath` before the completion sentinel is written or the staged directory is published; npm installs also receive a project manifest granting build approval for `node-pty` and `msgpackr-extract`.
> - `bootService.ts` and `selfUpdate.ts` pass the host executable path into `ensurePinnedRuntimeInstalled` so the probe runs before server preflight and launcher handoff.
> - Tests across `bootService.test.ts`, `pinnedRuntime.test.ts`, and `selfUpdate.test.ts` cover the probe success and failure paths, including verification that a failed probe leaves the running service untouched.
> - Behavioral Change: cached and newly staged runtimes that fail the `node-pty` load probe now produce a `PinnedRuntimeInstallError` and leave no final installation, whereas previously a runtime with missing or unusable native binaries could be accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49f6449.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pinned runtime installations now verify that required native modules load successfully before completing.
  - Runtime updates and installations report a clear failure when native module loading is unavailable.
  - Reinstall attempts preserve the currently running service when validation fails, avoiding unnecessary stops or restarts.
  - Improved compatibility with environments requiring explicit approval for native module builds.
  - Failed runtime preparation no longer interrupts an existing service unnecessarily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->