### PR TITLE
feat(web): pinch to zoom and scroll expanded images

### DIFF
--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -1,12 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-  type RefObject,
-} from "react";
+import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { ChevronLeftIcon, ChevronRightIcon, ImageIcon, TextIcon, XIcon } from "lucide-react";
 import { Button } from "../ui/button";
@@ -24,16 +16,7 @@ import {
 } from "./SnapShotAttachmentDetails";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
-import {
-  clampImagePan,
-  clickZoomScale,
-  IMAGE_ZOOM_IDENTITY,
-  type ImageZoomFrame,
-  type ImageZoomState,
-  panImage,
-  wheelZoomFactor,
-  zoomImageAt,
-} from "./imageZoom";
+import { ZoomableImage } from "./ZoomableImage";
 
 interface ExpandedImageDialogProps {
   preview: ExpandedImagePreview;
@@ -72,204 +55,6 @@ function ExpandedVideo({ item }: { readonly item: ExpandedImageItem }) {
       videoClassName="aspect-auto max-h-[86vh] w-auto max-w-[92vw] rounded-lg border border-border/70 shadow-2xl"
       stateClassName={EXPANDED_MEDIA_STATE_CLASS_NAME}
       onRetry={asset ? refreshAssetUrl : undefined}
-    />
-  );
-}
-
-function zoomFrame(image: HTMLImageElement, zoom: ImageZoomState): ImageZoomFrame {
-  // The rect is already transformed. Scaling around the center leaves the
-  // center put, so subtracting the translate gives the untransformed center.
-  const rect = image.getBoundingClientRect();
-  return {
-    width: image.offsetWidth,
-    height: image.offsetHeight,
-    viewportWidth: window.innerWidth,
-    viewportHeight: window.innerHeight,
-    centerX: rect.left + rect.width / 2 - zoom.x - window.innerWidth / 2,
-    centerY: rect.top + rect.height / 2 - zoom.y - window.innerHeight / 2,
-  };
-}
-
-/** Pointer position relative to the untransformed center of the image box. */
-function zoomAnchor(frame: ImageZoomFrame, event: { clientX: number; clientY: number }) {
-  return {
-    x: event.clientX - frame.viewportWidth / 2 - frame.centerX,
-    y: event.clientY - frame.viewportHeight / 2 - frame.centerY,
-  };
-}
-
-/**
- * Safari reports trackpad pinch as gesture events instead of ctrl+wheel.
- * Apple documents `clientX` and `clientY` on them, but they are not in any
- * standard, so callers must be ready for them to be missing.
- */
-interface SafariGestureEvent extends UIEvent {
-  readonly scale: number;
-  readonly clientX?: number;
-  readonly clientY?: number;
-}
-
-/**
- * The screenshot with the zoom model of a native image viewer: pinch or
- * ctrl+wheel zooms around the pointer, two-finger scroll or drag pans, and a
- * click toggles between fitted and actual size. Gestures are read from the
- * whole dialog so the pointer does not have to sit on the image. Only the
- * transform changes while zooming, so Chromium keeps the work on the
- * compositor and never repaints the bitmap.
- */
-function ZoomableImage({
-  src,
-  alt,
-  surfaceRef,
-  onError,
-}: {
-  readonly src: string;
-  readonly alt: string;
-  /** The dialog element that receives pinch and wheel gestures. */
-  readonly surfaceRef: RefObject<HTMLElement | null>;
-  readonly onError: () => void;
-}) {
-  const imageRef = useRef<HTMLImageElement | null>(null);
-  const [zoom, setZoom] = useState<ImageZoomState>(IMAGE_ZOOM_IDENTITY);
-  const dragRef = useRef<{
-    pointerId: number;
-    x: number;
-    y: number;
-    startX: number;
-    startY: number;
-    moved: boolean;
-  } | null>(null);
-
-  // Wheel and gesture listeners must be non-passive to stop the page from
-  // scrolling and the browser from zooming the whole window. React registers
-  // wheel as passive, so attach them by hand.
-  useEffect(() => {
-    const surface = surfaceRef.current;
-    const image = imageRef.current;
-    if (!surface || !image) return;
-    const onWheel = (event: WheelEvent) => {
-      event.preventDefault();
-      const lineScale = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : 1;
-      if (event.ctrlKey) {
-        // Chromium and Firefox report a trackpad pinch as ctrl+wheel.
-        const factor = wheelZoomFactor(event.deltaY * lineScale);
-        setZoom((current) => {
-          const frame = zoomFrame(image, current);
-          return zoomImageAt(current, factor, zoomAnchor(frame, event), frame);
-        });
-        return;
-      }
-      // A plain two-finger scroll pans the zoomed image, like a native viewer.
-      const dx = -event.deltaX * lineScale;
-      const dy = -event.deltaY * lineScale;
-      setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
-    };
-    // The last pointer position over the dialog, for gesture events that
-    // arrive without coordinates of their own.
-    let pointer = { clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 };
-    const onPointerMove = (event: PointerEvent) => {
-      pointer = { clientX: event.clientX, clientY: event.clientY };
-    };
-    // Safari's `scale` is cumulative from the start of the gesture.
-    let gestureStartScale = 1;
-    const onGestureStart = (event: Event) => {
-      event.preventDefault();
-      setZoom((current) => {
-        gestureStartScale = current.scale;
-        return current;
-      });
-    };
-    const onGestureChange = (event: Event) => {
-      event.preventDefault();
-      const gesture = event as SafariGestureEvent;
-      const at =
-        Number.isFinite(gesture.clientX) && Number.isFinite(gesture.clientY)
-          ? { clientX: gesture.clientX as number, clientY: gesture.clientY as number }
-          : pointer;
-      setZoom((current) => {
-        const frame = zoomFrame(image, current);
-        const factor = (gestureStartScale * gesture.scale) / current.scale;
-        return zoomImageAt(current, factor, zoomAnchor(frame, at), frame);
-      });
-    };
-    surface.addEventListener("wheel", onWheel, { passive: false });
-    surface.addEventListener("pointermove", onPointerMove, { passive: true });
-    surface.addEventListener("gesturestart", onGestureStart, { passive: false });
-    surface.addEventListener("gesturechange", onGestureChange, { passive: false });
-    return () => {
-      surface.removeEventListener("wheel", onWheel);
-      surface.removeEventListener("pointermove", onPointerMove);
-      surface.removeEventListener("gesturestart", onGestureStart);
-      surface.removeEventListener("gesturechange", onGestureChange);
-    };
-  }, [surfaceRef]);
-
-  // A resize changes the pan bounds. Reclamp so a grown window does not leave
-  // the image offset with backdrop showing at one edge.
-  useEffect(() => {
-    const image = imageRef.current;
-    if (!image) return;
-    const onResize = () => setZoom((current) => clampImagePan(current, zoomFrame(image, current)));
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
-
-  const zoomed = zoom.scale > 1;
-  return (
-    <img
-      ref={imageRef}
-      src={src}
-      alt={alt}
-      className={`max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] touch-none select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none ${
-        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-in"
-      }`}
-      style={{ transform: `translate(${zoom.x}px, ${zoom.y}px) scale(${zoom.scale})` }}
-      draggable={false}
-      onError={onError}
-      onPointerDown={(event) => {
-        if (event.button !== 0) return;
-        dragRef.current = {
-          pointerId: event.pointerId,
-          x: event.clientX,
-          y: event.clientY,
-          startX: event.clientX,
-          startY: event.clientY,
-          moved: false,
-        };
-        if (zoomed) event.currentTarget.setPointerCapture(event.pointerId);
-      }}
-      onPointerMove={(event) => {
-        const drag = dragRef.current;
-        if (!drag || drag.pointerId !== event.pointerId) return;
-        const dx = event.clientX - drag.x;
-        const dy = event.clientY - drag.y;
-        drag.x = event.clientX;
-        drag.y = event.clientY;
-        // A few pixels of jitter during a click still count as a click.
-        if (Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) > 4) {
-          drag.moved = true;
-        }
-        if (!zoomed) return;
-        const image = event.currentTarget;
-        setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
-      }}
-      onPointerUp={(event) => {
-        const drag = dragRef.current;
-        if (drag?.pointerId !== event.pointerId) return;
-        dragRef.current = null;
-        // A drag that moved is a pan, not a click.
-        if (drag.moved) return;
-        const image = event.currentTarget;
-        setZoom((current) => {
-          if (current.scale > 1) return IMAGE_ZOOM_IDENTITY;
-          const frame = zoomFrame(image, current);
-          const scale = clickZoomScale(image.naturalWidth, image.offsetWidth);
-          return zoomImageAt(current, scale, zoomAnchor(frame, event), frame);
-        });
-      }}
-      onPointerCancel={() => {
-        dragRef.current = null;
-      }}
     />
   );
 }
@@ -431,6 +216,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               alt={item.name}
               surfaceRef={surfaceRef}
               onError={() => setFailedImageSrc(item.src)}
+              onClose={onClose}
             />
           )}
           <div className="mt-2 flex max-w-[92vw] items-center justify-center gap-1.5 text-xs text-white/80">

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -135,8 +135,6 @@ function ZoomableImage({
   const zoomed = zoom.scale > 1;
   return (
     <img
-      // A new image starts unzoomed.
-      key={src}
       ref={imageRef}
       src={src}
       alt={alt}
@@ -333,6 +331,8 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
             </ExpandedMediaFailure>
           ) : (
             <ZoomableImage
+              // A new image starts unzoomed with its own wheel listener.
+              key={item.src}
               src={item.src}
               alt={item.name}
               onError={() => setFailedImageSrc(item.src)}

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -16,6 +16,15 @@ import {
 } from "./SnapShotAttachmentDetails";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
+import {
+  DOUBLE_CLICK_IMAGE_ZOOM,
+  IMAGE_ZOOM_IDENTITY,
+  type ImageZoomFrame,
+  type ImageZoomState,
+  panImage,
+  wheelZoomFactor,
+  zoomImageAt,
+} from "./imageZoom";
 
 interface ExpandedImageDialogProps {
   preview: ExpandedImagePreview;
@@ -54,6 +63,123 @@ function ExpandedVideo({ item }: { readonly item: ExpandedImageItem }) {
       videoClassName="aspect-auto max-h-[86vh] w-auto max-w-[92vw] rounded-lg border border-border/70 shadow-2xl"
       stateClassName={EXPANDED_MEDIA_STATE_CLASS_NAME}
       onRetry={asset ? refreshAssetUrl : undefined}
+    />
+  );
+}
+
+function zoomFrame(image: HTMLImageElement): ImageZoomFrame {
+  return {
+    width: image.offsetWidth,
+    height: image.offsetHeight,
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  };
+}
+
+/** Pointer position relative to the untransformed center of the image box. */
+function zoomAnchor(
+  image: HTMLImageElement,
+  zoom: ImageZoomState,
+  event: { clientX: number; clientY: number },
+) {
+  // The rect is already transformed. Undo the translate so the anchor is
+  // measured against the untransformed center, which the transform origin uses.
+  const rect = image.getBoundingClientRect();
+  return {
+    x: event.clientX - (rect.left + rect.width / 2 - zoom.x),
+    y: event.clientY - (rect.top + rect.height / 2 - zoom.y),
+  };
+}
+
+/**
+ * The screenshot with pinch, wheel and double-click zoom plus drag to pan.
+ * Only the transform changes while zooming, so Chromium keeps the work on the
+ * compositor and never repaints the bitmap.
+ */
+function ZoomableImage({
+  src,
+  alt,
+  onError,
+}: {
+  readonly src: string;
+  readonly alt: string;
+  readonly onError: () => void;
+}) {
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  const [zoom, setZoom] = useState<ImageZoomState>(IMAGE_ZOOM_IDENTITY);
+  // Mirrors `zoom` for the native wheel listener, which is registered once.
+  const zoomRef = useRef(zoom);
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
+  const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+
+  // Wheel must be non-passive to stop the page from scrolling or, in the
+  // desktop app, from zooming the whole window. React registers wheel as
+  // passive, so attach it by hand.
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image) return;
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      // macOS reports trackpad pinch as ctrl+wheel with small deltas. A plain
+      // wheel zooms too, since the dialog has nothing else to scroll.
+      const factor = wheelZoomFactor(event.ctrlKey ? event.deltaY * 3 : event.deltaY);
+      const anchor = zoomAnchor(image, zoomRef.current, event);
+      setZoom((current) => zoomImageAt(current, factor, anchor, zoomFrame(image)));
+    };
+    image.addEventListener("wheel", onWheel, { passive: false });
+    return () => image.removeEventListener("wheel", onWheel);
+  }, []);
+
+  const zoomed = zoom.scale > 1;
+  return (
+    <img
+      // A new image starts unzoomed.
+      key={src}
+      ref={imageRef}
+      src={src}
+      alt={alt}
+      className={`max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none ${
+        zoomed ? "cursor-grab touch-none active:cursor-grabbing" : "cursor-zoom-in"
+      }`}
+      style={{ transform: `translate(${zoom.x}px, ${zoom.y}px) scale(${zoom.scale})` }}
+      draggable={false}
+      onError={onError}
+      onPointerDown={(event) => {
+        if (!zoomed || event.button !== 0) return;
+        dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) return;
+        const dx = event.clientX - drag.x;
+        const dy = event.clientY - drag.y;
+        drag.x = event.clientX;
+        drag.y = event.clientY;
+        const frame = zoomFrame(event.currentTarget);
+        setZoom((current) => panImage(current, dx, dy, frame));
+      }}
+      onPointerUp={(event) => {
+        if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null;
+      }}
+      onPointerCancel={() => {
+        dragRef.current = null;
+      }}
+      onDoubleClick={(event) => {
+        const image = event.currentTarget;
+        setZoom((current) =>
+          current.scale > 1
+            ? IMAGE_ZOOM_IDENTITY
+            : zoomImageAt(
+                current,
+                DOUBLE_CLICK_IMAGE_ZOOM,
+                zoomAnchor(image, current, event),
+                zoomFrame(image),
+              ),
+        );
+      }}
     />
   );
 }
