### PR TITLE
feat(web): add PR Link to thread copy menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2146,6 +2146,21 @@ export default function Sidebar() {
       );
     },
   });
+  const { copyToClipboard: copyPrLinkToClipboard } = useCopyToClipboard<{ url: string }>({
+    target: "PR link",
+    onCopy: ({ url }) => {
+      toastManager.add({ type: "success", title: "PR link copied", description: url });
+    },
+    onError: (error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to copy PR link",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    },
+  });
   const { copyToClipboard: copyThreadIdToClipboard } = useCopyToClipboard<{ threadId: ThreadId }>({
     onCopy: ({ threadId }) => {
       toastManager.add({
@@ -3956,12 +3971,14 @@ export default function Sidebar() {
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
         const isPinned = thread.pinnedAt != null;
+        const prUrl = (thread.linkedPullRequest ?? thread.branchPullRequest)?.url ?? null;
         // Presets resolve at menu-open time (same as the popover).
         const snoozePresets = resolveSnoozePresets(new Date(), timestampFormat);
         const clicked = await settlePromise(() =>
           api.contextMenu.show(
             buildThreadActionMenuItems({
               branch: thread.branch ?? null,
+              prUrl,
               isPinned,
               isSettled,
               isSnoozed,
@@ -4080,6 +4097,11 @@ export default function Sidebar() {
               copyBranchToClipboard(thread.branch, { branch: thread.branch });
             }
             return;
+          case "copy-pr-link":
+            if (prUrl) {
+              copyPrLinkToClipboard(prUrl, { url: prUrl });
+            }
+            return;
           case "copy-thread-id":
             copyThreadIdToClipboard(thread.id, { threadId: thread.id });
             return;
@@ -4155,6 +4177,7 @@ export default function Sidebar() {
       confirmThreadDelete,
       copyBranchToClipboard,
       copyPathToClipboard,
+      copyPrLinkToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
       handleMultiSelectContextMenu,

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -4,6 +4,7 @@ import { buildThreadActionMenuItems, type ThreadActionMenuState } from "./thread
 
 const baseState: ThreadActionMenuState = {
   branch: null,
+  prUrl: null,
   isPinned: false,
   isSettled: false,
   isSnoozed: false,
@@ -53,6 +54,19 @@ describe("buildThreadActionMenuItems", () => {
     expect(withBranch).toContain("copy-branch");
     expect(allIds(baseState)).not.toContain("new-thread-on-branch");
     expect(allIds(baseState)).not.toContain("copy-branch");
+  });
+
+  it("offers PR Link in Copy only when a PR URL is available", () => {
+    const copy = buildThreadActionMenuItems({
+      ...baseState,
+      prUrl: "https://github.com/pingdotgg/t3code/pull/8531",
+    }).find((item) => item.id === "copy");
+    expect(copy?.children).toContainEqual({
+      id: "copy-pr-link",
+      label: "PR Link",
+      icon: "link",
+    });
+    expect(allIds(baseState)).not.toContain("copy-pr-link");
   });
 
   it("flips lifecycle labels with thread state", () => {

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -21,6 +21,7 @@ export type ThreadActionMenuId =
   | "mark-unread"
   | "copy"
   | "copy-path"
+  | "copy-pr-link"
   | "copy-branch"
   | "copy-thread-id"
   | "archive"
@@ -28,6 +29,7 @@ export type ThreadActionMenuId =
 
 export interface ThreadActionMenuState {
   readonly branch: string | null;
+  readonly prUrl: string | null;
   readonly isPinned: boolean;
   readonly isSettled: boolean;
   readonly isSnoozed: boolean;
@@ -117,6 +119,7 @@ export function buildThreadActionMenuItems(
         ...(state.branch
           ? [{ id: "copy-branch" as const, label: "Branch", icon: "git-branch" }]
           : []),
+        ...(state.prUrl ? [{ id: "copy-pr-link" as const, label: "PR Link", icon: "link" }] : []),
         { id: "copy-thread-id", label: "Thread ID", icon: "hash" },
       ],
     },

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -51,6 +51,16 @@ const ICON_PATHS: Record<string, ReadonlyArray<{ tag: string; attrs: Record<stri
     { tag: "line", attrs: { x1: "10", x2: "8", y1: "3", y2: "21" } },
     { tag: "line", attrs: { x1: "16", x2: "14", y1: "3", y2: "21" } },
   ],
+  link: [
+    {
+      tag: "path",
+      attrs: { d: "M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" },
+    },
+    {
+      tag: "path",
+      attrs: { d: "M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" },
+    },
+  ],
   "mail-open": [
     {
       tag: "path",

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -111,6 +111,13 @@ export function useThreadActionMenu(input: {
     },
     onError: (error) => failureToast("Failed to copy branch", error),
   });
+  const { copyToClipboard: copyPrLinkToClipboard } = useCopyToClipboard<{ url: string }>({
+    target: "PR link",
+    onCopy: ({ url }) => {
+      toastManager.add({ type: "success", title: "PR link copied", description: url });
+    },
+    onError: (error) => failureToast("Failed to copy PR link", error),
+  });
   const { copyToClipboard: copyThreadIdToClipboard } = useCopyToClipboard<{ threadId: ThreadId }>({
     onCopy: ({ threadId }) => {
       toastManager.add({ type: "success", title: "Thread ID copied", description: threadId });
@@ -136,9 +143,11 @@ export function useThreadActionMenu(input: {
           titleRegeneration: readEnvironmentSupportsTitleRegeneration(threadRef.environmentId),
         };
         const isRegeneratingTitle = thread.titleRegeneration != null;
+        const prUrl = (thread.linkedPullRequest ?? thread.branchPullRequest)?.url ?? null;
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,
+          prUrl,
           isPinned: thread.pinnedAt != null,
           isSettled: supports.settlement && thread.settledOverride === "settled",
           isSnoozed: supports.snooze && effectiveSnoozed(thread, { now: now.toISOString() }),
@@ -273,6 +282,11 @@ export function useThreadActionMenu(input: {
               copyBranchToClipboard(thread.branch, { branch: thread.branch });
             }
             return;
+          case "copy-pr-link":
+            if (prUrl) {
+              copyPrLinkToClipboard(prUrl, { url: prUrl });
+            }
+            return;
           case "copy-thread-id":
             copyThreadIdToClipboard(thread.id, { threadId: thread.id });
             return;
@@ -335,6 +349,7 @@ export function useThreadActionMenu(input: {
       confirmAndUnpinThread,
       copyBranchToClipboard,
       copyPathToClipboard,
+      copyPrLinkToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
       handleNewThread,


### PR DESCRIPTION
> [!NOTE]
> 🤖 **GPT-6 on behalf of Oliver**

## ELI5

Copy a thread's pull request URL from **Copy → PR Link**.

## Problem

The thread Copy submenu offers its path, branch, and ID, but no PR URL.

## Implementation

Add PR Link to the shared sidebar and chat-header menu when a linked or branch PR exists. Prefer the explicitly linked PR and reuse the clipboard helper and success/error toasts. Add the link icon to the web context-menu renderer.

Validated with 19 focused tests, web typecheck, targeted lint, and browser checks for linked PRs, branch PRs, no-PR visibility, and the chat header. Lint reports existing Sidebar warnings. Independent code review found no remaining issues.

## UI Changes

### Before

![Copy menu before](https://github.com/flamboh/t3code/releases/download/pr-evidence-thread-pr-link-20260908/pr-menu-before.png)

### After

![Copy menu with PR Link](https://github.com/flamboh/t3code/releases/download/pr-evidence-thread-pr-link-20260908/pr-menu-after.png)

Made with GPT-6 in Codex.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `copy-PR-link` action to thread context menu
> - Extends `ThreadActionMenuState` with a nullable `prUrl` field and conditionally adds the PR Link item to the Copy submenu when a URL is present
> - The sidebar and `useThreadActionMenu` hook resolve the PR URL from the thread's linked pull request, falling back to its branch pull request, and copy it with success/failure toasts
> - Adds a link icon to the fallback context menu renderer in [contextMenuFallback.ts](https://github.com/pingdotgg/t3code/pull/10710/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be)
> - Behavioral Change: `ThreadActionMenuState` adds a required `prUrl` field; in-tree consumers are updated, but external consumers of this shared builder must provide it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6084827.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Copy PR Link** option to thread context menus when a pull request is associated with the thread.
  * Copies the pull request URL to the clipboard and displays a success or error notification.
  * Added a link icon for the new menu action.
  * Added drag-and-drop file support for sidebar thread and search result rows.

* **Tests**
  * Added coverage for displaying the PR link option only when a pull request URL is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->