### PR TITLE
fix(swift-ios): start queued uploads before draft persistence completes

### DIFF
--- a/apps/swift-ios/Features/Shared/FeatureAttachmentUploadCoordinator.swift
+++ b/apps/swift-ios/Features/Shared/FeatureAttachmentUploadCoordinator.swift
@@ -261,15 +261,14 @@ public final class FeatureAttachmentUploadCoordinator {
         result: Result<FeatureUploadedAttachmentReference?, any Error>
     ) async {
         runningTokens.remove(token)
-        guard jobs[key]?.token == token, jobs[key]?.state == .uploading else {
-            startQueuedJobs()
-            return
-        }
+        // Free the slot before awaiting draft persistence so the next transfer
+        // is not held up by a slow save.
+        startQueuedJobs()
+        guard jobs[key]?.token == token, jobs[key]?.state == .uploading else { return }
         switch result {
         case let .failure(error):
             fail(key: key, token: token, error: error)
         case let .success(reference):
-            startQueuedJobs()
             await persistThenPublish(
                 key: key,
                 token: token,
@@ -277,7 +276,6 @@ public final class FeatureAttachmentUploadCoordinator {
                 reference: reference
             )
         }
-        startQueuedJobs()
     }
 
     private func persistThenPublish(

--- a/apps/swift-ios/Features/Shared/FeatureAttachmentUploadCoordinator.swift
+++ b/apps/swift-ios/Features/Shared/FeatureAttachmentUploadCoordinator.swift
@@ -269,6 +269,7 @@ public final class FeatureAttachmentUploadCoordinator {
         case let .failure(error):
             fail(key: key, token: token, error: error)
         case let .success(reference):
+            startQueuedJobs()
             await persistThenPublish(
                 key: key,
                 token: token,

--- a/apps/swift-ios/Tests/FeatureTests/FeatureAttachmentUploadCoordinatorTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureAttachmentUploadCoordinatorTests.swift
@@ -6,6 +6,35 @@ import Testing
 @Suite("Attachment pre-upload coordinator")
 @MainActor
 struct FeatureAttachmentUploadCoordinatorTests {
+    @Test func completedTransferStartsNextUploadBeforeDraftSaveFinishes() async throws {
+        let uploads = CoordinatorUploadHarness()
+        let persistence = CoordinatorPersistenceHarness(suspended: true)
+        let coordinator = FeatureAttachmentUploadCoordinator(
+            maximumConcurrentUploads: 1,
+            upload: uploads.upload,
+            persist: persistence.persist
+        )
+        let values = [attachment(byte: 1), attachment(byte: 2)]
+        coordinator.syncOwner(draftKey: "draft", environmentID: "one", attachments: values)
+        let first = await uploads.nextStart()
+        uploads.complete(first, environmentID: "one")
+        await persistence.nextCall()
+
+        let second = await uploads.nextStart()
+        #expect(second != first)
+        #expect(uploads.maximumActive == 1)
+        #expect(coordinator.state(environmentID: "one", attachmentID: first) == .uploading)
+
+        persistence.resume(result: true)
+        uploads.complete(second, environmentID: "one")
+        await waitUntilObserved {
+            values.allSatisfy {
+                coordinator.state(environmentID: "one", attachmentID: $0.id)
+                    == .ready(.init(environmentID: "one", attachmentID: "uploaded"))
+            }
+        }
+    }
+
     @Test func canceledTransferKeepsConcurrencySlotUntilItReturns() async throws {
         let uploads = CoordinatorUploadHarness()
         let coordinator = makeCoordinator(limit: 3, uploads: uploads)


### PR DESCRIPTION
When an attachment finished uploading, the SwiftUI upload coordinator kept its concurrency slot until the draft save for that attachment completed. A slow save therefore held up the next queued upload.

`transferReturned` now calls `startQueuedJobs()` once, right after the finished transfer releases its slot and before draft persistence is awaited. That single call covers the success, failure, and stale-token paths, replacing the three separate calls. The attachment still becomes `.ready` only after its save succeeds.

Verification:
- New regression `completedTransferStartsNextUploadBeforeDraftSaveFinishes`: with persistence held, the next transfer starts, the concurrency limit stays at 1, the first attachment stays `.uploading` until its save completes, and both attachments end `.ready`.
- Focused run of `T3CodeTests/FeatureAttachmentUploadCoordinatorTests` on an iPhone 16 Pro simulator (iOS 26.5) with isolated DerivedData: 8 tests, 0 failures. The independent reviewer re-ran the same suite green.
- CI `Contract fixtures and native tests` and all other checks pass on `c6487a3`.

No visible UI changes, so no media.

Base: `t3code/rebuild-mobile-app-swift` at `93ca26695e`; the branch is already current with it.

Independent review: Codex CLI (GPT-5.6 Sol, read-only, high effort) reviewed the diff against the base and reported no actionable findings.

Coordination trace: T3 thread c2f54b1d-58b5-40a3-bafa-87a436c894ec

Model and harness: GPT-6 / Codex (original fix); Claude Opus 5 / Claude Code (simplification and refresh); SWE-2 High / Devin in T3 Code (ownership pass, review gate, body refresh).