### PR TITLE
feat(mobile): use Android wallpaper colors

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -7,11 +7,13 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
+import android.os.Build
 import android.text.Editable
 import android.text.InputType
 import android.text.Spanned
 import android.text.TextWatcher
 import android.text.style.ReplacementSpan
+import android.util.TypedValue
 import android.view.Gravity
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
@@ -27,6 +29,11 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
   appContext
 ) {
   private val editor = SelectionAwareEditText(context)
+  private val defaultHighlightColor = editor.highlightColor
+  private val defaultSelectionColor = context.resolveThemeColor(
+    android.R.attr.colorAccent,
+    editor.currentTextColor,
+  )
   private val onComposerChange by EventDispatcher()
   private val onComposerSelectionChange by EventDispatcher()
   private val onComposerFocus by EventDispatcher()
@@ -152,6 +159,11 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
       val theme = JSONObject(themeJson)
       editor.setTextColor(parseColor(theme.optString("text"), Color.BLACK))
       editor.setHintTextColor(parseColor(theme.optString("placeholder"), Color.GRAY))
+      if (theme.isNull("selection")) {
+        resetSelectionTheme()
+      } else {
+        applySelectionTheme(parseColor(theme.optString("selection"), editor.currentTextColor))
+      }
       chipTheme = ComposerChipTheme(
         chipBackground = parseColor(theme.optString("chipBackground"), chipTheme.chipBackground),
         chipBorder = parseColor(theme.optString("chipBorder"), chipTheme.chipBorder),
@@ -277,6 +289,21 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
     editor.setLineSpacing(max(0, desiredLineHeightPx - fontHeight).toFloat(), 1f)
   }
 
+  private fun applySelectionTheme(color: Int) {
+    editor.highlightColor = color.withAlpha(0x52)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+
+    editor.textCursorDrawable = editor.textCursorDrawable?.mutate()?.apply { setTint(color) }
+    editor.textSelectHandle?.mutate()?.setTint(color)
+    editor.textSelectHandleLeft?.mutate()?.setTint(color)
+    editor.textSelectHandleRight?.mutate()?.setTint(color)
+  }
+
+  private fun resetSelectionTheme() {
+    applySelectionTheme(defaultSelectionColor)
+    editor.highlightColor = defaultHighlightColor
+  }
+
   private fun currentSelectionPayload(): Map<String, Int> =
     mapOf(
       "start" to editor.selectionStart.coerceAtLeast(0),
@@ -335,10 +362,22 @@ class T3ComposerEditorView(context: Context, appContext: AppContext) : ExpoView(
 
   private fun parseColor(value: String, fallback: Int): Int =
     try {
-      Color.parseColor(value)
+      val androidColor = if (value.length == 9 && value.startsWith("#")) {
+        "#${value.takeLast(2)}${value.substring(1, 7)}"
+      } else {
+        value
+      }
+      Color.parseColor(androidColor)
     } catch (_: Exception) {
       fallback
     }
+}
+
+private fun Int.withAlpha(alpha: Int): Int = (this and 0x00FFFFFF) or (alpha shl 24)
+
+private fun Context.resolveThemeColor(attribute: Int, fallback: Int): Int {
+  val value = TypedValue()
+  return if (theme.resolveAttribute(attribute, value, true)) value.data else fallback
 }
 
 private data class ComposerToken(

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -51,6 +51,7 @@
     "@expo/metro-runtime": "~57.0.14",
     "@expo/ui": "~57.0.14",
     "@legendapp/list": "catalog:",
+    "@material/material-color-utilities": "0.3.0",
     "@noble/curves": "catalog:",
     "@pierre/diffs": "catalog:",
     "@react-native-ai/apple": "0.12.0",

--- a/apps/mobile/src/features/review/nativeReviewDiffAdapter.test.ts
+++ b/apps/mobile/src/features/review/nativeReviewDiffAdapter.test.ts
@@ -66,7 +66,7 @@ function filesPatch(paths: ReadonlyArray<string>) {
 }
 
 function appTheme(themeId: MobileThemeId, appearance: MobileThemeAppearance) {
-  return themeId === DEFAULT_MOBILE_THEME_ID
+  return themeId === DEFAULT_MOBILE_THEME_ID || themeId === "material-you"
     ? readDefaultMobileThemeVariables(appearance)
     : getMobileThemeVariables(themeId, appearance);
 }

--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -100,8 +100,12 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
   const [systemColorPalettes, setSystemColorPalettes] = useState(readSystemColorPalettes);
   useEffect(() => {
     if (!systemColorsActive) return;
-    const refresh = () => setSystemColorPalettes(readSystemColorPalettes());
-    refresh();
+    const refresh = () => {
+      const next = readSystemColorPalettes();
+      setSystemColorPalettes((previous) =>
+        JSON.stringify(previous) === JSON.stringify(next) ? previous : next,
+      );
+    };
     const subscription = AppState.addEventListener("change", (state) => {
       if (state === "active") refresh();
     });
@@ -241,7 +245,10 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
   );
 
   const setSystemColorsEnabled = useCallback(
-    (value: boolean) => updateThemePreferences({ systemColorsEnabled: value }),
+    (value: boolean) => {
+      if (value) setSystemColorPalettes(readSystemColorPalettes());
+      updateThemePreferences({ systemColorsEnabled: value });
+    },
     [updateThemePreferences],
   );
 

--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -52,13 +52,12 @@ interface AppearancePreferencesContextValue {
   readonly themeMode: MobileThemeMode;
   readonly themeAppearance: MobileThemeAppearance;
   readonly systemColorsAvailable: boolean;
-  readonly systemColorsEnabled: boolean;
   readonly systemColorsActive: boolean;
   readonly themeVariables: MobileThemeVariables;
   readonly themeVariablesByAppearance: Readonly<
     Record<MobileThemeAppearance, MobileThemeVariables>
   >;
-  readonly setSystemColorsEnabled: (value: boolean) => void;
+  readonly systemColorPalettes: ReturnType<typeof readSystemColorPalettes>;
   readonly isReady: boolean;
   readonly setThemeIdForAppearance: (
     appearance: MobileThemeAppearance,
@@ -95,11 +94,10 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [resolvedThemeIds.dark, resolvedThemeIds.light],
   );
   const themeId = themeIds[themeAppearance];
-  const systemColorsEnabled = storedPreferences?.systemColorsEnabled ?? false;
-  const systemColorsActive = systemColorsEnabled && isSystemColorsAvailable;
+  const systemColorsActive = themeId === "material-you" && isSystemColorsAvailable;
   const [systemColorPalettes, setSystemColorPalettes] = useState(readSystemColorPalettes);
   useEffect(() => {
-    if (!systemColorsActive) return;
+    if (!isSystemColorsAvailable) return;
     const refresh = () => {
       const next = readSystemColorPalettes();
       setSystemColorPalettes((previous) =>
@@ -114,11 +112,11 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       subscription.remove();
       focusSubscription.remove();
     };
-  }, [systemColorsActive]);
+  }, []);
   const themeVariablesByAppearance = useMemo(() => {
     const resolve = (appearance: MobileThemeAppearance) => {
       const base = getMobileThemeRuntimeVariables(themeIds[appearance], appearance);
-      return systemColorsActive && systemColorPalettes
+      return themeIds[appearance] === "material-you" && systemColorPalettes
         ? materialYouPaletteToMobileThemeVariables(
             systemColorPalettes[appearance],
             appearance,
@@ -127,7 +125,7 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
         : base;
     };
     return { light: resolve("light"), dark: resolve("dark") };
-  }, [themeIds, systemColorsActive, systemColorPalettes]);
+  }, [themeIds, systemColorPalettes]);
   const themeVariables = themeVariablesByAppearance[themeAppearance];
   const activeThemeName = getMobileUniwindThemeName(themeId, themeAppearance);
   const { baseFontSize, codeFontSize, codeWordBreak, terminalFontSize } = preferences;
@@ -244,14 +242,6 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [runtimeState, syncThemeRuntime, updateThemePreferences],
   );
 
-  const setSystemColorsEnabled = useCallback(
-    (value: boolean) => {
-      if (value) setSystemColorPalettes(readSystemColorPalettes());
-      updateThemePreferences({ systemColorsEnabled: value });
-    },
-    [setSystemColorPalettes, updateThemePreferences],
-  );
-
   const setBaseFontSize = useCallback(
     (value: number) => {
       const current = appliedRuntimeStateRef.current ?? runtimeState;
@@ -290,11 +280,10 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeMode,
       themeAppearance,
       systemColorsAvailable: isSystemColorsAvailable,
-      systemColorsEnabled,
       systemColorsActive,
       themeVariables,
       themeVariablesByAppearance,
-      setSystemColorsEnabled,
+      systemColorPalettes,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,
@@ -310,11 +299,10 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeIds,
       themeMode,
       themeAppearance,
-      systemColorsEnabled,
       systemColorsActive,
       themeVariables,
       themeVariablesByAppearance,
-      setSystemColorsEnabled,
+      systemColorPalettes,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,

--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -249,7 +249,7 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       if (value) setSystemColorPalettes(readSystemColorPalettes());
       updateThemePreferences({ systemColorsEnabled: value });
     },
-    [updateThemePreferences],
+    [setSystemColorPalettes, updateThemePreferences],
   );
 
   const setBaseFontSize = useCallback(

--- a/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
+++ b/apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx
@@ -3,17 +3,19 @@ import {
   startTransition,
   use,
   useCallback,
+  useEffect,
+  useState,
   useLayoutEffect,
   useMemo,
   useRef,
   type ReactNode,
 } from "react";
-import { Appearance, useColorScheme } from "react-native";
+import { AppState, Appearance, useColorScheme } from "react-native";
 
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { AsyncResult } from "effect/unstable/reactivity";
 
-import { ScopedTheme, Uniwind } from "uniwind";
+import { ScopedTheme, ScopedVariables, Uniwind } from "uniwind";
 
 import {
   resolveAppearance,
@@ -22,6 +24,10 @@ import {
 } from "../../../lib/appearancePreferences";
 import { mobilePreferencesAtom, updateMobilePreferencesAtom } from "../../../state/preferences";
 import type { Preferences } from "../../../persistence/mobile-preferences";
+import { isSystemColorsAvailable, readSystemColorPalettes } from "../../../lib/materialYouPalette";
+import { materialYouPaletteToMobileThemeVariables } from "../../../lib/materialYouTheme";
+import { getMobileThemeRuntimeVariables } from "../../../lib/mobileThemeVariables";
+import type { MobileThemeVariables } from "../../../lib/mobileTheme";
 import {
   createMobileThemePairPatch,
   createMobileThemeSelectionPatch,
@@ -45,6 +51,14 @@ interface AppearancePreferencesContextValue {
   readonly themeIds: MobileThemeIds;
   readonly themeMode: MobileThemeMode;
   readonly themeAppearance: MobileThemeAppearance;
+  readonly systemColorsAvailable: boolean;
+  readonly systemColorsEnabled: boolean;
+  readonly systemColorsActive: boolean;
+  readonly themeVariables: MobileThemeVariables;
+  readonly themeVariablesByAppearance: Readonly<
+    Record<MobileThemeAppearance, MobileThemeVariables>
+  >;
+  readonly setSystemColorsEnabled: (value: boolean) => void;
   readonly isReady: boolean;
   readonly setThemeIdForAppearance: (
     appearance: MobileThemeAppearance,
@@ -81,6 +95,36 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [resolvedThemeIds.dark, resolvedThemeIds.light],
   );
   const themeId = themeIds[themeAppearance];
+  const systemColorsEnabled = storedPreferences?.systemColorsEnabled ?? false;
+  const systemColorsActive = systemColorsEnabled && isSystemColorsAvailable;
+  const [systemColorPalettes, setSystemColorPalettes] = useState(readSystemColorPalettes);
+  useEffect(() => {
+    if (!systemColorsActive) return;
+    const refresh = () => setSystemColorPalettes(readSystemColorPalettes());
+    refresh();
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") refresh();
+    });
+    const focusSubscription = AppState.addEventListener("focus", refresh);
+    return () => {
+      subscription.remove();
+      focusSubscription.remove();
+    };
+  }, [systemColorsActive]);
+  const themeVariablesByAppearance = useMemo(() => {
+    const resolve = (appearance: MobileThemeAppearance) => {
+      const base = getMobileThemeRuntimeVariables(themeIds[appearance], appearance);
+      return systemColorsActive && systemColorPalettes
+        ? materialYouPaletteToMobileThemeVariables(
+            systemColorPalettes[appearance],
+            appearance,
+            base,
+          )
+        : base;
+    };
+    return { light: resolve("light"), dark: resolve("dark") };
+  }, [themeIds, systemColorsActive, systemColorPalettes]);
+  const themeVariables = themeVariablesByAppearance[themeAppearance];
   const activeThemeName = getMobileUniwindThemeName(themeId, themeAppearance);
   const { baseFontSize, codeFontSize, codeWordBreak, terminalFontSize } = preferences;
   const appearance = useMemo(
@@ -196,6 +240,11 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
     [runtimeState, syncThemeRuntime, updateThemePreferences],
   );
 
+  const setSystemColorsEnabled = useCallback(
+    (value: boolean) => updateThemePreferences({ systemColorsEnabled: value }),
+    [updateThemePreferences],
+  );
+
   const setBaseFontSize = useCallback(
     (value: number) => {
       const current = appliedRuntimeStateRef.current ?? runtimeState;
@@ -233,6 +282,12 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeIds,
       themeMode,
       themeAppearance,
+      systemColorsAvailable: isSystemColorsAvailable,
+      systemColorsEnabled,
+      systemColorsActive,
+      themeVariables,
+      themeVariablesByAppearance,
+      setSystemColorsEnabled,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,
@@ -248,6 +303,11 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
       themeIds,
       themeMode,
       themeAppearance,
+      systemColorsEnabled,
+      systemColorsActive,
+      themeVariables,
+      themeVariablesByAppearance,
+      setSystemColorsEnabled,
       isReady,
       setThemeIdForAppearance,
       setThemeIdForBothAppearances,
@@ -261,7 +321,9 @@ export function AppearancePreferencesProvider(props: { readonly children: ReactN
 
   return (
     <AppearancePreferencesContext.Provider value={value}>
-      <ScopedTheme theme={activeThemeName}>{props.children}</ScopedTheme>
+      <ScopedTheme theme={activeThemeName}>
+        <ScopedVariables variables={themeVariables}>{props.children}</ScopedVariables>
+      </ScopedTheme>
     </AppearancePreferencesContext.Provider>
   );
 }

--- a/apps/mobile/src/features/settings/appearance/sections/ThemeAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/ThemeAppearanceSection.tsx
@@ -1,7 +1,7 @@
 import { memo, useId } from "react";
-import { Pressable, View } from "react-native";
+import { Platform, Pressable, View } from "react-native";
 import Svg, { Circle, Defs, RadialGradient, Stop } from "react-native-svg";
-import { ScopedTheme } from "uniwind";
+import { ScopedTheme, ScopedVariables } from "uniwind";
 
 import { mixThemePreviewBase, THEME_PREVIEW_RENDER_SPECS } from "@t3tools/shared/themePreview";
 
@@ -18,6 +18,9 @@ import {
 import { getMobileUniwindThemeName } from "../../../../lib/mobileThemeRuntime";
 import { cn } from "../../../../lib/cn";
 import { useAppearancePreferences } from "../AppearancePreferencesProvider";
+
+import { SettingsSection } from "../../components/SettingsSection";
+import { SettingsSwitchRow } from "../../components/SettingsSwitchRow";
 
 const APPEARANCE_MODES: ReadonlyArray<{
   readonly id: MobileThemeMode;
@@ -204,15 +207,20 @@ function PreviewPane(props: { readonly compact?: boolean }) {
 }
 
 function ModePreview(props: { readonly mode: MobileThemeMode; readonly themeIds: MobileThemeIds }) {
+  const { themeVariablesByAppearance } = useAppearancePreferences();
   if (props.mode === "system") {
     return (
       <View className="h-24 w-14 self-center rounded-[16px] border-[1.5px] border-border bg-drawer p-[3px]">
         <View className="flex-1 flex-row overflow-hidden rounded-[11px]">
           <ScopedTheme theme={getMobileUniwindThemeName(props.themeIds.light, "light")}>
-            <PreviewPane compact />
+            <ScopedVariables variables={themeVariablesByAppearance.light}>
+              <PreviewPane compact />
+            </ScopedVariables>
           </ScopedTheme>
           <ScopedTheme theme={getMobileUniwindThemeName(props.themeIds.dark, "dark")}>
-            <PreviewPane compact />
+            <ScopedVariables variables={themeVariablesByAppearance.dark}>
+              <PreviewPane compact />
+            </ScopedVariables>
           </ScopedTheme>
         </View>
         <View className="absolute bottom-[6px] left-1/2 h-1 w-4 -translate-x-1/2 rounded-full bg-foreground-muted" />
@@ -224,7 +232,9 @@ function ModePreview(props: { readonly mode: MobileThemeMode; readonly themeIds:
     <ScopedTheme theme={getMobileUniwindThemeName(props.themeIds[props.mode], props.mode)}>
       <View className="h-24 w-14 self-center rounded-[16px] border-[1.5px] border-border bg-drawer p-[3px]">
         <View className="flex-1 flex-row overflow-hidden rounded-[11px]">
-          <PreviewPane />
+          <ScopedVariables variables={themeVariablesByAppearance[props.mode]}>
+            <PreviewPane />
+          </ScopedVariables>
         </View>
         <View className="absolute bottom-[6px] left-1/2 h-1 w-4 -translate-x-1/2 rounded-full bg-foreground-muted" />
       </View>
@@ -278,10 +288,29 @@ export function ThemeAppearanceSection() {
     setThemeMode,
     themeIds,
     themeMode,
+    systemColorsAvailable,
+    systemColorsEnabled,
+    setSystemColorsEnabled,
   } = useAppearancePreferences();
 
   return (
     <View className="gap-6">
+      {Platform.OS === "android" ? (
+        <SettingsSection card title="Android">
+          <SettingsSwitchRow
+            disabled={!isReady || !systemColorsAvailable}
+            icon="paintbrush"
+            label="System Colors"
+            onValueChange={setSystemColorsEnabled}
+            subtitle={
+              systemColorsAvailable
+                ? "Use Material You colors from your wallpaper."
+                : "Requires Android 12 or newer."
+            }
+            value={systemColorsAvailable && systemColorsEnabled}
+          />
+        </SettingsSection>
+      ) : null}
       <View className="gap-2">
         <SectionLabel>Color scheme</SectionLabel>
         <View accessibilityRole="radiogroup" className="flex-row gap-2">

--- a/apps/mobile/src/features/settings/appearance/sections/ThemeAppearanceSection.tsx
+++ b/apps/mobile/src/features/settings/appearance/sections/ThemeAppearanceSection.tsx
@@ -1,5 +1,5 @@
 import { memo, useId } from "react";
-import { Platform, Pressable, View } from "react-native";
+import { Pressable, View } from "react-native";
 import Svg, { Circle, Defs, RadialGradient, Stop } from "react-native-svg";
 import { ScopedTheme, ScopedVariables } from "uniwind";
 
@@ -18,9 +18,6 @@ import {
 import { getMobileUniwindThemeName } from "../../../../lib/mobileThemeRuntime";
 import { cn } from "../../../../lib/cn";
 import { useAppearancePreferences } from "../AppearancePreferencesProvider";
-
-import { SettingsSection } from "../../components/SettingsSection";
-import { SettingsSwitchRow } from "../../components/SettingsSwitchRow";
 
 const APPEARANCE_MODES: ReadonlyArray<{
   readonly id: MobileThemeMode;
@@ -41,7 +38,12 @@ const PreviewOrb = memo(function PreviewOrb(props: {
   const idPrefix = useId().replaceAll(":", "");
   const accentGradientId = `${idPrefix}-accent-glow`;
   const actionGradientId = `${idPrefix}-action-glow`;
-  const colors = getMobileThemePreviewColors(props.themeId, props.appearance);
+  const { systemColorPalettes } = useAppearancePreferences();
+  const palette = systemColorPalettes?.[props.appearance];
+  const colors =
+    props.themeId === "material-you" && palette
+      ? { canvas: palette.surface, accent: palette.primary, messageAction: palette.tertiary }
+      : getMobileThemePreviewColors(props.themeId, props.appearance);
   const spec = THEME_PREVIEW_RENDER_SPECS[props.appearance];
   const accentRadius = Math.hypot(
     Math.max(spec.accent.center[0], 1 - spec.accent.center[0]),
@@ -289,28 +291,10 @@ export function ThemeAppearanceSection() {
     themeIds,
     themeMode,
     systemColorsAvailable,
-    systemColorsEnabled,
-    setSystemColorsEnabled,
   } = useAppearancePreferences();
 
   return (
     <View className="gap-6">
-      {Platform.OS === "android" ? (
-        <SettingsSection card title="Android">
-          <SettingsSwitchRow
-            disabled={!isReady || !systemColorsAvailable}
-            icon="paintbrush"
-            label="System Colors"
-            onValueChange={setSystemColorsEnabled}
-            subtitle={
-              systemColorsAvailable
-                ? "Use Material You colors from your wallpaper."
-                : "Requires Android 12 or newer."
-            }
-            value={systemColorsAvailable && systemColorsEnabled}
-          />
-        </SettingsSection>
-      ) : null}
       <View className="gap-2">
         <SectionLabel>Color scheme</SectionLabel>
         <View accessibilityRole="radiogroup" className="flex-row gap-2">
@@ -331,7 +315,9 @@ export function ThemeAppearanceSection() {
       <View className="gap-3">
         <SectionLabel>Themes</SectionLabel>
         <View className="flex-row flex-wrap gap-3">
-          {MOBILE_THEME_OPTIONS.map((theme) => (
+          {MOBILE_THEME_OPTIONS.filter(
+            (theme) => theme.id !== "material-you" || systemColorsAvailable,
+          ).map((theme) => (
             <ThemeCard
               disabled={!isReady}
               key={theme.id}

--- a/apps/mobile/src/features/settings/components/SettingsSwitchRow.tsx
+++ b/apps/mobile/src/features/settings/components/SettingsSwitchRow.tsx
@@ -37,6 +37,7 @@ export function SettingsSwitchRow(props: {
         ) : null}
       </View>
       <ThemedSwitch
+        accessibilityLabel={props.label}
         disabled={props.disabled}
         onValueChange={props.onValueChange}
         value={props.value}

--- a/apps/mobile/src/features/terminal/terminalTheme.ts
+++ b/apps/mobile/src/features/terminal/terminalTheme.ts
@@ -83,7 +83,7 @@ export function getMobileTerminalTheme(
   scheme: TerminalAppearanceScheme,
 ): TerminalTheme {
   const base = getPierreTerminalTheme(scheme);
-  if (themeId === "t3-code") return base;
+  if (themeId === "t3-code" || themeId === "material-you") return base;
 
   const theme = BUILT_IN_THEMES.find((candidate) => candidate.id === themeId) ?? BUILT_IN_THEMES[0];
   const palette = getThemeColorsForAppearance(theme, scheme) ?? theme.colors;

--- a/apps/mobile/src/lib/materialYouPalette.android.ts
+++ b/apps/mobile/src/lib/materialYouPalette.android.ts
@@ -1,0 +1,14 @@
+import { getMaterialColors, isDynamicColorAvailable } from "@expo/ui/jetpack-compose";
+
+import type { MaterialYouPalettes } from "./materialYouPalette";
+
+export const isSystemColorsAvailable = isDynamicColorAvailable;
+
+export function readSystemColorPalettes(): MaterialYouPalettes | null {
+  if (!isDynamicColorAvailable) return null;
+
+  return {
+    light: getMaterialColors({ scheme: "light" }),
+    dark: getMaterialColors({ scheme: "dark" }),
+  };
+}

--- a/apps/mobile/src/lib/materialYouPalette.ts
+++ b/apps/mobile/src/lib/materialYouPalette.ts
@@ -1,0 +1,36 @@
+export interface MaterialYouPalette {
+  readonly primary: string;
+  readonly onPrimary: string;
+  readonly primaryContainer: string;
+  readonly onPrimaryContainer: string;
+  readonly inversePrimary: string;
+  readonly secondaryContainer: string;
+  readonly onSecondaryContainer: string;
+  readonly tertiary: string;
+  readonly tertiaryContainer: string;
+  readonly onTertiaryContainer: string;
+  readonly surface: string;
+  readonly onSurface: string;
+  readonly onSurfaceVariant: string;
+  readonly surfaceContainer: string;
+  readonly surfaceContainerHigh: string;
+  readonly surfaceContainerHighest: string;
+  readonly surfaceContainerLow: string;
+  readonly surfaceContainerLowest: string;
+  readonly errorContainer: string;
+  readonly onErrorContainer: string;
+  readonly outline: string;
+  readonly outlineVariant: string;
+  readonly scrim: string;
+}
+
+export interface MaterialYouPalettes {
+  readonly light: MaterialYouPalette;
+  readonly dark: MaterialYouPalette;
+}
+
+export const isSystemColorsAvailable = false;
+
+export function readSystemColorPalettes(): MaterialYouPalettes | null {
+  return null;
+}

--- a/apps/mobile/src/lib/materialYouTheme.test.ts
+++ b/apps/mobile/src/lib/materialYouTheme.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { getMobileThemeRuntimeVariables } from "./mobileThemeVariables";
+import type { MaterialYouPalette } from "./materialYouPalette";
+import { materialYouPaletteToMobileThemeVariables } from "./materialYouTheme";
+
+const palette: MaterialYouPalette = {
+  primary: "#6750A4FF",
+  onPrimary: "#FFFFFFFF",
+  primaryContainer: "#EADDFFFF",
+  onPrimaryContainer: "#21005DFF",
+  inversePrimary: "#D0BCFFFF",
+  secondaryContainer: "#E8DEF8FF",
+  onSecondaryContainer: "#1D192BFF",
+  tertiary: "#7D5260FF",
+  tertiaryContainer: "#FFD8E4FF",
+  onTertiaryContainer: "#31111DFF",
+  surface: "#FFFBFEFF",
+  onSurface: "#1C1B1FFF",
+  onSurfaceVariant: "#49454FFF",
+  surfaceContainer: "#F3EDF7FF",
+  surfaceContainerHigh: "#ECE6F0FF",
+  surfaceContainerHighest: "#E6E0E9FF",
+  surfaceContainerLow: "#F7F2FAFF",
+  surfaceContainerLowest: "#FFFFFFFF",
+  errorContainer: "#F9DEDCFF",
+  onErrorContainer: "#410E0BFF",
+  outline: "#79747EFF",
+  outlineVariant: "#CAC4D0FF",
+  scrim: "#000000FF",
+};
+
+describe("Material You system colors", () => {
+  it("overrides the selected theme without mutating its base variables", () => {
+    const base = getMobileThemeRuntimeVariables("t3-code", "dark");
+    const snapshot = { ...base };
+
+    const variables = materialYouPaletteToMobileThemeVariables(palette, "dark", base);
+
+    expect(base).toEqual(snapshot);
+    expect(variables["--color-screen"]).toBe(palette.surface);
+    expect(variables["--color-header"]).toBe(palette.surfaceContainerHigh);
+    expect(variables["--color-primary"]).toBe(palette.primary);
+    expect(variables["--color-placeholder"]).toBe("#1C1B1F9E");
+  });
+
+  it("uses the Messages-style RCS tones for sent messages", () => {
+    const base = getMobileThemeRuntimeVariables("t3-code", "dark");
+    const dark = materialYouPaletteToMobileThemeVariables(
+      { ...palette, inversePrimary: "#A31D8DFF" },
+      "dark",
+      base,
+    );
+    const light = materialYouPaletteToMobileThemeVariables(
+      { ...palette, inversePrimary: "#A31D8DFF" },
+      "light",
+      getMobileThemeRuntimeVariables("t3-code", "light"),
+    );
+
+    expect(dark["--color-user-bubble"]).toBe("#850073FF");
+    expect(dark["--color-user-bubble-foreground"]).toBe("#FFD7EFFF");
+    expect(light["--color-user-bubble"]).toBe(palette.primary);
+    expect(light["--color-user-bubble-foreground"]).toBe(palette.onPrimary);
+  });
+});

--- a/apps/mobile/src/lib/materialYouTheme.ts
+++ b/apps/mobile/src/lib/materialYouTheme.ts
@@ -1,0 +1,101 @@
+import { Hct, argbFromHex, hexFromArgb } from "@material/material-color-utilities";
+
+import type { MobileThemeAppearance, MobileThemeVariables } from "./mobileTheme";
+import type { MaterialYouPalette } from "./materialYouPalette";
+
+function withAlpha(color: string, alpha: number): string {
+  const match = /^#([\da-f]{6})(?:[\da-f]{2})?$/iu.exec(color);
+  if (!match?.[1]) return color;
+  const alphaByte = Math.round(Math.min(1, Math.max(0, alpha)) * 255)
+    .toString(16)
+    .padStart(2, "0")
+    .toUpperCase();
+  return `#${match[1]}${alphaByte}`;
+}
+
+function materialTone(color: string, tone: number): string {
+  const match = /^#([\da-f]{6})(?:[\da-f]{2})?$/iu.exec(color);
+  if (!match?.[1]) return color;
+
+  const source = Hct.fromInt(argbFromHex(match[1]));
+  return `${hexFromArgb(Hct.from(source.hue, source.chroma, tone).toInt()).toUpperCase()}FF`;
+}
+
+export function materialYouPaletteToMobileThemeVariables(
+  palette: MaterialYouPalette,
+  appearance: MobileThemeAppearance,
+  base: MobileThemeVariables,
+): MobileThemeVariables {
+  const dark = appearance === "dark";
+  const userBubble = dark ? materialTone(palette.inversePrimary, 30) : palette.primary;
+  const userBubbleForeground = dark ? materialTone(palette.inversePrimary, 90) : palette.onPrimary;
+
+  return {
+    ...base,
+    "--color-screen": palette.surface,
+    "--color-sheet": withAlpha(palette.surfaceContainerLow, 0.98),
+    "--color-sheet-solid": palette.surfaceContainerLow,
+    "--color-card": palette.surfaceContainer,
+    "--color-card-alt": palette.surfaceContainerHigh,
+    "--color-card-translucent": withAlpha(palette.surfaceContainer, 0.8),
+    "--color-foreground": palette.onSurface,
+    "--color-foreground-secondary": palette.onSurfaceVariant,
+    "--color-foreground-muted": palette.onSurfaceVariant,
+    "--color-foreground-tertiary": withAlpha(palette.onSurfaceVariant, 0.58),
+    "--color-border": withAlpha(palette.outlineVariant, dark ? 0.5 : 0.65),
+    "--color-border-subtle": withAlpha(palette.outlineVariant, dark ? 0.34 : 0.46),
+    "--color-separator": withAlpha(palette.outlineVariant, dark ? 0.24 : 0.34),
+    "--color-subtle": withAlpha(palette.onSurface, 0.05),
+    "--color-subtle-strong": withAlpha(palette.onSurface, 0.1),
+    "--color-inline-skill-background": withAlpha(palette.tertiaryContainer, 0.52),
+    "--color-inline-skill-border": withAlpha(palette.tertiary, 0.38),
+    "--color-inline-skill-foreground": palette.onTertiaryContainer,
+    "--color-primary": palette.primary,
+    "--color-primary-foreground": palette.onPrimary,
+    "--color-primary-shadow": withAlpha(palette.scrim, dark ? 0.22 : 0.18),
+    "--color-secondary": palette.secondaryContainer,
+    "--color-secondary-foreground": palette.onSecondaryContainer,
+    "--color-secondary-border": withAlpha(palette.outlineVariant, dark ? 0.42 : 0.56),
+    "--color-switch-active-track": palette.primary,
+    "--color-switch-active-thumb": palette.onPrimary,
+    "--color-switch-inactive-track": palette.surfaceContainerHighest,
+    "--color-switch-inactive-thumb": palette.outline,
+    "--color-danger": palette.errorContainer,
+    "--color-danger-border": withAlpha(palette.onErrorContainer, dark ? 0.42 : 0.5),
+    "--color-danger-foreground": palette.onErrorContainer,
+    "--color-input": palette.surfaceContainerLowest,
+    "--color-input-border": withAlpha(palette.outline, dark ? 0.42 : 0.5),
+    "--color-sidebar-search": palette.surfaceContainerLowest,
+    "--color-placeholder": withAlpha(palette.onSurface, 0.62),
+    "--color-icon": palette.onSurface,
+    "--color-icon-muted": palette.onSurfaceVariant,
+    "--color-icon-subtle": withAlpha(palette.onSurfaceVariant, 0.68),
+    "--color-header": palette.surfaceContainerHigh,
+    "--color-header-border": withAlpha(palette.outlineVariant, dark ? 0.36 : 0.48),
+    "--color-glass-surface": withAlpha(palette.surfaceContainerHigh, dark ? 0.78 : 0.72),
+    "--color-glass-tint": withAlpha(palette.primaryContainer, dark ? 0.24 : 0.18),
+    "--color-status-bar": palette.surfaceContainerLow,
+    "--color-md-body": materialTone(palette.onSurfaceVariant, dark ? 90 : 10),
+    "--color-md-strong": materialTone(palette.onSurfaceVariant, dark ? 90 : 10),
+    "--color-md-link": palette.primary,
+    "--color-md-blockquote-border": withAlpha(palette.primary, dark ? 0.34 : 0.26),
+    "--color-md-blockquote-bg": withAlpha(palette.primaryContainer, dark ? 0.14 : 0.2),
+    "--color-md-code-bg": withAlpha(palette.onSurface, dark ? 0.08 : 0.06),
+    "--color-md-code-text": palette.onSurface,
+    "--color-md-user-code-bg": withAlpha(userBubbleForeground, dark ? 0.18 : 0.22),
+    "--color-md-user-code-text": userBubbleForeground,
+    "--color-md-user-fence-bg": withAlpha(userBubbleForeground, dark ? 0.14 : 0.18),
+    "--color-md-user-fence-text": userBubbleForeground,
+    "--color-md-hr": withAlpha(palette.outlineVariant, dark ? 0.48 : 0.6),
+    "--color-user-bubble": userBubble,
+    "--color-user-bubble-foreground": userBubbleForeground,
+    "--color-user-bubble-foreground-muted": withAlpha(userBubbleForeground, 0.78),
+    "--color-user-bubble-skill-foreground": userBubbleForeground,
+    "--color-backdrop": withAlpha(palette.scrim, dark ? 0.48 : 0.22),
+    "--color-drawer": palette.surface,
+    "--color-drawer-shadow": withAlpha(palette.scrim, dark ? 0.32 : 0.12),
+    "--color-dot-separator": withAlpha(palette.onSurface, 0.2),
+    "--color-wordmark": palette.onSurface,
+    "--color-chevron": withAlpha(palette.onSurface, 0.2),
+  };
+}

--- a/apps/mobile/src/lib/mobileTheme.ts
+++ b/apps/mobile/src/lib/mobileTheme.ts
@@ -14,8 +14,8 @@ import {
 } from "@t3tools/shared/themePreview";
 
 export const DEFAULT_MOBILE_THEME_ID = MOBILE_DEFAULT_THEME_ID;
-export const MOBILE_THEME_IDS = SHARED_MOBILE_THEME_IDS;
-export type MobileThemeId = SharedMobileThemeId;
+export const MOBILE_THEME_IDS = [...SHARED_MOBILE_THEME_IDS, "material-you"] as const;
+export type MobileThemeId = SharedMobileThemeId | "material-you";
 export type MobileThemeAppearance = ThemeAppearance;
 export type MobileThemeMode = MobileThemeAppearance | "system";
 export type MobileThemeIds = Readonly<Record<MobileThemeAppearance, MobileThemeId>>;
@@ -25,6 +25,7 @@ export const MOBILE_THEME_OPTIONS: ReadonlyArray<{
   readonly label: string;
 }> = [
   { id: DEFAULT_MOBILE_THEME_ID, label: "T3 Code" },
+  { id: "material-you", label: "Material You" },
   ...BUILT_IN_THEMES.map((theme) => ({ id: theme.id as MobileThemeId, label: theme.label })),
 ];
 
@@ -306,7 +307,8 @@ export function getMobileThemePreviewColors(
   themeId: MobileThemeId,
   appearance: MobileThemeAppearance,
 ): ThemePreviewColors {
-  if (themeId === DEFAULT_MOBILE_THEME_ID) return STANDARD_THEME_PREVIEW_COLORS[appearance];
+  if (themeId === DEFAULT_MOBILE_THEME_ID || themeId === "material-you")
+    return STANDARD_THEME_PREVIEW_COLORS[appearance];
   const theme = BUILT_IN_THEMES.find((candidate) => candidate.id === themeId) ?? BUILT_IN_THEMES[0];
   const colors = getThemeColorsForAppearance(theme, appearance) ?? theme.colors;
   return {

--- a/apps/mobile/src/lib/mobileThemeRuntime.ts
+++ b/apps/mobile/src/lib/mobileThemeRuntime.ts
@@ -42,7 +42,9 @@ export function getMobileUniwindThemeName(
   themeId: MobileThemeId,
   appearance: MobileThemeAppearance,
 ): MobileUniwindThemeName {
-  return themeId === DEFAULT_MOBILE_THEME_ID ? appearance : `${themeId}-${appearance}`;
+  return themeId === DEFAULT_MOBILE_THEME_ID || themeId === "material-you"
+    ? appearance
+    : `${themeId}-${appearance}`;
 }
 
 /**

--- a/apps/mobile/src/lib/mobileThemeVariables.ts
+++ b/apps/mobile/src/lib/mobileThemeVariables.ts
@@ -21,7 +21,7 @@ export function getMobileThemeRuntimeVariables(
   themeId: MobileThemeId,
   appearance: MobileThemeAppearance,
 ): MobileThemeVariables {
-  return themeId === DEFAULT_MOBILE_THEME_ID
+  return themeId === DEFAULT_MOBILE_THEME_ID || themeId === "material-you"
     ? defaults[appearance]
     : getMobileThemeVariables(themeId, appearance);
 }

--- a/apps/mobile/src/lib/storage.test.ts
+++ b/apps/mobile/src/lib/storage.test.ts
@@ -196,6 +196,15 @@ describe("mobile connection storage", () => {
     });
   });
 
+  it("keeps saved themes when system colors are enabled and disabled", async () => {
+    const themes = { lightThemeId: "iris", darkThemeId: "ocean" } as const;
+    await savePreferencesPatch(themes);
+    await savePreferencesPatch({ systemColorsEnabled: true });
+    await expect(loadPreferences()).resolves.toEqual({ ...themes, systemColorsEnabled: true });
+    await savePreferencesPatch({ systemColorsEnabled: false });
+    await expect(loadPreferences()).resolves.toEqual({ ...themes, systemColorsEnabled: false });
+  });
+
   it("drops the removed theme transition preference", async () => {
     mocks.setPreferencesJson(JSON.stringify({ themeTransition: "circle-bottom-left" }), 10);
 

--- a/apps/mobile/src/lib/storage.test.ts
+++ b/apps/mobile/src/lib/storage.test.ts
@@ -196,13 +196,12 @@ describe("mobile connection storage", () => {
     });
   });
 
-  it("keeps saved themes when system colors are enabled and disabled", async () => {
-    const themes = { lightThemeId: "iris", darkThemeId: "ocean" } as const;
+  it("persists Material You independently for each appearance", async () => {
+    const themes = { lightThemeId: "material-you", darkThemeId: "ocean" } as const;
     await savePreferencesPatch(themes);
-    await savePreferencesPatch({ systemColorsEnabled: true });
-    await expect(loadPreferences()).resolves.toEqual({ ...themes, systemColorsEnabled: true });
-    await savePreferencesPatch({ systemColorsEnabled: false });
-    await expect(loadPreferences()).resolves.toEqual({ ...themes, systemColorsEnabled: false });
+    await expect(loadPreferences()).resolves.toEqual(themes);
+    await savePreferencesPatch({ lightThemeId: "t3-chat" });
+    await expect(loadPreferences()).resolves.toEqual({ ...themes, lightThemeId: "t3-chat" });
   });
 
   it("drops the removed theme transition preference", async () => {

--- a/apps/mobile/src/lib/useUniwindTheme.ts
+++ b/apps/mobile/src/lib/useUniwindTheme.ts
@@ -1,8 +1,5 @@
-import { useMemo } from "react";
-
 import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 import type { MobileThemeVariables } from "./mobileTheme";
-import { getMobileThemeRuntimeVariables } from "./mobileThemeVariables";
 
 /**
  * Complete JS palette for native and third-party APIs that cannot consume a
@@ -13,9 +10,5 @@ import { getMobileThemeRuntimeVariables } from "./mobileThemeVariables";
  * ScopedTheme instead of subscribing every consumer to CSS-variable updates.
  */
 export function useUniwindTheme(): MobileThemeVariables {
-  const { themeAppearance, themeId } = useAppearancePreferences();
-  return useMemo(
-    () => getMobileThemeRuntimeVariables(themeId, themeAppearance),
-    [themeAppearance, themeId],
-  );
+  return useAppearancePreferences().themeVariables;
 }

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -18,6 +18,7 @@ import { resolveMarkdownFileIcon } from "@t3tools/mobile-markdown-text/links";
 import { MOBILE_TYPOGRAPHY } from "../lib/typography";
 import { useNativePaste } from "../lib/useNativePaste";
 import { useFontFamily } from "../lib/useFontFamily";
+import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 import { useUniwindTheme } from "../lib/useUniwindTheme";
 import {
   acknowledgeComposerNativeEvent,
@@ -211,7 +212,9 @@ export function ComposerEditor({
     },
     [],
   );
+  const { systemColorsActive } = useAppearancePreferences();
   const themeJson = JSON.stringify({
+    selection: systemColorsActive ? theme["--color-primary"] : null,
     text: theme["--color-foreground"],
     placeholder: theme["--color-placeholder"],
     chipBackground: theme["--color-subtle"],

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -21,6 +21,7 @@ export interface Preferences {
   readonly lightThemeId?: MobileThemeId;
   readonly darkThemeId?: MobileThemeId;
   readonly themeMode?: MobileThemeMode;
+  readonly systemColorsEnabled?: boolean;
   readonly baseFontSize?: number;
   readonly terminalFontSize?: number | null;
   readonly markdownFontSize?: number;
@@ -90,6 +91,7 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     lightThemeId?: MobileThemeId;
     darkThemeId?: MobileThemeId;
     themeMode?: MobileThemeMode;
+    systemColorsEnabled?: boolean;
     baseFontSize?: number;
     terminalFontSize?: number | null;
     markdownFontSize?: number;
@@ -132,6 +134,9 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     parsed.themeMode === "dark"
   ) {
     preferences.themeMode = parsed.themeMode;
+  }
+  if (typeof parsed.systemColorsEnabled === "boolean") {
+    preferences.systemColorsEnabled = parsed.systemColorsEnabled;
   }
   if (typeof parsed.baseFontSize === "number") preferences.baseFontSize = parsed.baseFontSize;
   if (typeof parsed.terminalFontSize === "number" || parsed.terminalFontSize === null) {

--- a/apps/mobile/src/persistence/mobile-preferences.ts
+++ b/apps/mobile/src/persistence/mobile-preferences.ts
@@ -21,7 +21,6 @@ export interface Preferences {
   readonly lightThemeId?: MobileThemeId;
   readonly darkThemeId?: MobileThemeId;
   readonly themeMode?: MobileThemeMode;
-  readonly systemColorsEnabled?: boolean;
   readonly baseFontSize?: number;
   readonly terminalFontSize?: number | null;
   readonly markdownFontSize?: number;
@@ -91,7 +90,6 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     lightThemeId?: MobileThemeId;
     darkThemeId?: MobileThemeId;
     themeMode?: MobileThemeMode;
-    systemColorsEnabled?: boolean;
     baseFontSize?: number;
     terminalFontSize?: number | null;
     markdownFontSize?: number;
@@ -134,9 +132,6 @@ function sanitizePreferences(parsed: Preferences): Preferences {
     parsed.themeMode === "dark"
   ) {
     preferences.themeMode = parsed.themeMode;
-  }
-  if (typeof parsed.systemColorsEnabled === "boolean") {
-    preferences.systemColorsEnabled = parsed.systemColorsEnabled;
   }
   if (typeof parsed.baseFontSize === "number") preferences.baseFontSize = parsed.baseFontSize;
   if (typeof parsed.terminalFontSize === "number" || parsed.terminalFontSize === null) {

--- a/docs/user/appearance.md
+++ b/docs/user/appearance.md
@@ -7,6 +7,9 @@ within each theme. Appearance preferences are saved separately on each device or
 Mobile has its own themes and text, code, and terminal preferences. It does not follow environment
 themes or defaults.
 
+On Android 12 or newer, enable **System Colors** in Appearance to use Material You colors from
+your wallpaper. Turn it off to return to your saved themes.
+
 ## Motion
 
 The main sidebar, right panel, and terminal drawer open and close immediately by default. Move the

--- a/docs/user/appearance.md
+++ b/docs/user/appearance.md
@@ -7,8 +7,9 @@ within each theme. Appearance preferences are saved separately on each device or
 Mobile has its own themes and text, code, and terminal preferences. It does not follow environment
 themes or defaults.
 
-On Android 12 or newer, enable **System Colors** in Appearance to use Material You colors from
-your wallpaper. Turn it off to return to your saved themes.
+On Android 12 or newer, choose the **Material You** theme in Appearance to use colors from
+your wallpaper. Selecting another theme replaces those colors. Like other themes, Material You
+can be selected separately for light and dark appearances.
 
 ## Motion
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       '@legendapp/list':
         specifier: 'catalog:'
         version: 3.3.5(patch_hash=a05e968651a1352d2f374324016d1034b763b9fb2c5bf5f95111540d6899a52b)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      '@material/material-color-utilities':
+        specifier: 0.3.0
+        version: 0.3.0
       '@noble/curves':
         specifier: 'catalog:'
         version: 1.9.1
@@ -3411,6 +3414,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@material/material-color-utilities@0.3.0':
+    resolution: {integrity: sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -14207,6 +14213,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@material/material-color-utilities@0.3.0': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
Android users can select **Material You** alongside T3 Code, T3 Chat, and the other themes on Android 12+. It uses the live wallpaper palette, with independent light and dark choices. Selecting another theme immediately replaces wallpaper colors. The preview reflects the current Android palette, which refreshes when the app regains focus.

Continues Alex / @PixPMusic's system-color work from [#6081](https://github.com/pingdotgg/t3code/pull/6081), retaining the original author on the ported commit. The optional layout is separate in [#10692](https://github.com/pingdotgg/t3code/pull/10692).

Verified on an Android API 36 emulator with a disposable environment and seeded conversation:

- Selected Material You, then T3 Chat: the selected theme and visible colors change together.
- Selected Material You for light and T3 Chat for dark, then switched appearance modes.
- Changed the actual wallpaper between Google Green and Vivid Pink; returning to T3 refreshes the palette and preview without restarting.
- Checked light, dark, system appearance, conversation contrast, Markdown, and composer colors. Native Android build passed.
- Focused theme, persistence, terminal, and review tests, mobile typecheck, and scoped lint pass.

| Before: main, dark mode | After: system colors, green wallpaper |
| --- | --- |
| ![Before: standard T3 Code conversation](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5b6246fc8cb64575/before-thread-dark.png) | ![After: green Material You conversation](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/2e4c57cd10cf8f31/colors-thread-green-dark.png) |

| Material You: green wallpaper, light | Material You: pink wallpaper, dark |
| --- | --- |
| ![Green Material You theme](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4cff3439f9d7d52d/choice-material-green-light.png) | ![Pink Material You theme](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/00ca98bede60bbe3/choice-material-pink-dark.png) |

| T3 Chat replaces Material You | Independent light and dark choices |
| --- | --- |
| ![T3 Chat selected](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8dc10c2c67ca5f3a/choice-t3chat-dark.png) | ![Material You light and T3 Chat dark](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ad4977996c338c2b/choice-mixed-light.png) |

Model: GPT-6 | Harness: Codex in T3 Code


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `material-you` theme and Android wallpaper colors to mobile
> - Adds a `material-you` theme that derives mobile runtime variables from Android dynamic-color palettes in [AppearancePreferencesProvider.tsx](apps/mobile/src/features/settings/appearance/AppearancePreferencesProvider.tsx)
> - The provider tracks system palettes, refreshes them on app focus, and derives variables separately for light and dark appearances
> - Updates the `T3ComposerEditorView` native bridge to use the Material You primary color for text selection, cursor, and handle tinting on Android Q+
> - Fixes `parseColor` to convert CSS `RRGGBBAA` to Android `AARRGGBB` order so eight-digit colors render with correct opacity
> - Behavioral Change: The `ThemeAppearanceSection` hides the `material-you` theme option when the platform does not support system colors
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b62ffde.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Material You theming for Android 12+, using wallpaper-derived system colors.
  - Added independent light and dark appearance support for Material You.
  - Updated editor selections, cursor, and handles to follow the active accent color.
  - Material You is hidden when system colors are unavailable.
- **Bug Fixes**
  - Improved accessibility by labeling settings switches.
- **Documentation**
  - Documented selecting and configuring the Material You theme.
- **Tests**
  - Added coverage for theme conversion and independent appearance preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->