### PR TITLE
fix(swift-ios): retain subscriptions created during connection setup

### DIFF
--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -658,7 +658,6 @@ public actor WebSocketRPCClient {
         for id in Array(unary.keys) {
             await sendUnary(id)
         }
-        subscriptionByRequestID.removeAll()
         for id in Array(subscriptions.keys) {
             await sendSubscription(id)
         }

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -598,7 +598,7 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
-    func testConnectionSetupAndSubscribeRaceSendsOneWireRequest() async throws {
+    func testConnectionSetupAndSubscribeRaceSendsOnceAndDeliversEvents() async throws {
         let connection = SetupSubscriptionRaceConnection()
         let client = WebSocketRPCClient(
             connector: SequencedConnector(connections: [connection]),
@@ -621,8 +621,10 @@ final class WebSocketRPCRaceTests: XCTestCase {
             1,
             "Connection setup and subscribe() must not both own the same subscription send."
         )
-        _ = stream
         await connection.releaseSubscriptionSend()
+        var events = stream.makeAsyncIterator()
+        let value = try await events.next()
+        XCTAssertEqual(value, .number(42))
         await client.stop()
     }
 
@@ -959,6 +961,11 @@ private actor SetupSubscriptionRaceConnection: WebSocketConnection {
             subscriptionWaiters.removeAll()
             waiters.forEach { $0.resume() }
             await withCheckedContinuation { subscriptionSendContinuation = $0 }
+            enqueue(try JSONEncoder.t3.encode(JSONValue.object([
+                "_tag": .string("Chunk"),
+                "requestId": .number(Double(requestID)),
+                "values": .array([.number(42)]),
+            ])))
         }
     }
 


### PR DESCRIPTION
A subscription created while connection setup is suspended on a queued unary send lost its request-ID routing when setup resumed, because `connected()` cleared `subscriptionByRequestID` after the unary sends. Its chunks were then dropped.

Fix: remove that redundant clear from `connected()`. `stop()` and `disconnected()` already clear stale mappings, so setup never inherits routing from a previous connection. The existing race regression now asserts both a single wire subscription and that the subscription's chunk is actually delivered.

Verification: `WebSocketRPCRaceTests.testConnectionSetupAndSubscribeRaceSendsOnceAndDeliversEvents` passed in [Contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226219290/job/102060886584) at `fcd124e`; all other current-head checks pass. The head is on the tip of `t3code/rebuild-mobile-app-swift` (`93ca266`), and no later SwiftUI commit covers this behavior.

No visible UI change, so no media.

Coordination trace: T3 thread 24d1bedb-b114-47e6-a98e-c28d0d732686
Earlier coordination trace: T3 thread 5b6fc384-841c-4e5a-90d7-d5079ae5d544

Model and harness: GPT-6 / Codex (fix); Claude Opus 5 / Claude Code (refresh and re-verification); SWE-2 High / Devin via T3 Code (re-verification, independent review, PR maintenance); GPT-5.6 Sol / Codex CLI (independent review, no actionable findings).
