### PR TITLE
fix(swift-ios): keep stopped connections stopped during reconnect

### DIFF
--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -351,6 +351,8 @@ public actor WebSocketRPCClient {
         loopTask?.cancel()
         loopTask = nil
         await disconnected()
+        // Closing suspends: a later stop must remain authoritative.
+        guard desired else { return }
         start()
     }
 

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -521,6 +521,28 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await connection.releaseClose()
     }
 
+    func testStopDuringReconnectCloseDoesNotRestartTheClient() async throws {
+        let closing = BlockingStopConnection()
+        let client = WebSocketRPCClient(
+            connector: SequencedConnector(connections: [closing, AutoReplyConnection()]),
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+        await client.start()
+        await closing.waitUntilReceiving()
+
+        let reconnect = Task { await client.reconnect() }
+        await closing.waitUntilCloseStarted()
+        await client.stop()
+        await closing.releaseClose()
+        await reconnect.value
+
+        do {
+            _ = try await client.waitForConnection(after: nil)
+            XCTFail("An old reconnect must not restart a client that has since stopped.")
+        } catch RPCError.disconnected {}
+        await client.stop()
+    }
+
     func testRestartWhileOldSocketClosesKeepsTheNewConnection() async throws {
         let closing = BlockingStopConnection()
         let recovered = AutoReplyConnection()


### PR DESCRIPTION
Stopping a SwiftUI connection while an older `reconnect()` is awaiting the old socket's close could restart the client the user just stopped, because `reconnect()` called `start()` unconditionally after the await.

`WebSocketRPCClient.reconnect()` now rechecks `desired` after `disconnected()` returns, so a stop that lands during the close stays authoritative. A later explicit `start()` still works.

Verification:
- New regression test `WebSocketRPCRaceTests.testStopDuringReconnectCloseDoesNotRestartTheClient` blocks the old socket's close, stops the client mid-reconnect, then asserts `waitForConnection` throws `RPCError.disconnected`. It passed in [Contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226225917/job/102060908965) on this head (`7652bbd`). The base branch has not moved since then, so it was not re-run locally.
- Nothing visible changes, so there is no media.

Base: `t3code/rebuild-mobile-app-swift` at `93ca26695`. Open PRs in the same area (#10747, #10843) don't change `reconnect()`.

Independent cross-provider review was skipped because Codex weekly quota was at 7%, below the 10% threshold. No outside review or maintainer approval is claimed.

Coordination trace: T3 thread c6221653-3deb-424d-b89a-990cf879749b

Model and harness: GPT-6 / Codex (original change); Claude Opus 5 / Claude Code (refresh and verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
