### PR TITLE
fix(usage): clarify pace labels and account reset details

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -7,6 +7,7 @@ import {
   collectLimitPools,
   formatDuration,
   formatResetsIn,
+  PACE_LABEL,
   remainingPercent,
   type LimitAccount,
   type LimitPoolWindow,
@@ -26,7 +27,6 @@ import { ResetCredits } from "./UsageLimitsSection";
 import { useProviderColors } from "./usageProviders";
 
 const DRIVER_LABEL: Partial<Record<string, string>> = { codex: "Codex", claudeAgent: "Claude" };
-const PACE_LABEL = { ahead: "Ahead of pace", on: "On pace", under: "Under pace" } as const;
 
 function accountName(account: LimitAccount) {
   if (account.displayName) return account.displayName;
@@ -111,7 +111,7 @@ function PoolWindowCard({
       </View>
       {nextRefill ? (
         <Text className="text-xs tabular-nums text-foreground-muted">
-          ↻ +{nextRefill.restoresPercent}%{" "}
+          ↻{pool.members.length > 1 ? ` +${nextRefill.restoresPercent}%` : ""}{" "}
           {nextRefill.at <= now ? "now" : `in ${formatDuration(nextRefill.at - now)}`}
         </Text>
       ) : null}

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -13,6 +13,7 @@ import {
   formatDuration,
   formatResetsIn,
   type LimitPace,
+  PACE_LABEL,
   paceOf,
   remainingPercent,
 } from "@t3tools/shared/usageLimits";
@@ -39,9 +40,9 @@ import { UsageLimitsPooled } from "./UsageLimitsPooled";
 import { PROVIDER_PRESENTATION } from "./usageProviders";
 
 const PACE: Record<LimitPace, { readonly label: string; readonly icon: typeof GaugeIcon }> = {
-  ahead: { label: "Ahead of pace: spending faster than the window elapses", icon: TrendingUpIcon },
+  ahead: { label: "Above pace: spending faster than the window elapses", icon: TrendingUpIcon },
   on: { label: "On pace with the window", icon: GaugeIcon },
-  under: { label: "Under pace: headroom left for the rest of the window", icon: TrendingDownIcon },
+  under: { label: "Below pace: headroom left for the rest of the window", icon: TrendingDownIcon },
 };
 
 /** The series colour the cost chart uses for this driver, so the two views read as one. */
@@ -51,23 +52,30 @@ export function barColor(driver: ServerProvider["driver"]): string {
   return kind ? PROVIDER_PRESENTATION[kind].color : "var(--foreground)";
 }
 
-/** Pace as a glyph with the words on hover. */
-export function PaceIcon({ pace }: { readonly pace: LimitPace }) {
-  const Icon = PACE[pace].icon;
+/** Pace as a glyph, optionally with its two words, and the full sentence on hover. */
+export function PaceIcon({
+  pace,
+  words = false,
+}: {
+  readonly pace: LimitPace;
+  readonly words?: boolean;
+}) {
+  const { icon: Icon, label } = PACE[pace];
   return (
     <Tooltip>
       <TooltipTrigger
         render={
           <span
-            role="img"
-            aria-label={PACE[pace].label}
-            className="inline-flex text-muted-foreground"
+            tabIndex={0}
+            aria-label={words ? undefined : PACE_LABEL[pace]}
+            className="inline-flex cursor-default items-center gap-1 rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         }
       >
         <Icon className="size-3.5" aria-hidden />
+        {words ? PACE_LABEL[pace] : null}
       </TooltipTrigger>
-      <TooltipPopup side="top">{PACE[pace].label}</TooltipPopup>
+      <TooltipPopup side="top">{label}</TooltipPopup>
     </Tooltip>
   );
 }

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -21,6 +21,7 @@ import { getDriverOption } from "../settings/providerDriverMeta";
 import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
 import { Button } from "../ui/button";
 import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
   PaceIcon,
   ResetCreditDialog,
@@ -484,8 +485,15 @@ function PoolWindowCard({
 }) {
   // The soonest reset that hands anything back; an untouched account resets to no effect.
   const nextRefill = pool.resets.find((reset) => reset.restoresPercent > 0);
+  // One account: the share restored is the number above, so only the time is news.
+  const several = pool.members.length > 1;
+  const refillWhen = nextRefill
+    ? nextRefill.at <= now
+      ? "now"
+      : `in ${formatDuration(nextRefill.at - now)}`
+    : null;
   return (
-    <div className="grid items-center gap-x-6 gap-y-3 rounded-lg border border-border/60 p-4 md:grid-cols-[11rem_minmax(0,1fr)]">
+    <div className="grid items-center gap-x-6 gap-y-3 rounded-lg border border-border/60 p-4 md:grid-cols-[13rem_minmax(0,1fr)]">
       <div className="flex flex-col gap-1">
         <span className="text-sm font-medium text-foreground">{pool.label}</span>
         <span className="flex items-baseline gap-2">
@@ -493,12 +501,33 @@ function PoolWindowCard({
             {pool.remainingPercent}%
           </span>
           <span className="text-sm text-muted-foreground">left</span>
-          {pool.pace ? <PaceIcon pace={pool.pace} /> : null}
         </span>
-        {nextRefill ? (
-          <span className="text-xs text-muted-foreground tabular-nums">
-            <span className="font-medium text-foreground">↻ +{nextRefill.restoresPercent}%</span>{" "}
-            {nextRefill.at <= now ? "now" : `in ${formatDuration(nextRefill.at - now)}`}
+        {pool.pace || nextRefill ? (
+          <span className="flex items-center gap-x-1 text-xs whitespace-nowrap text-muted-foreground tabular-nums">
+            {pool.pace ? <PaceIcon pace={pool.pace} words /> : null}
+            {pool.pace && nextRefill ? <span aria-hidden>·</span> : null}
+            {nextRefill ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      tabIndex={0}
+                      className="cursor-default rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    />
+                  }
+                >
+                  <span className="font-medium text-foreground">
+                    ↻{several ? ` +${nextRefill.restoresPercent}%` : ""}
+                  </span>{" "}
+                  {refillWhen}
+                </TooltipTrigger>
+                <TooltipPopup side="top" className="max-w-72 text-xs">
+                  <AccountName account={nextRefill.member.account} className="font-medium" /> resets{" "}
+                  {refillWhen}
+                  {several ? `, restoring ${nextRefill.restoresPercent}% of the pool` : ""}
+                </TooltipPopup>
+              </Tooltip>
+            ) : null}
           </span>
         ) : null}
       </div>

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -45,7 +45,8 @@ list. Each window card shows how much of the pool is left and a bar with one seg
 kept in the same column across windows. Accounts are ordered by their 5-hour reset, soonest
 first, or by the first available window when no account reports a 5-hour limit. A gap means the
 account does not report that window. When the provider reports reset times, the card also says
-when the next reset lands and how much it hands back. The hatched
+whether you are above, on, or below pace, when the next reset lands, and with more than one
+account how much of the pool it hands back. The hatched
 part of a segment is what that reset restores. Tap a segment or account row for the account's plan,
 where it is signed in, and its reset time. On web, you can hover too. Codex accounts with banked
 reset credits show a ticket count and the **Use reset** action in the account details. On narrow screens, numbered rows below

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -521,6 +521,13 @@ export function elapsedShare(window: ServerProviderUsageWindow, now: number): nu
 
 export type LimitPace = "ahead" | "on" | "under";
 
+/** Pace in two words, shared so every client names the same state the same way. */
+export const PACE_LABEL: Record<LimitPace, string> = {
+  ahead: "Above pace",
+  on: "On pace",
+  under: "Below pace",
+};
+
 /**
  * Usage against the clock. Spending evenly leaves the same share of quota as
  * there is time left in the window; within five points of that counts as on


### PR DESCRIPTION
Usage limits showed pace as an unlabeled icon and included a reset percentage even when it added no information.

With **one account**, a card showing **60% left** also showed **↻ +40% in 2h**. The +40% is just the missing portion of the same allowance: 100% − 60%. When that account resets, its allowance returns to 100%, so the percentage repeats what the balance already tells you. The useful new information is **when** it resets. This change keeps **↻ in 2h** and removes the redundant +40%.

With **multiple accounts**, resets happen at different times. The next reset replenishes only one account, so the current pooled balance does not tell you how much will come back next. **↻ +33% in 25m** therefore stays: it tells you the next reset will restore 33 percentage points of the pool. Its tooltip identifies the account that resets.

The change also adds **Above pace**, **On pace**, and **Below pace** labels on web, with tooltips explaining each state. Mobile shares the pace labels and the single-account reset rule.

## Before / after

Crops from the same dark-mode desktop screenshots, using identical fixture data. The comparisons focus on the changed summary; the full multi-account view is below.

### Single account

**60% left already implies 40% used.** The reset now shows only when that allowance returns, alongside the visible pace label.

| Before | After |
| --- | --- |
| ![before-single](https://github.com/user-attachments/assets/cfc5485d-77c7-45a0-b5ec-7afb9cc6c5bd) | ![after-single](https://github.com/user-attachments/assets/6822fd69-af21-4b55-9d51-06979ea5dc43) |

### Multiple accounts

**25% left does not tell you how much the next account reset restores.** The +33% stays because the accounts reset separately; the pace label is now visible too.

| Before | After |
| --- | --- |
| ![before-multi](https://github.com/user-attachments/assets/6b5f38e3-b553-45b9-9edf-1b15cfdd286b) | ![after-multi](https://github.com/user-attachments/assets/719fdfd8-f032-454d-93dc-7adc8f6846da) |

### Account overview

Three Codex accounts and two Claude accounts, with their individual balances and reset times.

![after-multi-overview](https://github.com/user-attachments/assets/74e3927d-41b9-444f-a91e-084ede0b07f1)

### Tooltips

**Pace explanation**

![after-multi-pace-tooltip](https://github.com/user-attachments/assets/b7d08cbd-2f5c-4365-857b-851a523129f4)

**Multiple-account reset: account, time, and restored share**

![after-multi-reset-tooltip](https://github.com/user-attachments/assets/d77af02b-3250-4fe5-ac3a-c34d05306c0c)

**Single-account reset: account and time**

![after-single-reset-tooltip](https://github.com/user-attachments/assets/6e1ae779-1958-4787-a646-9060000d5631)

## Verification

- Web rendered with fixture data for single, multi, exhausted, and no-reset-time pools at wide and narrow widths; lines stay on one row, tooltip text checked.
- `vp lint` and `tsc` clean for the touched files in `apps/web`, `apps/mobile`, and `packages/shared`.
- Mobile was not run on a device for this change; the edit is limited to the label import and the reset string.

Written by Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name usage pace states in words and drop redundant refill share for single-account pools
> - Extracts shared two-word pace labels into [usageLimits.ts](https://github.com/pingdotgg/t3code/pull/10703/files#diff-68cfbbd2d613fbb904208024425af193a1c663fa233b1c58b58735a924530b7f) so mobile and web use the same terminology; web descriptions for ahead/under states now say "above pace" and "below pace"
> - Adds a web `PaceLabel` component with a focusable tooltip and a mobile `PACE_SYMBOL` map so pooled usage cards on both platforms show a pace icon beside the short label
> - Drops the restored-percentage text for single-member pools on both platforms; multi-member pools still show it. Web moves account-specific reset details into a hover/focus tooltip
> - Adds Android SF-symbol fallbacks in [AppSymbol.tsx](https://github.com/pingdotgg/t3code/pull/10703/files#diff-0467e2f7db105dd39d77324805e7df721b1334a9629ced647d2ef2c28b01df9d) for the new trend and gauge icons
> - Updates [usage.md](https://github.com/pingdotgg/t3code/pull/10703/files#diff-d73591feaa8c26e8f16b7467464af0044ee0a9c288ef17901538a61715440e62) to document the pace status and single-account refill behavior
> - Behavioral Change: `PACE` ahead/under descriptions in [UsageLimits.tsx](https://github.com/pingdotgg/t3code/pull/10703/files#diff-2764f260dc4f879cad990f9601cd2a8d41a4af19eea6398254e9bbf00bdad23a) now read "above pace"/"below pace" instead of the prior wording; single-account pool cards no longer display the restored percentage
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10fd8c7. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pace labels such as “Above pace,” “On pace,” and “Below pace” across usage displays.
  - Added keyboard focus styling and optional visible labels for pace indicators.
  - Added tooltips with account-specific reset details for pooled usage limits.
  - Pooled usage cards now show reset timing and refill information more clearly.

- **Bug Fixes**
  - Restore percentages are now shown only for pools with multiple accounts.

- **Documentation**
  - Updated usage limit documentation with pace status, reset timing, and pool restoration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->