### PR TITLE
fix(usage): deduplicate native subscription accounts

### DIFF
--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -1020,7 +1020,7 @@ describe("/usage-limits", () => {
     expect(report?.accounts[0]?.limits.resetCredits?.availableCount).toBe(3);
   });
 
-  it("keeps accounts and custom instances separate, filtering by driver", () => {
+  it("keeps unidentified custom instances separate, filtering by driver", () => {
     const report = collectProviderUsageLimits(
       selected.instanceId,
       [
@@ -1059,6 +1059,45 @@ describe("/usage-limits", () => {
       plan: "Codex OSS",
     });
     expect(report?.notices).toEqual([]);
+  });
+
+  it("keeps the freshest usable duplicate and its latest native credits", () => {
+    const failed = provider({
+      auth: selected.auth,
+      usageLimits: { ...limits, unavailable: { reason: "probeFailed" } },
+    });
+    const credited = provider({
+      instanceId: ProviderInstanceId.make("codex-credit"),
+      auth: selected.auth,
+      usageLimits: {
+        checkedAt: "2026-09-03T11:20:00.000Z",
+        windows: [{ ...window, usedPercent: 50 }],
+        resetCredits: { availableCount: 2 },
+      },
+    });
+    const freshest = provider({
+      instanceId: ProviderInstanceId.make("codex-fresh"),
+      auth: selected.auth,
+      usageLimits: {
+        checkedAt: "2026-09-03T11:30:00.000Z",
+        windows: [{ ...window, usedPercent: 55 }],
+      },
+    });
+    const report = collectProviderUsageLimits(
+      failed.instanceId,
+      [failed, credited, freshest],
+      sources,
+      now,
+    );
+    expect(report?.accounts.map((account) => account.id)).toEqual(["codex-fresh", "hub:oss"]);
+    expect(report?.accounts[0]).toMatchObject({
+      limits: {
+        checkedAt: "2026-09-03T11:30:00.000Z",
+        windows: [{ usedPercent: 55 }],
+        resetCredits: { availableCount: 2 },
+      },
+      resetCreditInput: { instanceId: "codex-credit" },
+    });
   });
 
   it("supports a source-only provider and keeps duplicates when the native probe failed", () => {

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -644,11 +644,39 @@ export function collectProviderUsageLimits(
 ): UsageLimitsReport | null {
   const selected = providers.find((provider) => provider.instanceId === instanceId);
   if (!selected || !hasProviderUsageLimits(selected.driver, providers, sources)) return null;
-  const native = providersWithLimits(providers).filter(
-    (provider) => provider.driver === selected.driver,
-  );
-  const nativeAccounts = new Set(
-    native.flatMap((provider) => {
+  const nativeByAccount = new Map<
+    string,
+    { provider: ServerProvider; creditProvider: ServerProvider | null }
+  >();
+  for (const provider of providersWithLimits(providers)) {
+    if (provider.driver !== selected.driver || !provider.usageLimits) continue;
+    const key =
+      accountKey(provider.driver, provider.auth.email) ?? `instance:${provider.instanceId}`;
+    const previous = nativeByAccount.get(key);
+    const previousUsable = previous ? limitsNotice(previous.provider.usageLimits!) === null : false;
+    const usable = limitsNotice(provider.usageLimits) === null;
+    const providerWins =
+      !previous ||
+      (usable && !previousUsable) ||
+      (usable === previousUsable &&
+        Date.parse(provider.usageLimits.checkedAt) >
+          Date.parse(previous.provider.usageLimits!.checkedAt));
+    const previousCredit = previous?.creditProvider;
+    const creditProvider =
+      provider.usageLimits.resetCredits &&
+      (!previousCredit ||
+        Date.parse(provider.usageLimits.checkedAt) >
+          Date.parse(previousCredit.usageLimits!.checkedAt))
+        ? provider
+        : (previousCredit ?? null);
+    nativeByAccount.set(key, {
+      provider: providerWins ? provider : previous.provider,
+      creditProvider,
+    });
+  }
+  const native = [...nativeByAccount.values()];
+  const nativeAccountKeys = new Set(
+    native.flatMap(({ provider }) => {
       const key = accountKey(provider.driver, provider.auth.email);
       return key && provider.usageLimits?.windows.length && !provider.usageLimits.unavailable
         ? [key]
@@ -657,7 +685,7 @@ export function collectProviderUsageLimits(
   );
   const accounts: Array<UsageLimitsReport["accounts"][number]> = [];
   const notices: string[] = [];
-  for (const provider of native) {
+  for (const { provider, creditProvider } of native) {
     if (!provider.usageLimits) continue;
     const key = accountKey(provider.driver, provider.auth.email);
     const hubCredits = sources
@@ -684,9 +712,12 @@ export function collectProviderUsageLimits(
     const hubCreditId = hubCredits?.account.usageLimits.resetCredits?.nextCreditId;
     const showHubCredits =
       hubCredits &&
-      (!provider.usageLimits.resetCredits ||
+      (!creditProvider ||
         Date.parse(hubCredits.account.usageLimits.checkedAt) >
-          Date.parse(provider.usageLimits.checkedAt));
+          Date.parse(creditProvider.usageLimits!.checkedAt));
+    const shownCredits = showHubCredits
+      ? hubCredits.account.usageLimits.resetCredits
+      : creditProvider?.usageLimits?.resetCredits;
     accounts.push({
       id: provider.instanceId,
       driver: provider.driver,
@@ -700,12 +731,12 @@ export function collectProviderUsageLimits(
               accountId: hubCredits.account.id,
               creditId: hubCreditId,
             }
-          : { instanceId: provider.instanceId },
+          : { instanceId: creditProvider?.instanceId ?? provider.instanceId },
       ...(provider.displayName ? { displayName: provider.displayName } : {}),
       ...(provider.accentColor ? { accentColor: provider.accentColor } : {}),
       ...(provider.auth.email ? { email: provider.auth.email } : {}),
-      limits: showHubCredits
-        ? { ...provider.usageLimits, resetCredits: hubCredits.account.usageLimits.resetCredits }
+      limits: shownCredits
+        ? { ...provider.usageLimits, resetCredits: shownCredits }
         : provider.usageLimits,
     });
   }
@@ -713,7 +744,7 @@ export function collectProviderUsageLimits(
     const matching = source.accounts.filter((account) => account.driver === selected.driver);
     for (const account of matching) {
       const key = accountKey(account.driver, account.email);
-      if (key && nativeAccounts.has(key)) continue;
+      if (key && nativeAccountKeys.has(key)) continue;
       accounts.push({
         id: `${source.id}:${account.id}`,
         driver: account.driver,


### PR DESCRIPTION
Fixes #10701.

The `/usage-limits` composer report counted each native provider instance as a separate subscription, even when multiple instances were authenticated with the same provider and email. This could show the same Codex plan twice and inflate the account count.

Deduplicate native candidates with the existing normalized account key before merging CLIProxy sources. Instances without an email remain separate. A focused regression test covers duplicate native instances alongside hub accounts.

Checks:
- `vp test run packages/shared/src/usageLimits.test.ts`
- `vp run --filter @t3tools/shared typecheck`
- `vp fmt --check packages/shared/src/usageLimits.ts packages/shared/src/usageLimits.test.ts`

Generated by gpt-5.6-sol via the Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage limits now count multiple native instances authenticated to the same account only once.
  - Unidentified custom instances remain separately accounted for when filtering by driver.
  - Usage and credit information now reflects the most current usable provider data.
  - Reset-credit displays and fallback calculations use the freshest available credit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->