### PR TITLE
fix(swift-ios): preserve literal plus signs in pairing tokens

### DIFF
--- a/apps/swift-ios/App/Cloud/T3ConnectManagedAuthorization.swift
+++ b/apps/swift-ios/App/Cloud/T3ConnectManagedAuthorization.swift
@@ -271,7 +271,11 @@ public actor T3ConnectManagedEnvironmentAuthorizer {
         components.queryItems = fields.keys.sorted().map {
             URLQueryItem(name: $0, value: fields[$0])
         }
-        return Data((components.percentEncodedQuery ?? "").utf8)
+        return Data(
+            (components.percentEncodedQuery ?? "")
+                .replacingOccurrences(of: "+", with: "%2B")
+                .utf8
+        )
     }
 }
 

--- a/apps/swift-ios/App/Cloud/T3ConnectRelayClient.swift
+++ b/apps/swift-ios/App/Cloud/T3ConnectRelayClient.swift
@@ -512,7 +512,11 @@ public actor T3ConnectRelayClient {
         components.queryItems = fields.keys.sorted().map {
             URLQueryItem(name: $0, value: fields[$0])
         }
-        return Data((components.percentEncodedQuery ?? "").utf8)
+        return Data(
+            (components.percentEncodedQuery ?? "")
+                .replacingOccurrences(of: "+", with: "%2B")
+                .utf8
+        )
     }
 
     private struct ConnectRequest: Encodable {

--- a/apps/swift-ios/Core/PairingService.swift
+++ b/apps/swift-ios/Core/PairingService.swift
@@ -140,7 +140,9 @@ public actor PairingService {
         form.queryItems = fields
         var request = URLRequest(url: endpoint(target.httpBaseURL, path: "/oauth/token"))
         request.httpMethod = "POST"
-        request.httpBody = form.percentEncodedQuery?.data(using: .utf8)
+        request.httpBody = form.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
+            .data(using: .utf8)
         request.setValue(
             "application/x-www-form-urlencoded",
             forHTTPHeaderField: "Content-Type"

--- a/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PairingServiceTests.swift
@@ -3,6 +3,35 @@ import XCTest
 
 @MainActor
 final class PairingServiceTests: XCTestCase {
+    func testPairingFormPreservesLiteralPlusInTokenAndClientLabel() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-pairing-form-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let transport = PairingHTTPTransport()
+        let service = PairingService(
+            transport: transport,
+            environmentStore: EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json")),
+            credentialStore: InMemoryCredentialStore()
+        )
+
+        _ = try await service.pair(
+            host: "https://studio.example",
+            code: "pair+once",
+            label: "Alex + iPhone"
+        )
+
+        let requests = await transport.requests
+        let request = try XCTUnwrap(requests.first { $0.url?.path == "/oauth/token" })
+        let data = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(String(data: data, encoding: .utf8))
+        // Form decoding converts raw plus signs to spaces before percent decoding.
+        var form = URLComponents()
+        form.percentEncodedQuery = body.replacingOccurrences(of: "+", with: "%20")
+        let fields = try XCTUnwrap(form.queryItems)
+        XCTAssertEqual(fields.first { $0.name == "subject_token" }?.value, "pair+once")
+        XCTAssertEqual(fields.first { $0.name == "client_label" }?.value, "Alex + iPhone")
+    }
+
     func testPairingExchangesTokenAndPersistsSecretSeparately() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-swift-pairing-\(UUID().uuidString)", isDirectory: true)

--- a/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/T3ConnectRuntimeTests.swift
@@ -150,6 +150,49 @@ final class T3ConnectRuntimeTests: XCTestCase {
         XCTAssertTrue(requests.allSatisfy { $0.url?.query == nil })
     }
 
+    func testManagedExchangePreservesLiteralPlusInBootstrapCredentialAndLabel() async throws {
+        let signer = try testSigner()
+        let transport = T3ConnectScriptedHTTPTransport { _, _ in
+            (
+                .token(
+                    scopes: T3ConnectManagedEnvironmentAuthorizer.standardScopes
+                        .joined(separator: " ")
+                ),
+                200
+            )
+        }
+        let authorizer = T3ConnectManagedEnvironmentAuthorizer(
+            transport: transport,
+            signer: signer
+        )
+        let endpoint = T3ConnectManagedEndpoint(
+            httpBaseUrl: "https://managed.example",
+            wsBaseUrl: "wss://managed.example/ws",
+            providerKind: .t3Relay
+        )
+        let bootstrap = T3ConnectManagedEnvironmentCredential(
+            environmentID: "managed-1",
+            label: "Managed Studio",
+            endpoint: endpoint,
+            bootstrapCredential: "bootstrap+once",
+            bootstrapExpiresAt: "2026-08-01T12:00:00.000Z",
+            proofKeyThumbprint: try await signer.thumbprint()
+        )
+
+        _ = try await authorizer.exchange(bootstrap, clientLabel: "Alex + iPhone")
+
+        let requests = await transport.requests
+        let request = try XCTUnwrap(requests.first { $0.url?.path == "/oauth/token" })
+        let data = try XCTUnwrap(request.httpBody)
+        let body = try XCTUnwrap(String(data: data, encoding: .utf8))
+        // Form decoding converts raw plus signs to spaces before percent decoding.
+        var form = URLComponents()
+        form.percentEncodedQuery = body.replacingOccurrences(of: "+", with: "%20")
+        let fields = try XCTUnwrap(form.queryItems)
+        XCTAssertEqual(fields.first { $0.name == "subject_token" }?.value, "bootstrap+once")
+        XCTAssertEqual(fields.first { $0.name == "client_label" }?.value, "Alex + iPhone")
+    }
+
     func testSixtySecondMarginRefreshesAndPersistsBeforeFirstRequest() async throws {
         let fixture = try await refreshFixture(
             savedThumbprint: nil,


### PR DESCRIPTION
The SwiftUI client posts the `/oauth/token` pairing exchange as `application/x-www-form-urlencoded`. `URLComponents.percentEncodedQuery` leaves `+` unescaped. The server decodes the form with URLSearchParams semantics (`HttpApiSchema.asFormUrlEncoded()` in `packages/contracts/src/auth.ts`), so a literal `+` in a pairing token or client label became a space, and pairing failed.

Fix: escape `+` as `%2B` in the encoded query before it becomes the request body. Applied to all three form-encoded token exchange bodies: `Core/PairingService.swift` (pairing code and client label) and the two duplicated `formEncoded` helpers in `App/Cloud/T3ConnectManagedAuthorization.swift` and `App/Cloud/T3ConnectRelayClient.swift`, which post the same `environment-bootstrap` `subject_token` and a user-entered `client_label` to the same endpoint shape.

Coverage: `PairingServiceTests.testPairingFormPreservesLiteralPlusInTokenAndClientLabel` and `T3ConnectRuntimeTests.testManagedExchangePreservesLiteralPlusInBootstrapCredentialAndLabel` capture the request body, decode it the way a form decoder does, and assert `subject_token`/`client_label` round-trip.

Verification: the `Contract fixtures and native tests` CI job runs the SwiftUI Core XCTests on this head. Locally verified the Foundation encode/decode semantics with a standalone `URLComponents` check and a `swiftc -parse` pass on the touched files; the XCTest itself is exercised by CI (no local Xcode build, per shared-host policy). Nothing a user can see changes, so there is no media.

Independent cross-provider review: Codex GPT-5.6 Sol, high effort, read-only, on commit 3708ab4033 — no actionable findings.

Coordination trace: T3 thread 9106f210-eb03-496d-a615-36d253870b8e

Model and harness: GPT-6 / Codex (original change); swe-2-high / Devin in T3 Code (refresh).