### PR TITLE
perf(swift-ios): decode stream values directly within bounded batches

### DIFF
--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -142,7 +142,15 @@ private struct RPCResponseEnvelope: Decodable, Sendable {
 
     let _tag: String
     let requestId: Int?
-    let values: [JSONValue]?
+    // Validate array framing without materializing values before their
+    // subscription's concrete decoder consumes them.
+    struct Values: Decodable, Sendable {
+        init(from decoder: any Decoder) throws {
+            _ = try decoder.unkeyedContainer()
+        }
+    }
+
+    let values: Values?
     let exit: Exit?
     let defect: JSONValue?
 }
@@ -173,6 +181,45 @@ public actor WebSocketRPCClient {
         case terminated
     }
 
+    /// Decode and yield in order: a bad value retains its delivered prefix,
+    /// and a full buffer stops decoding before later values can change the error.
+    private struct SubscriptionChunk<Value: Decodable & Sendable>: DecodableWithConfiguration {
+        typealias DecodingConfiguration = (batchSize: Int, yield: @Sendable (Result<[Value], Error>) -> SubscriptionYieldResult)
+        private enum CodingKeys: String, CodingKey { case values }
+        let result: SubscriptionYieldResult
+
+        init(from decoder: any Decoder, configuration: DecodingConfiguration) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guard container.contains(.values), try !container.decodeNil(forKey: .values) else {
+                result = .enqueued
+                return
+            }
+            var values = try container.nestedUnkeyedContainer(forKey: .values)
+            while !values.isAtEnd {
+                var batch: [Value] = []
+                batch.reserveCapacity(configuration.batchSize)
+                do {
+                    while !values.isAtEnd && batch.count < configuration.batchSize {
+                        batch.append(try values.decode(Value.self))
+                    }
+                } catch {
+                    result = configuration.yield(.failure(error))
+                    return
+                }
+                switch configuration.yield(.success(batch)) {
+                case .enqueued: continue
+                case .dropped:
+                    result = .dropped
+                    return
+                case .terminated:
+                    result = .terminated
+                    return
+                }
+            }
+            result = .enqueued
+        }
+    }
+
     private struct Subscription {
         let tag: String
         let payload: JSONValue
@@ -181,8 +228,7 @@ public actor WebSocketRPCClient {
         /// The connection that assigned `requestID`. Request IDs are reissued
         /// after reconnects, so an Interrupt is only valid on this connection.
         var requestConnectionID: UUID?
-        let batchSize: Int
-        let yield: @Sendable ([JSONValue]) -> SubscriptionYieldResult
+        let yieldChunk: @Sendable (Data) throws -> SubscriptionYieldResult
         let finish: @Sendable (Error?) -> Void
     }
 
@@ -400,9 +446,7 @@ public actor WebSocketRPCClient {
         reconnect: Bool = true,
         as type: Value.Type
     ) -> AsyncThrowingStream<Value, Error> {
-        subscribe(tag, payload: payload, reconnect: reconnect, batchSize: 1) {
-            try $0[0].decode(type)
-        }
+        subscribe(tag, payload: payload, reconnect: reconnect, batchSize: 1, as: type) { $0[0] }
     }
 
     /// Preserve server batches for consumers that can apply several events at once.
@@ -414,18 +458,17 @@ public actor WebSocketRPCClient {
         as type: Value.Type
     ) -> AsyncThrowingStream<[Value], Error> {
         subscribe(tag, payload: payload, reconnect: reconnect,
-                  batchSize: min(64, subscriptionBufferLimit)) { values in
-            try values.map { try $0.decode(type) }
-        }
+                  batchSize: min(64, subscriptionBufferLimit), as: type) { $0 }
     }
 
