### PR TITLE
fix(swift-ios): preserve unsupported saved message queues

### DIFF
--- a/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
@@ -230,8 +230,18 @@ public enum FeatureOutboxPolicy {
 
 public actor FeatureOutboxStore {
     private struct Document: Codable {
-        var version = 1
+        static let currentVersion = 1
+
+        var version = currentVersion
         var submissions: [FeatureQueuedSubmission]
+    }
+
+    private struct UnsupportedDocumentVersion: LocalizedError {
+        let version: Int
+
+        var errorDescription: String? {
+            "The saved message queue uses unsupported version \(version)."
+        }
     }
 
     public static let shared = FeatureOutboxStore()
@@ -266,6 +276,9 @@ public actor FeatureOutboxStore {
             Document.self,
             from: Data(contentsOf: fileURL)
         )
+        guard document.version == Document.currentVersion else {
+            throw UnsupportedDocumentVersion(version: document.version)
+        }
         cached = document.submissions.map { submission in
             var submission = submission
             submission.interactionMode = submission.interactionMode.mobileNormalized

--- a/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
@@ -5,6 +5,52 @@ import Testing
 @Suite("Durable mobile outbox")
 struct FeatureOutboxStoreTests {
     @Test
+    func unreadableDocumentCannotBeSilentlyReplacedByTheNextMutation() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-feature-outbox-corrupt-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("outbox.json")
+        let original = Data("{not valid json".utf8)
+        try original.write(to: fileURL)
+        let store = FeatureOutboxStore(fileURL: fileURL)
+
+        do {
+            _ = try await store.submissions()
+            Issue.record("A corrupt outbox must not be treated as empty.")
+        } catch {}
+
+        do {
+            try await store.enqueue(queuedSubmission(text: "Must not replace the recovery copy"))
+            Issue.record("Mutation must remain blocked while the persisted outbox is unreadable.")
+        } catch {}
+        #expect(try Data(contentsOf: fileURL) == original)
+    }
+
+    @Test
+    func futureDocumentVersionIsPreservedInsteadOfDecodedAsCurrent() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-feature-outbox-future-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("outbox.json")
+        let original = Data(#"{"version":2,"submissions":[]}"#.utf8)
+        try original.write(to: fileURL)
+        let store = FeatureOutboxStore(fileURL: fileURL)
+
+        do {
+            _ = try await store.submissions()
+            Issue.record("A future outbox version must require an explicit migration.")
+        } catch {}
+
+        do {
+            try await store.enqueue(queuedSubmission(text: "Must not downgrade the document"))
+            Issue.record("Mutation must not overwrite a future-version outbox.")
+        } catch {}
+        #expect(try Data(contentsOf: fileURL) == original)
+    }
+
+    @Test
     func roundTripPreservesStableWireIdentityAndAttachments() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-feature-outbox-\(UUID().uuidString)", isDirectory: true)
@@ -332,6 +378,19 @@ struct FeatureOutboxStoreTests {
                 snapshot: snapshot,
                 pendingCreationThreadIDs: [creation.threadID]
             ) == .wait
+        )
+    }
+
+    private func queuedSubmission(text: String) -> FeatureQueuedSubmission {
+        FeatureQueuedSubmission(
+            environmentID: "environment-1",
+            identity: FeatureSubmissionIdentity(),
+            threadID: "thread-1",
+            text: text,
+            selection: nil,
+            runtimeMode: .fullAccess,
+            interactionMode: .standard,
+            attachments: []
         )
     }
 }


### PR DESCRIPTION
An older SwiftUI client could decode a saved message queue written by a newer client as if it were the current format, then rewrite it and drop whatever it didn't understand.

`FeatureOutboxStore` now checks the document `version` before it caches anything. For an unsupported version, reading throws and the result is not cached, so later enqueue/mutation calls also throw and never touch the file. The saved bytes stay intact until a client that supports that version loads them. Version-1 queues behave exactly as before.

Verification: `Contract fixtures and native tests` ran on this head (`ef10b52`) and both new tests passed: `futureDocumentVersionIsPreservedInsteadOfDecodedAsCurrent` and `unreadableDocumentCannotBeSilentlyReplacedByTheNextMutation` ([job log](https://github.com/pingdotgg/t3code/actions/runs/34226666832/job/102062348731)). The branch sits directly on the current `t3code/rebuild-mobile-app-swift` tip (`93ca266`), so nothing changed since that run.

There is no visible UI change, so no media.

Review: Claude Opus 5 read the diff against CODING_STANDARDS.md and found nothing actionable.

Coordination trace: T3 thread c7b0678c-4c50-4793-b0e2-da6d50144eda

Model and harness: implemented with GPT-6 / Codex; refreshed and reviewed with Claude Opus 5 / Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
