### PR TITLE
fix(swift-ios): classify numeric local addresses consistently

### DIFF
--- a/apps/swift-ios/Core/LocalNetworkProbe.swift
+++ b/apps/swift-ios/Core/LocalNetworkProbe.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 
 public struct ConnectionProbeResult: Equatable, Sendable {
     public let baseURL: URL
@@ -132,24 +133,21 @@ public actor LocalNetworkProbe {
         if value == "localhost" || value == "::1" || value.hasSuffix(".local") {
             return true
         }
-        if value.hasPrefix("10.")
-            || value.hasPrefix("127.")
-            || value.hasPrefix("192.168.")
-            || value.hasPrefix("169.254.")
-        {
-            return true
+        if let address = IPv4Address(value) {
+            let octets = Array(address.rawValue)
+            return octets[0] == 10
+                || octets[0] == 127
+                || (octets[0] == 192 && octets[1] == 168)
+                || (octets[0] == 169 && octets[1] == 254)
+                || (octets[0] == 172 && (16...31).contains(octets[1]))
         }
-        let octets = value.split(separator: ".").compactMap { Int($0) }
-        if octets.count == 4, octets[0] == 172, (16...31).contains(octets[1]) {
-            return true
-        }
-        // IPv6 unique-local and link-local ranges.
-        return value.hasPrefix("fc")
-            || value.hasPrefix("fd")
-            || value.hasPrefix("fe8")
-            || value.hasPrefix("fe9")
-            || value.hasPrefix("fea")
-            || value.hasPrefix("feb")
+        let unscoped = value.components(separatedBy: "%")[0]
+        guard let address = IPv6Address(unscoped) else { return false }
+        let octets = Array(address.rawValue)
+        // IPv6 loopback, unique-local (fc00::/7), and link-local (fe80::/10).
+        return (octets.prefix(15).allSatisfy { $0 == 0 } && octets[15] == 1)
+            || octets[0] & 0xfe == 0xfc
+            || (octets[0] == 0xfe && octets[1] & 0xc0 == 0x80)
     }
 
     private static func hasPermissionDenialEvidence(_ error: NSError) -> Bool {

--- a/apps/swift-ios/Features/Connection/ConnectionDetails.swift
+++ b/apps/swift-ios/Features/Connection/ConnectionDetails.swift
@@ -216,29 +216,7 @@ enum EndpointNetworkScope {
     }
 
     static func isLocalHost(_ rawHost: String) -> Bool {
-        let host = hostWithoutPort(rawHost).lowercased()
-
-        if host == "localhost" || host.hasSuffix(".local") || host == "::1" {
-            return true
-        }
-
-        let octets = host.split(separator: ".").compactMap { Int($0) }
-        if octets.count == 4, octets.allSatisfy({ 0 ... 255 ~= $0 }) {
-            return octets[0] == 10
-                || octets[0] == 127
-                || (octets[0] == 169 && octets[1] == 254)
-                || (octets[0] == 172 && 16 ... 31 ~= octets[1])
-                || (octets[0] == 192 && octets[1] == 168)
-        }
-
-        guard host.contains(":"),
-              let firstHextetText = host.split(separator: ":", omittingEmptySubsequences: true).first,
-              let firstHextet = UInt16(firstHextetText, radix: 16)
-        else {
-            return false
-        }
-        return firstHextet & 0xffc0 == 0xfe80
-            || firstHextet & 0xfe00 == 0xfc00
+        LocalNetworkProbe.isLocalHost(hostWithoutPort(rawHost))
     }
 
     private static func hostWithoutPort(_ rawHost: String) -> String {

--- a/apps/swift-ios/Tests/CoreTests/TransportReliabilityTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/TransportReliabilityTests.swift
@@ -815,6 +815,38 @@ final class TransportReliabilityTests: XCTestCase {
         XCTAssertEqual(target.webSocketBaseURL.absoluteString, "ws://192.168.1.7:18773/")
     }
 
+    func testLocalNetworkProbeRecognizesAddressesInsteadOfHostnamePrefixes() {
+        for host in [
+            "fc.example.com", "fd.example.com", "fe80.example.com",
+            "10.example.com", "192.168.example.com", "10.999.0.1",
+        ] {
+            XCTAssertFalse(LocalNetworkProbe.isLocalHost(host), host)
+        }
+        for host in [
+            "localhost", "studio.local", "10.0.0.1", "172.16.0.1", "172.31.255.255",
+            "192.168.1.1", "127.0.0.1", "169.254.1.1", "::1", "0:0:0:0:0:0:0:1",
+            "fc00::1", "[fd12::1]", "fe80::1%en0", "febf::1",
+        ] {
+            XCTAssertTrue(LocalNetworkProbe.isLocalHost(host), host)
+        }
+        for host in [
+            "172.15.255.255", "172.32.0.1", "8.8.8.8", "2001:db8::1",
+            "fbff::1", "fe7f::1", "fec0::1",
+        ] {
+            XCTAssertFalse(LocalNetworkProbe.isLocalHost(host), host)
+        }
+        let host = "fc.example.com"
+        let denied = NSError(
+            domain: NSURLErrorDomain,
+            code: URLError.notConnectedToInternet.rawValue,
+            userInfo: [NSUnderlyingErrorKey: NSError(domain: NSPOSIXErrorDomain, code: 13)]
+        )
+        XCTAssertEqual(
+            LocalNetworkProbe.classify(denied, host: host, isLocal: LocalNetworkProbe.isLocalHost(host)),
+            .unavailableHost(host)
+        )
+    }
+
     func testLocalNetworkProbeClassificationDistinguishesFailureModes() {
         XCTAssertTrue(LocalNetworkProbe.isLocalHost("192.168.20.4"))
         XCTAssertTrue(LocalNetworkProbe.isLocalHost("studio.local"))

--- a/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
@@ -111,6 +111,7 @@ struct LocalEndpointDetectionTests {
         "192.168.213.171",
         "[::1]",
         "::1",
+        "0:0:0:0:0:0:0:1",
         "[fe80::aede:48ff:fe00:1122]:3773",
         "fd12:3456:789a::1",
         "fc00::1",
@@ -124,6 +125,10 @@ struct LocalEndpointDetectionTests {
         "172.32.0.1",
         "example.com",
         "2001:4860:4860::8888",
+        "::fd00",
+        "fc.example.com",
+        "10.example.com",
+        "10.999.0.1",
     ])
     func rejectsPublicHosts(_ host: String) {
         #expect(!EndpointNetworkScope.isLocalHost(host))


### PR DESCRIPTION
SwiftUI local-address classification matched textual prefixes, so hostnames like `fc.example.com` or `10.example.com` were treated as local, and the connection details parser kept its own separate copy of the rules.

`LocalNetworkProbe.isLocalHost` now parses the host with `IPv4Address` / `IPv6Address` and classifies the address bytes: 10/8, 127/8, 172.16/12, 192.168/16, 169.254/16, IPv6 loopback, fc00::/7, and fe80::/10, with IPv6 zone IDs stripped. `EndpointNetworkScope.isLocalHost` removes its port and brackets, then calls the same function, so both entry points follow one policy.

Verification: the [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226180824/job/102060755552) job on `062c9a6` ran the new `TransportReliabilityTests.testLocalNetworkProbeRecognizesAddressesInsteadOfHostnamePrefixes` and the extended `LocalEndpointDetectionTests` accept/reject matrices, and both passed. Skipped checks are not counted as executed. A follow-up pass additionally exercised the classifier against 23 literal/hostname cases through the real `Network` framework parsers, and an independent read-only review found no actionable findings.

The branch is current with `t3code/rebuild-mobile-app-swift` (`93ca26695e`), and no newer upstream commit or PR covers this change. There is no visible UI change.

Model and harness: GPT-6 / Codex (implementation); Claude Opus 5 / Claude Code (freshness check and read-through, no code changes); SWE-2 / Devin via Cursor (re-verification and review pass, no code changes).
Coordination trace: T3 thread aa878c83-27fc-4c1c-b6a9-c24f0b59b306
Coordination trace: T3 thread 3bc9efe4-d6bb-4893-9404-606f3cb61daf

🤖 Generated with [Claude Code](https://claude.com/claude-code)