### PR TITLE
fix(swift-ios): reconnect after short background suspension

### DIFF
--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -137,12 +137,10 @@ public final class FeatureRootModel {
         backgroundedAt = date
     }
 
-    func applicationDidBecomeActive(at date: Date = .now) async {
-        guard let backgroundedAt else { return }
+    func applicationDidBecomeActive(at _: Date = .now) async {
+        guard backgroundedAt != nil else { return }
         self.backgroundedAt = nil
-        await client.resumeAfterBackground(
-            reconnect: date.timeIntervalSince(backgroundedAt) >= 10
-        )
+        await client.resumeAfterBackground(reconnect: true)
     }
 
     /// Background refresh is deliberately separate from `reload()`: native

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -69,7 +69,7 @@ struct FeatureRootModelTests {
     }
 
     @Test
-    func foregroundRecoveryIgnoresInitialActivationAndReplacesLongSuspendedSockets() async {
+    func foregroundRecoveryIgnoresInitialActivationAndReplacesEverySuspendedSocket() async {
         let client = FeatureClientStub()
         let model = testRootModel(client: client)
         let start = Date(timeIntervalSince1970: 100)
@@ -80,7 +80,7 @@ struct FeatureRootModelTests {
         model.applicationDidEnterBackground(at: start)
         await model.applicationDidBecomeActive(at: start.addingTimeInterval(10))
         await model.applicationDidBecomeActive(at: start.addingTimeInterval(11))
-        #expect(client.foregroundReconnects == [false, true])
+        #expect(client.foregroundReconnects == [true, true])
     }
 
     @Test


### PR DESCRIPTION
A brief background suspension can leave the native client using a stale socket. Reconnect on every recorded foreground return, including suspensions shorter than ten seconds, while ignoring duplicate foreground notifications.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226675131/job/102062375827). Skipped checks are not claimed as executed proof.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Baseline verification at 93ca26695: the actual foreground policy returned [false,true] for 9s and 10s suspensions; the regression expected [true,true] and failed (1 test, exit65). On this PR, foregroundRecoveryIgnoresInitialActivationAndReplacesEverySuspendedSocket passed in native CI, including ignored initial activation and duplicate foreground notification. The change is the reconnect policy; no new presentation or measured phone responsiveness is claimed.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
