### PR TITLE
fix(mobile): keep terminal arrows accessible for TUI navigation

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt
@@ -10,7 +10,7 @@ class T3TerminalModule : Module() {
     // Bumped when native hardware-keyboard handling changes; surfaced in the JS debug
     // logs so a stale native binary is distinguishable from a broken key pipeline.
     Constants(
-      "hardwareKeyRevision" to 2,
+      "hardwareKeyRevision" to 3,
     )
 
     View(T3TerminalView::class) {

--- a/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
@@ -229,6 +229,20 @@ class T3TerminalView(context: Context, appContext: AppContext) : ExpoView(contex
     }
     inputView.setOnKeyListener { _, keyCode, event ->
       if (event.action != KeyEvent.ACTION_DOWN) return@setOnKeyListener false
+      val arrow = when (keyCode) {
+        KeyEvent.KEYCODE_DPAD_UP -> "A"
+        KeyEvent.KEYCODE_DPAD_DOWN -> "B"
+        KeyEvent.KEYCODE_DPAD_RIGHT -> "C"
+        KeyEvent.KEYCODE_DPAD_LEFT -> "D"
+        else -> null
+      }
+      if (arrow != null) {
+        val modifier = 1 + (if (event.isShiftPressed) 1 else 0) +
+          (if (event.isAltPressed) 2 else 0) + (if (event.isCtrlPressed) 4 else 0)
+        val sequence = if (modifier == 1) "\u001B[$arrow" else "\u001B[1;$modifier$arrow"
+        onInput(mapOf("data" to sequence))
+        return@setOnKeyListener true
+      }
       when {
         keyCode == KeyEvent.KEYCODE_DEL -> {
           onInput(mapOf("data" to "\u007F"))

--- a/apps/mobile/src/components/ComposerToolbar.tsx
+++ b/apps/mobile/src/components/ComposerToolbar.tsx
@@ -267,6 +267,8 @@ export function ComposerToolbarButton(props: {
   readonly maxWidth?: number;
   readonly minWidth?: number;
   readonly onPress?: () => void;
+  readonly onPressIn?: () => void;
+  readonly onPressOut?: () => void;
   readonly showChevron?: boolean;
   readonly textTransform?: "none" | "uppercase";
   readonly variant?: "default" | "primary" | "danger";
@@ -290,6 +292,8 @@ export function ComposerToolbarButton(props: {
       accessibilityRole="button"
       disabled={props.disabled}
       onPress={props.onPress}
+      onPressIn={props.onPressIn}
+      onPressOut={props.onPressOut}
       className={cn(
         // Default width cap lives in the class chain (not the inline style)
         // so callers can lift it with max-w-full — flex-filling pills in the

--- a/apps/mobile/src/features/terminal/TerminalArrowControls.tsx
+++ b/apps/mobile/src/features/terminal/TerminalArrowControls.tsx
@@ -1,0 +1,89 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { AppState, View } from "react-native";
+
+import { ComposerToolbarButton } from "../../components/ComposerToolbar";
+import { createTerminalKeyRepeat } from "./terminalKeyRepeat";
+
+const ARROWS = [
+  { label: "←", name: "Left arrow", data: "\u001b[D" },
+  { label: "↓", name: "Down arrow", data: "\u001b[B" },
+  { label: "↑", name: "Up arrow", data: "\u001b[A" },
+  { label: "→", name: "Right arrow", data: "\u001b[C" },
+] as const;
+
+function TerminalArrowButton(props: {
+  readonly label: string;
+  readonly name: string;
+  readonly data: string;
+  readonly disabled: boolean;
+  readonly onInput: (data: string) => Promise<boolean>;
+}) {
+  const [repeat] = useState(createTerminalKeyRepeat);
+  const input = useRef(props.onInput);
+  const touchStarted = useRef(false);
+  const releaseTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    input.current = props.onInput;
+  }, [props.onInput]);
+
+  useLayoutEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state !== "active") {
+        repeat.stop();
+        clearTimeout(releaseTimer.current);
+        touchStarted.current = false;
+      }
+    });
+    if (props.disabled) repeat.stop();
+    return () => {
+      repeat.stop();
+      clearTimeout(releaseTimer.current);
+      touchStarted.current = false;
+      subscription.remove();
+    };
+  }, [props.disabled, repeat]);
+
+  return (
+    <ComposerToolbarButton
+      accessibilityLabel={props.name}
+      disabled={props.disabled}
+      label={props.label}
+      minWidth={44}
+      maxWidth={44}
+      className="shrink-0 px-0"
+      onPressIn={() => {
+        clearTimeout(releaseTimer.current);
+        touchStarted.current = true;
+        repeat.start(() => input.current(props.data));
+      }}
+      onPressOut={() => {
+        repeat.stop();
+        // Pressability calls onPress after onPressOut for a successful touch.
+        // A canceled touch has no onPress, so clear its marker next tick too.
+        releaseTimer.current = setTimeout(() => {
+          touchStarted.current = false;
+        }, 0);
+      }}
+      onPress={() => {
+        // Screen-reader activation can arrive without the touch press lifecycle.
+        if (!touchStarted.current) void input.current(props.data);
+        touchStarted.current = false;
+      }}
+      showChevron={false}
+    />
+  );
+}
+
+export function TerminalArrowControls(props: {
+  readonly disabled: boolean;
+  readonly onInput: (data: string) => Promise<boolean>;
+}) {
+  return (
+    <View className="shrink-0 flex-row gap-1">
+      {ARROWS.map((arrow) => (
+        <TerminalArrowButton key={arrow.name} {...arrow} {...props} />
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -1,16 +1,19 @@
 import { DEFAULT_TERMINAL_ID, EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { type KnownTerminalSession } from "@t3tools/client-runtime/state/terminal";
 import type { MenuAction } from "@react-native-menu/menu";
-import { SymbolView } from "../../components/AppSymbol";
 import { NativeHeaderToolbar, NativeStackScreenOptions } from "../../native/StackHeader";
-import { StackActions, useNavigation, type StaticScreenProps } from "@react-navigation/native";
+import {
+  StackActions,
+  useIsFocused,
+  useNavigation,
+  type StaticScreenProps,
+} from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Platform, Pressable, View } from "react-native";
+import { Platform, View } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import * as Schema from "effect/Schema";
 import {
   KeyboardController,
-  KeyboardEvents,
   KeyboardStickyView,
   useKeyboardState,
 } from "react-native-keyboard-controller";
@@ -23,7 +26,6 @@ import {
 } from "../../components/ComposerToolbar";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { EmptyState } from "../../components/EmptyState";
-import { GlassSurface } from "../../components/GlassSurface";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { environmentCatalog } from "../../connection/catalog";
 import { useEnvironmentPresentation } from "../../state/presentation";
@@ -46,6 +48,8 @@ import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadDetail } from "../../state/use-thread-detail";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
 import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { TerminalArrowControls } from "./TerminalArrowControls";
 import { TerminalSurface } from "./NativeTerminalSurface";
 import { getMobileTerminalTheme } from "./terminalTheme";
 import { terminalDebugLog } from "./terminalDebugLog";
@@ -245,7 +249,8 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     },
   );
   const [keyboardFocusRequest, setKeyboardFocusRequest] = useState(0);
-  const [isAccessoryDismissed, setIsAccessoryDismissed] = useState(false);
+  const isFocused = useIsFocused();
+  const insets = useSafeAreaInsets();
   const bufferReplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const firstNonEmptyBufferLoggedRef = useRef(false);
   const lastBufferReplayKeyRef = useRef<string | null>(null);
@@ -493,10 +498,6 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
       { kind: "send", key: "tab", label: "tab", data: "\t" },
       { kind: "paste", key: "paste", label: "paste" },
       { kind: "clear", key: "clear", label: "clear" },
-      { kind: "send", key: "up", label: "↑", data: "\u001b[A" },
-      { kind: "send", key: "down", label: "↓", data: "\u001b[B" },
-      { kind: "send", key: "left", label: "←", data: "\u001b[D" },
-      { kind: "send", key: "right", label: "→", data: "\u001b[C" },
       { kind: "send", key: "tilde", label: "~", data: "~" },
       { kind: "send", key: "pipe", label: "|", data: "|" },
       { kind: "send", key: "slash", label: "/", data: "/" },
@@ -507,24 +508,11 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     height: state.height,
     isVisible: state.isVisible,
   }));
-  const isAccessoryVisible = keyboardState.isVisible && !isAccessoryDismissed;
+  const accessoryBottomInset = keyboardState.isVisible ? 0 : insets.bottom;
   const terminalBottomInset =
     (keyboardState.isVisible ? keyboardState.height : 0) +
-    (isAccessoryVisible ? TERMINAL_ACCESSORY_HEIGHT : 0);
-
-  useEffect(() => {
-    const keyboardWillShow = KeyboardEvents.addListener("keyboardWillShow", () => {
-      setIsAccessoryDismissed(false);
-    });
-    const keyboardWillHide = KeyboardEvents.addListener("keyboardWillHide", () => {
-      setIsAccessoryDismissed(true);
-    });
-
-    return () => {
-      keyboardWillShow.remove();
-      keyboardWillHide.remove();
-    };
-  }, []);
+    TERMINAL_ACCESSORY_HEIGHT +
+    accessoryBottomInset;
 
   const terminalMenuSessions = useMemo<ReadonlyArray<TerminalMenuSession>>(
     () =>
@@ -743,10 +731,9 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
 
   /** Sends a key through the armed toolbar modifier, if any, and disarms it. */
   const writeModifiedInput = useCallback(
-    (data: string) => {
+    async (data: string): Promise<boolean> => {
       if (pendingModifier === null) {
-        void writeInput(data);
-        return;
+        return writeInput(data);
       }
 
       setPendingModifierState({ terminalId, value: null });
@@ -756,10 +743,10 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         hostPlatform,
       });
       if (resolved.kind === "paste") {
-        void pasteFromClipboard();
-        return;
+        await pasteFromClipboard();
+        return false;
       }
-      void writeInput(resolved.data);
+      return writeInput(resolved.data);
     },
     [hostPlatform, pasteFromClipboard, pendingModifier, terminalId, writeInput],
   );
@@ -770,7 +757,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         return;
       }
 
-      writeModifiedInput(data);
+      void writeModifiedInput(data);
     },
     [writeModifiedInput],
   );