-    private func subscribe<Value: Sendable>(
+    private func subscribe<Value: Decodable & Sendable, Output: Sendable>(
         _ tag: String,
         payload: JSONValue,
         reconnect: Bool,
         batchSize: Int,
-        decode: @escaping @Sendable ([JSONValue]) throws -> Value
-    ) -> AsyncThrowingStream<Value, Error> {
+        as type: Value.Type,
+        transform: @escaping @Sendable ([Value]) -> Output
+    ) -> AsyncThrowingStream<Output, Error> {
         let subscriptionID = UUID()
         return AsyncThrowingStream(bufferingPolicy: .bufferingOldest(max(1, subscriptionBufferLimit / batchSize))) {
             continuation in
@@ -434,23 +477,25 @@ public actor WebSocketRPCClient {
                 payload: payload,
                 reconnect: reconnect,
                 requestID: nil,
-                batchSize: batchSize,
-                yield: { value in
-                    do {
-                        switch continuation.yield(try decode(value)) {
-                        case .enqueued:
-                            return .enqueued
-                        case .dropped:
-                            return .dropped
-                        case .terminated:
-                            return .terminated
-                        @unknown default:
-                            return .dropped
-                        }
-                    } catch {
-                        continuation.finish(throwing: error)
-                        return .terminated
-                    }
+                yieldChunk: { data in
+                    try JSONDecoder.t3.decode(
+                        SubscriptionChunk<Value>.self,
+                        from: data,
+                        configuration: (batchSize: batchSize, yield: { result in
+                            switch result {
+                            case let .success(value):
+                                switch continuation.yield(transform(value)) {
+                                case .enqueued: return .enqueued
+                                case .dropped: return .dropped
+                                case .terminated: return .terminated
+                                @unknown default: return .dropped
+                                }
+                            case let .failure(error):
+                                continuation.finish(throwing: error)
+                                return .terminated
+                            }
+                        })
+                    ).result
                 },
                 finish: { error in
                     if let error {
@@ -698,11 +743,11 @@ public actor WebSocketRPCClient {
         guard connectionID == expectedConnectionID else { return false }
         let response = try JSONDecoder.t3.decode(RPCResponseEnvelope.self, from: data)
         awaitingKeepaliveResponse = false
-        try await handle(response)
+        try await handle(response, data: data)
         return connectionID == expectedConnectionID
     }
 
-    private func handle(_ response: RPCResponseEnvelope) async throws {
+    private func handle(_ response: RPCResponseEnvelope, data: Data) async throws {
         switch response._tag {
         case "Pong":
             return
@@ -711,26 +756,22 @@ public actor WebSocketRPCClient {
                   let subscriptionID = subscriptionByRequestID[requestID],
                   let subscription = subscriptions[subscriptionID]
             else { return }
-            let values = response.values ?? []
-            for start in stride(from: 0, to: values.count, by: subscription.batchSize) {
-                let end = min(start + subscription.batchSize, values.count)
-                switch subscription.yield(Array(values[start..<end])) {
-                case .enqueued:
-                    continue
-                case .dropped:
-                    let error = RPCError.protocolViolation(
-                        "The live stream exceeded its buffered event limit."
-                    )
-                    if !subscription.reconnect {
-                        subscriptionByRequestID.removeValue(forKey: requestID)
-                        subscriptions.removeValue(forKey: subscriptionID)
-                        subscription.finish(error)
-                    }
-                    throw error
-                case .terminated:
-                    await removeSubscription(subscriptionID)
-                    return
+            switch try subscription.yieldChunk(data) {
+            case .enqueued:
+                break
+            case .dropped:
+                let error = RPCError.protocolViolation(
+                    "The live stream exceeded its buffered event limit."
+                )
+                if !subscription.reconnect {
+                    subscriptionByRequestID.removeValue(forKey: requestID)
+                    subscriptions.removeValue(forKey: subscriptionID)
+                    subscription.finish(error)
                 }
+                throw error
+            case .terminated:
+                await removeSubscription(subscriptionID)
+                return
             }
             try await sendControl("Ack", requestID: requestID)
         case "Exit":

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCDecodingTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCDecodingTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("WebSocket Chunk decoding")
+struct WebSocketRPCDecodingTests {
+    @Test
+    func malformedMiddleValueKeepsItsPrefixAndHealthySibling() async throws {
+        let socket = ChunkDecodingSocket()
+        let rpc = makeClient(socket)
+        var sent = socket.sent.makeAsyncIterator()
+        let numbers = await rpc.subscribe("numbers", as: Int.self)
+        let numberID = try await nextRequestID(&sent)
+        let strings = await rpc.subscribe("strings", as: String.self)
+        let stringID = try await nextRequestID(&sent)
+
+        try await socket.chunk(numberID, values: [.number(1), .string("invalid"), .number(3)])
+        let interrupt = try await nextFrame(&sent)
+        #expect(interrupt["_tag"] == .string("Interrupt"))
+        #expect(interrupt["requestId"] == numberID)
+        var numberEvents = numbers.makeAsyncIterator()
+        let prefix = try await numberEvents.next()
+        #expect(prefix == 1)
+        do {
+            _ = try await numberEvents.next()
+            Issue.record("The malformed middle value must terminate this subscription.")
+        } catch is DecodingError {}
+
+        // A late chunk for the failed request cannot leak into its sibling.
+        try await socket.chunk(numberID, values: [.string("late")])
+        try await socket.chunk(stringID, values: [.string("healthy")])
+        let ack = try await nextFrame(&sent)
+        #expect(ack["_tag"] == .string("Ack"))
+        #expect(ack["requestId"] == stringID)
+        var stringEvents = strings.makeAsyncIterator()
+        let healthy = try await stringEvents.next()
+        #expect(healthy == "healthy")
+        let acknowledgements = await socket.acknowledgements
+        #expect(acknowledgements == [stringID])
+        await rpc.stop()
+    }
+
+    @Test
+    func overflowStopsBeforeLaterMalformedValueWithoutAcknowledging() async throws {
+        let socket = ChunkDecodingSocket()
+        let rpc = makeClient(socket, bufferLimit: 2)
+        var sent = socket.sent.makeAsyncIterator()
+        let stream = await rpc.subscribe("numbers", reconnect: false, as: Int.self)
+        let id = try await nextRequestID(&sent)
+        try await socket.chunk(id, values: [.number(1), .number(2), .number(3), .string("invalid")])
+        await socket.waitUntilClosed()
+
+        var events = stream.makeAsyncIterator()
+        let first = try await events.next()
+        let second = try await events.next()
+        #expect(first == 1)
+        #expect(second == 2)
+        do {
+            _ = try await events.next()
+            Issue.record("Overflow must terminate a one-shot subscription.")
+        } catch let error as RPCError {
+            guard case .protocolViolation = error else { throw error }
+        }
+        let acknowledgements = await socket.acknowledgements
+        #expect(acknowledgements.isEmpty)
+        await rpc.stop()
+    }
+
+    @Test
+    func emptyChunksAcknowledgeAndUnknownRequestsStayIsolated() async throws {
+        let socket = ChunkDecodingSocket()
+        let rpc = makeClient(socket)
+        var sent = socket.sent.makeAsyncIterator()
+        let stream = await rpc.subscribe("numbers", as: Int.self)
+        let id = try await nextRequestID(&sent)
+        for values in [nil, JSONValue.null, .array([])] {
+            var envelope: [String: JSONValue] = ["_tag": .string("Chunk"), "requestId": id]
+            envelope["values"] = values
+            try await socket.feed(.object(envelope))
+            let ack = try await nextFrame(&sent)
+            #expect(ack["_tag"] == .string("Ack"))
+            #expect(ack["requestId"] == id)
+        }
+        try await socket.chunk(.number(999_999), values: [.string("unknown request")])
+        try await socket.chunk(id, values: [.number(7)])
+        let ack = try await nextFrame(&sent)
+        #expect(ack["_tag"] == .string("Ack"))
+        #expect(ack["requestId"] == id)
+        var events = stream.makeAsyncIterator()
+        let value = try await events.next()
+        #expect(value == 7)
+        let acknowledgements = await socket.acknowledgements
+        #expect(acknowledgements == Array(repeating: id, count: 4))
+        await rpc.stop()
+    }
+
+    @Test
+    func malformedChunkEnvelopeFailsTheSocketBeforeYielding() async throws {
+        for values in [JSONValue.string("not an array"), .object(["0": .number(1)])] {
+            let socket = ChunkDecodingSocket()
+            let rpc = makeClient(socket)
+            var sent = socket.sent.makeAsyncIterator()
+            let stream = await rpc.subscribe("numbers", reconnect: false, as: Int.self)
+            let id = try await nextRequestID(&sent)
+            try await socket.feed(.object(["_tag": .string("Chunk"), "requestId": id, "values": values]))
+            await socket.waitUntilClosed()
+            var events = stream.makeAsyncIterator()
+            do {
+                _ = try await events.next()
+                Issue.record("Invalid array framing must fail the socket.")
+            } catch let error as RPCError {
+                guard case .protocolViolation = error else { throw error }
+            }
+            let acknowledgements = await socket.acknowledgements
+            #expect(acknowledgements.isEmpty)
+            await rpc.stop()
+        }
+    }
+
+    @Test
+    func snapshotFixtureAndFollowingEventKeepWireOrder() async throws {
+        let fixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appending(path: "Fixtures/Wire/thread-stream-snapshot.json")
+        let data = try Data(contentsOf: fixture)
+        let raw = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        let expected = try JSONDecoder.t3.decode(ThreadStreamItem.self, from: data)
+        let socket = ChunkDecodingSocket()
+        let rpc = makeClient(socket)
+        var sent = socket.sent.makeAsyncIterator()
+        let stream = await rpc.subscribe("orchestration.subscribeThread", as: ThreadStreamItem.self)
+        let id = try await nextRequestID(&sent)
+        try await socket.chunk(id, values: [raw, .object(["kind": .string("synchronized")])])
+        let ack = try await nextFrame(&sent)
+        #expect(ack["_tag"] == .string("Ack"))
+        var events = stream.makeAsyncIterator()
+        let first = try await events.next()
+        let second = try await events.next()
+        guard case let .snapshot(actual) = first, case let .snapshot(expected) = expected,
+              case .synchronized = second else {
+            Issue.record("Snapshot and completion marker must retain their order.")
+            await rpc.stop()
+            return
+        }
+        #expect(actual == expected)
+        await rpc.stop()
+    }
+
+    @Test
+    func malformedBatchKeepsCompletedBatchesAndDoesNotAcknowledge() async throws {
+        let socket = ChunkDecodingSocket()
+        let rpc = makeClient(socket)
+        var sent = socket.sent.makeAsyncIterator()
+        let stream = await rpc.subscribeBatches("numbers", as: Int.self)
+        let id = try await nextRequestID(&sent)
+        let prefix = (0..<64).map { JSONValue.number(Double($0)) }
+        try await socket.chunk(id, values: prefix + [.number(64), .string("invalid")])
+        let interrupt = try await nextFrame(&sent)
+        #expect(interrupt["_tag"] == .string("Interrupt"))
+        var events = stream.makeAsyncIterator()
+        let first = try await events.next()
+        #expect(first == Array(0..<64))
+        do {
+            _ = try await events.next()
+            Issue.record("Malformed batch must end the subscription.")
+        } catch is DecodingError {}
+        let acknowledgements = await socket.acknowledgements
+        #expect(acknowledgements.isEmpty)
+        await rpc.stop()
+    }
+
+    private func makeClient(_ socket: ChunkDecodingSocket, bufferLimit: Int = 128) -> WebSocketRPCClient {
+        WebSocketRPCClient(
+            connector: ChunkDecodingConnector(socket: socket),
+            subscriptionBufferLimit: bufferLimit,
+            reconnectBackoff: { _ in .seconds(60) },
+            endpointProvider: { URL(string: "wss://fixture.example/ws")! }
+        )
+    }
+
+    private func nextFrame(_ frames: inout AsyncStream<JSONValue>.Iterator) async throws -> JSONValue {
+        try #require(await frames.next())
+    }
+
+    private func nextRequestID(_ frames: inout AsyncStream<JSONValue>.Iterator) async throws -> JSONValue {
+        let frame = try await nextFrame(&frames)
+        #expect(frame["_tag"] == .string("Request"))
+        return try #require(frame["id"])
+    }
+}
+
+private struct ChunkDecodingConnector: WebSocketConnecting {
+    let socket: ChunkDecodingSocket
+    func connect(to _: URL) -> any WebSocketConnection { socket }
+}
+
+private actor ChunkDecodingSocket: WebSocketConnection {
+    nonisolated let sent: AsyncStream<JSONValue>
+    private let sender: AsyncStream<JSONValue>.Continuation
+    private var queued: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+    private var closed = false
+    private var closeWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var acknowledgements: [JSONValue] = []
+
+    init() { (sent, sender) = AsyncStream.makeStream() }
+
+    func send(_ data: Data) throws {
+        let value = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        if value["_tag"] == .string("Ack"), let id = value["requestId"] {
+            acknowledgements.append(id)
+        }
+        sender.yield(value)
+    }
+
+    func receive() async throws -> Data {
+        if !queued.isEmpty { return queued.removeFirst() }
+        if closed { throw RPCError.disconnected }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func feed(_ value: JSONValue) throws {
+        let data = try JSONEncoder.t3.encode(value)
+        if let receiver {
+            self.receiver = nil
+            receiver.resume(returning: data)
+        } else {
+            queued.append(data)
+        }
+    }
+
+    func chunk(_ requestID: JSONValue, values: [JSONValue]) throws {
+        try feed(.object(["_tag": .string("Chunk"), "requestId": requestID, "values": .array(values)]))
+    }
+
+    func close() {
+        closed = true
+        receiver?.resume(throwing: RPCError.disconnected)
+        receiver = nil
+        let waiters = closeWaiters
+        closeWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitUntilClosed() async {
+        if closed { return }
+        await withCheckedContinuation { closeWaiters.append($0) }
+    }
+}


### PR DESCRIPTION
SwiftUI stream chunks materialized every value as a generic `JSONValue`, then re-encoded and decoded each item into its concrete type. This decodes typed values directly from the chunk while keeping the current batched subscription API, its event budget, wire ordering, sibling isolation, and Ack behavior.

How: the envelope now only validates that `values` is an array. A `DecodableWithConfiguration` chunk decoder walks that array in bounded batches and yields each batch as it goes. When a value is malformed, the batches before it are still delivered and only that subscription ends. When the buffer is full, decoding stops before later values can change the error.

Verification: `WebSocketRPCDecodingTests` (Swift Testing, `apps/swift-ios/Tests/CoreTests`) covers prefix retention with a healthy sibling, overflow without Ack, empty/null/absent chunks, malformed array framing, fixture snapshot ordering, and malformed batches. They ran green in CI in [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226137616/job/102060615337). No phone responsiveness measurement or visible UI change is claimed, so there is no media.

Base: Theo's `t3code/rebuild-mobile-app-swift` at `93ca26695e`, which is still the tip. It was rechecked on 2026-09-13, and neither the base nor `main` has superseding changes (`apps/swift-ios` does not exist on `main` yet; it lands with #5178).

Independent review: Claude Opus 5 (cross-provider to the GPT-6 author) read the frozen head `3da18f1` and found no actionable issues. A second read-only pass with GPT-5.6 Sol at high effort on 2026-09-13 re-inspected the same diff and found no actionable issues. No maintainer approval is claimed.

Model and harness: GPT-6 / Codex (implementation); Claude Opus 5 / Claude Code in T3 Code (refresh and review); SWE-2 / Devin in T3 Code (2026-09-13 refresh and review).

Coordination trace: T3 thread f599eac4-0568-4282-aa60-3cc7e55f7dcc
