### PR TITLE
feat(settings): allow configuring hosting CLI paths

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -771,7 +771,9 @@ export const makeServerLayer = Layer.unwrap(
       Layer.provide(ApplicationObservabilityLive),
       Layer.provideMerge(FetchHttpClient.layer),
       // PR reads, Git operations, and WebSocket discovery share one process limiter.
-      Layer.provide(VcsProcess.layer),
+      Layer.provide(
+        VcsProcess.layerWithConfiguredExecutables.pipe(Layer.provide(ServerSettingsLayerLive)),
+      ),
       Layer.provideMerge(PlatformServicesLive),
     );
   }),

--- a/apps/server/src/vcs/VcsExecutables.test.ts
+++ b/apps/server/src/vcs/VcsExecutables.test.ts
@@ -1,0 +1,50 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as NodeOS from "node:os";
+
+import * as ServerSettings from "../serverSettings.ts";
+import * as VcsExecutables from "./VcsExecutables.ts";
+
+const resolveWith = (paths: Partial<Record<"gh" | "glab" | "az", string>>, command: string) =>
+  Effect.gen(function* () {
+    const executables = yield* VcsExecutables.VcsExecutables;
+    return yield* executables.resolve(command);
+  }).pipe(
+    Effect.provide(
+      VcsExecutables.layer.pipe(
+        Layer.provide(ServerSettings.layerTest({ sourceControlCliPaths: paths })),
+        Layer.provide(NodeServices.layer),
+      ),
+    ),
+  );
+
+describe("VcsExecutables.resolve", () => {
+  it.effect("spawns the configured path instead of the command name", () =>
+    Effect.gen(function* () {
+      expect(yield* resolveWith({ gh: "/opt/gh/bin/gh" }, "gh")).toBe("/opt/gh/bin/gh");
+    }),
+  );
+
+  it.effect("expands a leading ~ so hand-typed home paths work", () =>
+    Effect.gen(function* () {
+      expect(yield* resolveWith({ glab: "~/.local/bin/glab" }, "glab")).toBe(
+        `${NodeOS.homedir()}/.local/bin/glab`,
+      );
+    }),
+  );
+
+  it.effect("falls back to PATH resolution when the override is blank", () =>
+    Effect.gen(function* () {
+      expect(yield* resolveWith({ az: "   " }, "az")).toBe("az");
+      expect(yield* resolveWith({}, "gh")).toBe("gh");
+    }),
+  );
+
+  it.effect("leaves commands that are not configurable untouched", () =>
+    Effect.gen(function* () {
+      expect(yield* resolveWith({ gh: "/opt/gh/bin/gh" }, "git")).toBe("git");
+    }),
+  );
+});

