### PR TITLE
fix(swift-ios): preserve pairing link tokens and fragment precedence

### DIFF
--- a/apps/swift-ios/Core/PairingURL.swift
+++ b/apps/swift-ios/Core/PairingURL.swift
@@ -84,8 +84,9 @@ public enum PairingURL {
         let query = components.queryItems ?? []
         let fragment = queryItems(fromFragment: components.percentEncodedFragment)
         let token = [fragment, query].compactMap { items in
-            items.first(where: { $0.name.caseInsensitiveCompare("token") == .orderedSame })?
-                .value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            items.lazy.filter { $0.name.caseInsensitiveCompare("token") == .orderedSame }
+                .compactMap { $0.value?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first(where: { !$0.isEmpty })
         }.first(where: { !$0.isEmpty }) ?? ""
         let label = query
             .first(where: { $0.name.caseInsensitiveCompare("label") == .orderedSame })?

--- a/apps/swift-ios/Core/PairingURL.swift
+++ b/apps/swift-ios/Core/PairingURL.swift
@@ -83,11 +83,7 @@ public enum PairingURL {
 
         let query = components.queryItems ?? []
         let fragment = queryItems(fromFragment: components.percentEncodedFragment)
-        let token = [fragment, query].compactMap { items in
-            items.lazy.filter { $0.name.caseInsensitiveCompare("token") == .orderedSame }
-                .compactMap { $0.value?.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .first(where: { !$0.isEmpty })
-        }.first(where: { !$0.isEmpty }) ?? ""
+        let token = firstNonemptyToken(in: fragment) ?? firstNonemptyToken(in: query) ?? ""
         let label = query
             .first(where: { $0.name.caseInsensitiveCompare("label") == .orderedSame })?
             .value?
@@ -233,6 +229,13 @@ public enum PairingURL {
         var components = URLComponents()
         components.percentEncodedQuery = fragment
         return components.queryItems ?? []
+    }
+
+    private static func firstNonemptyToken(in items: [URLQueryItem]) -> String? {
+        items.lazy
+            .filter { $0.name.caseInsensitiveCompare("token") == .orderedSame }
+            .compactMap { $0.value?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
     }
 
     private static func displayHost(_ url: URL) -> String {

--- a/apps/swift-ios/Core/PairingURL.swift
+++ b/apps/swift-ios/Core/PairingURL.swift
@@ -82,11 +82,11 @@ public enum PairingURL {
         try requireSupportedScheme(components.scheme)
 
         let query = components.queryItems ?? []
-        let fragment = queryItems(fromFragment: components.fragment)
-        let token = (fragment + query)
-            .first(where: { $0.name.caseInsensitiveCompare("token") == .orderedSame })?
-            .value?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let fragment = queryItems(fromFragment: components.percentEncodedFragment)
+        let token = [fragment, query].compactMap { items in
+            items.first(where: { $0.name.caseInsensitiveCompare("token") == .orderedSame })?
+                .value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.first(where: { !$0.isEmpty }) ?? ""
         let label = query
             .first(where: { $0.name.caseInsensitiveCompare("label") == .orderedSame })?
             .value?

--- a/apps/swift-ios/Features/Connection/ConnectionDetails.swift
+++ b/apps/swift-ios/Features/Connection/ConnectionDetails.swift
@@ -116,8 +116,8 @@ enum ConnectionDetailsParser {
         let fragmentItems = URLComponents(string: "?\(components.percentEncodedFragment ?? "")")?.queryItems ?? []
         let queryItems = components.queryItems ?? []
         let allItems = queryItems + fragmentItems
-        let token = normalizedCode(firstValue(named: tokenNames, in: fragmentItems))
-            ?? normalizedCode(firstValue(named: tokenNames, in: queryItems))
+        let token = firstNonemptyToken(in: fragmentItems)
+            ?? firstNonemptyToken(in: queryItems)
 
         if ["t3", "t3code", "t3code-swiftui", "t3code-swiftui-dev"].contains(scheme) {
             if let wrappedPairingURL = firstValue(named: wrappedPairingURLNames, in: allItems) {
@@ -151,6 +151,12 @@ enum ConnectionDetailsParser {
         items.first { item in
             names.contains { $0.caseInsensitiveCompare(item.name) == .orderedSame }
         }?.value
+    }
+
+    private static func firstNonemptyToken(in items: [URLQueryItem]) -> String? {
+        items.lazy.filter { item in
+            tokenNames.contains { $0.caseInsensitiveCompare(item.name) == .orderedSame }
+        }.compactMap { normalizedCode($0.value) }.first
     }
 
     private static func normalizedCode(_ input: String?) -> String? {

--- a/apps/swift-ios/Features/Connection/ConnectionDetails.swift
+++ b/apps/swift-ios/Features/Connection/ConnectionDetails.swift
@@ -113,10 +113,11 @@ enum ConnectionDetailsParser {
             throw ConnectionDetailsError.invalidAddress
         }
 
-        let fragmentItems = URLComponents(string: "?\(components.fragment ?? "")")?.queryItems ?? []
+        let fragmentItems = URLComponents(string: "?\(components.percentEncodedFragment ?? "")")?.queryItems ?? []
         let queryItems = components.queryItems ?? []
         let allItems = queryItems + fragmentItems
-        let token = firstValue(named: tokenNames, in: allItems)
+        let token = normalizedCode(firstValue(named: tokenNames, in: fragmentItems))
+            ?? normalizedCode(firstValue(named: tokenNames, in: queryItems))
 
         if ["t3", "t3code", "t3code-swiftui", "t3code-swiftui-dev"].contains(scheme) {
             if let wrappedPairingURL = firstValue(named: wrappedPairingURLNames, in: allItems) {

--- a/apps/swift-ios/Tests/CoreTests/PairingTokenPrecedenceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PairingTokenPrecedenceTests.swift
@@ -5,6 +5,10 @@ import Testing
 struct PairingTokenPrecedenceTests {
     @Test(arguments: [
         ("?token=OLD#token=NEW", "NEW"),
+        ("?token=QUERY#token=&token=FRAGMENT", "FRAGMENT"),
+        ("?token=QUERY#token=%20&token=FRAGMENT", "FRAGMENT"),
+        ("#token=&token=FRAGMENT", "FRAGMENT"),
+        ("?token=&token=QUERY#token=", "QUERY"),
         ("?token=QUERY#token=", "QUERY"),
         ("?token=#token=FRAGMENT", "FRAGMENT"),
         ("?token=QUERY", "QUERY"),

--- a/apps/swift-ios/Tests/CoreTests/PairingTokenPrecedenceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/PairingTokenPrecedenceTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import T3Code
+
+@Suite("Pairing token precedence")
+struct PairingTokenPrecedenceTests {
+    @Test(arguments: [
+        ("?token=OLD#token=NEW", "NEW"),
+        ("?token=QUERY#token=", "QUERY"),
+        ("?token=#token=FRAGMENT", "FRAGMENT"),
+        ("?token=QUERY", "QUERY"),
+        ("#token=FRAGMENT", "FRAGMENT"),
+    ])
+    func prefersNonemptyFragmentWithQueryFallback(_ suffix: String, _ expected: String) throws {
+        let url = "https://studio.example/pair" + suffix
+        let fields = try PairingURL.parseFields(url)
+        let details = try ConnectionDetailsParser.parse(url)
+        #expect(fields.pairingCode == expected)
+        #expect(details.pairingCode == expected)
+    }
+}

--- a/apps/swift-ios/Tests/CoreTests/TransportReliabilityTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/TransportReliabilityTests.swift
@@ -778,6 +778,22 @@ final class TransportReliabilityTests: XCTestCase {
         XCTAssertEqual(echoed, payload)
     }
 
+    func testPairingTokensDecodeFragmentExactlyOnce() throws {
+        for token in ["part&second=value", "literal%", "literal%26value", "plus+equals=", "unicode-雪"] {
+            let link = try PairingURL.build(host: "https://studio.example", pairingCode: token)
+            XCTAssertEqual(try PairingURL.resolve(link).credential, token)
+            XCTAssertEqual(try PairingURL.parseFields(link).pairingCode, token)
+
+            var wrapper = URLComponents(string: "t3code://pair")!
+            wrapper.queryItems = [URLQueryItem(name: "pairingUrl", value: link)]
+            XCTAssertEqual(try PairingURL.resolve(wrapper.url!.absoluteString).credential, token)
+        }
+        XCTAssertEqual(
+            try PairingURL.resolve("https://studio.example/pair?token=query#token=first%26second").credential,
+            "first&second"
+        )
+    }
+
     func testPairingInputParsesClipboardQRHostedAndLooseFormats() throws {
         let direct = try PairingURL.parseFields(
             " https://studio.example:3773/pair#token=N735%4BQXJ "

--- a/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
@@ -21,6 +21,14 @@ struct ConnectionDetailsTests {
     }
 
     @Test
+    func skipsEmptyFragmentTokenBeforeCodeAlias() throws {
+        let details = try ConnectionDetailsParser.parse(
+            "https://studio.example/pair?token=QUERY#token=&code=FRAGMENT"
+        )
+        #expect(details.pairingCode == "FRAGMENT")
+    }
+
+    @Test
     func parsesRawPairingURL() throws {
         let details = try ConnectionDetailsParser.parse(
             "http://192.168.1.42:3773/pair#token=PAIRCODE"

--- a/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/ConnectionDetailsTests.swift
@@ -1,8 +1,25 @@
+import Foundation
 import Testing
 @testable import T3Code
 
 @Suite("Connection details")
 struct ConnectionDetailsTests {
+    @Test(arguments: [
+        "part&second=value", "literal%26value", "part#second",
+        "literal%", "plus+equals=", "unicode-雪",
+    ])
+    func decodesFragmentTokensOnce(_ token: String) throws {
+        let link = try PairingURL.build(host: "https://studio.example", pairingCode: token)
+        let direct = try ConnectionDetailsParser.parse(link)
+        #expect(direct.endpoint == "https://studio.example")
+        #expect(direct.pairingCode == token)
+
+        var wrapper = URLComponents(string: "t3code://pair")!
+        wrapper.queryItems = [URLQueryItem(name: "pairingUrl", value: link)]
+        let wrapped = try ConnectionDetailsParser.parse(wrapper.url!.absoluteString)
+        #expect(wrapped.pairingCode == token)
+    }
+
     @Test
     func parsesRawPairingURL() throws {
         let details = try ConnectionDetailsParser.parse(


### PR DESCRIPTION
Pairing links could decode fragment tokens twice (so `%26` inside a token became `&` and split it), and an empty fragment `token=` could hide a usable token later in the fragment or in the query.

Both SwiftUI pairing parsers, `PairingURL.parseFields` (Core) and `ConnectionDetailsParser` (onboarding), now read the fragment from `percentEncodedFragment` so it is decoded exactly once. They also take the first nonempty fragment token before falling back to the query; onboarding's `code` alias is included. Direct links and `t3code://pair?pairingUrl=` wrapped links resolve to the same token.

No visible UI change; this only affects which credential a pasted or scanned pairing link produces. SwiftUI mobile only. React Native parses links separately and is not changed here.

Verification: CI "Contract fixtures and native tests" passed on `56db6099c6`. A local focused Simulator run (`PairingTokenPrecedenceTests`, `ConnectionDetailsTests`, `TransportReliabilityTests`) is being rerun on a private Simulator after a shared-Simulator collision loaded another tree's test bundle; the result will be added here.

Independent cross-provider review was skipped: Codex weekly headroom was 6%, below the 10% threshold.

Model and harness: GPT-6 / Codex (original fix); Claude Opus 5 / Claude Code (refresh and cleanup).

Coordination trace: T3 thread 729352fd-e313-4e49-9c5d-0dd5b27d0f04

🤖 Generated with [Claude Code](https://claude.com/claude-code)