@@ -206,11 +332,9 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               {openOriginalLink}
             </ExpandedMediaFailure>
           ) : (
-            <img
+            <ZoomableImage
               src={item.src}
               alt={item.name}
-              className="max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none"
-              draggable={false}
               onError={() => setFailedImageSrc(item.src)}
             />
           )}

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -98,11 +98,15 @@ function zoomAnchor(frame: ImageZoomFrame, event: { clientX: number; clientY: nu
   };
 }
 
-/** Safari reports trackpad pinch as gesture events instead of ctrl+wheel. */
+/**
+ * Safari reports trackpad pinch as gesture events instead of ctrl+wheel.
+ * Apple documents `clientX` and `clientY` on them, but they are not in any
+ * standard, so callers must be ready for them to be missing.
+ */
 interface SafariGestureEvent extends UIEvent {
   readonly scale: number;
-  readonly clientX: number;
-  readonly clientY: number;
+  readonly clientX?: number;
+  readonly clientY?: number;
 }
 
 /**
@@ -160,6 +164,12 @@ function ZoomableImage({
       const dy = -event.deltaY * lineScale;
       setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
     };
+    // The last pointer position over the dialog, for gesture events that
+    // arrive without coordinates of their own.
+    let pointer = { clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 };
+    const onPointerMove = (event: PointerEvent) => {
+      pointer = { clientX: event.clientX, clientY: event.clientY };
+    };
     // Safari's `scale` is cumulative from the start of the gesture.
     let gestureStartScale = 1;
     const onGestureStart = (event: Event) => {
@@ -172,17 +182,23 @@ function ZoomableImage({
     const onGestureChange = (event: Event) => {
       event.preventDefault();
       const gesture = event as SafariGestureEvent;
+      const at =
+        Number.isFinite(gesture.clientX) && Number.isFinite(gesture.clientY)
+          ? { clientX: gesture.clientX as number, clientY: gesture.clientY as number }
+          : pointer;
       setZoom((current) => {
         const frame = zoomFrame(image, current);
         const factor = (gestureStartScale * gesture.scale) / current.scale;
-        return zoomImageAt(current, factor, zoomAnchor(frame, gesture), frame);
+        return zoomImageAt(current, factor, zoomAnchor(frame, at), frame);
       });
     };
     surface.addEventListener("wheel", onWheel, { passive: false });
+    surface.addEventListener("pointermove", onPointerMove, { passive: true });
     surface.addEventListener("gesturestart", onGestureStart, { passive: false });
     surface.addEventListener("gesturechange", onGestureChange, { passive: false });
     return () => {
       surface.removeEventListener("wheel", onWheel);
+      surface.removeEventListener("pointermove", onPointerMove);
       surface.removeEventListener("gesturestart", onGestureStart);
       surface.removeEventListener("gesturechange", onGestureChange);
     };

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -117,8 +117,11 @@ function ZoomableImage({
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
       // macOS reports trackpad pinch as ctrl+wheel with small deltas. A plain
-      // wheel zooms too, since the dialog has nothing else to scroll.
-      const factor = wheelZoomFactor(event.ctrlKey ? event.deltaY * 3 : event.deltaY);
+      // wheel zooms too, since the dialog has nothing else to scroll. Firefox
+      // reports mouse wheels in lines, not pixels, so scale those up first.
+      const deltaY =
+        event.deltaMode === WheelEvent.DOM_DELTA_LINE ? event.deltaY * 16 : event.deltaY;
+      const factor = wheelZoomFactor(event.ctrlKey ? deltaY * 3 : deltaY);
       setZoom((current) => {
         const frame = zoomFrame(image, current);
         return zoomImageAt(current, factor, zoomAnchor(frame, event), frame);

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { createPortal } from "react-dom";
 import { ChevronLeftIcon, ChevronRightIcon, ImageIcon, TextIcon, XIcon } from "lucide-react";
 import { Button } from "../ui/button";
@@ -18,7 +26,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
 import {
   clampImagePan,
-  DOUBLE_CLICK_IMAGE_ZOOM,
+  clickZoomScale,
   IMAGE_ZOOM_IDENTITY,
   type ImageZoomFrame,
   type ImageZoomState,
@@ -90,46 +98,88 @@ function zoomAnchor(frame: ImageZoomFrame, event: { clientX: number; clientY: nu
   };
 }
 
+/** Safari reports trackpad pinch as gesture events instead of ctrl+wheel. */
+interface SafariGestureEvent extends UIEvent {
+  readonly scale: number;
+  readonly clientX: number;
+  readonly clientY: number;
+}
+
 /**
- * The screenshot with pinch, wheel and double-click zoom plus drag to pan.
- * Only the transform changes while zooming, so Chromium keeps the work on the
+ * The screenshot with the zoom model of a native image viewer: pinch or
+ * ctrl+wheel zooms around the pointer, two-finger scroll or drag pans, and a
+ * click toggles between fitted and actual size. Gestures are read from the
+ * whole dialog so the pointer does not have to sit on the image. Only the
+ * transform changes while zooming, so Chromium keeps the work on the
  * compositor and never repaints the bitmap.
  */
 function ZoomableImage({
   src,
   alt,
+  surfaceRef,
   onError,
 }: {
   readonly src: string;
   readonly alt: string;
+  /** The dialog element that receives pinch and wheel gestures. */
+  readonly surfaceRef: RefObject<HTMLElement | null>;
   readonly onError: () => void;
 }) {
   const imageRef = useRef<HTMLImageElement | null>(null);
   const [zoom, setZoom] = useState<ImageZoomState>(IMAGE_ZOOM_IDENTITY);
-  const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
+  const dragRef = useRef<{ pointerId: number; x: number; y: number; moved: boolean } | null>(null);
 
-  // Wheel must be non-passive to stop the page from scrolling or, in the
-  // desktop app, from zooming the whole window. React registers wheel as
-  // passive, so attach it by hand.
+  // Wheel and gesture listeners must be non-passive to stop the page from
+  // scrolling and the browser from zooming the whole window. React registers
+  // wheel as passive, so attach them by hand.
   useEffect(() => {
+    const surface = surfaceRef.current;
     const image = imageRef.current;
-    if (!image) return;
+    if (!surface || !image) return;
     const onWheel = (event: WheelEvent) => {
       event.preventDefault();
-      // macOS reports trackpad pinch as ctrl+wheel with small deltas. A plain
-      // wheel zooms too, since the dialog has nothing else to scroll. Firefox
-      // reports mouse wheels in lines, not pixels, so scale those up first.
-      const deltaY =
-        event.deltaMode === WheelEvent.DOM_DELTA_LINE ? event.deltaY * 16 : event.deltaY;
-      const factor = wheelZoomFactor(event.ctrlKey ? deltaY * 3 : deltaY);
+      const lineScale = event.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : 1;
+      if (event.ctrlKey) {
+        // Chromium and Firefox report a trackpad pinch as ctrl+wheel.
+        const factor = wheelZoomFactor(event.deltaY * lineScale);
+        setZoom((current) => {
+          const frame = zoomFrame(image, current);
+          return zoomImageAt(current, factor, zoomAnchor(frame, event), frame);
+        });
+        return;
+      }
+      // A plain two-finger scroll pans the zoomed image, like a native viewer.
+      const dx = -event.deltaX * lineScale;
+      const dy = -event.deltaY * lineScale;
+      setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
+    };
+    // Safari's `scale` is cumulative from the start of the gesture.
+    let gestureStartScale = 1;
+    const onGestureStart = (event: Event) => {
+      event.preventDefault();
       setZoom((current) => {
-        const frame = zoomFrame(image, current);
-        return zoomImageAt(current, factor, zoomAnchor(frame, event), frame);
+        gestureStartScale = current.scale;
+        return current;
       });
     };
-    image.addEventListener("wheel", onWheel, { passive: false });
-    return () => image.removeEventListener("wheel", onWheel);
-  }, []);
+    const onGestureChange = (event: Event) => {
+      event.preventDefault();
+      const gesture = event as SafariGestureEvent;
+      setZoom((current) => {
+        const frame = zoomFrame(image, current);
+        const factor = (gestureStartScale * gesture.scale) / current.scale;
+        return zoomImageAt(current, factor, zoomAnchor(frame, gesture), frame);
+      });
+    };
+    surface.addEventListener("wheel", onWheel, { passive: false });
+    surface.addEventListener("gesturestart", onGestureStart, { passive: false });
+    surface.addEventListener("gesturechange", onGestureChange, { passive: false });
+    return () => {
+      surface.removeEventListener("wheel", onWheel);
+      surface.removeEventListener("gesturestart", onGestureStart);
+      surface.removeEventListener("gesturechange", onGestureChange);
+    };
+  }, [surfaceRef]);
 
   // A resize changes the pan bounds. Reclamp so a grown window does not leave
   // the image offset with backdrop showing at one edge.
