### PR TITLE
fix(swift-ios): probe bracketed IPv6 endpoints correctly

### DIFF
--- a/apps/swift-ios/Features/Connection/LocalNetworkAccessChecker.swift
+++ b/apps/swift-ios/Features/Connection/LocalNetworkAccessChecker.swift
@@ -30,7 +30,7 @@ struct LocalNetworkAccessChecker: ConnectionReadinessChecking {
 
         return await withCheckedContinuation { continuation in
             let connection = NWConnection(
-                host: NWEndpoint.Host(hostname),
+                host: NWEndpoint.Host(hostname.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))),
                 port: port,
                 using: .tcp
             )

--- a/apps/swift-ios/Tests/FeatureTests/LocalNetworkAccessCheckerTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/LocalNetworkAccessCheckerTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Network
+import Testing
+@testable import T3Code
+
+@Suite("Local network readiness probe")
+@MainActor
+struct LocalNetworkAccessCheckerTests {
+    @Test func connectsToBracketedIPv6Loopback() async throws {
+        let listener = try IPv6ProbeListener()
+        defer { listener.stop() }
+        var ports = listener.ready.makeAsyncIterator()
+        let port = try #require(try await ports.next())
+
+        let result = await LocalNetworkAccessChecker().check(endpoint: "http://[::1]:\(port)")
+
+        #expect(result == .ready)
+    }
+}
+
+@MainActor
+private final class IPv6ProbeListener {
+    let ready: AsyncThrowingStream<UInt16, Error>
+    private let listener: NWListener
+    private var connections: [NWConnection] = []
+    private var stopped = false
+
+    init() throws {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: .ipv6(.loopback), port: .any)
+        let listener = try NWListener(using: parameters, on: .any)
+        self.listener = listener
+        let (ready, continuation) = AsyncThrowingStream.makeStream(of: UInt16.self)
+        self.ready = ready
+        listener.stateUpdateHandler = { [weak listener] state in
+            switch state {
+            case .ready:
+                if let port = listener?.port {
+                    continuation.yield(port.rawValue)
+                    continuation.finish()
+                }
+            case let .failed(error):
+                continuation.finish(throwing: error)
+            case .cancelled:
+                continuation.finish(throwing: CancellationError())
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            Task { @MainActor [weak self] in
+                guard let self, !self.stopped else {
+                    connection.cancel()
+                    return
+                }
+                self.connections.append(connection)
+                connection.start(queue: .global(qos: .userInitiated))
+            }
+        }
+        listener.start(queue: .global(qos: .userInitiated))
+    }
+
+    func stop() {
+        stopped = true
+        listener.cancel()
+        connections.forEach { $0.cancel() }
+        connections.removeAll()
+    }
+}


### PR DESCRIPTION
The SwiftUI local-network readiness probe passed the URL host straight into `NWEndpoint.Host`. For an IPv6 literal such as `http://[::1]:3773`, that host keeps its brackets, so Network treated it as a DNS name and the probe reported a reachable IPv6 server as unreachable.

The fix strips the URL brackets before building the endpoint — the same normalization `LocalNetworkProbe.isLocalHost` already uses. A new Swift Testing case opens a real IPv6 loopback listener and checks that `LocalNetworkAccessChecker` reports `.ready` for `http://[::1]:<port>`.

Verification:
- Contract fixtures and native tests ran `connectsToBracketedIPv6Loopback()` on this head (`7ce59bd`) and it passed ([job log](https://github.com/pingdotgg/t3code/actions/runs/34226195789/job/102060804593)). All checks on this head are green.
- As of 2026-09-13 the branch sits directly on the current `t3code/rebuild-mobile-app-swift` (`93ca266`), so no rebase was needed. The base still has the unstripped `NWEndpoint.Host(hostname)`, so this fix is not superseded. #10736 is a separate change to how local addresses are classified.

Nothing visible changes in the UI, so there are no screenshots.

Cross-provider review: `codex exec review --base` with GPT-5.6 Sol (high effort, read-only) inspected the diff against the base and found no actionable defects.

Coordination trace: T3 thread a4a57dfb-f2c9-4d57-ada3-8dcf50f1abd1
Coordination trace: T3 thread 8ec52c06-70b0-4442-97ad-6558a44316a4

Model and harness: GPT-6 / Codex (implementation); Claude Opus 5 / Claude Code (refresh and verification); SWE-2 High / Devin (re-review and babysit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