@@ -1072,13 +1059,12 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         return;
       }
 
-      writeModifiedInput(action.data);
+      void writeModifiedInput(action.data);
     },
     [handleClearTerminal, pasteFromClipboard, terminalId, writeModifiedInput],
   );
 
   const handleDismissKeyboard = useCallback(() => {
-    setIsAccessoryDismissed(true);
     void KeyboardController.dismiss();
   }, []);
 
@@ -1275,91 +1261,67 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
               />
             </View>
 
-            {isAccessoryVisible ? (
-              <KeyboardStickyView
-                style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
-                offset={{ closed: 0, opened: 0 }}
+            <KeyboardStickyView
+              style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
+              offset={{ closed: 0, opened: 0 }}
+            >
+              <View
+                className="border-t"
+                style={{
+                  backgroundColor: terminalTheme.background,
+                  borderTopColor: terminalTheme.border,
+                  minHeight: TERMINAL_ACCESSORY_HEIGHT,
+                  paddingBottom: accessoryBottomInset,
+                }}
               >
-                <View
-                  className="border-t"
-                  style={{
-                    backgroundColor: terminalTheme.background,
-                    borderTopColor: terminalTheme.border,
-                    minHeight: TERMINAL_ACCESSORY_HEIGHT,
-                  }}
-                >
-                  <ComposerToolbarRow paddingBottom={4} paddingHorizontal={8} paddingTop={4}>
-                    <ComposerToolbarScroller
-                      contentPaddingRight={2}
-                      fadeOpaque={terminalTheme.background}
-                      fadeTransparent={`${terminalTheme.background}00`}
-                    >
-                      {terminalToolbarActions.map((action) => {
-                        const active =
-                          action.kind === "modifier" && pendingModifier === action.modifier;
+                <ComposerToolbarRow paddingBottom={4} paddingHorizontal={8} paddingTop={4}>
+                  <ComposerToolbarScroller
+                    contentPaddingRight={2}
+                    fadeOpaque={terminalTheme.background}
+                    fadeTransparent={`${terminalTheme.background}00`}
+                  >
+                    {terminalToolbarActions.map((action) => {
+                      const active =
+                        action.kind === "modifier" && pendingModifier === action.modifier;
 
-                        return (
-                          <ComposerToolbarButton
-                            key={action.key}
-                            active={active}
-                            label={action.label}
-                            maxWidth={120}
-                            minWidth={action.label.length > 1 ? 56 : 44}
-                            onPress={() => handleToolbarActionPress(action)}
-                            showChevron={false}
-                            textTransform={
-                              action.kind === "modifier" || action.kind === "clear"
-                                ? "uppercase"
-                                : "none"
-                            }
-                          />
-                        );
-                      })}
-                    </ComposerToolbarScroller>
-                    <ComposerToolbarButton
-                      accessibilityLabel="Dismiss keyboard"
-                      icon={{ ios: "keyboard.chevron.compact.down", android: "keyboard_hide" }}
-                      onPress={handleDismissKeyboard}
-                      showChevron={false}
-                    />
-                  </ComposerToolbarRow>
-                </View>
-              </KeyboardStickyView>
-            ) : !keyboardState.isVisible ? (
-              <Pressable
-                accessibilityLabel="Show keyboard"
-                accessibilityRole="button"
-                onPress={handleShowKeyboard}
-                style={({ pressed }) => ({
-                  bottom: 16,
-                  borderRadius: 28,
-                  opacity: pressed ? 0.72 : 1,
-                  position: "absolute",
-                  right: 16,
-                })}
-              >
-                <GlassSurface
-                  chrome="none"
-                  glassEffectStyle="regular"
-                  tintColor="transparent"
-                  style={{
-                    alignItems: "center",
-                    borderRadius: 24,
-                    height: 48,
-                    justifyContent: "center",
-                    width: 48,
-                  }}
-                  pointerEvents="none"
-                >
-                  <SymbolView
-                    name={{ ios: "keyboard", android: "keyboard" }}
-                    size={20}
-                    tintColor={terminalTheme.foreground}
-                    type="monochrome"
+                      return (
+                        <ComposerToolbarButton
+                          key={action.key}
+                          active={active}
+                          label={action.label}
+                          maxWidth={120}
+                          minWidth={action.label.length > 1 ? 56 : 44}
+                          onPress={() => handleToolbarActionPress(action)}
+                          showChevron={false}
+                          textTransform={
+                            action.kind === "modifier" || action.kind === "clear"
+                              ? "uppercase"
+                              : "none"
+                          }
+                        />
+                      );
+                    })}
+                  </ComposerToolbarScroller>
+                  <TerminalArrowControls
+                    key={`${terminalKey}:${terminal.lifecycleVersion}`}
+                    disabled={!isRunning || !isFocused}
+                    onInput={writeModifiedInput}
                   />
-                </GlassSurface>
-              </Pressable>
-            ) : null}
+                  <ComposerToolbarButton
+                    accessibilityLabel={
+                      keyboardState.isVisible ? "Dismiss keyboard" : "Show keyboard"
+                    }
+                    icon={
+                      keyboardState.isVisible
+                        ? { ios: "keyboard.chevron.compact.down", android: "keyboard_hide" }
+                        : { ios: "keyboard", android: "keyboard" }
+                    }
+                    onPress={keyboardState.isVisible ? handleDismissKeyboard : handleShowKeyboard}
+                    showChevron={false}
+                  />
+                </ComposerToolbarRow>
+              </View>
+            </KeyboardStickyView>
           </>
         )}
       </View>