@@ -147,16 +197,21 @@ function ZoomableImage({
       ref={imageRef}
       src={src}
       alt={alt}
-      className={`max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none ${
-        zoomed ? "cursor-grab touch-none active:cursor-grabbing" : "cursor-zoom-in"
+      className={`max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] touch-none select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none ${
+        zoomed ? "cursor-grab active:cursor-grabbing" : "cursor-zoom-in"
       }`}
       style={{ transform: `translate(${zoom.x}px, ${zoom.y}px) scale(${zoom.scale})` }}
       draggable={false}
       onError={onError}
       onPointerDown={(event) => {
-        if (!zoomed || event.button !== 0) return;
-        dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY };
-        event.currentTarget.setPointerCapture(event.pointerId);
+        if (event.button !== 0) return;
+        dragRef.current = {
+          pointerId: event.pointerId,
+          x: event.clientX,
+          y: event.clientY,
+          moved: false,
+        };
+        if (zoomed) event.currentTarget.setPointerCapture(event.pointerId);
       }}
       onPointerMove={(event) => {
         const drag = dragRef.current;
@@ -165,22 +220,27 @@ function ZoomableImage({
         const dy = event.clientY - drag.y;
         drag.x = event.clientX;
         drag.y = event.clientY;
+        if (dx !== 0 || dy !== 0) drag.moved = true;
+        if (!zoomed) return;
         const image = event.currentTarget;
         setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
       }}
       onPointerUp={(event) => {
-        if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null;
-      }}
-      onPointerCancel={() => {
+        const drag = dragRef.current;
+        if (drag?.pointerId !== event.pointerId) return;
         dragRef.current = null;
-      }}
-      onDoubleClick={(event) => {
+        // A drag that moved is a pan, not a click.
+        if (drag.moved && zoomed) return;
         const image = event.currentTarget;
         setZoom((current) => {
           if (current.scale > 1) return IMAGE_ZOOM_IDENTITY;
           const frame = zoomFrame(image, current);
-          return zoomImageAt(current, DOUBLE_CLICK_IMAGE_ZOOM, zoomAnchor(frame, event), frame);
+          const scale = clickZoomScale(image.naturalWidth, image.offsetWidth);
+          return zoomImageAt(current, scale, zoomAnchor(frame, event), frame);
         });
+      }}
+      onPointerCancel={() => {
+        dragRef.current = null;
       }}
     />
   );
@@ -190,6 +250,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   preview,
   onClose,
 }: ExpandedImageDialogProps) {
+  const surfaceRef = useRef<HTMLDivElement | null>(null);
   const [imageOffset, setImageOffset] = useState(0);
   const [failedImageSrc, setFailedImageSrc] = useState<string | null>(null);
   const [accessibilityDetailsSrc, setAccessibilityDetailsSrc] = useState<string | null>(null);
@@ -280,6 +341,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   return createPortal(
     <div
       {...composerFloatingLayerProps}
+      ref={surfaceRef}
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 px-4 py-6 [-webkit-app-region:no-drag]"
       role="dialog"
       aria-modal="true"
@@ -339,6 +401,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               key={item.src}
               src={item.src}
               alt={item.name}
+              surfaceRef={surfaceRef}
               onError={() => setFailedImageSrc(item.src)}
             />
           )}

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
 import {
+  clampImagePan,
   DOUBLE_CLICK_IMAGE_ZOOM,
   IMAGE_ZOOM_IDENTITY,
   type ImageZoomFrame,
@@ -67,27 +68,25 @@ function ExpandedVideo({ item }: { readonly item: ExpandedImageItem }) {
   );
 }
 
-function zoomFrame(image: HTMLImageElement): ImageZoomFrame {
+function zoomFrame(image: HTMLImageElement, zoom: ImageZoomState): ImageZoomFrame {
+  // The rect is already transformed. Scaling around the center leaves the
+  // center put, so subtracting the translate gives the untransformed center.
+  const rect = image.getBoundingClientRect();
   return {
     width: image.offsetWidth,
     height: image.offsetHeight,
     viewportWidth: window.innerWidth,
     viewportHeight: window.innerHeight,
+    centerX: rect.left + rect.width / 2 - zoom.x - window.innerWidth / 2,
+    centerY: rect.top + rect.height / 2 - zoom.y - window.innerHeight / 2,
   };
 }
 
 /** Pointer position relative to the untransformed center of the image box. */
-function zoomAnchor(
-  image: HTMLImageElement,
-  zoom: ImageZoomState,
-  event: { clientX: number; clientY: number },
-) {
-  // The rect is already transformed. Undo the translate so the anchor is
-  // measured against the untransformed center, which the transform origin uses.
-  const rect = image.getBoundingClientRect();
+function zoomAnchor(frame: ImageZoomFrame, event: { clientX: number; clientY: number }) {
   return {
-    x: event.clientX - (rect.left + rect.width / 2 - zoom.x),
-    y: event.clientY - (rect.top + rect.height / 2 - zoom.y),
+    x: event.clientX - frame.viewportWidth / 2 - frame.centerX,
+    y: event.clientY - frame.viewportHeight / 2 - frame.centerY,
   };
 }
 
@@ -107,11 +106,6 @@ function ZoomableImage({
 }) {
   const imageRef = useRef<HTMLImageElement | null>(null);
   const [zoom, setZoom] = useState<ImageZoomState>(IMAGE_ZOOM_IDENTITY);
-  // Mirrors `zoom` for the native wheel listener, which is registered once.
-  const zoomRef = useRef(zoom);
-  useEffect(() => {
-    zoomRef.current = zoom;
-  }, [zoom]);
   const dragRef = useRef<{ pointerId: number; x: number; y: number } | null>(null);
 
   // Wheel must be non-passive to stop the page from scrolling or, in the
@@ -125,11 +119,23 @@ function ZoomableImage({
       // macOS reports trackpad pinch as ctrl+wheel with small deltas. A plain
       // wheel zooms too, since the dialog has nothing else to scroll.
       const factor = wheelZoomFactor(event.ctrlKey ? event.deltaY * 3 : event.deltaY);
-      const anchor = zoomAnchor(image, zoomRef.current, event);
-      setZoom((current) => zoomImageAt(current, factor, anchor, zoomFrame(image)));
+      setZoom((current) => {
+        const frame = zoomFrame(image, current);
+        return zoomImageAt(current, factor, zoomAnchor(frame, event), frame);
+      });
     };
     image.addEventListener("wheel", onWheel, { passive: false });
     return () => image.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // A resize changes the pan bounds. Reclamp so a grown window does not leave
+  // the image offset with backdrop showing at one edge.
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image) return;
+    const onResize = () => setZoom((current) => clampImagePan(current, zoomFrame(image, current)));
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
   }, []);
 
   const zoomed = zoom.scale > 1;
@@ -156,8 +162,8 @@ function ZoomableImage({
         const dy = event.clientY - drag.y;
         drag.x = event.clientX;
         drag.y = event.clientY;
-        const frame = zoomFrame(event.currentTarget);
-        setZoom((current) => panImage(current, dx, dy, frame));
+        const image = event.currentTarget;
+        setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
       }}
       onPointerUp={(event) => {
         if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null;
@@ -167,16 +173,11 @@ function ZoomableImage({
       }}
       onDoubleClick={(event) => {
         const image = event.currentTarget;
-        setZoom((current) =>
-          current.scale > 1
-            ? IMAGE_ZOOM_IDENTITY
-            : zoomImageAt(
-                current,
-                DOUBLE_CLICK_IMAGE_ZOOM,
-                zoomAnchor(image, current, event),
-                zoomFrame(image),
-              ),
-        );
+        setZoom((current) => {
+          if (current.scale > 1) return IMAGE_ZOOM_IDENTITY;
+          const frame = zoomFrame(image, current);
+          return zoomImageAt(current, DOUBLE_CLICK_IMAGE_ZOOM, zoomAnchor(frame, event), frame);
+        });
       }}
     />
   );

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -127,7 +127,14 @@ function ZoomableImage({
 }) {
   const imageRef = useRef<HTMLImageElement | null>(null);
   const [zoom, setZoom] = useState<ImageZoomState>(IMAGE_ZOOM_IDENTITY);
-  const dragRef = useRef<{ pointerId: number; x: number; y: number; moved: boolean } | null>(null);
+  const dragRef = useRef<{
+    pointerId: number;
+    x: number;
+    y: number;
+    startX: number;
+    startY: number;
+    moved: boolean;
+  } | null>(null);
 
   // Wheel and gesture listeners must be non-passive to stop the page from
   // scrolling and the browser from zooming the whole window. React registers
@@ -209,6 +216,8 @@ function ZoomableImage({
           pointerId: event.pointerId,
           x: event.clientX,
           y: event.clientY,
+          startX: event.clientX,
+          startY: event.clientY,
           moved: false,
         };
         if (zoomed) event.currentTarget.setPointerCapture(event.pointerId);
@@ -220,7 +229,10 @@ function ZoomableImage({
         const dy = event.clientY - drag.y;
         drag.x = event.clientX;
         drag.y = event.clientY;
-        if (dx !== 0 || dy !== 0) drag.moved = true;
+        // A few pixels of jitter during a click still count as a click.
+        if (Math.abs(event.clientX - drag.startX) + Math.abs(event.clientY - drag.startY) > 4) {
+          drag.moved = true;
+        }
         if (!zoomed) return;
         const image = event.currentTarget;
         setZoom((current) => panImage(current, dx, dy, zoomFrame(image, current)));
@@ -230,7 +242,7 @@ function ZoomableImage({
         if (drag?.pointerId !== event.pointerId) return;
         dragRef.current = null;
         // A drag that moved is a pan, not a click.
-        if (drag.moved && zoomed) return;
+        if (drag.moved) return;
         const image = event.currentTarget;
         setZoom((current) => {
           if (current.scale > 1) return IMAGE_ZOOM_IDENTITY;

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+import {
+  clickZoomScale,
+  IMAGE_ZOOM_IDENTITY,
+  imageZoomLayout,
+  resizeImageZoom,
+  type ImageZoomFrame,
+  type ImageZoomState,
+  wheelZoomFactor,
+  zoomImageAt,
+} from "./imageZoom";
+
+/**
+ * The browser owns scrolling, including trackpad momentum and diagonal pans.
+ * Pinch changes the image transform and scroll bounds without a React render.
+ */
+export function ZoomableImage({
+  src,
+  alt,
+  surfaceRef,
+  onError,
+  onClose,
+}: {
+  readonly src: string;
+  readonly alt: string;
+  readonly surfaceRef: RefObject<HTMLElement | null>;
+  readonly onError: () => void;
+  readonly onClose: () => void;
+}) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    const surface = surfaceRef.current;
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+    const image = imageRef.current;
+    if (!surface || !viewport || !content || !image) return;
+
+    let scale = 1;
+    let frame: ImageZoomFrame | undefined;
+    let pointer = { x: 0, y: 0 };
+    let gestureScale = 1;
+    let drag: {
+      pointerId: number;
+      x: number;
+      y: number;
+      startX: number;
+      startY: number;
+      moved: boolean;
+    } | null = null;
+
+    const currentState = (): ImageZoomState => ({
+      scale,
+      scrollLeft: viewport.scrollLeft,
+      scrollTop: viewport.scrollTop,
+    });
+
+    const renderZoom = (state: ImageZoomState) => {
+      if (!frame) return;
+      const layout = imageZoomLayout(frame, state.scale);
+      scale = state.scale;
+      content.style.width = `${layout.contentWidth}px`;
+      content.style.height = `${layout.contentHeight}px`;
+      image.style.width = `${frame.width}px`;
+      image.style.height = `${frame.height}px`;
+      image.style.transform = `translate(${layout.left}px, ${layout.top}px) scale(${scale})`;
+      image.style.cursor = scale > 1 ? "grab" : "zoom-in";
+      image.style.visibility = "visible";
+      viewport.scrollTo({ left: state.scrollLeft, top: state.scrollTop, behavior: "instant" });
+    };
+
+    const resize = () => {
+      if (!image.naturalWidth || !image.naturalHeight) return;
+      const viewportWidth = viewport.clientWidth;
+      const viewportHeight = viewport.clientHeight;
+      if (!viewportWidth || !viewportHeight) return;
+      const fit = Math.min(
+        1,
+        viewportWidth / image.naturalWidth,
+        viewportHeight / image.naturalHeight,
+      );
+      const nextFrame = {
+        width: image.naturalWidth * fit,
+        height: image.naturalHeight * fit,
+        viewportWidth,
+        viewportHeight,
+      };
+      const state = frame ? resizeImageZoom(currentState(), frame, nextFrame) : IMAGE_ZOOM_IDENTITY;
+      frame = nextFrame;
+      renderZoom(state);
+    };
+
+    const anchorAt = (event: { clientX: number; clientY: number }) => {
+      const rect = viewport.getBoundingClientRect();
+      return { x: event.clientX - rect.left, y: event.clientY - rect.top };
+    };
+    const zoomAt = (factor: number, anchor: { x: number; y: number }) => {
+      if (!frame) return;
+      const state = currentState();
+      const next = zoomImageAt(state, factor, anchor, frame);
+      if (next !== state) renderZoom(next);
+    };
+    const onWheel = (event: WheelEvent) => {
+      // Leave ordinary wheel events to the scroll area. Canceling them loses
+      // the browser's scroll handling and routes every pan through JavaScript.
+      if (!event.ctrlKey) return;
+      event.preventDefault();
+      const unit = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? viewport.clientHeight : 1;
+      zoomAt(wheelZoomFactor(event.deltaY * unit), anchorAt(event));
+    };
+    const onPointerMove = (event: PointerEvent) => {
+      pointer = anchorAt(event);
+    };
+    const onGestureStart = (event: Event) => {
+      event.preventDefault();
+      gestureScale = 1;
+    };
+    const onGestureChange = (event: Event) => {
+      event.preventDefault();
+      if (!("scale" in event) || typeof event.scale !== "number" || !(event.scale > 0)) return;
+      const anchor =
+        "clientX" in event &&
+        typeof event.clientX === "number" &&
+        Number.isFinite(event.clientX) &&
+        "clientY" in event &&
+        typeof event.clientY === "number" &&
+        Number.isFinite(event.clientY)
+          ? anchorAt({ clientX: event.clientX, clientY: event.clientY })
+          : pointer;
+      zoomAt(event.scale / gestureScale, anchor);
+      // Use consecutive samples so reversing a pinch responds immediately,
+      // even after the gesture has passed the minimum or maximum zoom.
+      gestureScale = event.scale;
+    };
+    const onGestureEnd = (event: Event) => event.preventDefault();
+
+    const clearDrag = () => {
+      drag = null;
+      image.style.cursor = scale > 1 ? "grab" : "zoom-in";
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.button !== 0 || event.pointerType === "touch") return;
+      drag = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false,
+      };
+      image.setPointerCapture(event.pointerId);
+      if (scale > 1) image.style.cursor = "grabbing";
+    };
+    const onDrag = (event: PointerEvent) => {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      if (!(event.buttons & 1)) {
+        clearDrag();
+        return;
+      }
+      if (Math.hypot(event.clientX - drag.startX, event.clientY - drag.startY) > 4)
+        drag.moved = true;
+      if (!drag.moved) return;
+      viewport.scrollBy({
+        left: drag.x - event.clientX,
+        top: drag.y - event.clientY,
+        behavior: "instant",
+      });
+      drag.x = event.clientX;
+      drag.y = event.clientY;
+    };
+    const onPointerUp = (event: PointerEvent) => {
+      if (!drag || drag.pointerId !== event.pointerId) return;
+      const wasClick = !drag.moved;
+      clearDrag();
+      if (!wasClick || !frame) return;
+      if (scale > 1) renderZoom(IMAGE_ZOOM_IDENTITY);
+      else zoomAt(clickZoomScale(image.naturalWidth, frame.width), anchorAt(event));
+    };
+
+    const observer = new ResizeObserver(resize);
+    observer.observe(viewport);
+    image.addEventListener("load", resize);
+    resize();
+    pointer = { x: viewport.clientWidth / 2, y: viewport.clientHeight / 2 };
+    surface.addEventListener("wheel", onWheel, { passive: false });
+    surface.addEventListener("pointermove", onPointerMove, { passive: true });
+    surface.addEventListener("gesturestart", onGestureStart, { passive: false });
+    surface.addEventListener("gesturechange", onGestureChange, { passive: false });
+    surface.addEventListener("gestureend", onGestureEnd, { passive: false });
+    image.addEventListener("pointerdown", onPointerDown);
+    image.addEventListener("pointermove", onDrag);
+    image.addEventListener("pointerup", onPointerUp);
+    image.addEventListener("pointercancel", clearDrag);
+    image.addEventListener("lostpointercapture", clearDrag);
+    window.addEventListener("blur", clearDrag);
+    return () => {
+      observer.disconnect();
+      image.removeEventListener("load", resize);
+      surface.removeEventListener("wheel", onWheel);
+      surface.removeEventListener("pointermove", onPointerMove);
+      surface.removeEventListener("gesturestart", onGestureStart);
+      surface.removeEventListener("gesturechange", onGestureChange);
+      surface.removeEventListener("gestureend", onGestureEnd);
+      image.removeEventListener("pointerdown", onPointerDown);
+      image.removeEventListener("pointermove", onDrag);
+      image.removeEventListener("pointerup", onPointerUp);
+      image.removeEventListener("pointercancel", clearDrag);
+      image.removeEventListener("lostpointercapture", clearDrag);
+      window.removeEventListener("blur", clearDrag);
+    };
+  }, [surfaceRef]);
+
+  return (
+    <div
+      ref={viewportRef}
+      className="h-[86vh] w-[92vw] overflow-auto overscroll-contain [overflow-anchor:none] [scrollbar-width:none]"
+      onClick={(event) => {
+        if (event.target === viewportRef.current || event.target === contentRef.current) onClose();
+      }}
+    >
+      <div ref={contentRef} className="relative">
+        <img
+          ref={imageRef}
+          src={src}
+          alt={alt}
+          className="invisible absolute left-0 top-0 max-w-none origin-top-left select-none rounded-lg border border-border/70 bg-background shadow-2xl"
+          draggable={false}
+          onError={onError}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/imageZoom.test.ts
+++ b/apps/web/src/components/chat/imageZoom.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   clampImagePan,
+  clickZoomScale,
   IMAGE_ZOOM_IDENTITY,
   MAX_IMAGE_ZOOM,
   panImage,
@@ -89,9 +90,25 @@ describe("panImage", () => {
 });
 
 describe("wheelZoomFactor", () => {
-  it("zooms in on negative deltas and caps a mouse notch", () => {
-    expect(wheelZoomFactor(-5)).toBeGreaterThan(1);
-    expect(wheelZoomFactor(5)).toBeLessThan(1);
-    expect(wheelZoomFactor(-100)).toBe(wheelZoomFactor(-50));
+  it("matches the native pinch rate for small deltas", () => {
+    // Chromium encodes a 5% pinch as deltaY -5.
+    expect(wheelZoomFactor(-5)).toBeCloseTo(1.05, 2);
+    expect(wheelZoomFactor(5)).toBeCloseTo(0.95, 2);
+  });
+
+  it("caps a mouse wheel notch", () => {
+    expect(wheelZoomFactor(-100)).toBe(wheelZoomFactor(-25));
+  });
+});
+
+describe("clickZoomScale", () => {
+  it("zooms to the actual pixel size of a large image", () => {
+    expect(clickZoomScale(3000, 1000)).toBe(3);
+  });
+
+  it("zooms to 2x when the image already shows near its actual size", () => {
+    expect(clickZoomScale(1000, 1000)).toBe(2);
+    expect(clickZoomScale(1500, 1000)).toBe(2);
+    expect(clickZoomScale(0, 1000)).toBe(2);
   });
 });

--- a/apps/web/src/components/chat/imageZoom.test.ts
+++ b/apps/web/src/components/chat/imageZoom.test.ts
@@ -9,7 +9,14 @@ import {
   zoomImageAt,
 } from "./imageZoom";
 
-const frame = { width: 400, height: 300, viewportWidth: 1000, viewportHeight: 800 };
+const frame = {
+  width: 400,
+  height: 300,
+  viewportWidth: 1000,
+  viewportHeight: 800,
+  centerX: 0,
+  centerY: 0,
+};
 
 describe("zoomImageAt", () => {
   it("keeps the anchored point fixed on screen", () => {
@@ -56,6 +63,14 @@ describe("clampImagePan", () => {
       x: 300,
       y: -200,
     });
+  });
+
+  it("shifts the bounds by the image center offset so the viewport stays covered", () => {
+    // The caption sits the image 12px above the viewport center. Dragging down
+    // must stop 12px earlier and dragging up may go 12px further.
+    const offset = { ...frame, centerY: -12 };
+    expect(clampImagePan({ scale: 4, x: 0, y: 900 }, offset).y).toBe(212);
+    expect(clampImagePan({ scale: 4, x: 0, y: -900 }, offset).y).toBe(-188);
   });
 });
 

--- a/apps/web/src/components/chat/imageZoom.test.ts
+++ b/apps/web/src/components/chat/imageZoom.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  clampImagePan,
+  IMAGE_ZOOM_IDENTITY,
+  MAX_IMAGE_ZOOM,
+  panImage,
+  wheelZoomFactor,
+  zoomImageAt,
+} from "./imageZoom";
+
+const frame = { width: 400, height: 300, viewportWidth: 1000, viewportHeight: 800 };
+
+describe("zoomImageAt", () => {
+  it("keeps the anchored point fixed on screen", () => {
+    const anchor = { x: 100, y: -50 };
+    // 4x overflows the viewport on both axes, so the clamp leaves room to
+    // keep the anchor fixed. The image point under the anchor before the zoom
+    // is `anchor` itself, and after the zoom it renders at x + scale * anchor.
+    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 4, anchor, frame);
+    expect(zoomed.scale).toBe(4);
+    expect(zoomed.x + zoomed.scale * anchor.x).toBeCloseTo(anchor.x);
+    expect(zoomed.y + zoomed.scale * anchor.y).toBeCloseTo(anchor.y);
+  });
+
+  it("recenters when the zoomed image still fits the viewport", () => {
+    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 2, { x: 100, y: 100 }, frame)).toEqual({
+      scale: 2,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it("clamps the scale and returns the same state when nothing changes", () => {
+    const max = zoomImageAt(IMAGE_ZOOM_IDENTITY, 100, { x: 0, y: 0 }, frame);
+    expect(max.scale).toBe(MAX_IMAGE_ZOOM);
+    expect(zoomImageAt(max, 2, { x: 0, y: 0 }, frame)).toBe(max);
+    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 0.5, { x: 0, y: 0 }, frame)).toBe(IMAGE_ZOOM_IDENTITY);
+  });
+
+  it("recenters when zooming back out to 1x", () => {
+    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 4, { x: 150, y: 100 }, frame);
+    expect(zoomImageAt(zoomed, 0.25, { x: 0, y: 0 }, frame)).toEqual(IMAGE_ZOOM_IDENTITY);
+  });
+});
+
+describe("clampImagePan", () => {
+  it("centers an axis where the image still fits the viewport", () => {
+    expect(clampImagePan({ scale: 2, x: 300, y: 200 }, frame)).toEqual({ scale: 2, x: 0, y: 0 });
+  });
+
+  it("stops the far edge at the viewport edge once the image overflows", () => {
+    // 400 * 4 = 1600 wide in a 1000 viewport leaves 300 of slack per side.
+    expect(clampImagePan({ scale: 4, x: 900, y: -900 }, frame)).toEqual({
+      scale: 4,
+      x: 300,
+      y: -200,
+    });
+  });
+});
+
+describe("panImage", () => {
+  it("ignores pans at 1x", () => {
+    expect(panImage(IMAGE_ZOOM_IDENTITY, 40, 40, frame)).toBe(IMAGE_ZOOM_IDENTITY);
+  });
+
+  it("moves a zoomed image within the clamp", () => {
+    expect(panImage({ scale: 4, x: 0, y: 0 }, -100, 50, frame)).toEqual({
+      scale: 4,
+      x: -100,
+      y: 50,
+    });
+  });
+});
+
+describe("wheelZoomFactor", () => {
+  it("zooms in on negative deltas and caps a mouse notch", () => {
+    expect(wheelZoomFactor(-5)).toBeGreaterThan(1);
+    expect(wheelZoomFactor(5)).toBeLessThan(1);
+    expect(wheelZoomFactor(-100)).toBe(wheelZoomFactor(-50));
+  });
+});

--- a/apps/web/src/components/chat/imageZoom.test.ts
+++ b/apps/web/src/components/chat/imageZoom.test.ts
@@ -1,114 +1,124 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  clampImagePan,
   clickZoomScale,
   IMAGE_ZOOM_IDENTITY,
+  imageZoomLayout,
   MAX_IMAGE_ZOOM,
-  panImage,
+  resizeImageZoom,
   wheelZoomFactor,
   zoomImageAt,
 } from "./imageZoom";
 
-const frame = {
-  width: 400,
-  height: 300,
-  viewportWidth: 1000,
-  viewportHeight: 800,
-  centerX: 0,
-  centerY: 0,
-};
+const frame = { width: 1000, height: 600, viewportWidth: 1000, viewportHeight: 800 };
+
+function imagePoint(
+  state: typeof IMAGE_ZOOM_IDENTITY,
+  anchor: { x: number; y: number },
+  imageFrame = frame,
+) {
+  const layout = imageZoomLayout(imageFrame, state.scale);
+  return {
+    x: (state.scrollLeft + anchor.x - layout.left) / layout.width,
+    y: (state.scrollTop + anchor.y - layout.top) / layout.height,
+  };
+}
 
 describe("zoomImageAt", () => {
-  it("keeps the anchored point fixed on screen", () => {
-    const anchor = { x: 100, y: -50 };
-    // 4x overflows the viewport on both axes, so the clamp leaves room to
-    // keep the anchor fixed. The image point under the anchor before the zoom
-    // is `anchor` itself, and after the zoom it renders at x + scale * anchor.
-    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 4, anchor, frame);
-    expect(zoomed.scale).toBe(4);
-    expect(zoomed.x + zoomed.scale * anchor.x).toBeCloseTo(anchor.x);
-    expect(zoomed.y + zoomed.scale * anchor.y).toBeCloseTo(anchor.y);
+  it("keeps the image point under the pointer when the centered image starts overflowing", () => {
+    const anchor = { x: 600, y: 300 };
+    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 2, anchor, frame);
+    expect(zoomed).toEqual({ scale: 2, scrollLeft: 600, scrollTop: 100 });
+    expect(imagePoint(zoomed, anchor)).toEqual(imagePoint(IMAGE_ZOOM_IDENTITY, anchor));
   });
 
-  it("recenters when the zoomed image still fits the viewport", () => {
-    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 2, { x: 100, y: 100 }, frame)).toEqual({
+  it("anchors a pinch to the browser's latest diagonal scroll position", () => {
+    const scrolled = { scale: 3, scrollLeft: 940, scrollTop: 370 };
+    const anchor = { x: 230, y: 510 };
+    const zoomed = zoomImageAt(scrolled, 1.2, anchor, frame);
+    const before = imagePoint(scrolled, anchor);
+    const after = imagePoint(zoomed, anchor);
+    expect(after.x).toBeCloseTo(before.x);
+    expect(after.y).toBeCloseTo(before.y);
+  });
+
+  it("centers an image that still fits on one axis", () => {
+    const narrow = { ...frame, width: 200, height: 600 };
+    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 2, { x: 500, y: 400 }, narrow);
+    expect(zoomed).toEqual({ scale: 2, scrollLeft: 0, scrollTop: 200 });
+    expect(imageZoomLayout(narrow, 2).left).toBe(300);
+  });
+
+  it("clamps scroll offsets to the resized content at both edges", () => {
+    const atEnd = { scale: 4, scrollLeft: 3000, scrollTop: 1600 };
+    const zoomed = zoomImageAt(atEnd, 0.5, { x: 0, y: 0 }, frame);
+    expect(zoomed).toEqual({ scale: 2, scrollLeft: 1000, scrollTop: 400 });
+    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 2, { x: -50, y: -50 }, frame)).toEqual({
       scale: 2,
-      x: 0,
-      y: 0,
+      scrollLeft: 0,
+      scrollTop: 0,
     });
   });
 
-  it("clamps the scale and returns the same state when nothing changes", () => {
-    const max = zoomImageAt(IMAGE_ZOOM_IDENTITY, 100, { x: 0, y: 0 }, frame);
+  it("returns to fitted size without a residual scroll offset", () => {
+    expect(
+      zoomImageAt({ scale: 4, scrollLeft: 1000, scrollTop: 600 }, 0.1, { x: 300, y: 400 }, frame),
+    ).toEqual(IMAGE_ZOOM_IDENTITY);
+  });
+
+  it("limits zoom and allows the next reverse sample to move away from the limit", () => {
+    const anchor = { x: 500, y: 400 };
+    const max = zoomImageAt(IMAGE_ZOOM_IDENTITY, 100, anchor, frame);
     expect(max.scale).toBe(MAX_IMAGE_ZOOM);
-    expect(zoomImageAt(max, 2, { x: 0, y: 0 }, frame)).toBe(max);
-    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 0.5, { x: 0, y: 0 }, frame)).toBe(IMAGE_ZOOM_IDENTITY);
-  });
-
-  it("recenters when zooming back out to 1x", () => {
-    const zoomed = zoomImageAt(IMAGE_ZOOM_IDENTITY, 4, { x: 150, y: 100 }, frame);
-    expect(zoomImageAt(zoomed, 0.25, { x: 0, y: 0 }, frame)).toEqual(IMAGE_ZOOM_IDENTITY);
+    expect(zoomImageAt(max, 2, anchor, frame)).toBe(max);
+    expect(zoomImageAt(max, 0.9, anchor, frame).scale).toBeCloseTo(7.2);
+    expect(zoomImageAt(IMAGE_ZOOM_IDENTITY, 0.5, anchor, frame)).toBe(IMAGE_ZOOM_IDENTITY);
   });
 });
 
-describe("clampImagePan", () => {
-  it("centers an axis where the image still fits the viewport", () => {
-    expect(clampImagePan({ scale: 2, x: 300, y: 200 }, frame)).toEqual({ scale: 2, x: 0, y: 0 });
+describe("resizeImageZoom", () => {
+  it("keeps the same image point at the center of a resized viewport", () => {
+    const state = { scale: 3, scrollLeft: 940, scrollTop: 370 };
+    const resizedFrame = { width: 800, height: 480, viewportWidth: 800, viewportHeight: 600 };
+    const resized = resizeImageZoom(state, frame, resizedFrame);
+    const before = imagePoint(state, { x: 500, y: 400 });
+    const after = imagePoint(resized, { x: 400, y: 300 }, resizedFrame);
+    expect(resized.scale).toBe(3);
+    expect(after.x).toBeCloseTo(before.x);
+    expect(after.y).toBeCloseTo(before.y);
   });
 
-  it("stops the far edge at the viewport edge once the image overflows", () => {
-    // 400 * 4 = 1600 wide in a 1000 viewport leaves 300 of slack per side.
-    expect(clampImagePan({ scale: 4, x: 900, y: -900 }, frame)).toEqual({
-      scale: 4,
-      x: 300,
-      y: -200,
-    });
-  });
-
-  it("shifts the bounds by the image center offset so the viewport stays covered", () => {
-    // The caption sits the image 12px above the viewport center. Dragging down
-    // must stop 12px earlier and dragging up may go 12px further.
-    const offset = { ...frame, centerY: -12 };
-    expect(clampImagePan({ scale: 4, x: 0, y: 900 }, offset).y).toBe(212);
-    expect(clampImagePan({ scale: 4, x: 0, y: -900 }, offset).y).toBe(-188);
-  });
-});
-
-describe("panImage", () => {
-  it("ignores pans at 1x", () => {
-    expect(panImage(IMAGE_ZOOM_IDENTITY, 40, 40, frame)).toBe(IMAGE_ZOOM_IDENTITY);
-  });
-
-  it("moves a zoomed image within the clamp", () => {
-    expect(panImage({ scale: 4, x: 0, y: 0 }, -100, 50, frame)).toEqual({
-      scale: 4,
-      x: -100,
-      y: 50,
+  it("recenters when the viewport grows beyond the zoomed image", () => {
+    const larger = { ...frame, viewportWidth: 3000, viewportHeight: 2000 };
+    expect(resizeImageZoom({ scale: 2, scrollLeft: 600, scrollTop: 100 }, frame, larger)).toEqual({
+      scale: 2,
+      scrollLeft: 0,
+      scrollTop: 0,
     });
   });
 });
 
 describe("wheelZoomFactor", () => {
-  it("matches the native pinch rate for small deltas", () => {
-    // Chromium encodes a 5% pinch as deltaY -5.
-    expect(wheelZoomFactor(-5)).toBeCloseTo(1.05, 2);
-    expect(wheelZoomFactor(5)).toBeCloseTo(0.95, 2);
+  it("recovers Chromium's exact pinch scale, including a fast gesture", () => {
+    for (const scale of [0.5, 0.95, 1.05, 1.8, 2]) {
+      expect(wheelZoomFactor(-100 * Math.log(scale))).toBeCloseTo(scale);
+    }
   });
 
-  it("caps a mouse wheel notch", () => {
-    expect(wheelZoomFactor(-100)).toBe(wheelZoomFactor(-25));
+  it("gives the same zoom for coalesced and separate trackpad samples", () => {
+    expect(wheelZoomFactor(-60)).toBeCloseTo(wheelZoomFactor(-20) ** 3);
+    expect(wheelZoomFactor(60) * wheelZoomFactor(-60)).toBeCloseTo(1);
   });
 });
 
 describe("clickZoomScale", () => {
-  it("zooms to the actual pixel size of a large image", () => {
+  it("shows actual pixels for a large image", () => {
     expect(clickZoomScale(3000, 1000)).toBe(3);
   });
 
-  it("zooms to 2x when the image already shows near its actual size", () => {
+  it("enlarges an image that already fits and respects the zoom limit", () => {
     expect(clickZoomScale(1000, 1000)).toBe(2);
-    expect(clickZoomScale(1500, 1000)).toBe(2);
     expect(clickZoomScale(0, 1000)).toBe(2);
+    expect(clickZoomScale(12000, 1000)).toBe(MAX_IMAGE_ZOOM);
   });
 });

--- a/apps/web/src/components/chat/imageZoom.ts
+++ b/apps/web/src/components/chat/imageZoom.ts
@@ -23,7 +23,7 @@ export interface Point {
 }
 
 export const IMAGE_ZOOM_IDENTITY: ImageZoomState = { scale: 1, x: 0, y: 0 };
-export const MIN_IMAGE_ZOOM = 1;
+const MIN_IMAGE_ZOOM = 1;
 export const MAX_IMAGE_ZOOM = 8;
 /** Zoom applied by a double click on an unzoomed image. */
 export const DOUBLE_CLICK_IMAGE_ZOOM = 2.5;

--- a/apps/web/src/components/chat/imageZoom.ts
+++ b/apps/web/src/components/chat/imageZoom.ts
@@ -32,8 +32,6 @@ export interface Point {
 export const IMAGE_ZOOM_IDENTITY: ImageZoomState = { scale: 1, x: 0, y: 0 };
 const MIN_IMAGE_ZOOM = 1;
 export const MAX_IMAGE_ZOOM = 8;
-/** Zoom applied by a double click on an unzoomed image. */
-export const DOUBLE_CLICK_IMAGE_ZOOM = 2.5;
 
 function clampAxis(
   translate: number,
@@ -92,10 +90,20 @@ export function panImage(
 }
 
 /**
- * Converts a wheel delta into a zoom factor. Trackpad pinch on macOS arrives
- * as ctrl+wheel with small deltas, mouse wheels send about 100 per notch, so
- * the delta is capped to keep a notch from jumping more than about 1.6x.
+ * Converts a ctrl+wheel delta into a zoom factor. Chromium reports a trackpad
+ * pinch as ctrl+wheel where `1 - deltaY / 100` is the scale change, so this
+ * matches the native pinch rate. A mouse wheel with ctrl sends about 100 per
+ * notch, so the delta is capped to keep a notch near a 1.3x step.
  */
 export function wheelZoomFactor(deltaY: number): number {
-  return Math.exp(-Math.max(-50, Math.min(50, deltaY)) * 0.01);
+  return Math.exp(-Math.max(-25, Math.min(25, deltaY)) * 0.01);
+}
+
+/**
+ * The scale a click zooms to from the fitted size: the image's actual pixel
+ * size, or 2x when the image is already shown at or near its actual size.
+ */
+export function clickZoomScale(naturalWidth: number, displayedWidth: number): number {
+  if (naturalWidth <= 0 || displayedWidth <= 0) return 2;
+  return Math.max(2, naturalWidth / displayedWidth);
 }

--- a/apps/web/src/components/chat/imageZoom.ts
+++ b/apps/web/src/components/chat/imageZoom.ts
@@ -1,109 +1,110 @@
-/**
- * Pure zoom and pan math for the expanded image dialog. The image keeps its
- * layout box and is scaled around its center with a CSS transform, so `x` and
- * `y` are the translate applied after scaling, in CSS pixels.
- */
+/** Image scale and the browser's scroll position, in CSS pixels. */
 export interface ImageZoomState {
   readonly scale: number;
-  readonly x: number;
-  readonly y: number;
+  readonly scrollLeft: number;
+  readonly scrollTop: number;
 }
 
-/**
- * The untransformed image size, the viewport it must stay visible in, and the
- * offset of the untransformed image center from the viewport center. The
- * caption below the image pushes the image above the viewport center, so the
- * pan bounds are not symmetric.
- */
 export interface ImageZoomFrame {
   readonly width: number;
   readonly height: number;
   readonly viewportWidth: number;
   readonly viewportHeight: number;
-  readonly centerX: number;
-  readonly centerY: number;
 }
 
-export interface Point {
+interface Point {
   readonly x: number;
   readonly y: number;
 }
 
-export const IMAGE_ZOOM_IDENTITY: ImageZoomState = { scale: 1, x: 0, y: 0 };
-const MIN_IMAGE_ZOOM = 1;
+export const IMAGE_ZOOM_IDENTITY: ImageZoomState = { scale: 1, scrollLeft: 0, scrollTop: 0 };
 export const MAX_IMAGE_ZOOM = 8;
 
-function clampAxis(
-  translate: number,
-  scaledSize: number,
-  viewportSize: number,
-  center: number,
-): number {
-  // An image that fits on this axis keeps its layout position. One that
-  // overflows may be panned until its far edge meets the viewport edge, never
-  // past it, so it always covers the viewport on this axis.
-  if (scaledSize <= viewportSize) return 0;
-  const overflow = (scaledSize - viewportSize) / 2;
-  // `|| 0` turns a -0 from clamping into 0 so identity states compare equal.
-  return Math.min(overflow - center, Math.max(-overflow - center, translate)) || 0;
-}
-
-export function clampImagePan(state: ImageZoomState, frame: ImageZoomFrame): ImageZoomState {
+/** Centers each image axis until it is large enough to scroll. */
+export function imageZoomLayout(frame: ImageZoomFrame, scale: number) {
+  const width = frame.width * scale;
+  const height = frame.height * scale;
   return {
-    scale: state.scale,
-    x: clampAxis(state.x, frame.width * state.scale, frame.viewportWidth, frame.centerX),
-    y: clampAxis(state.y, frame.height * state.scale, frame.viewportHeight, frame.centerY),
+    width,
+    height,
+    left: Math.max(0, (frame.viewportWidth - width) / 2),
+    top: Math.max(0, (frame.viewportHeight - height) / 2),
+    contentWidth: Math.max(frame.viewportWidth, width),
+    contentHeight: Math.max(frame.viewportHeight, height),
   };
 }
 
-/**
- * Multiplies the scale by `factor` while keeping `anchor` fixed on screen.
- * `anchor` is the pointer position relative to the untransformed image center.
- */
+function imagePointAt(state: ImageZoomState, frame: ImageZoomFrame, anchor: Point) {
+  const layout = imageZoomLayout(frame, state.scale);
+  return {
+    x: (state.scrollLeft + anchor.x - layout.left) / layout.width,
+    y: (state.scrollTop + anchor.y - layout.top) / layout.height,
+  };
+}
+
+function scrollToImagePoint(
+  point: Point,
+  anchor: Point,
+  scale: number,
+  frame: ImageZoomFrame,
+): ImageZoomState {
+  const layout = imageZoomLayout(frame, scale);
+  return {
+    scale,
+    scrollLeft: Math.max(
+      0,
+      Math.min(
+        layout.contentWidth - frame.viewportWidth,
+        point.x * layout.width + layout.left - anchor.x,
+      ),
+    ),
+    scrollTop: Math.max(
+      0,
+      Math.min(
+        layout.contentHeight - frame.viewportHeight,
+        point.y * layout.height + layout.top - anchor.y,
+      ),
+    ),
+  };
+}
+
+/** Keeps the image point under the pointer fixed as the scroll area changes size. */
 export function zoomImageAt(
   state: ImageZoomState,
   factor: number,
   anchor: Point,
   frame: ImageZoomFrame,
 ): ImageZoomState {
-  const scale = Math.min(MAX_IMAGE_ZOOM, Math.max(MIN_IMAGE_ZOOM, state.scale * factor));
+  const scale = Math.min(MAX_IMAGE_ZOOM, Math.max(1, state.scale * factor));
   if (scale === state.scale) return state;
-  const ratio = scale / state.scale;
-  return clampImagePan(
-    {
-      scale,
-      x: anchor.x - ratio * (anchor.x - state.x),
-      y: anchor.y - ratio * (anchor.y - state.y),
-    },
+  return scrollToImagePoint(imagePointAt(state, frame, anchor), anchor, scale, frame);
+}
+
+/** Keeps the viewport centered on the same part of the image after a resize. */
+export function resizeImageZoom(
+  state: ImageZoomState,
+  previousFrame: ImageZoomFrame,
+  frame: ImageZoomFrame,
+): ImageZoomState {
+  const point = imagePointAt(state, previousFrame, {
+    x: previousFrame.viewportWidth / 2,
+    y: previousFrame.viewportHeight / 2,
+  });
+  return scrollToImagePoint(
+    point,
+    { x: frame.viewportWidth / 2, y: frame.viewportHeight / 2 },
+    state.scale,
     frame,
   );
 }
 
-export function panImage(
-  state: ImageZoomState,
-  dx: number,
-  dy: number,
-  frame: ImageZoomFrame,
-): ImageZoomState {
-  if (state.scale <= MIN_IMAGE_ZOOM) return state;
-  return clampImagePan({ scale: state.scale, x: state.x + dx, y: state.y + dy }, frame);
-}
-
-/**
- * Converts a ctrl+wheel delta into a zoom factor. Chromium reports a trackpad
- * pinch as ctrl+wheel where `1 - deltaY / 100` is the scale change, so this
- * matches the native pinch rate. A mouse wheel with ctrl sends about 100 per
- * notch, so the delta is capped to keep a notch near a 1.3x step.
- */
+/** Chromium encodes trackpad pinch as deltaY = -100 * log(scale). */
 export function wheelZoomFactor(deltaY: number): number {
-  return Math.exp(-Math.max(-25, Math.min(25, deltaY)) * 0.01);
+  return Math.exp(-deltaY / 100);
 }
 
-/**
- * The scale a click zooms to from the fitted size: the image's actual pixel
- * size, or 2x when the image is already shown at or near its actual size.
- */
+/** A click shows actual pixels, or enlarges an image that already fits at actual size. */
 export function clickZoomScale(naturalWidth: number, displayedWidth: number): number {
   if (naturalWidth <= 0 || displayedWidth <= 0) return 2;
-  return Math.max(2, naturalWidth / displayedWidth);
+  return Math.min(MAX_IMAGE_ZOOM, Math.max(2, naturalWidth / displayedWidth));
 }

--- a/apps/web/src/components/chat/imageZoom.ts
+++ b/apps/web/src/components/chat/imageZoom.ts
@@ -9,12 +9,19 @@ export interface ImageZoomState {
   readonly y: number;
 }
 
-/** The untransformed image size and the viewport it must stay visible in. */
+/**
+ * The untransformed image size, the viewport it must stay visible in, and the
+ * offset of the untransformed image center from the viewport center. The
+ * caption below the image pushes the image above the viewport center, so the
+ * pan bounds are not symmetric.
+ */
 export interface ImageZoomFrame {
   readonly width: number;
   readonly height: number;
   readonly viewportWidth: number;
   readonly viewportHeight: number;
+  readonly centerX: number;
+  readonly centerY: number;
 }
 
 export interface Point {
@@ -28,19 +35,26 @@ export const MAX_IMAGE_ZOOM = 8;
 /** Zoom applied by a double click on an unzoomed image. */
 export const DOUBLE_CLICK_IMAGE_ZOOM = 2.5;
 
-function clampAxis(translate: number, scaledSize: number, viewportSize: number): number {
-  // An image that fits on this axis stays centered. One that overflows may be
-  // panned until its far edge meets the viewport edge, never past it.
-  const overflow = Math.max(0, (scaledSize - viewportSize) / 2);
+function clampAxis(
+  translate: number,
+  scaledSize: number,
+  viewportSize: number,
+  center: number,
+): number {
+  // An image that fits on this axis keeps its layout position. One that
+  // overflows may be panned until its far edge meets the viewport edge, never
+  // past it, so it always covers the viewport on this axis.
+  if (scaledSize <= viewportSize) return 0;
+  const overflow = (scaledSize - viewportSize) / 2;
   // `|| 0` turns a -0 from clamping into 0 so identity states compare equal.
-  return Math.min(overflow, Math.max(-overflow, translate)) || 0;
+  return Math.min(overflow - center, Math.max(-overflow - center, translate)) || 0;
 }
 
 export function clampImagePan(state: ImageZoomState, frame: ImageZoomFrame): ImageZoomState {
   return {
     scale: state.scale,
-    x: clampAxis(state.x, frame.width * state.scale, frame.viewportWidth),
-    y: clampAxis(state.y, frame.height * state.scale, frame.viewportHeight),
+    x: clampAxis(state.x, frame.width * state.scale, frame.viewportWidth, frame.centerX),
+    y: clampAxis(state.y, frame.height * state.scale, frame.viewportHeight, frame.centerY),
   };
 }
 

--- a/apps/web/src/components/chat/imageZoom.ts
+++ b/apps/web/src/components/chat/imageZoom.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure zoom and pan math for the expanded image dialog. The image keeps its
+ * layout box and is scaled around its center with a CSS transform, so `x` and
+ * `y` are the translate applied after scaling, in CSS pixels.
+ */
+export interface ImageZoomState {
+  readonly scale: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+/** The untransformed image size and the viewport it must stay visible in. */
+export interface ImageZoomFrame {
+  readonly width: number;
+  readonly height: number;
+  readonly viewportWidth: number;
+  readonly viewportHeight: number;
+}
+
+export interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+export const IMAGE_ZOOM_IDENTITY: ImageZoomState = { scale: 1, x: 0, y: 0 };
+export const MIN_IMAGE_ZOOM = 1;
+export const MAX_IMAGE_ZOOM = 8;
+/** Zoom applied by a double click on an unzoomed image. */
+export const DOUBLE_CLICK_IMAGE_ZOOM = 2.5;
+
+function clampAxis(translate: number, scaledSize: number, viewportSize: number): number {
+  // An image that fits on this axis stays centered. One that overflows may be
+  // panned until its far edge meets the viewport edge, never past it.
+  const overflow = Math.max(0, (scaledSize - viewportSize) / 2);
+  // `|| 0` turns a -0 from clamping into 0 so identity states compare equal.
+  return Math.min(overflow, Math.max(-overflow, translate)) || 0;
+}
+
+export function clampImagePan(state: ImageZoomState, frame: ImageZoomFrame): ImageZoomState {
+  return {
+    scale: state.scale,
+    x: clampAxis(state.x, frame.width * state.scale, frame.viewportWidth),
+    y: clampAxis(state.y, frame.height * state.scale, frame.viewportHeight),
+  };
+}
+
+/**
+ * Multiplies the scale by `factor` while keeping `anchor` fixed on screen.
+ * `anchor` is the pointer position relative to the untransformed image center.
+ */
+export function zoomImageAt(
+  state: ImageZoomState,
+  factor: number,
+  anchor: Point,
+  frame: ImageZoomFrame,
+): ImageZoomState {
+  const scale = Math.min(MAX_IMAGE_ZOOM, Math.max(MIN_IMAGE_ZOOM, state.scale * factor));
+  if (scale === state.scale) return state;
+  const ratio = scale / state.scale;
+  return clampImagePan(
+    {
+      scale,
+      x: anchor.x - ratio * (anchor.x - state.x),
+      y: anchor.y - ratio * (anchor.y - state.y),
+    },
+    frame,
+  );
+}
+
+export function panImage(
+  state: ImageZoomState,
+  dx: number,
+  dy: number,
+  frame: ImageZoomFrame,
+): ImageZoomState {
+  if (state.scale <= MIN_IMAGE_ZOOM) return state;
+  return clampImagePan({ scale: state.scale, x: state.x + dx, y: state.y + dy }, frame);
+}
+
+/**
+ * Converts a wheel delta into a zoom factor. Trackpad pinch on macOS arrives
+ * as ctrl+wheel with small deltas, mouse wheels send about 100 per notch, so
+ * the delta is capped to keep a notch from jumping more than about 1.6x.
+ */
+export function wheelZoomFactor(deltaY: number): number {
+  return Math.exp(-Math.max(-50, Math.min(50, deltaY)) * 0.01);
+}


### PR DESCRIPTION
Expanded screenshots could not zoom. The first implementation added pinch handling, but it canceled two-finger scrolling and moved the image through React state. Larger pinch samples were capped, which changed the response based on how the browser grouped input events.

The image now sits in a real scroll area. The browser handles two-finger scrolling, diagonal panning, and momentum. Pinch preserves the image point under the pointer and uses Chromium's scale conversion without an event speed cap. It updates the image transform and scroll bounds directly. A click toggles fitted and actual size, and dragging pans. Image navigation resets zoom. Resizing keeps the same image point at the center.

This applies to expanded images in web and Electron, including remote attachments. Videos, extracted text, and the separate React Native client keep their existing behavior.

Validation: 12 focused tests, web typecheck, targeted lint, and diff checks pass. Theo is testing the gestures in the running Electron dev app with imported image attachments. Manual gesture validation and a recording are pending.

The original commits by Theo Browne are preserved. Reworked in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved expanded image viewing with smoother zooming, panning, and pinch gestures.
  * Added support for Safari trackpad pinch gestures.
  * Ctrl+wheel zooms images, while two-finger scrolling pans zoomed images.
  * Clicking an image toggles zoom, with zoom levels capped appropriately.
  * Image positioning now adapts when the viewport is resized.

* **Bug Fixes**
  * Improved zoom anchoring, centering, and movement limits across viewport sizes.

* **Tests**
  * Expanded coverage for zooming, panning, resizing, wheel behavior, and click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->