### PR TITLE
fix(swift-ios): compare Windows checkout paths consistently

### DIFF
--- a/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
+++ b/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
@@ -88,9 +88,9 @@ enum NewTaskWorkspaceDefaults {
             ?? branches.first
     }
 
-    private static func checkoutComparisonPath(_ value: String) -> String {
+    private static func checkoutComparisonPath(_ value: String, windowsCheckout: Bool) -> String {
         let path = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if ProjectCreationPath.isWindowsAbsolutePath(path) {
+        if windowsCheckout, ProjectCreationPath.isWindowsAbsolutePath(path) {
             return ProjectCreationPath.normalizedForComparison(path)
         }
         return URL(fileURLWithPath: value).standardizedFileURL.path
@@ -101,8 +101,15 @@ enum NewTaskWorkspaceDefaults {
         projectPath: String
     ) -> String? {
         guard let path = branch?.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !path.isEmpty,
-              checkoutComparisonPath(path) != checkoutComparisonPath(projectPath) else {
+              !path.isEmpty else { return nil }
+        // Forward-slash UNC paths are ambiguous without a Windows root in either input.
+        // Preserve POSIX case sensitivity unless a drive or backslash UNC path establishes it.
+        let windowsCheckout = [path, projectPath].contains { value in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !trimmed.hasPrefix("//") && ProjectCreationPath.isWindowsAbsolutePath(trimmed)
+        }
+        guard checkoutComparisonPath(path, windowsCheckout: windowsCheckout)
+            != checkoutComparisonPath(projectPath, windowsCheckout: windowsCheckout) else {
             return nil
         }
         return path

--- a/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
+++ b/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
@@ -88,14 +88,21 @@ enum NewTaskWorkspaceDefaults {
             ?? branches.first
     }
 
+    private static func checkoutComparisonPath(_ value: String) -> String {
+        let path = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if ProjectCreationPath.isWindowsAbsolutePath(path) {
+            return ProjectCreationPath.normalizedForComparison(path)
+        }
+        return URL(fileURLWithPath: value).standardizedFileURL.path
+    }
+
     static func normalizedWorktreePath(
         for branch: FeatureWorkspaceBranch?,
         projectPath: String
     ) -> String? {
         guard let path = branch?.worktreePath?.trimmingCharacters(in: .whitespacesAndNewlines),
               !path.isEmpty,
-              URL(fileURLWithPath: path).standardizedFileURL.path
-                != URL(fileURLWithPath: projectPath).standardizedFileURL.path else {
+              checkoutComparisonPath(path) != checkoutComparisonPath(projectPath) else {
             return nil
         }
         return path

--- a/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
+++ b/apps/swift-ios/Features/Workspace/NewTaskWorkspaceModels.swift
@@ -93,7 +93,7 @@ enum NewTaskWorkspaceDefaults {
         if windowsCheckout, ProjectCreationPath.isWindowsAbsolutePath(path) {
             return ProjectCreationPath.normalizedForComparison(path)
         }
-        return URL(fileURLWithPath: value).standardizedFileURL.path
+        return URL(fileURLWithPath: path).standardizedFileURL.path
     }
 
     static func normalizedWorktreePath(

--- a/apps/swift-ios/Features/Workspace/ProjectCreationModels.swift
+++ b/apps/swift-ios/Features/Workspace/ProjectCreationModels.swift
@@ -266,7 +266,7 @@ enum ProjectCreationPath {
         return isWindowsAbsolutePath(path)
     }
 
-    private static func isWindowsAbsolutePath(_ path: String) -> Bool {
+    static func isWindowsAbsolutePath(_ path: String) -> Bool {
         if path.hasPrefix("\\\\") || path.hasPrefix("//") { return true }
         let scalars = Array(path.unicodeScalars.prefix(3))
         return scalars.count == 3

--- a/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
@@ -36,6 +36,8 @@ struct RemoteCheckoutPathTests {
         (#"\\server\share\."#, "//server/share"),
         (#"\\server\share\..\repo"#, "//server/repo"),
         ("/srv/App", "/srv/app"),
+        ("//srv/Work", "//srv/work"),
+        ("//srv/work", "//srv/Work"),
         (#"/srv/a\b"#, "/srv/a/b"),
         (#"C:\work\linked"#, #"C:\work\repo"#),
     ])

--- a/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import T3Code
+
+@Suite("Remote checkout path comparison")
+struct RemoteCheckoutPathTests {
+    @Test(arguments: [
+        (#"C:\Work\T3Code"#, "c:/work/t3code"),
+        (#"C:\Work\T3Code\"#, #"C:\Work\T3Code"#),
+        (#"\\server\share\repo"#, "//SERVER/share/repo"),
+        (#"C:\"#, "c:/"),
+        (#"\\SERVER\Share\"#, "//server/share"),
+        ("/repo/./", "/repo"),
+        ("/work/other/../repo", "/work/repo"),
+    ])
+    func equivalentRootsUseCurrentCheckout(_ checkout: String, _ project: String) {
+        let branch = FeatureWorkspaceBranch(name: "main", worktreePath: checkout)
+        #expect(NewTaskWorkspaceDefaults.normalizedWorktreePath(for: branch, projectPath: project) == nil)
+    }
+
+    @Test(arguments: [
+        ("/srv/linked/../repo", "/srv/repo"),
+        (#"C:\linked\..\repo"#, "c:/repo"),
+    ])
+    func projectDeduplicationPreservesUnresolvedParentSegments(_ input: String, _ other: String) {
+        #expect(ProjectCreationPath.normalizedForComparison(input)
+            != ProjectCreationPath.normalizedForComparison(other))
+    }
+
+    @Test(arguments: [
+        (#"C:\linked\..\repo"#, "c:/repo"),
+        (#"D:\work\repo"#, #"C:\work\repo"#),
+        (#"\\server\other\repo"#, #"\\server\share\repo"#),
+        (#"D:\"#, "c:/"),
+        (#"\\server\other\"#, "//server/share"),
+        (#"C:\repo\."#, "c:/repo"),
+        (#"\\server\share\."#, "//server/share"),
+        (#"\\server\share\..\repo"#, "//server/repo"),
+        ("/srv/App", "/srv/app"),
+        (#"/srv/a\b"#, "/srv/a/b"),
+        (#"C:\work\linked"#, #"C:\work\repo"#),
+    ])
+    func distinctWorktreesPreserveServerSpelling(_ checkout: String, _ project: String) {
+        let branch = FeatureWorkspaceBranch(name: "linked", worktreePath: checkout)
+        #expect(NewTaskWorkspaceDefaults.normalizedWorktreePath(for: branch, projectPath: project) == checkout)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/RemoteCheckoutPathTests.swift
@@ -11,6 +11,7 @@ struct RemoteCheckoutPathTests {
         (#"\\SERVER\Share\"#, "//server/share"),
         ("/repo/./", "/repo"),
         ("/work/other/../repo", "/work/repo"),
+        ("/repo", " /repo "),
     ])
     func equivalentRootsUseCurrentCheckout(_ checkout: String, _ project: String) {
         let branch = FeatureWorkspaceBranch(name: "main", worktreePath: checkout)


### PR DESCRIPTION
New Task compared remote Windows checkout paths using the Mac's local file-URL rules, so equivalent drive or UNC spellings (`C:\Work\T3Code` vs `c:/work/t3code`, `\\server\share` vs `//SERVER/share`) looked like different checkouts and a redundant worktree path was sent.

`NewTaskWorkspaceDefaults.normalizedWorktreePath` now uses `ProjectCreationPath.normalizedForComparison` (backslash-to-slash, trailing-slash trim, case-insensitive) when a drive letter or backslash UNC root establishes Windows semantics. Everything else keeps the existing standardized file-URL comparison, so POSIX paths, including ambiguous `//srv/...` double-slash paths, stay case-sensitive. Both inputs are trimmed before either comparison, matching the project-path validation convention. Shared project deduplication is unchanged; `isWindowsAbsolutePath` just becomes internal so the helper can reuse it.

Verification: the parameterized `RemoteCheckoutPathTests` cover equivalent drive and UNC roots, POSIX `.`/`..` standardization, stray whitespace, distinct drives, shares and worktrees, and POSIX case in both directions. They run in the `Contract fixtures and native tests` job on this head. No visible UI change, so no screenshots.

Base: `t3code/rebuild-mobile-app-swift` at `93ca26695e`, which is still current. Rechecked on 2026-09-13: no equivalent fix exists on the base, `main`, or other open PRs. #10755 touches separate source-control subscription paths; #11133 does not touch this comparison.

Independent cross-provider review (GPT-5.6 Sol, high effort, read-only) inspected the diff against the base and reported no actionable findings.

Coordination trace: T3 thread 4b288089-2bef-4c4c-801d-985e67ae94a2

Model and harness: GPT-6 / Codex (original change); Claude Opus 5 / Claude Code (2026-09-11 refresh); SWE-2 High / Devin via T3 Code (2026-09-13 refresh).