--- a/apps/server/src/vcs/VcsExecutables.ts
+++ b/apps/server/src/vcs/VcsExecutables.ts
@@ -1,0 +1,58 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import { SOURCE_CONTROL_CLI_COMMANDS, type SourceControlCliCommand } from "@t3tools/contracts";
+
+import { expandHomePath } from "../os-jank.ts";
+import * as ServerSettings from "../serverSettings.ts";
+
+/**
+ * Maps the logical command name a caller passes to {@link VcsProcess} onto the
+ * executable actually spawned. Callers keep using `"gh"`, `"glab"`, and `"az"`
+ * as identifiers — in error payloads and in the process limiter — while the
+ * user stays free to point each one at a specific binary.
+ */
+export class VcsExecutables extends Context.Service<
+  VcsExecutables,
+  {
+    readonly resolve: (command: string) => Effect.Effect<string>;
+  }
+>()("t3/vcs/VcsExecutables") {}
+
+const OVERRIDABLE_COMMANDS: ReadonlySet<string> = new Set(SOURCE_CONTROL_CLI_COMMANDS);
+
+function isOverridable(command: string): command is SourceControlCliCommand {
+  return OVERRIDABLE_COMMANDS.has(command);
+}
+
+/** Every command resolves by name on PATH. */
+export const layerPathOnly = Layer.succeed(
+  VcsExecutables,
+  VcsExecutables.of({ resolve: Effect.succeed }),
+);
+
+export const make = Effect.gen(function* () {
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
+  const path = yield* Path.Path;
+
+  // Only the hosting CLIs are configurable, so Git — the hot path — never pays
+  // for a settings read.
+  const resolve = (command: string): Effect.Effect<string> =>
+    isOverridable(command)
+      ? serverSettings.getSettings.pipe(
+          Effect.map((settings) => settings.sourceControlCliPaths[command].trim()),
+          Effect.flatMap((override) =>
+            override.length === 0
+              ? Effect.succeed(command)
+              : expandHomePath(override).pipe(Effect.provideService(Path.Path, path)),
+          ),
+          Effect.orElseSucceed(() => command),
+        )
+      : Effect.succeed(command);
+
+  return VcsExecutables.of({ resolve });
+});
+
+export const layer = Layer.effect(VcsExecutables, make);

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -17,6 +17,7 @@ import {
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as VcsExecutables from "./VcsExecutables.ts";
 import * as VcsProcess from "./VcsProcess.ts";
 
 const run = (input: VcsProcess.VcsProcessInput) =>
@@ -37,6 +38,9 @@ const baseInput = {
   cwd: "/workspace",
 } satisfies VcsProcess.VcsProcessInput;
 
+/** The production default: every command resolves by name on PATH. */
+const pathOnlyExecutables = VcsExecutables.VcsExecutables.of({ resolve: Effect.succeed });
+
 const captureProcessResult = (
   result: Effect.Effect<ProcessRunner.ProcessRunOutput, ProcessRunner.ProcessRunError>,
 ) =>
@@ -45,11 +49,58 @@ const captureProcessResult = (
       ProcessRunner.ProcessRunner,
       ProcessRunner.ProcessRunner.of({ run: () => result }),
     ),
+    Effect.provideService(VcsExecutables.VcsExecutables, pathOnlyExecutables),
     Effect.flatMap((service) => service.run(baseInput)),
     Effect.flip,
   );
 
 describe("VcsProcess.run", () => {
+  it.effect("spawns the configured executable while still reporting the logical command", () =>
+    Effect.gen(function* () {
+      const spawned = yield* Ref.make<ReadonlyArray<string>>([]);
+      const service = yield* VcsProcess.make.pipe(
+        Effect.provideService(
+          VcsExecutables.VcsExecutables,
+          VcsExecutables.VcsExecutables.of({
+            resolve: (command) => Effect.succeed(command === "gh" ? "/opt/gh/bin/gh" : command),
+          }),
+        ),
+        Effect.provideService(
+          ProcessRunner.ProcessRunner,
+          ProcessRunner.ProcessRunner.of({
+            run: (input) =>
+              Ref.update(spawned, (commands) => [...commands, input.command]).pipe(
+                Effect.andThen(
+                  Effect.fail(
+                    new ProcessRunner.ProcessSpawnError({
+                      command: input.command,
+                      argumentCount: input.args.length,
+                      cwd: input.cwd ?? "/workspace",
+                      cause: new Error("ENOENT"),
+                    }),
+                  ),
+                ),
+              ),
+          }),
+        ),
+      );
+
+      const error = yield* service
+        .run({
+          operation: "test.configured-executable",
+          command: "gh",
+          args: ["api", "user"],
+          cwd: "/workspace",
+        })
+        .pipe(Effect.flip);
+
+      expect(yield* Ref.get(spawned)).toEqual(["/opt/gh/bin/gh"]);
+      // Callers, error payloads, and the GitHub limiter all key off "gh".
+      assert(error._tag === "VcsProcessSpawnError");
+      expect(error.command).toBe("gh");
+    }),
+  );
+
   it.effect("bounds a synthetic burst of GitHub API processes", () =>
     Effect.gen(function* () {
       const gate = yield* Deferred.make<void>();
@@ -58,6 +109,7 @@ describe("VcsProcess.run", () => {
       const peak = yield* Ref.make(0);
       const total = yield* Ref.make(0);
       const service = yield* VcsProcess.make.pipe(
+        Effect.provideService(VcsExecutables.VcsExecutables, pathOnlyExecutables),
         Effect.provideService(
           ProcessRunner.ProcessRunner,
           ProcessRunner.ProcessRunner.of({

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -17,6 +17,7 @@ import {
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as VcsExecutables from "./VcsExecutables.ts";
 
 export interface VcsProcessInput {
   readonly operation: string;
@@ -105,10 +106,14 @@ const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFai
 
 export const make = Effect.gen(function* () {
   const processRunner = yield* ProcessRunner.ProcessRunner;
+  const executables = yield* VcsExecutables.VcsExecutables;
   const vcsProcesses = yield* Semaphore.make(VCS_PROCESS_CONCURRENCY);
   const githubProcesses = yield* Semaphore.make(GITHUB_PROCESS_CONCURRENCY);
 
   const runUnbounded = Effect.fn("VcsProcess.runUnbounded")(function* (input: VcsProcessInput) {
+    // Errors and the process limiter keep reporting the logical command, so a
+    // configured path never leaks into diagnostics or changes how we throttle.
+    const executable = yield* executables.resolve(input.command);
     const baseError = {
       operation: input.operation,
       command: input.command,
@@ -118,7 +123,7 @@ export const make = Effect.gen(function* () {
 
     const result = yield* processRunner
       .run({
-        command: input.command,
+        command: executable,
         args: input.args,
         cwd: input.cwd,
         ...(input.spawnCwd !== undefined ? { spawnCwd: input.spawnCwd } : {}),
@@ -195,4 +200,10 @@ export const make = Effect.gen(function* () {
   return VcsProcess.of({ run });
 });
 
-export const layer = Layer.effect(VcsProcess, make).pipe(Layer.provide(ProcessRunner.layer));
+const baseLayer = Layer.effect(VcsProcess, make).pipe(Layer.provide(ProcessRunner.layer));
+
+/** Resolves every command by name on PATH. */
+export const layer = baseLayer.pipe(Layer.provide(VcsExecutables.layerPathOnly));
+
+/** Honours the hosting CLI paths configured in Source control settings. */
+export const layerWithConfiguredExecutables = baseLayer.pipe(Layer.provide(VcsExecutables.layer));

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -5,6 +5,7 @@ import * as Option from "effect/Option";
 import { useEffect, useState, type ReactNode } from "react";
 import type {
   BackgroundActivitySettings,
+  EnvironmentId,
   SourceControlCliCommand,
   SourceControlProviderKind,
   SourceControlDiscoveryResult,
@@ -19,7 +20,12 @@ import {
   resolveServerBackgroundActivitySettings,
 } from "@t3tools/shared/backgroundActivitySettings";
 
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useEnvironmentSettings,
+  usePrimarySettings,
+  useUpdateEnvironmentSettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { SharedSettingsMismatchAlert } from "./SharedSettingsMismatchAlert";
 import { cn } from "../../lib/utils";
 import { useEnvironments, usePrimaryEnvironment } from "../../state/environments";
@@ -360,14 +366,17 @@ function DiscoveryItemRow({
 }
 
 function HostingCliPathSettings({
+  environmentId,
   command,
   label,
 }: {
+  /** The executable is server-local, so it is read and written where discovery ran. */
+  readonly environmentId: EnvironmentId;
   readonly command: SourceControlCliCommand;
   readonly label: string;
 }) {
-  const settings = usePrimarySettings();
-  const updateSettings = useUpdatePrimarySettings();
+  const settings = useEnvironmentSettings(environmentId);
+  const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const savedPath = settings.sourceControlCliPaths[command];
   const [draft, setDraft] = useState(savedPath);
   const [lastSavedPath, setLastSavedPath] = useState(savedPath);
@@ -446,15 +455,18 @@ function HostingCliPathSettings({
   );
 }
 
-/** Only the primary environment's settings are writable from this screen. */
+/**
+ * The hosted app has no primary environment, so gating on one would leave
+ * remote-only users looking at an unavailable provider they cannot configure.
+ */
 function hostingCliPathField(
   kind: SourceControlProviderKind,
   label: string,
-  isPrimaryEnvironment: boolean,
+  environmentId: EnvironmentId | null,
 ) {
   const command = SOURCE_CONTROL_PROVIDER_CLI[kind];
-  if (!command || !isPrimaryEnvironment) return undefined;
-  return <HostingCliPathSettings command={command} label={label} />;
+  if (!command || environmentId === null) return undefined;
+  return <HostingCliPathSettings environmentId={environmentId} command={command} label={label} />;
 }
 
 function GitFetchIntervalSettings() {
@@ -704,12 +716,12 @@ export function SourceControlSettingsPanel() {
                     key={`provider:${item.kind}`}
                     item={item}
                     expandForSearchTarget={
-                      SOURCE_CONTROL_PROVIDER_CLI[item.kind] && isPrimaryEnvironment
+                      SOURCE_CONTROL_PROVIDER_CLI[item.kind] && environmentId !== null
                         ? searchableSetting("hosting-cli-path").id
                         : undefined
                     }
                   >
-                    {hostingCliPathField(item.kind, item.label, isPrimaryEnvironment)}
+                    {hostingCliPathField(item.kind, item.label, environmentId)}
                   </DiscoveryItemRow>
                 ))}
               </SettingsSection>

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -5,6 +5,7 @@ import * as Option from "effect/Option";
 import { useEffect, useState, type ReactNode } from "react";
 import type {
   BackgroundActivitySettings,
+  SourceControlCliCommand,
   SourceControlProviderKind,
   SourceControlDiscoveryResult,
   SourceControlProviderAuth,
@@ -43,6 +44,7 @@ import {
   NumberFieldIncrement,
   NumberFieldInput,
 } from "../ui/number-field";
+import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
@@ -82,6 +84,18 @@ const SOURCE_CONTROL_PROVIDER_ICONS: Partial<Record<SourceControlProviderKind, I
 const VCS_ICONS: Partial<Record<VcsDriverKind, Icon>> = {
   git: GitIcon,
   jj: JujutsuIcon,
+};
+
+/**
+ * Hosting providers T3 Code reaches through a CLI. Bitbucket talks to the REST
+ * API instead, so it has no executable to point anywhere.
+ */
+const SOURCE_CONTROL_PROVIDER_CLI: Partial<
+  Record<SourceControlProviderKind, SourceControlCliCommand>
+> = {
+  github: "gh",
+  gitlab: "glab",
+  "azure-devops": "az",
 };
 
 const SOURCE_CONTROL_SKELETON_ROWS = ["primary", "secondary"] as const;
@@ -342,6 +356,104 @@ function DiscoveryItemRow({
   );
 }
 
+function HostingCliPathSettings({
+  command,
+  label,
+}: {
+  readonly command: SourceControlCliCommand;
+  readonly label: string;
+}) {
+  const settings = usePrimarySettings();
+  const updateSettings = useUpdatePrimarySettings();
+  const savedPath = settings.sourceControlCliPaths[command];
+  const [draft, setDraft] = useState(savedPath);
+  const [lastSavedPath, setLastSavedPath] = useState(savedPath);
+  const setting = searchableSetting("hosting-cli-path");
+
+  // Another client, or an edit to the settings file, can change this while the
+  // row is open. Adjusting during render keeps the input on the saved value
+  // without a second render pass.
+  if (lastSavedPath !== savedPath) {
+    setLastSavedPath(savedPath);
+    setDraft(savedPath);
+  }
+
+  const commit = (value: string) => {
+    const next = value.trim();
+    setDraft(next);
+    if (next !== savedPath) {
+      updateSettings({ sourceControlCliPaths: { [command]: next } });
+    }
+  };
+
+  return (
+    <SettingsSearchTarget id={setting.id} className="grid gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 items-center gap-1">
+            <span className="text-xs font-medium text-foreground">{setting.title}</span>
+            <PolicyTooltip>
+              {`T3 Code runs \`${command}\` for ${label}. Point this at a specific binary when the name on PATH is a version-manager wrapper, or when the CLI lives somewhere the server cannot see. Rescan after changing it.`}
+            </PolicyTooltip>
+            <span
+              className={cn(
+                "inline-flex size-5 shrink-0 items-center justify-center transition-opacity",
+                savedPath ? "opacity-100" : "pointer-events-none opacity-0",
+              )}
+              aria-hidden={!savedPath}
+            >
+              {savedPath ? (
+                <SettingResetButton
+                  label={`${command} path`}
+                  onClick={() => {
+                    setDraft("");
+                    updateSettings({ sourceControlCliPaths: { [command]: "" } });
+                  }}
+                />
+              ) : null}
+            </span>
+          </div>
+          <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">
+            Leave empty to resolve <code>{command}</code> on the server&apos;s PATH.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Input
+            size="sm"
+            className="w-full sm:w-72"
+            aria-label={`${label} CLI path`}
+            placeholder={command}
+            value={draft}
+            spellCheck={false}
+            autoComplete="off"
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={(event) => commit(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.currentTarget.blur();
+              }
+              if (event.key === "Escape") {
+                setDraft(savedPath);
+              }
+            }}
+          />
+        </div>
+      </div>
+    </SettingsSearchTarget>
+  );
+}
+
+/** Only the primary environment's settings are writable from this screen. */
+function hostingCliPathField(
+  kind: SourceControlProviderKind,
+  label: string,
+  isPrimaryEnvironment: boolean,
+) {
+  const command = SOURCE_CONTROL_PROVIDER_CLI[kind];
+  if (!command || !isPrimaryEnvironment) return undefined;
+  return <HostingCliPathSettings command={command} label={label} />;
+}
+
 function GitFetchIntervalSettings() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();
@@ -574,7 +686,9 @@ export function SourceControlSettingsPanel() {
               headerAction={hasVersionControlSystems ? null : scanButton}
             >
               {result.sourceControlProviders.map((item) => (
-                <DiscoveryItemRow key={`provider:${item.kind}`} item={item} />
+                <DiscoveryItemRow key={`provider:${item.kind}`} item={item}>
+                  {hostingCliPathField(item.kind, item.label, isPrimaryEnvironment)}
+                </DiscoveryItemRow>
               ))}
             </SettingsSection>
           ) : null}

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -271,9 +271,12 @@ function itemSummary({
 
 function DiscoveryItemRow({
   item,
+  expandForSearchTarget,
   children,
 }: {
   readonly item: VcsDiscoveryItem | SourceControlProviderDiscoveryItem;
+  /** Search-target id of a setting inside this row, so a jump reveals it. */
+  readonly expandForSearchTarget?: string | undefined;
   readonly children?: ReactNode;
 }) {
   const version = optionLabel(item.version);
@@ -288,10 +291,10 @@ function DiscoveryItemRow({
   const searchTargetId = useSettingsSearchTargetId();
 
   useEffect(() => {
-    if (item.kind === "git" && searchTargetId === searchableSetting("git-fetch-interval").id) {
+    if (expandForSearchTarget !== undefined && searchTargetId === expandForSearchTarget) {
       setIsExpanded(true);
     }
-  }, [item.kind, searchTargetId]);
+  }, [expandForSearchTarget, searchTargetId]);
 
   return (
     <div
@@ -387,7 +390,7 @@ function HostingCliPathSettings({
   };
 
   return (
-    <SettingsSearchTarget id={setting.id} className="grid gap-3">
+    <div className="grid gap-3">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
           <div className="flex min-w-0 items-center gap-1">
@@ -439,7 +442,7 @@ function HostingCliPathSettings({
           />
         </div>
       </div>
-    </SettingsSearchTarget>
+    </div>
   );
 }
 
@@ -670,7 +673,15 @@ export function SourceControlSettingsPanel() {
               headerAction={scanButton}
             >
               {result.versionControlSystems.map((item) => (
-                <DiscoveryItemRow key={`vcs:${item.kind}`} item={item}>
+                <DiscoveryItemRow
+                  key={`vcs:${item.kind}`}
+                  item={item}
+                  expandForSearchTarget={
+                    item.kind === "git" && isPrimaryEnvironment
+                      ? searchableSetting("git-fetch-interval").id
+                      : undefined
+                  }
+                >
                   {item.kind === "git" && isPrimaryEnvironment ? (
                     <GitFetchIntervalSettings />
                   ) : undefined}
@@ -680,17 +691,29 @@ export function SourceControlSettingsPanel() {
           ) : null}
 
           {result.sourceControlProviders.length > 0 ? (
-            <SettingsSection
-              id={hasVersionControlSystems ? undefined : searchableSetting("source-control").id}
-              title="Source Control Providers"
-              headerAction={hasVersionControlSystems ? null : scanButton}
-            >
-              {result.sourceControlProviders.map((item) => (
-                <DiscoveryItemRow key={`provider:${item.kind}`} item={item}>
-                  {hostingCliPathField(item.kind, item.label, isPrimaryEnvironment)}
-                </DiscoveryItemRow>
-              ))}
-            </SettingsSection>
+            // The CLI path field renders once per provider inside a collapsed
+            // row, so the section owns the anchor and the rows expand into it.
+            <SettingsSearchTarget id={searchableSetting("hosting-cli-path").id}>
+              <SettingsSection
+                id={hasVersionControlSystems ? undefined : searchableSetting("source-control").id}
+                title="Source Control Providers"
+                headerAction={hasVersionControlSystems ? null : scanButton}
+              >
+                {result.sourceControlProviders.map((item) => (
+                  <DiscoveryItemRow
+                    key={`provider:${item.kind}`}
+                    item={item}
+                    expandForSearchTarget={
+                      SOURCE_CONTROL_PROVIDER_CLI[item.kind] && isPrimaryEnvironment
+                        ? searchableSetting("hosting-cli-path").id
+                        : undefined
+                    }
+                  >
+                    {hostingCliPathField(item.kind, item.label, isPrimaryEnvironment)}
+                  </DiscoveryItemRow>
+                ))}
+              </SettingsSection>
+            </SettingsSearchTarget>
           ) : null}
         </>
       ) : (

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -232,6 +232,18 @@ describe("searchSettings", () => {
     ]);
   });
 
+  it("anchors the hosting CLI path to its own id so provider rows can expand", () => {
+    // The field renders once per provider inside a collapsed row. The section
+    // owns the anchor, and the rows expand off this same id, so routing it to
+    // another target would land on the page with every field still hidden.
+    const result = searchSettings("hosting cli path")[0];
+    expect(result).toMatchObject({
+      id: "hosting-cli-path",
+      to: "/settings/source-control",
+    });
+    expect(result).not.toHaveProperty("targetId");
+  });
+
   it("routes browser recording quality to integrations", () => {
     const result = searchSettings("recording frame rate")[0];
     expect(result).toMatchObject({

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -452,6 +452,15 @@ export const SETTINGS_SEARCH_ITEMS = [
     ],
   },
   {
+    id: "hosting-cli-path",
+    title: "Hosting CLI path",
+    to: "/settings/source-control",
+    searchTerms: [
+      "gh glab az executable binary path custom location not found on path wrapper mise asdf volta homebrew",
+    ],
+    primaryOnly: true,
+  },
+  {
     id: "git-fetch-interval",
     title: "Git fetch interval",
     to: "/settings/source-control",

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -87,6 +87,10 @@ reopening a declined pull request.
 - **Not authenticated:** run the provider's login command on the server, then rescan. For Bitbucket,
   confirm the running server received the environment variables.
 - **GitHub sign-in cannot be verified:** update GitHub CLI to at least 2.81.0.
+- **A provider stays unavailable even though its CLI is installed:** the name on the server's PATH
+  may resolve to something other than the real binary, such as a version-manager wrapper. Expand the
+  provider's row in **Settings → Source Control**, set **Hosting CLI path** to the executable, and
+  rescan. Leave it empty to go back to resolving the command on PATH.
 - **Push fails despite a connected account:** check the Git remote's credentials. SSH and HTTPS
   remotes can require separate setup from the hosting provider's API access.
 - **A review cannot load:** open it on the host website while resolving connectivity, permissions,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -875,6 +875,28 @@ export const SourceControlWritingStyleSettings = Schema.Struct({
 });
 export type SourceControlWritingStyleSettings = typeof SourceControlWritingStyleSettings.Type;
 
+/**
+ * Hosting CLIs T3 Code shells out to, keyed by the logical command name the
+ * server passes to `VcsProcess`. An empty value means "resolve the name on
+ * PATH", which is the default.
+ */
+export const SOURCE_CONTROL_CLI_COMMANDS = ["gh", "glab", "az"] as const;
+export const SourceControlCliCommand = Schema.Literals(SOURCE_CONTROL_CLI_COMMANDS);
+export type SourceControlCliCommand = typeof SourceControlCliCommand.Type;
+
+/**
+ * Paths that override PATH resolution for the hosting CLIs. Empty means
+ * "resolve the command name on PATH", which is the default. Needed when the
+ * name on PATH is a version-manager wrapper too slow for the discovery probe,
+ * or when the binary lives outside the server's PATH.
+ */
+export const SourceControlCliPaths = Schema.Struct({
+  gh: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  glab: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  az: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+});
+export type SourceControlCliPaths = typeof SourceControlCliPaths.Type;
+
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const DEFAULT_PROVIDER_HEALTH_REFRESH_INTERVAL = Duration.minutes(5);
 
@@ -1025,6 +1047,7 @@ export const ServerSettings = Schema.Struct({
   sourceControlWriterModelSelection: Schema.NullOr(ModelSelection).pipe(
     Schema.withDecodingDefault(Effect.succeed(null)),
   ),
+  sourceControlCliPaths: SourceControlCliPaths.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
 
   // Legacy single-instance-per-driver settings. Continues to be the source
   // of truth until `providerInstances` (below) lands per-driver migration
@@ -1255,6 +1278,13 @@ export const ServerSettingsPatch = Schema.Struct({
     }),
   ),
   sourceControlWriterModelSelection: Schema.optionalKey(Schema.NullOr(ModelSelection)),
+  sourceControlCliPaths: Schema.optionalKey(
+    Schema.Struct({
+      gh: Schema.optionalKey(TrimmedString),
+      glab: Schema.optionalKey(TrimmedString),
+      az: Schema.optionalKey(TrimmedString),
+    }),
+  ),
   observability: Schema.optionalKey(
     Schema.Struct({
       otlpTracesUrl: Schema.optionalKey(TrimmedString),


### PR DESCRIPTION
## The problem

Source control discovery probes `gh`, `glab`, and `az` with a 5s budget and maps *any* failure — timeout, non-zero exit, real `ENOENT` — to the same message:

> Not available on this server: Install the GitHub command-line tool (`gh`)…

When the name on `PATH` is a version-manager wrapper rather than the real binary, the probe overruns that budget and an installed, authenticated CLI is reported missing, with a message telling the user to install what they already have. Details and measurements in #10728.

Closes #10728.

This also gives users hit by #7618 something to do. That issue is the opposite failure — the server's `PATH` genuinely lacks the CLI's directory on a Finder-launched macOS app — but the fix there is the same from the user's side: name the executable explicitly instead of depending on `PATH` resolution.

## What changed

A per-provider executable path in **Settings → Source Control**, expandable on each hosting provider's row.

The override is resolved in exactly one place. `VcsProcess` already receives the logical command name from every call site, so a new `VcsExecutables` service translates that name into the executable actually spawned:

- **No call site changed.** Discovery passes `spec.executable` (`"gh"`), so the probe picks the override up for free — as do `GitHubCli`, `GitLabCli`, and `AzureDevOpsCli`.
- **The logical name is preserved.** Error payloads (`Schema.Literal("gh")`), `classifyNonZeroExit`, and the 4-process GitHub limiter still key off `"gh"`, so a configured path never leaks into diagnostics or changes throttling.
- **Git pays nothing.** Only the three configurable commands read settings; the hot path short-circuits.

Empty means "resolve on `PATH`", which stays the default. `~` is expanded. A settings read failure falls back to the command name. Bitbucket gets no field — it talks to the REST API and has no executable. The setting is environment-local, not synced, since a binary path is machine config rather than a user preference.

## Scope note

I want to be upfront: `CONTRIBUTING.md` says feature work belongs in Ideas discussions. I opened this anyway because it is scoped to an open bug with two independent reporters and adds no product surface beyond one text field, but I understand entirely if you would rather this start as a discussion, or prefer a smaller fix — raising the probe timeout and propagating the real failure cause would address the misleading message without adding a setting. Happy to shrink it to that.

Deliberately left out of this PR: the discovery code still discards the captured failure cause and substitutes the fixed "not found on the server PATH" string, so a timeout is still reported as a `PATH` problem. That is a separate concern and belongs in its own change.

## Verification

- Typecheck clean on `packages/contracts`, `apps/server`, `apps/web`.
- `vp test run apps/server/src/vcs/ apps/server/src/sourceControl/` — 252 passing, including 5 new: four covering path resolution (configured path, `~` expansion, blank-override fallback, non-configurable command untouched) and one asserting the configured binary is spawned while the error still reports `"gh"`.
- Manual pass in the web client: entered a path for a provider whose `PATH` entry was a broken wrapper, rescanned, and the row went from unavailable to `gh version 2.100.0` and authenticated.

## Before / after

**Before** — `gh` is installed and authenticated, but the probe times out on a wrapper sitting in front of it. The row reports it as missing and tells the user to install what they already have. There is no control here, so nothing the user can do in the app changes the outcome.

![Source Control settings before the change: GitHub, GitLab, and Azure DevOps all reported as unavailable, with no way to point at an executable](https://raw.githubusercontent.com/vitorpacheco/t3code/pr-10729-assets/hosting-cli-path-before.png)

**After** — each CLI-backed provider expands to a **Hosting CLI path** field. Pointing GitHub at the real binary and rescanning resolves it to `gh version 2.100.0`, authenticated. Empty still means "resolve on PATH". Bitbucket has no field, since it uses the REST API.

![Source Control settings after the change: a Hosting CLI path field under GitHub, GitLab, and Azure DevOps, with GitHub now available and authenticated](https://raw.githubusercontent.com/vitorpacheco/t3code/pr-10729-assets/hosting-cli-path-after.png)

---
Written by Claude Opus 5 in T3 Code (Claude Code harness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable executable paths for GitHub, GitLab, and Azure DevOps command-line tools in **Settings → Source Control**.
  * Paths can be entered, cleared, or reverted to automatic PATH-based detection for each connected environment.
  * Added “Hosting CLI path” to settings search, automatically expanding the relevant provider.
  * Server-side operations now use configured CLI paths when available.

* **Documentation**
  * Added troubleshooting guidance for unavailable provider CLIs caused by PATH wrappers or version managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
