### PR TITLE
feat(command-palette): show environments in search results

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -3,6 +3,7 @@ import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools
 import type { Project, Thread } from "../types";
 import {
   buildBrowseGroups,
+  buildCommandPaletteProjectMetadata,
   buildProjectActionItems,
   buildThreadActionItems,
   buildLinkedThreadActionItems,
@@ -52,6 +53,100 @@ describe("linked pull request thread navigation", () => {
     expect(items[0]?.description).toBe("Archived thread");
     await items[0]?.run();
     expect(runThread).toHaveBeenCalledWith({ environmentId, id });
+  });
+});
+
+describe("buildCommandPaletteProjectMetadata", () => {
+  const localEnvironmentId = EnvironmentId.make("environment-local");
+  const remoteEnvironmentId = EnvironmentId.make("environment-build-box");
+  const locations = new Map([
+    [localEnvironmentId, { kind: "local" as const, label: "Local", machine: "laptop" as const }],
+    [
+      remoteEnvironmentId,
+      { kind: "remote" as const, label: "Build box", machine: "server" as const },
+    ],
+  ]);
+
+  it("makes every member environment and path searchable", () => {
+    const metadata = buildCommandPaletteProjectMetadata({
+      projects: [
+        {
+          environmentId: localEnvironmentId,
+          title: "T3 Code",
+          workspaceRoot: "/Users/theo/Projects/t3code",
+        },
+        {
+          environmentId: remoteEnvironmentId,
+          title: "t3code",
+          workspaceRoot: "/srv/t3code",
+        },
+      ],
+      locationByEnvironmentId: locations,
+    });
+
+    expect(metadata.searchTerms).toEqual([
+      "T3 Code",
+      "/Users/theo/Projects/t3code",
+      "Local",
+      "t3code",
+      "/srv/t3code",
+      "Build box",
+    ]);
+    expect(metadata.environmentLabels).toEqual(["Local", "Build box"]);
+
+    const [filteredGroup] = filterCommandPaletteGroups({
+      activeGroups: [],
+      query: "build box",
+      isInSubmenu: false,
+      projectSearchItems: [
+        {
+          kind: "action",
+          value: "project:t3code",
+          title: "T3 Code",
+          searchTerms: metadata.searchTerms,
+          icon: null,
+          run: async () => undefined,
+        },
+      ],
+      threadSearchItems: [],
+    });
+    expect(filteredGroup?.items).toHaveLength(1);
+  });
+
+  it("deduplicates grouped checkouts by environment", () => {
+    const metadata = buildCommandPaletteProjectMetadata({
+      projects: [
+        {
+          environmentId: remoteEnvironmentId,
+          title: "T3 Code",
+          workspaceRoot: "/srv/t3code",
+        },
+        {
+          environmentId: remoteEnvironmentId,
+          title: "T3 Code worktree",
+          workspaceRoot: "/srv/t3code-feature",
+        },
+      ],
+      locationByEnvironmentId: locations,
+    });
+
+    expect(metadata.environmentLabels).toEqual(["Build box"]);
+  });
+
+  it("uses a human-readable fallback when presentation data is unavailable", () => {
+    const metadata = buildCommandPaletteProjectMetadata({
+      projects: [
+        {
+          environmentId: remoteEnvironmentId,
+          title: "T3 Code",
+          workspaceRoot: "/srv/t3code",
+        },
+      ],
+      locationByEnvironmentId: new Map(),
+    });
+
+    expect(metadata.searchTerms).toContain("Remote");
+    expect(metadata.environmentLabels).toEqual(["Remote"]);
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -133,6 +133,30 @@ describe("buildCommandPaletteProjectMetadata", () => {
     expect(metadata.environmentLabels).toEqual(["Build box"]);
   });
 
+  it("deduplicates distinct environments with the same label", () => {
+    const secondRemoteEnvironmentId = EnvironmentId.make("environment-build-box-2");
+    const metadata = buildCommandPaletteProjectMetadata({
+      projects: [
+        {
+          environmentId: remoteEnvironmentId,
+          title: "T3 Code",
+          workspaceRoot: "/srv/t3code",
+        },
+        {
+          environmentId: secondRemoteEnvironmentId,
+          title: "T3 Code mirror",
+          workspaceRoot: "/srv/mirror/t3code",
+        },
+      ],
+      locationByEnvironmentId: new Map([
+        [remoteEnvironmentId, { label: "Build box" }],
+        [secondRemoteEnvironmentId, { label: "Build box" }],
+      ]),
+    });
+
+    expect(metadata.environmentLabels).toEqual(["Build box"]);
+  });
+
   it("uses a human-readable fallback when presentation data is unavailable", () => {
     const metadata = buildCommandPaletteProjectMetadata({
       projects: [

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,6 +1,7 @@
 import { threadPullRequestSearchTerms } from "@t3tools/shared/threadPullRequests";
 import type { CommandPaletteLinkedThreads } from "../commandPaletteBus";
 import {
+  type EnvironmentId,
   type FilesystemBrowseEntry,
   type KeybindingCommand,
   THREAD_JUMP_KEYBINDING_COMMANDS,
@@ -184,6 +185,24 @@ export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-b
 // as the real project title: the automatic project icon is derived from it, and
 // every other surface uses the real title, so overriding it desyncs the icon.
 export type CommandPaletteProject = Project & { readonly displayName: string };
+
+export function buildCommandPaletteProjectMetadata(input: {
+  readonly projects: ReadonlyArray<Pick<Project, "environmentId" | "title" | "workspaceRoot">>;
+  readonly locationByEnvironmentId: ReadonlyMap<EnvironmentId, { readonly label: string }>;
+}) {
+  const searchTerms: string[] = [];
+  const environmentLabelById = new Map<EnvironmentId, string>();
+
+  for (const project of input.projects) {
+    const label = input.locationByEnvironmentId.get(project.environmentId)?.label ?? "Remote";
+    searchTerms.push(project.title, project.workspaceRoot, label);
+    if (!environmentLabelById.has(project.environmentId)) {
+      environmentLabelById.set(project.environmentId, label);
+    }
+  }
+
+  return { searchTerms, environmentLabels: [...environmentLabelById.values()] };
+}
 
 export function buildProjectActionItems(input: {
   projects: ReadonlyArray<CommandPaletteProject>;

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -191,17 +191,15 @@ export function buildCommandPaletteProjectMetadata(input: {
   readonly locationByEnvironmentId: ReadonlyMap<EnvironmentId, { readonly label: string }>;
 }) {
   const searchTerms: string[] = [];
-  const environmentLabelById = new Map<EnvironmentId, string>();
+  const environmentLabels = new Set<string>();
 
   for (const project of input.projects) {
     const label = input.locationByEnvironmentId.get(project.environmentId)?.label ?? "Remote";
     searchTerms.push(project.title, project.workspaceRoot, label);
-    if (!environmentLabelById.has(project.environmentId)) {
-      environmentLabelById.set(project.environmentId, label);
-    }
+    environmentLabels.add(label);
   }
 
-  return { searchTerms, environmentLabels: [...environmentLabelById.values()] };
+  return { searchTerms, environmentLabels: [...environmentLabels] };
 }
 
 export function buildProjectActionItems(input: {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1237,6 +1237,9 @@ function OpenCommandPaletteDialog(props: {
             <ThreadCommandSubtitle
               project={projectByKey.get(`${thread.environmentId}:${thread.projectId}`) ?? null}
               projectTitle={projectTitle ?? null}
+              environmentLabel={
+                projectEnvironmentLocationById.get(thread.environmentId)?.label ?? "Remote"
+              }
               branch={thread.branch}
               worktreePath={thread.worktreePath}
               isCurrent={thread.id === activeThreadId}
@@ -1274,6 +1277,7 @@ function OpenCommandPaletteDialog(props: {
       clientSettings.sidebarThreadSortOrder,
       navigate,
       projectByKey,
+      projectEnvironmentLocationById,
       projectTitleById,
       providerEntryByEnvironmentAndInstanceId,
       threadContentMatchByKey,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -126,6 +126,7 @@ import {
   ADDON_ICON_CLASS,
   browseInputEndPaddingClass,
   buildBrowseGroups,
+  buildCommandPaletteProjectMetadata,
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
@@ -184,6 +185,38 @@ const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
 
 function projectFavicon(project: Project) {
   return <ProjectFavicon project={project} className="size-4" />;
+}
+
+function ProjectSearchDescription(props: {
+  readonly environmentLabels: ReadonlyArray<string>;
+  readonly grouped: boolean;
+  readonly location: {
+    readonly kind: "local" | "remote";
+    readonly label: string;
+    readonly machine: EnvironmentMachineKind;
+  };
+  readonly workspaceRoot: string;
+}) {
+  if (!props.grouped) {
+    return (
+      <span className="flex min-w-0 items-center gap-1">
+        <span className="inline-flex min-w-0 items-center gap-1">
+          {props.location.kind === "remote" ? (
+            <EnvironmentMachineIcon
+              aria-hidden
+              kind={props.location.machine}
+              className={COMMAND_PALETTE_META_ICON_CLASS}
+            />
+          ) : null}
+          <span className="truncate">{props.location.label}</span>
+        </span>
+        <CommandPaletteMetaDot />
+        <span className="truncate">{props.workspaceRoot}</span>
+      </span>
+    );
+  }
+
+  return <span className="truncate">{props.environmentLabels.join(" · ")}</span>;
 }
 
 function getEnvironmentBrowsePlatform(os: string | null | undefined): string {
@@ -1079,15 +1112,43 @@ function OpenCommandPaletteDialog(props: {
         projects: pickerProjects,
         valuePrefix: "project",
         searchTerms: (project) => {
-          const group = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`);
+          const members = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`)
+            ?.memberProjects ?? [project];
+          return buildCommandPaletteProjectMetadata({
+            projects: members,
+            locationByEnvironmentId: projectEnvironmentLocationById,
+          }).searchTerms;
+        },
+        renderDescription: (project) => {
+          const members = projectGroupByTargetKey.get(`${project.environmentId}:${project.id}`)
+            ?.memberProjects ?? [project];
+          const metadata = buildCommandPaletteProjectMetadata({
+            projects: members,
+            locationByEnvironmentId: projectEnvironmentLocationById,
+          });
+          const location = projectEnvironmentLocationById.get(project.environmentId) ?? {
+            kind: "remote" as const,
+            label: "Remote",
+            machine: "server" as const,
+          };
           return (
-            group?.memberProjects.flatMap((member) => [member.title, member.workspaceRoot]) ?? []
+            <ProjectSearchDescription
+              environmentLabels={metadata.environmentLabels}
+              grouped={members.length > 1}
+              location={location}
+              workspaceRoot={project.workspaceRoot}
+            />
           );
         },
         icon: projectFavicon,
         runProject: openProjectFromSearch,
       }),
-    [openProjectFromSearch, pickerProjects, projectGroupByTargetKey],
+    [
+      openProjectFromSearch,
+      pickerProjects,
+      projectEnvironmentLocationById,
+      projectGroupByTargetKey,
+    ],
   );
 
   const projectThreadItems = useMemo(

--- a/apps/web/src/components/ThreadCommandSubtitle.tsx
+++ b/apps/web/src/components/ThreadCommandSubtitle.tsx
@@ -36,6 +36,7 @@ function WorkspaceIcon(props: { variant: ThreadCommandSubtitleVariant; isWorktre
 export function ThreadCommandSubtitle(props: {
   project: ProjectFaviconProject | null;
   projectTitle: string | null;
+  environmentLabel?: string | null;
   branch: string | null;
   worktreePath: string | null;
   isCurrent: boolean;
@@ -69,6 +70,12 @@ export function ThreadCommandSubtitle(props: {
             <ProjectFavicon project={props.project} className="size-3 shrink-0" />
           ) : null}
           <span className="min-w-0 truncate">{projectLabel}</span>
+          {props.environmentLabel ? (
+            <>
+              <CommandPaletteMetaDot />
+              <span className="shrink-0">{props.environmentLabel}</span>
+            </>
+          ) : null}
         </span>
       ) : null}
 


### PR DESCRIPTION
## Problem

Projects and threads with the same name are hard to distinguish in CMD+K when they live on different T3 environments. Grouped repositories can also span environments, so showing only the representative checkout would be misleading.

## What changed

- Show the environment label and workspace path for individual project results.
- Show every environment label for grouped project results.
- Show the environment label alongside the project name for thread results.
- Match project searches against environment labels as well as every grouped title and path.
- Follow the command palette's existing local/remote labeling and machine-icon treatment.

## Verification

- `pnpm exec vp test run apps/web/src/components/CommandPalette.logic.test.ts` (21 tests)
- `pnpm exec vp lint apps/web/src/components/CommandPalette.tsx apps/web/src/components/ThreadCommandSubtitle.tsx apps/web/src/components/CommandPalette.logic.ts apps/web/src/components/CommandPalette.logic.test.ts`
- `pnpm exec vp run --filter @t3tools/web typecheck`
- Browser-tested two same-named projects and two identically titled threads across connected environments, environment-name search, and a grouped repository spanning both environments.

## Screenshots

### Before

<img width="900" height="600" alt="CMD+K project results before, showing workspace paths without environment labels" src="https://github.com/user-attachments/assets/485d8cd2-9f84-4e68-9052-8b1f558883c7" />

### After

<img width="900" height="600" alt="CMD+K project results after, showing environment labels and workspace paths" src="https://github.com/user-attachments/assets/0126b412-b040-4680-a72b-44bf06a3e5b6" />

### Thread results

<img width="900" height="600" alt="Identically titled CMD+K thread results distinguished by environment" src="https://github.com/user-attachments/assets/c839956d-9845-46af-b1ce-521a825cb2c9" />

Scope is limited to the shared web/desktop command palette. No server, contract, mobile, or documentation changes are needed.

Built with GPT-5.6 Sol in T3 Code through the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command palette project search to include environment names, project titles, and workspace paths.
  * Added clearer project details, including environment labels, locations, and workspace roots.
  * Added environment context to thread search results, with a “Remote” fallback when needed.
  * Grouped project results now display their associated environments more clearly, including deduplicated environment labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->