### PR TITLE
fix(swift-ios): preserve unsupported environment documents

### DIFF
--- a/apps/swift-ios/Core/Persistence.swift
+++ b/apps/swift-ios/Core/Persistence.swift
@@ -337,6 +337,9 @@ public actor EnvironmentStore {
         }
         let data = try Data(contentsOf: fileURL)
         let document = try JSONDecoder.t3.decode(Document.self, from: data)
+        guard document.version == 1 else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
         cached = document
         return document
     }

--- a/apps/swift-ios/Tests/CoreTests/EnvironmentStoreVersionTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/EnvironmentStoreVersionTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+@Suite("Environment store format compatibility")
+struct EnvironmentStoreVersionTests {
+    @Test(arguments: [0, 2])
+    func unsupportedFormatIsNotCachedOrOverwritten(_ version: Int) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-environment-format-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let file = directory.appendingPathComponent("environments.json")
+        let original = try JSONSerialization.data(withJSONObject: [
+            "version": version,
+            "environments": [],
+            "unrecognizedState": "preserve this",
+        ])
+        try original.write(to: file)
+        let store = EnvironmentStore(fileURL: file)
+
+        await #expect(throws: CocoaError.self) { try await store.load() }
+        await #expect(throws: CocoaError.self) { try await store.setActiveEnvironment(id: nil) }
+        #expect(try Data(contentsOf: file) == original)
+
+        let supported = Data(#"{"version":1,"environments":[]}"#.utf8)
+        try supported.write(to: file, options: .atomic)
+        #expect(try await store.load().isEmpty)
+        try await store.setActiveEnvironment(id: nil)
+        #expect(try await store.activeEnvironmentID() == nil)
+    }
+}


### PR DESCRIPTION
`EnvironmentStore` decoded `environments.json` without checking `version`, cached it, and the next write re-encoded it as version 1, silently dropping any fields a newer (or older) format carried.

`loadDocument()` now rejects any version other than 1 before caching, so every read and write fails instead of overwriting the file. Once a supported document replaces it, the same store instance recovers.

Verification: `EnvironmentStoreVersionTests` (new, versions 0 and 2) asserts the load and write both throw, the file bytes are unchanged, and a later v1 document loads and saves. It passed in CI's `Contract fixtures and native tests` job on this head ([run](https://github.com/pingdotgg/t3code/actions/runs/34226188456/job/102060780017), 664 tests in 54 suites). The base branch has not moved since, so no local rebuild was needed. An independent read-only review (GPT-5.6 Sol, high effort) found no actionable findings on this head.

No visible UI change; SwiftUI mobile only.

Coordination trace: T3 thread eee1e800-c036-4d8f-ac10-d2fe595583b5
Coordination trace: T3 thread eb799c25-4e0d-43fe-9de4-acd552ee870a

Model and harness: GPT-6 / Codex (original change); Claude Opus 5 / Claude Code (refresh); SWE-2 High / Devin in T3 Code via Cursor harness (this pass).
