### PR TITLE
fix(swift-ios): retry transient server configuration streams

### DIFF
--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -607,6 +607,7 @@ public actor T3Client {
     }
 
     private func isRetryableServerConfigSubscriptionError(_ error: any Error) -> Bool {
+        if error is DecodingError { return false }
         guard case let RPCError.remote(message) = error else { return true }
         let value = message.lowercased()
         return !value.contains("authentication")

--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -26,9 +26,11 @@ public actor T3Client {
     private let api: EnvironmentAPI
     private let rpc: WebSocketRPCClient
     private let configSnapshotWaitTimeout: Duration
+    private let serverConfigRetryDelay: @Sendable (Int) async throws -> Void
     private var latestServerEnvironment: EnvironmentDescriptor?
     private var serverConfigCache: ServerConfigSnapshot?
     private var serverConfigGeneration: UInt64 = 0
+    private var serverConfigRetryAttempt = 0
     private var serverConfigTask: Task<Void, Never>?
     private var serverConfigWaiters: [UUID: CheckedContinuation<ServerConfigSnapshot, any Error>] = [:]
     private var serverConfigListeners: [UUID: AsyncThrowingStream<ServerConfigStreamEvent, any Error>.Continuation] = [:]
@@ -39,7 +41,11 @@ public actor T3Client {
         httpTransport: any HTTPTransport = URLSessionHTTPTransport(),
         webSocketConnector: any WebSocketConnecting = URLSessionWebSocketConnector(),
         managedAuthorization: (any ManagedEnvironmentAuthorizing)? = nil,
-        rpcConnectionWaitTimeout: Duration = .seconds(4)
+        rpcConnectionWaitTimeout: Duration = .seconds(4),
+        serverConfigRetryDelay: @escaping @Sendable (Int) async throws -> Void = { attempt in
+            let seconds = min(16, 1 << min(attempt, 4))
+            try await Task.sleep(for: .seconds(seconds))
+        }
     ) {
         self.environment = environment
         let api = EnvironmentAPI(
@@ -49,6 +55,7 @@ public actor T3Client {
         )
         self.api = api
         self.configSnapshotWaitTimeout = rpcConnectionWaitTimeout
+        self.serverConfigRetryDelay = serverConfigRetryDelay
         self.rpc = WebSocketRPCClient(
             connector: webSocketConnector,
             connectionWaitTimeout: rpcConnectionWaitTimeout
@@ -455,7 +462,10 @@ public actor T3Client {
                     guard !Task.isCancelled else { return }
                     await self.consumeServerConfig(event, generation: generation)
                 }
-                await self.finishServerConfigSubscription(generation: generation, error: RPCError.disconnected)
+                await self.retryServerConfigSubscription(
+                    generation: generation,
+                    error: RPCError.disconnected
+                )
             } catch {
                 await self.handleServerConfigSubscriptionFailure(error, generation: generation)
             }
@@ -464,6 +474,7 @@ public actor T3Client {
 
     private func consumeServerConfig(_ event: ServerConfigStreamEvent, generation: UInt64) {
         guard generation == serverConfigGeneration else { return }
+        serverConfigRetryAttempt = 0
         var emittedEvent = event
         switch event {
         case var .snapshot(config):
@@ -539,7 +550,11 @@ public actor T3Client {
     private func handleServerConfigSubscriptionFailure(_ error: any Error, generation: UInt64) async {
         guard generation == serverConfigGeneration else { return }
         guard isUnsupportedServerConfigSubscription(error) else {
-            finishServerConfigSubscription(generation: generation, error: error)
+            if isRetryableServerConfigSubscriptionError(error) {
+                await retryServerConfigSubscription(generation: generation, error: error)
+            } else {
+                finishServerConfigSubscription(generation: generation, error: error)
+            }
             return
         }
         do {
@@ -548,12 +563,37 @@ public actor T3Client {
                 as: ServerConfigSnapshot.self
             )
             guard generation == serverConfigGeneration else { return }
+            serverConfigRetryAttempt = 0
             cacheServerConfig(config)
             serverConfigListeners.values.forEach { $0.yield(.snapshot(config)) }
             serverConfigTask = nil
         } catch {
             finishServerConfigSubscription(generation: generation, error: error)
         }
+    }
+
+    func retryServerConfigSubscription(generation: UInt64, error: any Error) async {
+        guard generation == serverConfigGeneration, !Task.isCancelled else { return }
+        guard !serverConfigListeners.isEmpty || !serverConfigWaiters.isEmpty else {
+            serverConfigTask = nil
+            return
+        }
+        let attempt = serverConfigRetryAttempt
+        serverConfigRetryAttempt += 1
+        do {
+            try await serverConfigRetryDelay(attempt)
+        } catch {
+            guard generation == serverConfigGeneration else { return }
+            finishServerConfigSubscription(generation: generation, error: error)
+            return
+        }
+        guard generation == serverConfigGeneration else { return }
+        guard !serverConfigListeners.isEmpty || !serverConfigWaiters.isEmpty else {
+            serverConfigTask = nil
+            return
+        }
+        serverConfigTask = nil
+        startServerConfigSubscriptionIfNeeded()
     }
 
     private func isUnsupportedServerConfigSubscription(_ error: any Error) -> Bool {
@@ -566,9 +606,20 @@ public actor T3Client {
             || value.contains("unknown request") || value.contains("method not found")
     }
 
+    private func isRetryableServerConfigSubscriptionError(_ error: any Error) -> Bool {
+        guard case let RPCError.remote(message) = error else { return true }
+        let value = message.lowercased()
+        return !value.contains("authentication")
+            && !value.contains("unauthenticated")
+            && !value.contains("unauthorized")
+            && !value.contains("forbidden")
+            && !value.contains("permission denied")
+    }
+
     private func finishServerConfigSubscription(generation: UInt64, error: any Error) {
         guard generation == serverConfigGeneration else { return }
         serverConfigTask = nil
+        serverConfigRetryAttempt = 0
         serverConfigCache = nil
         latestServerEnvironment = nil
         let waiters = serverConfigWaiters.values
@@ -581,6 +632,7 @@ public actor T3Client {
 
     private func stopServerConfigSubscription(error: any Error) {
         serverConfigGeneration &+= 1
+        serverConfigRetryAttempt = 0
         serverConfigTask?.cancel()
         serverConfigTask = nil
         serverConfigCache = nil

--- a/apps/swift-ios/Tests/CoreTests/T3ClientServerConfigTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/T3ClientServerConfigTests.swift
@@ -393,6 +393,33 @@ final class T3ClientServerConfigTests: XCTestCase {
         await authClient.disconnect()
     }
 
+    func testMalformedSubscriptionFinishesListenersAndBootstrapWithoutRetry() async throws {
+        let connection = ServerConfigTestConnection(mode: .malformed)
+        let retries = ServerConfigRetryRecorder()
+        let client = makeClient(connection: connection, retryDelay: { attempt in
+            await retries.record(attempt)
+            throw CancellationError()
+        })
+        addTeardownBlock { await client.disconnect() }
+        var iterator = await client.serverConfigEvents().makeAsyncIterator()
+        do {
+            _ = try await iterator.next()
+            XCTFail("Malformed configuration must fail the listener")
+        } catch {
+            XCTAssertTrue(error is DecodingError, "Unexpected listener error: \(error)")
+        }
+        do {
+            _ = try await client.serverConfig()
+            XCTFail("Malformed configuration must fail bootstrap")
+        } catch {
+            XCTAssertTrue(error is DecodingError, "Unexpected bootstrap error: \(error)")
+        }
+        let attempts = await retries.attempts
+        XCTAssertTrue(attempts.isEmpty, "Permanent decoding errors must not enter retry backoff")
+        let tags = await connection.tags()
+        XCTAssertEqual(tags, ["subscribeServerConfig", "subscribeServerConfig"])
+    }
+
     func testTerminalSubscriptionFailureRetainsListenersAndRecovers() async throws {
         let connection = ServerConfigTestConnection(mode: .recovering)
         let client = makeClient(connection: connection, retryDelay: { _ in })
@@ -551,7 +578,7 @@ private actor ServerConfigTestConnector: WebSocketConnecting {
 }
 
 private actor ServerConfigTestConnection: WebSocketConnection {
-    enum Mode { case snapshot, silent, failure(String), recovering }
+    enum Mode { case snapshot, silent, failure(String), recovering, malformed }
 
     private let mode: Mode
     private let supportsUsageLimitSources: Bool?
@@ -589,6 +616,7 @@ private actor ServerConfigTestConnection: WebSocketConnection {
             subscriptionRequestID = id
             switch mode {
             case .snapshot: try enqueue(chunk(id: id, value: snapshot(id: "codex-old")))
+            case .malformed: try enqueue(chunk(id: id, value: .object(["type": .number(42)])))
             case .silent: break
             case let .failure(message): try enqueue(failure(id: id, message: message))
             case .recovering:

--- a/apps/swift-ios/Tests/CoreTests/T3ClientServerConfigTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/T3ClientServerConfigTests.swift
@@ -393,11 +393,113 @@ final class T3ClientServerConfigTests: XCTestCase {
         await authClient.disconnect()
     }
 
+    func testTerminalSubscriptionFailureRetainsListenersAndRecovers() async throws {
+        let connection = ServerConfigTestConnection(mode: .recovering)
+        let client = makeClient(connection: connection, retryDelay: { _ in })
+        addTeardownBlock { await client.disconnect() }
+        let events = await client.serverConfigEvents()
+        var iterator = events.makeAsyncIterator()
+
+        guard case let .snapshot(initial)? = try await iterator.next() else {
+            return XCTFail("Expected the initial configuration snapshot.")
+        }
+        XCTAssertEqual(initial.providers.first?.instanceId, "codex-old")
+
+        try await connection.pushSubscriptionFailure("Temporary stream failure")
+        guard case let .snapshot(recovered)? = try await iterator.next() else {
+            return XCTFail("Expected the listener to survive and receive the retried snapshot.")
+        }
+        XCTAssertEqual(recovered.providers.first?.instanceId, "codex-recovered")
+        let requestTags = await connection.tags()
+        XCTAssertEqual(requestTags, ["subscribeServerConfig", "subscribeServerConfig"])
+        await client.disconnect()
+    }
+
+    func testUnexpectedSubscriptionCompletionRetainsListenersAndRecovers() async throws {
+        let connection = ServerConfigTestConnection(mode: .recovering)
+        let client = makeClient(connection: connection, retryDelay: { _ in })
+        addTeardownBlock { await client.disconnect() }
+        let events = await client.serverConfigEvents()
+        var iterator = events.makeAsyncIterator()
+
+        guard case let .snapshot(initial)? = try await iterator.next() else {
+            return XCTFail("Expected the initial configuration snapshot.")
+        }
+        XCTAssertEqual(initial.providers.first?.instanceId, "codex-old")
+
+        try await connection.completeSubscription()
+        guard case let .snapshot(recovered)? = try await iterator.next() else {
+            return XCTFail("Expected the listener to survive a completed live stream.")
+        }
+        XCTAssertEqual(recovered.providers.first?.instanceId, "codex-recovered")
+        let requestTags = await connection.tags()
+        XCTAssertEqual(requestTags, ["subscribeServerConfig", "subscribeServerConfig"])
+        await client.disconnect()
+    }
+
+    func testRetiredSubscriptionCompletionPreservesReplacementOwner() async throws {
+        try await assertObsoleteCompletionPreservesReplacement(cancelled: false)
+    }
+
+    func testCancelledSubscriptionCompletionPreservesReplacementOwner() async throws {
+        try await assertObsoleteCompletionPreservesReplacement(cancelled: true)
+    }
+
+    private func assertObsoleteCompletionPreservesReplacement(cancelled: Bool) async throws {
+        let original = ServerConfigTestConnection(mode: .snapshot)
+        let replacement = ServerConfigTestConnection(mode: .recovering)
+        let retries = ServerConfigRetryRecorder()
+        let client = makeClient(connection: original, reconnectConnection: replacement,
+                                retryDelay: { attempt in await retries.record(attempt) })
+        addTeardownBlock { await client.disconnect() }
+        var initial = await client.serverConfigEvents().makeAsyncIterator()
+        guard case .snapshot? = try await initial.next() else {
+            return XCTFail("Expected the first subscription generation.")
+        }
+        await client.disconnect()
+        var current = await client.serverConfigEvents().makeAsyncIterator()
+        guard case .snapshot? = try await current.next() else {
+            return XCTFail("Expected the replacement subscription generation.")
+        }
+
+        // Start advances to 1, disconnect retires it at 2, replacement starts at 3.
+        // Deliver the delayed EOF callback directly after the replacement receipt,
+        // so this checks ownership without racing task cancellation against startup.
+        if cancelled {
+            await Task {
+                withUnsafeCurrentTask { $0?.cancel() }
+                await client.retryServerConfigSubscription(generation: 3, error: RPCError.disconnected)
+            }.value
+        } else {
+            await client.retryServerConfigSubscription(generation: 1, error: RPCError.disconnected)
+        }
+        let ignoredAttempts = await retries.attempts
+        XCTAssertEqual(ignoredAttempts, [], "An obsolete completion must not start or increment backoff")
+        var replay = await client.serverConfigEvents().makeAsyncIterator()
+        guard case .snapshot? = try await replay.next() else {
+            return XCTFail("The replacement config must remain available.")
+        }
+        let replacementTags = await replacement.tags()
+        XCTAssertEqual(replacementTags, ["subscribeServerConfig"], "The existing replacement owns its subscription")
+
+        try await replacement.completeSubscription()
+        guard case let .snapshot(recovered)? = try await current.next() else {
+            return XCTFail("The replacement must still recover from its own completion.")
+        }
+        XCTAssertEqual(recovered.providers.first?.instanceId, "codex-recovered")
+        let attempts = await retries.attempts
+        XCTAssertEqual(attempts, [0], "Only the current generation may consume the first retry attempt")
+    }
+
     private func makeClient(
         connection: ServerConfigTestConnection,
         reconnectConnection: ServerConfigTestConnection? = nil,
         waitTimeout: Duration = .seconds(4),
-        failAttachmentUploads: Bool = false
+        failAttachmentUploads: Bool = false,
+        retryDelay: @escaping @Sendable (Int) async throws -> Void = { attempt in
+            let seconds = min(16, 1 << min(attempt, 4))
+            try await Task.sleep(for: .seconds(seconds))
+        }
     ) -> T3Client {
         let environment = Environment(
             id: "environment-1",
@@ -414,7 +516,8 @@ final class T3ClientServerConfigTests: XCTestCase {
             webSocketConnector: ServerConfigTestConnector(
                 connections: [connection] + (reconnectConnection.map { [$0] } ?? [])
             ),
-            rpcConnectionWaitTimeout: waitTimeout
+            rpcConnectionWaitTimeout: waitTimeout,
+            serverConfigRetryDelay: retryDelay
         )
     }
 }
@@ -448,7 +551,7 @@ private actor ServerConfigTestConnector: WebSocketConnecting {
 }
 
 private actor ServerConfigTestConnection: WebSocketConnection {
-    enum Mode { case snapshot, silent, failure(String) }
+    enum Mode { case snapshot, silent, failure(String), recovering }
 
     private let mode: Mode
     private let supportsUsageLimitSources: Bool?
@@ -488,6 +591,9 @@ private actor ServerConfigTestConnection: WebSocketConnection {
             case .snapshot: try enqueue(chunk(id: id, value: snapshot(id: "codex-old")))
             case .silent: break
             case let .failure(message): try enqueue(failure(id: id, message: message))
+            case .recovering:
+                let providerID = requestTags.count == 1 ? "codex-old" : "codex-recovered"
+                try enqueue(chunk(id: id, value: snapshot(id: providerID)))
             }
         case "server.getConfig":
             try enqueue(success(id: id, value: config(id: "codex-old")))
@@ -569,6 +675,16 @@ private actor ServerConfigTestConnection: WebSocketConnection {
         try enqueue(success(id: refreshRequestID, value: .object([
             "providers": .array([provider(id: id)]),
         ])))
+    }
+
+    func pushSubscriptionFailure(_ message: String) throws {
+        guard let subscriptionRequestID else { return }
+        try enqueue(failure(id: subscriptionRequestID, message: message))
+    }
+
+    func completeSubscription() throws {
+        guard let subscriptionRequestID else { return }
+        try enqueue(success(id: subscriptionRequestID, value: .null))
     }
 
     private func snapshot(id: String) -> JSONValue {
@@ -661,4 +777,9 @@ private actor ServerConfigTestConnection: WebSocketConnection {
             responses.append(data)
         }
     }
+}
+
+private actor ServerConfigRetryRecorder {
+    private(set) var attempts: [Int] = []
+    func record(_ attempt: Int) { attempts.append(attempt) }
 }


### PR DESCRIPTION
A transient server-configuration stream failure ends observation permanently. Retry eligible transport failures with bounded backoff and generation checks; keep unsupported-method fallback and permanent errors distinct.

Verification: Review repair at `2d1ac4779`: permanent DecodingError finishes configuration listeners and bootstrap instead of entering retry backoff. All 20 T3ClientServerConfigTests passed on Simulator (exit 0), including malformed input and transient recovery. The first local build stalled in a compiler metadata subprocess and was interrupted (exit 130); the clean retry passed. All latest-head CI checks pass, including [native tests](https://github.com/pingdotgg/t3code/actions/runs/34283527825/job/102253683168). Neutral approvability results do not establish maintainer approval.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

The claimed behavior is covered at the native protocol, persistence, or client boundary. No visible layout change or measured phone responsiveness improvement is claimed.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