--- a/apps/mobile/src/features/terminal/terminalInput.test.ts
+++ b/apps/mobile/src/features/terminal/terminalInput.test.ts
@@ -30,6 +30,27 @@ describe("applyCtrlModifier", () => {
 });
 
 describe("resolveModifiedTerminalInput", () => {
+  it("encodes Ctrl and Alt arrows as modified cursor keys", () => {
+    for (const direction of ["A", "B", "C", "D"]) {
+      for (const prefix of ["[", "O"]) {
+        expect(
+          resolveModifiedTerminalInput({
+            data: `${ESC}${prefix}${direction}`,
+            modifier: "ctrl",
+            hostPlatform: "linux",
+          }),
+        ).toEqual({ kind: "write", data: `${ESC}[1;5${direction}` });
+        expect(
+          resolveModifiedTerminalInput({
+            data: `${ESC}${prefix}${direction}`,
+            modifier: "meta",
+            hostPlatform: "linux",
+          }),
+        ).toEqual({ kind: "write", data: `${ESC}[1;3${direction}` });
+      }
+    }
+  });
+
   it("pastes on ctrl+v for windows, linux, and unknown hosts", () => {
     for (const hostPlatform of ["windows", "linux", "unknown"] as const) {
       expect(resolveModifiedTerminalInput({ data: "v", modifier: "ctrl", hostPlatform })).toEqual({

--- a/apps/mobile/src/features/terminal/terminalInput.ts
+++ b/apps/mobile/src/features/terminal/terminalInput.ts
@@ -59,6 +59,16 @@ export function resolveModifiedTerminalInput(input: {
     return { kind: "paste" };
   }
 
+  // Cursor keys use a CSI modifier parameter, rather than a control byte or ESC prefix.
+  // eslint-disable-next-line no-control-regex -- Match terminal cursor-key sequences.
+  const arrow = /^\u001b(?:\[|O)([ABCD])$/.exec(input.data);
+  if (arrow) {
+    return {
+      kind: "write",
+      data: `\u001b[1;${input.modifier === "ctrl" ? 5 : 3}${arrow[1]}`,
+    };
+  }
+
   return {
     kind: "write",
     data: input.modifier === "ctrl" ? applyCtrlModifier(input.data) : `\u001b${input.data}`,

--- a/apps/mobile/src/features/terminal/terminalKeyRepeat.test.ts
+++ b/apps/mobile/src/features/terminal/terminalKeyRepeat.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { createTerminalKeyRepeat } from "./terminalKeyRepeat";
+
+describe("terminal key repeat", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("sends a tap immediately and does not repeat after release", async () => {
+    const repeat = createTerminalKeyRepeat();
+    const write = vi.fn(async () => true);
+    repeat.start(write);
+    expect(write).toHaveBeenCalledTimes(1);
+    repeat.stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("repeats after the hold delay and stops on cancellation", async () => {
+    const repeat = createTerminalKeyRepeat();
+    const write = vi.fn(async () => true);
+    repeat.start(write);
+    await vi.advanceTimersByTimeAsync(399);
+    expect(write).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(write).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(160);
+    expect(write).toHaveBeenCalledTimes(4);
+    repeat.stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(write).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not queue repeats while a remote write is pending or resume a released hold", async () => {
+    const pending = Promise.withResolvers<boolean>();
+    const write = vi.fn(() => pending.promise);
+    const repeat = createTerminalKeyRepeat();
+    repeat.start(write);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    repeat.stop();
+    pending.resolve(true);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("never resumes an old hold when another key has started", async () => {
+    const pending = Promise.withResolvers<boolean>();
+    const oldWrite = vi.fn(() => pending.promise);
+    const newWrite = vi.fn(async () => true);
+    const repeat = createTerminalKeyRepeat();
+    repeat.start(oldWrite);
+    repeat.start(newWrite);
+    pending.resolve(true);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(oldWrite).toHaveBeenCalledTimes(1);
+    expect(newWrite).toHaveBeenCalledTimes(2);
+    repeat.stop();
+  });
+
+  it.each([false, new Error("Disconnected")])(
+    "ends a hold after a failed write: %s",
+    async (result) => {
+      const repeat = createTerminalKeyRepeat();
+      const write = vi.fn(async () => {
+        if (result instanceof Error) throw result;
+        return result;
+      });
+      repeat.start(write);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(write).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/apps/mobile/src/features/terminal/terminalKeyRepeat.ts
+++ b/apps/mobile/src/features/terminal/terminalKeyRepeat.ts
@@ -1,0 +1,29 @@
+/** Repeats a held key without queuing writes behind a slow connection. */
+export function createTerminalKeyRepeat() {
+  let generation = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const stop = () => {
+    generation += 1;
+    clearTimeout(timer);
+    timer = undefined;
+  };
+
+  return {
+    stop,
+    start(write: () => Promise<boolean>) {
+      stop();
+      const current = generation;
+      const send = async (delay: number) => {
+        if (current !== generation) return;
+        try {
+          if (!(await write()) || current !== generation) return;
+          timer = setTimeout(() => void send(80), delay);
+        } catch {
+          // A failed write ends this hold; the terminal owns connection errors.
+        }
+      };
+      void send(400);
+    },
+  };
+}


### PR DESCRIPTION
﻿## What Changed

Pin four 44-point arrow buttons beside the mobile terminal's scrolling command buttons, and keep the toolbar available when the keyboard is hidden. Taps send one movement; holding repeats until release, navigation, session replacement, backgrounding, or a failed write. Repeats wait for writes to finish so a slow remote connection does not accumulate queued movements.

Encode the toolbar's Ctrl/Alt arrows as modified cursor keys and forward Android hardware arrows, including Shift/Alt/Ctrl combinations, to the terminal.

## Why

The existing arrows were buried after six commands in a horizontal scroller and disappeared with the keyboard. This made TUI navigation difficult to discover and use on phones.

## Validation

- 22 focused tests pass for terminal input and key repeat, including cancellation during pending writes and failed connections.
- Mobile TypeScript check passes. Targeted lint passes; the existing terminal screen still has React compiler warnings in unchanged code.
- Independent code review completed; corrected canceled-touch handling for accessibility activation.
- Uses the shared mobile terminal route for iOS and Android, with the existing environment-scoped terminal write transport. No provider, web/desktop, server, or wire-contract changes.
- Production: +227 / -119 lines. Tests: +95 / -0 lines.

## UI Changes

Device verification, before/after screenshots, and a short hold-to-repeat video are deferred at the requester's direction until an emulator is available. Native Android build and iOS runtime validation have not been performed. Shell history, TUI navigation, keyboard transitions, and screen-reader behavior still need an integrated device pass. Application cursor-key mode handling is unchanged and needs compatibility verification during that pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with GPT-6 in the Codex harness.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add press-and-hold arrow controls and hardware arrow-key support for terminal navigation
> - Adds a four-button `TerminalArrowControls` group that sends terminal arrow sequences on press and repeats while held, using `createTerminalKeyRepeat` (400ms initial delay, 80ms interval) with cancellation on release, unmount, or failed writes.
> - Adds Android hardware DPAD arrow-key handling in `T3TerminalView` that maps arrow presses to terminal cursor sequences with Shift/Alt/Ctrl modifier awareness, and bumps `hardwareKeyRevision` to 3.
> - Fixes `resolveModifiedTerminalInput` so pending Ctrl and Meta modifiers produce CSI cursor sequences (modifier params 5 and 3) for both CSI and SS3 arrow notation instead of generic control-byte transforms.
> - Reworks `ThreadTerminalRouteScreen` to always render the keyboard accessory with the toolbar, arrow controls, and a toggle button; arrow controls are disabled when the terminal is stopped or the route is unfocused.
> - Adds `onPressIn`/`onPressOut` props to `ComposerToolbarButton` to support the repeat lifecycle.
> - Behavioral Change: the terminal route no longer conditionally shows the accessory; it is always rendered and accounts for bottom safe-area inset when the keyboard is hidden. `writeModifiedInput` now returns `Promise<boolean>`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7eab49b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->