### PR TITLE
fix(web): show the same project icon in the command palette as everywhere else

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
-import type { Thread } from "../types";
+import type { Project, Thread } from "../types";
 import {
   buildBrowseGroups,
+  buildProjectActionItems,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterPinnedBrowseEntries,
@@ -112,6 +113,20 @@ describe("enumerateCommandPaletteItems", () => {
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
 const PROJECT_ID = ProjectId.make("project-1");
 
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: PROJECT_ID,
+    environmentId: LOCAL_ENVIRONMENT_ID,
+    title: "Project",
+    workspaceRoot: "/workspace/project",
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-03-01T00:00:00.000Z",
+    updatedAt: "2026-03-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
 function makeThread(overrides: Partial<Thread> = {}): Thread {
   return {
     id: ThreadId.make("thread-1"),
@@ -138,6 +153,28 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+describe("buildProjectActionItems", () => {
+  it("shows the grouped display name but keeps the real title for icons", () => {
+    const project = makeProject({ title: "fleet", workspaceRoot: "/Users/theo/Code/p/fleet" });
+    const iconTitles: string[] = [];
+    const [item] = buildProjectActionItems({
+      projects: [{ ...project, displayName: "t3dotgg/fleet" }],
+      valuePrefix: "project",
+      icon: (candidate) => {
+        iconTitles.push(candidate.title);
+        return null;
+      },
+      runProject: async () => undefined,
+    });
+
+    expect(item?.title).toBe("t3dotgg/fleet");
+    expect(item?.searchTerms).toEqual(
+      expect.arrayContaining(["t3dotgg/fleet", "fleet", "/Users/theo/Code/p/fleet"]),
+    );
+    expect(iconTitles).toEqual(["fleet"]);
+  });
+});
 
 describe("buildThreadActionItems", () => {
   it("orders threads by most recent activity and formats timestamps from updatedAt", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -139,20 +139,31 @@ export function enumerateCommandPaletteItems(
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
+// A project as the palette shows it. `displayName` is the grouped label (for
+// example "owner/repo" when projects are merged across machines). Keep `title`
+// as the real project title: the automatic project icon is derived from it, and
+// every other surface uses the real title, so overriding it desyncs the icon.
+export type CommandPaletteProject = Project & { readonly displayName: string };
+
 export function buildProjectActionItems(input: {
-  projects: ReadonlyArray<Project>;
+  projects: ReadonlyArray<CommandPaletteProject>;
   valuePrefix: string;
-  icon: (project: Project) => ReactNode;
-  runProject: (project: Project) => Promise<void>;
-  searchTerms?: (project: Project) => ReadonlyArray<string>;
-  renderDescription?: (project: Project) => ReactNode;
+  icon: (project: CommandPaletteProject) => ReactNode;
+  runProject: (project: CommandPaletteProject) => Promise<void>;
+  searchTerms?: (project: CommandPaletteProject) => ReadonlyArray<string>;
+  renderDescription?: (project: CommandPaletteProject) => ReactNode;
   shortcutCommand?: KeybindingCommand;
 }): CommandPaletteActionItem[] {
   return input.projects.map((project) => ({
     kind: "action",
     value: `${input.valuePrefix}:${project.environmentId}:${project.id}`,
-    searchTerms: [project.title, project.workspaceRoot, ...(input.searchTerms?.(project) ?? [])],
-    title: project.title,
+    searchTerms: [
+      project.displayName,
+      project.title,
+      project.workspaceRoot,
+      ...(input.searchTerms?.(project) ?? []),
+    ],
+    title: project.displayName,
     description: input.renderDescription?.(project) ?? project.workspaceRoot,
     icon: input.icon(project),
     ...(input.shortcutCommand !== undefined ? { shortcutCommand: input.shortcutCommand } : {}),

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -794,7 +794,7 @@ function OpenCommandPaletteDialog(props: {
     () =>
       projectPickerEntries.map(({ group, targetProject }) => ({
         ...targetProject,
-        title: group.displayName,
+        displayName: group.displayName,
       })),
     [projectPickerEntries],
   );


### PR DESCRIPTION
Grouped projects like \`t3dotgg/fleet\` showed a different icon in the Command-K menu than in the sidebar and chat header. The palette overwrote each project's \`title\` with the grouped display name before rendering the icon, and the automatic icon is derived from the title. Every other surface passes the real title, so only the palette drifted.

Palette rows now carry a separate \`displayName\` for the label and search terms. The icon keeps the real \`title\`. A test asserts the icon callback receives the real title while the row shows the grouped name.

Audit result: all 17 web call sites go through one \`ProjectFavicon\` component and one \`selectProjectIcon\` function. This was the only site passing a non-title string. A follow-up will make \`ProjectFavicon\` take the project object instead of loose strings so this cannot regress.

Created with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project icon in command palette to use real project title instead of grouped name
> The command palette was overwriting the project's real title with a grouped display name, causing icons to render with the wrong label. This introduces a palette-specific `CommandPaletteProject` type with a separate `displayName` field so the real title stays available for icon generation and callbacks while the grouped name is used for display and search.
> - Updated `buildProjectActionItems` to use `displayName` for the action item title and search terms, while passing the full project object to the icon factory and execution callbacks
> - Updated `OpenCommandPaletteDialog` mapping to store the grouped label in `displayName` instead of replacing the project title
> - Added test coverage for grouped project names in [CommandPalette.logic.test.ts](https://github.com/pingdotgg/t3code/pull/10712/files#diff-7e27ce8f14aaa0d915ad6b3770ec03d8acaa092915823abfb90caaec3cb00e34)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7fece8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project search in the command palette by matching both grouped display names and original project titles.
  * Preserved original project titles for accurate project actions and icons.
  * Updated displayed project names without changing the underlying project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->