### PR TITLE
fix(web): rest the composer again when focus leaves a scrolled thread

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -4640,10 +4640,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const handleImplementPlanInNewThreadPrimaryAction = useCallback(() => {
     void onImplementPlanInNewThread();
   }, [onImplementPlanInNewThread]);
-  // The phone composer collapses when the editor loses focus. Desktop only
-  // rests on a timeline scroll, so losing focus there changes nothing.
+  // The phone composer collapses whenever the editor loses focus. Desktop
+  // rests on a timeline scroll, and losing focus while the timeline is still
+  // scrolled away from its end rests it too, so focusing the composer is only
+  // a temporary lift. At the end there is nothing to give back, so blurring
+  // there changes nothing.
   const scheduleComposerCollapseCheck = useCallback(() => {
-    if (!isMobileViewport || mobileComposerExpandInFlightRef.current) {
+    if (mobileComposerExpandInFlightRef.current) {
       return;
     }
     if (composerBlurFrameRef.current !== null) {
@@ -4668,8 +4671,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return;
       }
       setIsComposerFocused(false);
+      if (
+        !isMobileViewport &&
+        composerScrollCollapseEligibleRef.current &&
+        !isTimelineAtLogicalEnd()
+      ) {
+        setIsComposerScrollCollapsed(true);
+      }
     });
-  }, [isMobileViewport, setIsComposerFocused]);
+  }, [
+    isMobileViewport,
+    isTimelineAtLogicalEnd,
+    setIsComposerFocused,
+    setIsComposerScrollCollapsed,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/src/components/chat/useComposerFocusState.test.tsx
+++ b/apps/web/src/components/chat/useComposerFocusState.test.tsx
@@ -53,11 +53,11 @@ afterEach(async () => {
 });
 
 describe("composer focus state", () => {
-  it("stays expanded when the composer loses focus", async () => {
+  it("does not rest from focus state alone", async () => {
     await act(() => composer.setIsComposerFocused(true));
     expect(isResting).toBe(false);
 
-    // A tool disclosure takes focus away from the editor.
+    // Resting on blur is the composer's call, made from the timeline position.
     await act(() => composer.setIsComposerFocused(false));
     expect(isResting).toBe(false);
   });

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -41,10 +41,10 @@ export function shouldUseRestingComposerLayout(input: {
   // desktop width, and where the strip is missing or too narrow the controls
   // simply return when the composer is focused.
   //
-  // Only a timeline scroll rests the composer: the user asked for it with the
-  // gesture, and it lifts on the next composer interaction. Losing focus never
-  // rests it, so clicking a message, copying output, or selecting text for a
-  // citation leaves the composer where it was.
+  // A timeline scroll rests the composer, and it lifts on the next composer
+  // interaction. That lift only lasts while the composer holds focus: if the
+  // timeline is still scrolled away from its end when focus leaves, the
+  // composer rests again. At the end, losing focus changes nothing.
   //
   // Resting exists to give reading space back to the timeline. A thread that
   // fits above the composer has nothing to reclaim, so it stays expanded and

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2345,7 +2345,7 @@ export function GeneralSettingsPanel() {
 
         <SettingsRow
           {...searchableSetting("composer-collapse")}
-          description="Rest the composer of an existing thread into a single line when you scroll the conversation. Focus the composer or start typing to expand it again."
+          description="Rest the composer of an existing thread into a single line when you scroll the conversation. Focus the composer or start typing to expand it. It rests again when focus leaves while the conversation is scrolled up."
           resetAction={
             settings.composerCollapseOnScroll !==
             DEFAULT_UNIFIED_SETTINGS.composerCollapseOnScroll ? (


### PR DESCRIPTION
Scrolling the timeline rests the composer into one line. Focusing it expands it again, and that expansion stuck until the next scroll, even after focus moved elsewhere. So a click into the composer while reading up the thread cost the reading space for good.

Now the expansion only lasts while the composer holds focus. When focus leaves and the timeline is still scrolled away from its end, the composer rests again. At the end of the timeline, blur changes nothing, and scrolling still rests it whether the composer is focused or not.

The blur check is deferred one frame and ignores focus that lands in the resting controls or the model picker, so opening those menus does not rest the composer.

Also updated the setting description in Settings and the comment in composerFooterLayout.ts that described the old "never rests on blur" rule.

Created with Claude Fable 5.1 in Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The chat composer now collapses after losing focus on desktop when the conversation is scrolled away from the latest messages.
  - Composer resting behavior now responds to both timeline position and focus state.

- **Documentation**
  - Updated composer-collapse settings text and in-app guidance to clarify when the composer rests or expands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->