### PR TITLE
fix(server): reuse index stat cache for checkpoints

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -116,6 +116,211 @@ it.layer(TestLayer)("CheckpointStore.layer", (it) => {
     );
   });
 
+  describe("captureCheckpoint", () => {
+    for (const scenario of [
+      "partial staging",
+      "staged deletion of ignored file",
+      "staged addition removed from disk",
+      "intent to add",
+      "subdirectory",
+      "unborn subdirectory",
+      "missing index",
+      "linked worktree",
+      "assume unchanged",
+      "skip worktree",
+      "split index",
+      "sparse checkout",
+      "unmerged index",
+    ]) {
+      it.effect(`preserves snapshot and index semantics with ${scenario}`, () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          const fileSystem = yield* FileSystem.FileSystem;
+          const vcsProcess = yield* VcsProcess.VcsProcess;
+          const checkpointStore = yield* CheckpointStore.CheckpointStore;
+          yield* initRepoWithCommit(tmp);
+          yield* fileSystem.makeDirectory(NodePath.join(tmp, "inside"));
+          yield* writeTextFile(NodePath.join(tmp, "inside", "file.txt"), "original\n");
+          yield* writeTextFile(NodePath.join(tmp, "outside.txt"), "outside\n");
+          yield* git(tmp, ["add", "."]);
+          yield* git(tmp, ["commit", "-m", "fixture"]);
+          let cwd = tmp;
+          let hasHead = true;
+          if (scenario === "linked worktree") {
+            cwd = NodePath.join(tmp, "linked");
+            yield* git(tmp, ["worktree", "add", "-b", "linked", cwd]);
+          }
+          if (scenario === "unborn subdirectory") {
+            cwd = yield* makeTmpDir();
+            yield* git(cwd, ["init"]);
+            yield* writeTextFile(NodePath.join(cwd, "outside.txt"), "staged outside\n");
+            yield* git(cwd, ["add", "."]);
+            yield* fileSystem.makeDirectory(NodePath.join(cwd, "inside"));
+            yield* writeTextFile(NodePath.join(cwd, "inside", "file.txt"), "new inside\n");
+            cwd = NodePath.join(cwd, "inside");
+            hasHead = false;
+          } else {
+            const file = NodePath.join(cwd, "inside", "file.txt");
+            yield* writeTextFile(file, "staged content\n");
+            yield* git(cwd, ["add", "inside/file.txt"]);
+            yield* writeTextFile(file, "working tree content\n");
+            if (scenario === "staged deletion of ignored file") {
+              yield* git(cwd, ["rm", "--cached", "-f", "inside/file.txt"]);
+              yield* writeTextFile(NodePath.join(cwd, ".gitignore"), "inside/file.txt\n");
+            } else if (scenario === "staged addition removed from disk") {
+              yield* writeTextFile(NodePath.join(cwd, "new.txt"), "new\n");
+              yield* git(cwd, ["add", "new.txt"]);
+              yield* fileSystem.remove(NodePath.join(cwd, "new.txt"));
+            } else if (scenario === "intent to add") {
+              yield* writeTextFile(NodePath.join(cwd, "new.txt"), "new\n");
+              yield* git(cwd, ["add", "-N", "new.txt"]);
+            } else if (scenario === "subdirectory") {
+              yield* writeTextFile(NodePath.join(cwd, "outside.txt"), "staged outside\n");
+              yield* git(cwd, ["add", "outside.txt"]);
+              cwd = NodePath.join(cwd, "inside");
+            } else if (scenario === "assume unchanged" || scenario === "skip worktree") {
+              yield* git(cwd, ["reset", "HEAD", "inside/file.txt"]);
+              yield* git(cwd, [
+                "update-index",
+                scenario === "assume unchanged" ? "--assume-unchanged" : "--skip-worktree",
+                "inside/file.txt",
+              ]);
+            } else if (scenario === "split index") {
+              yield* git(cwd, ["update-index", "--split-index"]);
+            } else if (scenario === "sparse checkout") {
+              yield* git(cwd, ["sparse-checkout", "set", "--cone", "inside"]);
+            } else if (scenario === "unmerged index") {
+              const blob = yield* git(cwd, ["rev-parse", "HEAD:inside/file.txt"]);
+              yield* git(cwd, ["update-index", "--force-remove", "inside/file.txt"]);
+              yield* vcsProcess.run({
+                operation: "CheckpointStore.test.conflict",
+                command: "git",
+                cwd,
+                args: ["update-index", "--index-info"],
+                stdin: `100644 ${blob} 1\tinside/file.txt\n100644 ${blob} 2\tinside/file.txt\n100644 ${blob} 3\tinside/file.txt\n`,
+              });
+            }
+          }
+          const indexPath = yield* git(cwd, [
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-path",
+            "index",
+          ]);
+          if (scenario === "missing index") yield* fileSystem.remove(indexPath);
+          const indexExists = yield* fileSystem.exists(indexPath);
+          const userIndex = indexExists ? yield* fileSystem.readFile(indexPath) : undefined;
+          const referenceIndex = NodePath.join(yield* makeTmpDir(), "index");
+          const referenceEnv = { ...process.env, GIT_INDEX_FILE: referenceIndex };
+          if (hasHead) {
+            yield* vcsProcess.run({
+              operation: "CheckpointStore.test.baseline",
+              command: "git",
+              cwd,
+              args: ["read-tree", "HEAD"],
+              env: referenceEnv,
+            });
+          }
+          yield* vcsProcess.run({
+            operation: "CheckpointStore.test.baseline",
+            command: "git",
+            cwd,
+            args: ["add", "-A", "--", "."],
+            env: referenceEnv,
+          });
+          const expected = yield* vcsProcess.run({
+            operation: "CheckpointStore.test.baseline",
+            command: "git",
+            cwd,
+            args: ["write-tree"],
+            env: referenceEnv,
+          });
+          const checkpointRef = checkpointRefForThreadTurn(ThreadId.make("semantics"), 1);
+          yield* checkpointStore.captureCheckpoint({ cwd, checkpointRef });
+          expect(yield* git(cwd, ["rev-parse", `${checkpointRef}^{tree}`])).toBe(
+            expected.stdout.trim(),
+          );
+          expect(yield* fileSystem.exists(indexPath)).toBe(indexExists);
+          if (userIndex) expect(yield* fileSystem.readFile(indexPath)).toEqual(userIndex);
+          // Restore only this disposable fixture; capture must include actual on-disk content.
+          if (scenario === "partial staging" || scenario === "linked worktree") {
+            yield* writeTextFile(NodePath.join(cwd, "inside", "file.txt"), "after capture\n");
+            expect(yield* checkpointStore.restoreCheckpoint({ cwd, checkpointRef })).toBe(true);
+            expect(yield* fileSystem.readFileString(NodePath.join(cwd, "inside", "file.txt"))).toBe(
+              "working tree content\n",
+            );
+          }
+        }),
+      );
+    }
+
+    it.effect("rehashes racy-clean files after copying the index", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["config", "core.trustctime", "false"]);
+        const file = NodePath.join(tmp, "racy.txt");
+        yield* writeTextFile(file, "before\n");
+        yield* fileSystem.utimes(file, 1000, 1000);
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "racy file"]);
+        const index = NodePath.join(tmp, ".git", "index");
+        yield* fileSystem.utimes(index, 1000, 1000);
+        yield* writeTextFile(file, "after!\n");
+        yield* fileSystem.utimes(file, 1000, 1000);
+        const userIndex = yield* fileSystem.readFile(index);
+        const checkpointRef = checkpointRefForThreadTurn(ThreadId.make("racy"), 1);
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+        expect(yield* git(tmp, ["show", `${checkpointRef}:racy.txt`])).toBe("after!");
+        expect(yield* fileSystem.readFile(index)).toEqual(userIndex);
+      }),
+    );
+
+    it.effect("reuses cached file metadata without changing the user index", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const fileSystem = yield* FileSystem.FileSystem;
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+        yield* initRepoWithCommit(tmp);
+        const filter = NodePath.join(tmp, ".git", "count-clean.cjs");
+        const calls = NodePath.join(tmp, ".git", "clean-calls");
+        yield* writeTextFile(
+          filter,
+          `const fs = require("node:fs"); fs.appendFileSync(${JSON.stringify(calls)}, "clean\\n"); process.stdin.pipe(process.stdout);`,
+        );
+        yield* git(tmp, ["config", "filter.count.clean", `node "${filter}"`]);
+        yield* writeTextFile(NodePath.join(tmp, ".gitattributes"), "*.count filter=count\n");
+        yield* writeTextFile(NodePath.join(tmp, "unchanged.count"), "unchanged\n");
+        // Keep the fixture out of Git's racy-clean timestamp window without sleeping.
+        yield* fileSystem.utimes(NodePath.join(tmp, "unchanged.count"), 1, 1);
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add filtered file"]);
+        yield* writeTextFile(calls, "");
+        const indexPath = NodePath.join(tmp, ".git", "index");
+        const userIndex = yield* fileSystem.readFile(indexPath);
+        const checkpointRef = checkpointRefForThreadTurn(ThreadId.make("cache-test"), 1);
+
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+
+        expect(yield* fileSystem.readFileString(calls)).toBe("");
+        expect(yield* fileSystem.readFile(indexPath)).toEqual(userIndex);
+        expect(yield* git(tmp, ["rev-parse", `${checkpointRef}^{tree}`])).toBe(
+          yield* git(tmp, ["rev-parse", "HEAD^{tree}"]),
+        );
+
+        yield* writeTextFile(NodePath.join(tmp, "unchanged.count"), "changed content\n");
+        yield* checkpointStore.captureCheckpoint({ cwd: tmp, checkpointRef });
+        expect(yield* git(tmp, ["show", `${checkpointRef}:unchanged.count`])).toBe(
+          "changed content",
+        );
+        expect(yield* fileSystem.readFileString(calls)).not.toBe("");
+        expect(yield* fileSystem.readFile(indexPath)).toEqual(userIndex);
+      }),
+    );
+  });
+
   describe("diffCheckpoints", () => {
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -735,12 +735,74 @@ export const makeVcsDriverShape = Effect.fn("makeGitVcsDriverShape")(function* (
       yield* Effect.gen(function* () {
         const headExists = yield* hasHeadCommit(input.cwd);
         if (headExists) {
-          yield* execute({
-            operation,
-            cwd: input.cwd,
-            args: ["read-tree", "HEAD"],
-            env: commitEnv,
-          });
+          // Borrow only the stat cache, not the user's staged snapshot or flags.
+          // A one-tree reset restores HEAD membership, including staged deletions.
+          const seeded = yield* Effect.gen(function* () {
+            const indexResult = yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: ["rev-parse", "--path-format=absolute", "--git-path", "index"],
+            });
+            const sharedIndex = yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: ["rev-parse", "--shared-index-path"],
+            });
+            const sparse = yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: ["config", "--bool", "--get", "core.sparseCheckout"],
+              allowNonZeroExit: true,
+            });
+            if (sharedIndex.stdout.trim() !== "" || sparse.stdout.trim() === "true") {
+              return false;
+            }
+            const indexPath = indexResult.stdout.trim();
+            const indexStat = yield* fileSystem.stat(indexPath);
+            if (Option.isNone(indexStat.mtime)) return false;
+            yield* fileSystem.copyFile(indexPath, tempIndexPath);
+            // A newer copy timestamp would make racy-clean entries look trustworthy.
+            yield* fileSystem.utimes(tempIndexPath, indexStat.mtime.value, indexStat.mtime.value);
+            const entries = yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: [
+                ...WORKSPACE_GIT_HARDENED_CONFIG_ARGS,
+                "ls-files",
+                "-v",
+                "-z",
+                "--full-name",
+                "--",
+                ":/",
+              ],
+              env: commitEnv,
+              maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+            });
+            if (
+              entries.stdoutTruncated ||
+              entries.stdout
+                .split("\0")
+                .some((entry) => entry.length > 0 && entry[0] !== "H" && entry[0] !== "M")
+            ) {
+              return false;
+            }
+            yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "read-tree", "--reset", "HEAD"],
+              env: commitEnv,
+            });
+            return true;
+          }).pipe(Effect.option);
+          if (!Option.getOrElse(seeded, () => false)) {
+            yield* cleanupTempIndex;
+            yield* execute({
+              operation,
+              cwd: input.cwd,
+              args: ["read-tree", "HEAD"],
+              env: commitEnv,
+            });
+          }
         }
 
         yield* execute({


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

Seed the temporary checkpoint index from the current worktree's index, then use a single-tree `read-tree --reset HEAD` to reuse matching stat entries without borrowing the user's staged snapshot. The scoped `git add -A -- .`, tree/commit creation, and checkpoint ref publication stay unchanged.

Preserve the source index timestamp so copying cannot hide racy-clean edits. Use the previous fresh-index path for sparse/split indexes, assume-unchanged/skip-worktree entries, truncated listings, unavailable indexes, or failed seeding. Unborn repositories keep the existing empty-index behavior. The real index is never modified.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

A fresh `read-tree HEAD` discards the stat cache, forcing checkpoint staging to reread unchanged tracked files. On a Linux workspace with 32,981 tracked files (448 MB), staging initially took 66.9 seconds and exceeded the existing 30-second timeout.

Related to #3646. Alternative to #8301: reuse Git's index cache rather than parse changed paths and introduce binary process I/O plumbing. This does not address failure backoff or temporary-pack cleanup, and intentionally does not accelerate special-index fallback cases.

Validation:
- 62 focused tests pass across `GitVcsDriver.test.ts`, `CheckpointStore.test.ts`, and `CheckpointReactor.test.ts`.
- A counting clean-filter regression fails on upstream and passes with this change: unchanged files are not filtered again, while changed content is captured.
- A racy-clean regression fails if timestamp preservation is removed and passes with it.
- Real Git fixtures compare snapshot trees against the original algorithm and verify byte-identical user indexes across partial staging, staged deletions/AD paths, intent-to-add, subdirectory scope, unborn HEAD, missing indexes, linked worktrees, flags, sparse/split indexes, and unmerged entries. Capture/restore is also exercised.
- Targeted lint and `git diff --check` pass.
- Server typecheck reports the same two TS2345 errors on both unmodified base `eb1150636` and this change: `HostPowerMonitor.ts:69` and `NativeTelemetryClient.ts:509`. No errors in modified files.
- Final same-run Linux comparison using bundled original/modified drivers and isolated Git metadata/objects: full capture plus tree lookup took **2.771 s → 0.386 s** (~7.2× faster), with identical tree OIDs and an unchanged real index. This later run did not reproduce the initial 66.9 s staging time; the initial and later measurements are not a controlled before/after pair. No installed T3 server was replaced.
- A Linux fixture verified changed content under a non-UTF-8 filename survives capture.
- macOS Git 2.55.0 tested locally; Linux Git 2.43.0 tested through an isolated actual-driver harness. Windows was not tested.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (N/A: server-only)
- [ ] I included a video for animation/interaction changes (N/A: no UI interaction changes)

Prepared with claude-copilot-gpt-6-astra in Claude Code through T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint creation now more reliably preserves the current staging state across partial staging, sparse checkouts, worktrees, and other complex repository configurations.
  * Improved handling of file changes, including recently modified files and files with cached metadata.
  * User index contents remain unchanged while checkpoints are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->