### PR TITLE
fix(swift-ios): recover when a keepalive send stalls

### DIFF
--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -840,6 +840,17 @@ public actor WebSocketRPCClient {
             await disconnected(expectedConnectionID: expectedConnectionID)
             return false
         }
+        let sendTimeout = keepaliveInterval
+        let sendDeadline = Task { [weak self] in
+            do {
+                try await Task.sleep(for: sendTimeout)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await self?.disconnected(expectedConnectionID: expectedConnectionID)
+        }
+        defer { sendDeadline.cancel() }
         do {
             awaitingKeepaliveResponse = true
             try await sendControl("Ping", requestID: nil)

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -68,6 +68,7 @@ final class WebSocketRPCRaceTests: XCTestCase {
         let response = try await client.request("server.afterHungPing", as: JSONValue.self)
         XCTAssertEqual(response, .object([:]))
         await hung.releaseSend()
+        try await hung.waitUntilSendReturned()
         let afterRelease = try await client.request("server.afterOldPingReturns", as: JSONValue.self)
         XCTAssertEqual(afterRelease, .object([:]))
     }
@@ -1527,11 +1528,13 @@ private actor HungSendConnection: WebSocketConnection {
 
 private actor SuspendedSendConnection: WebSocketConnection {
     private var sendContinuation: CheckedContinuation<Void, Error>?
+    private let sendReturns = AsyncStream.makeStream(of: Void.self)
     private var receiveContinuation: CheckedContinuation<Data, Error>?
     private var sendWaiters: [CheckedContinuation<Void, Never>] = []
     private var receiveWaiters: [CheckedContinuation<Void, Never>] = []
 
     func send(_: Data) async throws {
+        defer { sendReturns.continuation.yield(()) }
         let waiters = sendWaiters
         sendWaiters.removeAll()
         waiters.forEach { $0.resume() }
@@ -1573,6 +1576,11 @@ private actor SuspendedSendConnection: WebSocketConnection {
         receiveContinuation = nil
     }
 
+    func waitUntilSendReturned() async throws {
+        var returns = sendReturns.stream.makeAsyncIterator()
+        guard await returns.next() != nil else { throw CancellationError() }
+    }
+
     func releaseSend() {
         sendContinuation?.resume()
         sendContinuation = nil
@@ -1580,13 +1588,22 @@ private actor SuspendedSendConnection: WebSocketConnection {
 }
 
 private actor AutoReplyConnection: WebSocketConnection {
+    private let respondsToPings: Bool
     private var sentRequests = 0
     private var queuedResponses: [Data] = []
     private var receiveContinuation: CheckedContinuation<Data, Error>?
 
+    init(respondsToPings: Bool = false) {
+        self.respondsToPings = respondsToPings
+    }
+
     func send(_ data: Data) throws {
         sentRequests += 1
         let request = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        if respondsToPings, request["_tag"]?.stringValue == "Ping" {
+            enqueue(try JSONEncoder.t3.encode(JSONValue.object(["_tag": .string("Pong")])))
+            return
+        }
         guard case let .number(requestID) = request["id"] else { return }
         let response = JSONValue.object([
             "_tag": .string("Exit"),

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -47,6 +47,31 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
+    func testHungKeepaliveSendReplacesTheSocket() async throws {
+        let hung = SuspendedSendConnection()
+        let recovered = AutoReplyConnection(respondsToPings: true)
+        let connector = SequencedConnector(connections: [hung, recovered])
+        let client = WebSocketRPCClient(
+            connector: connector,
+            keepaliveInterval: .milliseconds(20),
+            reconnectBackoff: { _ in .zero },
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+        addTeardownBlock {
+            await hung.releaseSend()
+            await client.stop()
+        }
+
+        await client.start()
+        await hung.waitUntilSending()
+        await connector.waitUntilConnectionCount(2)
+        let response = try await client.request("server.afterHungPing", as: JSONValue.self)
+        XCTAssertEqual(response, .object([:]))
+        await hung.releaseSend()
+        let afterRelease = try await client.request("server.afterOldPingReturns", as: JSONValue.self)
+        XCTAssertEqual(afterRelease, .object([:]))
+    }
+
     func testColdSubscriptionRetainsFailedSocketIdentity() async throws {
         let connection = SubscriptionTrafficConnection(sendsInvalidSubscriptionValue: true)
         let connector = GatedConnector(connection: connection)


### PR DESCRIPTION
If a keepalive `Ping` send never returns, the SwiftUI client stops detecting a dead socket. The keepalive loop waits on that send, so its next tick, which would notice the missing `Pong` and reconnect, never runs.

Fix: `sendKeepalive` now starts a deadline, set to the existing keepalive interval, before it sends the `Ping`. The deadline is cancelled when the send returns. If the deadline fires, it calls `disconnected(expectedConnectionID:)` for the connection that sent the Ping. That scoping means it cannot close a replacement socket, and a stale send that returns late does nothing to the new connection. This is the same deadline-task pattern the client already uses for unary sends (`startUnarySendDeadline`).

Test: `WebSocketRPCRaceTests.testHungKeepaliveSendReplacesTheSocket` holds the first socket's Ping send open. It checks that the client reconnects and serves a request on the new socket, then releases the old send and checks that the new socket still works.

Stacked on `t3code/rebuild-mobile-app-swift` (#5178): `apps/swift-ios` does not exist on `main` yet, so this PR keeps that declared base.

Verification:
- The base tip is still `93ca26695e`, the parent of these two commits — nothing to rebase. Nothing on the base or on `main` touches this code path, and no merged or open PR duplicates the fix.
- [Contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226202862/job/102060829243) on head `1a9ab5e02` ran `testHungKeepaliveSendReplacesTheSocket`, which passed along with the rest of `T3CodeTests`. All PR checks are green.
- No visible UI change, so no media.
- Cross-provider review (`codex exec`, gpt-5.6-sol, high effort, read-only, exit 0) found no correctness issues. Its one low finding — prefer Swift Testing over XCTest for the new test — was rejected: every `WebSocketRPCClient` race fixture lives in the existing `WebSocketRPCRaceTests` XCTestCase and shares its private fixtures, and sibling PRs extend the same suite.

Coordination trace: T3 thread 32609fac-13f1-4d12-85a2-93984369c491

Model and harness: GPT-6 / Codex (implementation); Claude Opus 5 / Claude Code (first upkeep pass); SWE-2 High / Devin (upkeep pass).
