### PR TITLE
fix(swift-ios): avoid connecting for cancelled requests

### DIFF
--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -492,6 +492,7 @@ public actor WebSocketRPCClient {
     }
 
     private func requestRaw(_ tag: String, payload: JSONValue) async throws -> JSONValue {
+        try Task.checkCancellation()
         start()
         let id = allocateRequestID()
         let envelope = RPCRequestEnvelope(

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -416,7 +416,6 @@ final class WebSocketRPCRaceTests: XCTestCase {
             connector: SequencedConnector(connections: [connection]),
             endpointProvider: { URL(string: "wss://studio.example/ws")! }
         )
-        addTeardownBlock { await client.stop() }
         let request = Task {
             await gate.wait()
             return try await client.request("server.cancelledBeforeInstall", as: JSONValue.self)

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -416,6 +416,7 @@ final class WebSocketRPCRaceTests: XCTestCase {
             connector: SequencedConnector(connections: [connection]),
             endpointProvider: { URL(string: "wss://studio.example/ws")! }
         )
+        addTeardownBlock { await client.stop() }
         let request = Task {
             await gate.wait()
             return try await client.request("server.cancelledBeforeInstall", as: JSONValue.self)
@@ -430,6 +431,14 @@ final class WebSocketRPCRaceTests: XCTestCase {
         } catch is CancellationError {}
         let sentRequestCount = await connection.sentRequestCount()
         XCTAssertEqual(sentRequestCount, 0)
+        do {
+            _ = try await client.waitForConnection(after: nil)
+            XCTFail("An already-cancelled request must not start the connection loop")
+        } catch let error as RPCError {
+            guard case .disconnected = error else { throw error }
+        }
+        let response = try await client.request("server.afterCancelledRequest", as: JSONValue.self)
+        XCTAssertEqual(response, .object([:]))
         await client.stop()
     }
 


### PR DESCRIPTION
If an RPC request was already cancelled, `WebSocketRPCClient.requestRaw` still called `start()` and began connecting before it noticed the cancellation. That opened a socket nobody needed.

Fix: `requestRaw` calls `Task.checkCancellation()` before `start()` and before allocating the request ID. `subscribeOnCurrentConnection` and `waitForConnection` already use the same guard. The regression test checks three things: the cancelled request sends nothing, it doesn't start the connection loop (`waitForConnection` still throws `.disconnected`), and a later request still connects and completes.

Not superseded: the base branch's earlier `29836bd` guard stops a pre-cancelled request from being sent but still opens the connection; this PR avoids connecting at all. `main` doesn't contain `apps/swift-ios`, so this stays stacked on `t3code/rebuild-mobile-app-swift` at its current head (`93ca266`). No user-visible UI change, so no media.

Verification: `xcodebuild test -only-testing:T3CodeTests/WebSocketRPCRaceTests` on an iOS Simulator with isolated DerivedData ran 24 tests with 0 failures; CI "Contract fixtures and native tests" is green on the pushed head.

Independent cross-provider review: GPT-5.6 Sol (high effort, read-only) reviewed the diff against the base and reported no actionable findings.

Coordination trace: T3 thread af6348db-8ccd-49f4-bbe9-68eeca5de78e

Model and harness: GPT-6 / Codex (original change); Claude Opus 5 / Claude Code (first refresh); SWE-2 High / Devin in T3 Code (this refresh).

Generated with [Devin](https://devin.ai)
