### PR TITLE
fix(web): offer undo after unpinning a thread

### DIFF
--- a/apps/web/src/hooks/threadPinAction.test.ts
+++ b/apps/web/src/hooks/threadPinAction.test.ts
@@ -3,10 +3,9 @@ import { describe, expect, it } from "vite-plus/test";
 import * as ThreadPinAction from "./threadPinAction";
 
 describe("pin action ownership", () => {
-  it("does not revive the first Undo after a later pin and unpin finish", () => {
+  it("does not revive the first Undo after a later pin and unpin", () => {
     const firstUnpin = ThreadPinAction.begin("env/thread");
-    const pin = ThreadPinAction.begin("env/thread");
-    pin.finish();
+    ThreadPinAction.invalidate("env/thread");
     const secondUnpin = ThreadPinAction.begin("env/thread");
     expect(firstUnpin.isCurrent()).toBe(false);
     expect(secondUnpin.isCurrent()).toBe(true);
@@ -16,12 +15,10 @@ describe("pin action ownership", () => {
     expect(firstUnpin.isCurrent()).toBe(false);
   });
 
-  it("rejects late completion after a newer action has already completed", () => {
+  it("rejects a late unpin completion after a newer pin started", () => {
     const pendingUnpin = ThreadPinAction.begin("env/late");
-    const newerPin = ThreadPinAction.begin("env/late");
-    newerPin.finish();
+    ThreadPinAction.invalidate("env/late");
     expect(pendingUnpin.isCurrent()).toBe(false);
-    pendingUnpin.finish();
   });
 
   it("expires an Undo without invalidating another environment or thread", () => {

--- a/apps/web/src/hooks/threadPinAction.test.ts
+++ b/apps/web/src/hooks/threadPinAction.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import * as ThreadPinAction from "./threadPinAction";
+
+describe("pin action ownership", () => {
+  it("does not revive the first Undo after a later pin and unpin finish", () => {
+    const firstUnpin = ThreadPinAction.begin("env/thread");
+    const pin = ThreadPinAction.begin("env/thread");
+    pin.finish();
+    const secondUnpin = ThreadPinAction.begin("env/thread");
+    expect(firstUnpin.isCurrent()).toBe(false);
+    expect(secondUnpin.isCurrent()).toBe(true);
+    firstUnpin.finish();
+    expect(secondUnpin.isCurrent()).toBe(true);
+    secondUnpin.finish();
+    expect(firstUnpin.isCurrent()).toBe(false);
+  });
+
+  it("rejects late completion after a newer action has already completed", () => {
+    const pendingUnpin = ThreadPinAction.begin("env/late");
+    const newerPin = ThreadPinAction.begin("env/late");
+    newerPin.finish();
+    expect(pendingUnpin.isCurrent()).toBe(false);
+    pendingUnpin.finish();
+  });
+
+  it("expires an Undo without invalidating another environment or thread", () => {
+    const first = ThreadPinAction.begin("one/thread");
+    const otherEnvironment = ThreadPinAction.begin("two/thread");
+    const otherThread = ThreadPinAction.begin("one/other");
+    first.finish();
+    expect(first.isCurrent()).toBe(false);
+    expect(otherEnvironment.isCurrent()).toBe(true);
+    expect(otherThread.isCurrent()).toBe(true);
+    otherEnvironment.finish();
+    otherThread.finish();
+  });
+});

--- a/apps/web/src/hooks/threadPinAction.ts
+++ b/apps/web/src/hooks/threadPinAction.ts
@@ -1,6 +1,7 @@
 // Shared across hook instances so sidebar, header and menu actions invalidate each other.
 const currentActions = new Map<string, symbol>();
 
+/** Claims a thread's pin state for one unpin Undo; any later claim or invalidation expires it. */
 export function begin(key: string) {
   const token = Symbol();
   currentActions.set(key, token);
@@ -11,4 +12,9 @@ export function begin(key: string) {
       if (isCurrent()) currentActions.delete(key);
     },
   };
+}
+
+/** Expires any outstanding Undo for the thread, e.g. when it is pinned or reordered. */
+export function invalidate(key: string) {
+  currentActions.delete(key);
 }

--- a/apps/web/src/hooks/threadPinAction.ts
+++ b/apps/web/src/hooks/threadPinAction.ts
@@ -1,0 +1,14 @@
+// Shared across hook instances so sidebar, header and menu actions invalidate each other.
+const currentActions = new Map<string, symbol>();
+
+export function begin(key: string) {
+  const token = Symbol();
+  currentActions.set(key, token);
+  const isCurrent = () => currentActions.get(key) === token;
+  return {
+    isCurrent,
+    finish: () => {
+      if (isCurrent()) currentActions.delete(key);
+    },
+  };
+}

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -4,7 +4,11 @@ import {
   scopeThreadRef,
   scopedThreadKey,
 } from "@t3tools/client-runtime/environment";
-import { settlePromise, squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import {
+  isAtomCommandInterrupted,
+  settlePromise,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
 import { canSnooze, threadWokeAt } from "@t3tools/client-runtime/state/thread-settled";
 import { EnvironmentId, type ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -596,12 +600,50 @@ export function useThreadActions() {
           ),
         );
       }
-      return unpinThreadMutation({
+      const thread = readThreadShell(target);
+      const orderKey = thread?.pinOrderKey ?? undefined;
+      const result = await unpinThreadMutation({
         environmentId: target.environmentId,
         input: { threadId: target.threadId },
       });
+      if (result._tag === "Success") {
+        let undoStarted = false;
+        // Reuses the app's Base UI toast action: https://base-ui.com/react/components/toast
+        const toastId = toastManager.add(
+          stackedThreadToast({
+            type: "success",
+            title: "Thread unpinned",
+            description: thread?.title,
+            timeout: 5_000,
+            actionProps: {
+              children: "Undo",
+              onClick: () => {
+                if (undoStarted) return;
+                undoStarted = true;
+                toastManager.close(toastId);
+                void pinThread(target, orderKey === undefined ? {} : { orderKey }).then(
+                  (undone) => {
+                    if (undone._tag === "Failure" && !isAtomCommandInterrupted(undone)) {
+                      const error = squashAtomCommandFailure(undone);
+                      toastManager.add(
+                        stackedThreadToast({
+                          type: "error",
+                          title: "Failed to undo unpin",
+                          description:
+                            error instanceof Error ? error.message : "An error occurred.",
+                        }),
+                      );
+                    }
+                  },
+                );
+              },
+            },
+          }),
+        );
+      }
+      return result;
     },
-    [unpinThreadMutation],
+    [pinThread, unpinThreadMutation],
   );
 
   const confirmAndUnpinThread = useCallback(

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -43,6 +43,7 @@ import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
+import * as ThreadPinAction from "./threadPinAction";
 import { useAtomCommand } from "../state/use-atom-command";
 
 export class ThreadArchiveBlockedError extends Schema.TaggedError<ThreadArchiveBlockedError>()(
@@ -577,13 +578,18 @@ export function useThreadActions() {
       const orderKey = readEnvironmentSupportsPinReorder(target.environmentId)
         ? (opts.orderKey ?? topOfPinnedRunOrderKey())
         : undefined;
-      return pinThreadMutation({
-        environmentId: target.environmentId,
-        input: {
-          threadId: target.threadId,
-          ...(orderKey !== undefined ? { orderKey } : {}),
-        },
-      });
+      const action = ThreadPinAction.begin(scopedThreadKey(target));
+      try {
+        return await pinThreadMutation({
+          environmentId: target.environmentId,
+          input: {
+            threadId: target.threadId,
+            ...(orderKey !== undefined ? { orderKey } : {}),
+          },
+        });
+      } finally {
+        action.finish();
+      }
     },
     [pinThreadMutation],
   );
@@ -602,15 +608,16 @@ export function useThreadActions() {
       }
       const thread = readThreadShell(target);
       const orderKey = thread?.pinOrderKey ?? undefined;
+      const action = ThreadPinAction.begin(scopedThreadKey(target));
       const result = await unpinThreadMutation({
         environmentId: target.environmentId,
         input: { threadId: target.threadId },
       });
-      if (result._tag === "Success") {
+      if (result._tag === "Success" && action.isCurrent()) {
         let undoStarted = false;
         // Reuses the app's Base UI toast action: https://base-ui.com/react/components/toast
-        const toastId = toastManager.add(
-          stackedThreadToast({
+        const toastId = toastManager.add({
+          ...stackedThreadToast({
             type: "success",
             title: "Thread unpinned",
             description: thread?.title,
@@ -618,7 +625,7 @@ export function useThreadActions() {
             actionProps: {
               children: "Undo",
               onClick: () => {
-                if (undoStarted) return;
+                if (undoStarted || !action.isCurrent()) return;
                 undoStarted = true;
                 toastManager.close(toastId);
                 void pinThread(target, orderKey === undefined ? {} : { orderKey }).then(
@@ -639,7 +646,10 @@ export function useThreadActions() {
               },
             },
           }),
-        );
+          onClose: action.finish,
+        });
+      } else {
+        action.finish();
       }
       return result;
     },
@@ -681,10 +691,15 @@ export function useThreadActions() {
           ),
         );
       }
-      return reorderPinnedThreadMutation({
-        environmentId: target.environmentId,
-        input: { threadId: target.threadId, orderKey },
-      });
+      const action = ThreadPinAction.begin(scopedThreadKey(target));
+      try {
+        return await reorderPinnedThreadMutation({
+          environmentId: target.environmentId,
+          input: { threadId: target.threadId, orderKey },
+        });
+      } finally {
+        action.finish();
+      }
     },
     [reorderPinnedThreadMutation],
   );

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -578,18 +578,14 @@ export function useThreadActions() {
       const orderKey = readEnvironmentSupportsPinReorder(target.environmentId)
         ? (opts.orderKey ?? topOfPinnedRunOrderKey())
         : undefined;
-      const action = ThreadPinAction.begin(scopedThreadKey(target));
-      try {
-        return await pinThreadMutation({
-          environmentId: target.environmentId,
-          input: {
-            threadId: target.threadId,
-            ...(orderKey !== undefined ? { orderKey } : {}),
-          },
-        });
-      } finally {
-        action.finish();
-      }
+      ThreadPinAction.invalidate(scopedThreadKey(target));
+      return pinThreadMutation({
+        environmentId: target.environmentId,
+        input: {
+          threadId: target.threadId,
+          ...(orderKey !== undefined ? { orderKey } : {}),
+        },
+      });
     },
     [pinThreadMutation],
   );
@@ -691,15 +687,11 @@ export function useThreadActions() {
           ),
         );
       }
-      const action = ThreadPinAction.begin(scopedThreadKey(target));
-      try {
-        return await reorderPinnedThreadMutation({
-          environmentId: target.environmentId,
-          input: { threadId: target.threadId, orderKey },
-        });
-      } finally {
-        action.finish();
-      }
+      ThreadPinAction.invalidate(scopedThreadKey(target));
+      return reorderPinnedThreadMutation({
+        environmentId: target.environmentId,
+        input: { threadId: target.threadId, orderKey },
+      });
     },
     [reorderPinnedThreadMutation],
   );

--- a/apps/web/src/hooks/useThreadActions.undo.test.ts
+++ b/apps/web/src/hooks/useThreadActions.undo.test.ts
@@ -1,0 +1,69 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { useThreadActions } from "./useThreadActions";
+import { threadEnvironment } from "../state/threads";
+import { toastManager } from "../components/ui/toast";
+
+const commands = vi.hoisted(() => ({ pin: vi.fn(), unpin: vi.fn() }));
+vi.mock("react", async (original) => ({
+  ...(await original<typeof import("react")>()),
+  useCallback: (callback: unknown) => callback,
+  useMemo: (create: () => unknown) => create(),
+  useRef: (value: unknown) => ({ current: value }),
+}));
+vi.mock("@tanstack/react-router", () => ({ useRouter: () => ({}) }));
+vi.mock("./useSettings", () => ({ useClientSettings: () => false }));
+vi.mock("./useHandleNewThread", () => ({ useNewThreadHandler: () => vi.fn() }));
+vi.mock("../composerDraftStore", () => ({ useComposerDraftStore: () => vi.fn() }));
+vi.mock("../terminalUiStateStore", () => ({ useTerminalUiStateStore: () => vi.fn() }));
+vi.mock("../uiStateStore", () => ({ useUiStateStore: () => vi.fn() }));
+vi.mock("../state/entities", async (original) => ({
+  ...(await original<typeof import("../state/entities")>()),
+  readEnvironmentSupportsPinning: () => true,
+  readEnvironmentSupportsPinReorder: () => true,
+  readThreadShell: () => ({ title: "Thread", pinOrderKey: "a0" }),
+}));
+vi.mock("../state/use-atom-command", () => ({
+  useAtomCommand: (command: unknown) =>
+    command === threadEnvironment.pin
+      ? commands.pin
+      : command === threadEnvironment.unpin
+        ? commands.unpin
+        : vi.fn(),
+}));
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("unpin Undo", () => {
+  it("ignores an old toast across hook instances and still restores the latest unpin", async () => {
+    commands.pin.mockResolvedValue({ _tag: "Success", value: undefined });
+    commands.unpin.mockResolvedValue({ _tag: "Success", value: undefined });
+    const add = vi.spyOn(toastManager, "add").mockReturnValue("toast");
+    vi.spyOn(toastManager, "close").mockImplementation(() => {});
+    const sidebar = useThreadActions();
+    const header = useThreadActions();
+    const target = {
+      environmentId: EnvironmentId.make("undo-env"),
+      threadId: ThreadId.make("thread"),
+    };
+    await sidebar.unpinThread(target);
+    const staleUndo = add.mock.calls[0]?.[0].actionProps?.onClick;
+    await header.pinThread(target, { orderKey: "a1" });
+    await header.unpinThread(target);
+    const latestUndo = add.mock.calls[1]?.[0].actionProps?.onClick;
+    expect(staleUndo).toBeTypeOf("function");
+    expect(latestUndo).toBeTypeOf("function");
+    const event = {} as Parameters<NonNullable<typeof staleUndo>>[0];
+    staleUndo?.(event);
+    expect(commands.pin).toHaveBeenCalledTimes(1);
+    latestUndo?.(event);
+    expect(commands.pin).toHaveBeenCalledTimes(2);
+    expect(commands.pin).toHaveBeenLastCalledWith({
+      environmentId: target.environmentId,
+      input: { threadId: target.threadId, orderKey: "a0" },
+    });
+    latestUndo?.(event);
+    expect(commands.pin).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## What Changed

Unpinning a thread by mistake had no quick way back; the user had to find it and re-pin it, losing its place. Now a successful unpin shows a **Thread unpinned** toast naming the thread, with an **Undo** button for five seconds. Undo re-pins it at its original pinned order key.

The toast lives in the shared `useThreadActions` hook, so every web and desktop unpin path gets it: sidebar button, context and multi-select menus, keyboard, and dragging out of the pinned section. Multi-select unpin shows one toast per thread. The existing unpin confirmation setting is unchanged. Undo can only be clicked once, and a failed restore shows an error toast.

A small shared token map (`threadPinAction.ts`) keeps stale toasts from overriding newer choices. Each unpin claims the thread; a later pin, unpin, or pinned reorder of that thread from any hook instance expires the older Undo, including when an unpin finishes after a newer action has started. Closing the toast releases the claim. No wire contract changes. Mobile has no unpin Undo and is unchanged.

## UI Changes

Recorded in the Electron app with a disposable three-thread project (base `7220dfe2c9`, candidate `7bf021896a`). The rebase and follow-up commits don't change what the user sees.

**Before:** unpinning moves the thread out of the pinned section with no Undo.

![Before: unpinning offers no Undo](https://github.com/user-attachments/assets/435c90d1-bb0b-4bd1-8bb2-80deab7750b2)

**After:** unpin, click Undo to restore the original position, then unpin again and let the toast expire.

![After: Undo restores the thread and the unused message expires](https://github.com/user-attachments/assets/5077f9bf-9122-42c3-ad9c-24e2056e4b27)

[Full-size, unannotated Electron video](https://github.com/user-attachments/assets/2cbd5d21-a482-4f62-b005-66af3d280788)

![Thread unpinned message with the thread title and Undo button](https://github.com/user-attachments/assets/ae5ef722-19af-4870-b995-f13c2b2767e0)

## Validation

Rebased onto `origin/main` at `211618fd9f` with no conflicts.

- `vp test run src/hooks/useThreadActions.undo.test.ts src/hooks/threadPinAction.test.ts src/hooks/useThreadActions.test.ts` in `apps/web`: 11 tests pass. They cover a stale Undo across two hook instances, the latest Undo restoring its saved key, repeated-click suppression, a late unpin completion, and isolation between environments and threads.
- `tsc --noEmit` passes for `apps/web`. Formatting passes on the touched files. Lint on those files shows only the existing `react(refs)` warning that main also has. The earlier try/finally wrappers added two memo-dependency warnings; this version adds none.
- No new client pass was done for the stale-toast sequence. The recordings above cover the normal unpin, Undo, and expiry flow. Browser-only and remote/relay sessions weren't tested separately.
- No cross-provider review this round: Codex weekly quota was at 3%.

Coordination trace: T3 thread fe08de0f-1cab-49ff-b2f4-504651725786

Prepared with GPT-6 in the Codex harness; rebased and updated with Claude Opus 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Undo action to the confirmation shown after unpinning a thread.
  * Undo restores the thread to its previous pinned position, or to the top when no previous position is available.

* **Bug Fixes**
  * Unpin failures now display an error notification, except when the action is intentionally interrupted.
  * Prevented outdated Undo actions from reversing newer pin or unpin changes.
  * Improved coordination of pinning actions across different parts of the app to keep thread pin status consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->