### PR TITLE
fix(swift-ios): ignore stale device reads after revocation

### DIFF
--- a/apps/swift-ios/Features/Devices/DevicesView.swift
+++ b/apps/swift-ios/Features/Devices/DevicesView.swift
@@ -9,6 +9,7 @@ public struct DevicesView: View {
     @State private var errorMessage: String?
     @State private var revokeTarget: FeatureDeviceSession?
     @State private var showingRevokeOthers = false
+    @State private var operationGeneration: UInt64 = 0
 
     public init(manager: any FeatureDeviceManaging) {
         self.manager = manager
@@ -174,43 +175,65 @@ public struct DevicesView: View {
 
     @MainActor
     private func reload() async {
+        guard !isRevoking else { return }
+        operationGeneration &+= 1
+        let generation = operationGeneration
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            if operationGeneration == generation { isLoading = false }
+        }
         do {
-            sessions = FeatureDeviceSession.sortedForDisplay(
+            let loaded = FeatureDeviceSession.sortedForDisplay(
                 try await manager.loadDeviceSessions()
             )
+            guard operationGeneration == generation else { return }
+            sessions = loaded
             errorMessage = nil
         } catch {
+            guard operationGeneration == generation else { return }
             errorMessage = DeviceManagementErrorCopy.message(for: error)
         }
     }
 
     @MainActor
     private func revoke(_ session: FeatureDeviceSession) async {
+        operationGeneration &+= 1
+        let generation = operationGeneration
+        isLoading = false
         isRevoking = true
         defer {
-            isRevoking = false
-            revokeTarget = nil
+            if operationGeneration == generation {
+                isRevoking = false
+                revokeTarget = nil
+            }
         }
         do {
             try await manager.revokeDeviceSession(id: session.id)
+            guard operationGeneration == generation else { return }
             sessions.removeAll { $0.id == session.id }
             errorMessage = nil
         } catch {
+            guard operationGeneration == generation else { return }
             errorMessage = DeviceManagementErrorCopy.message(for: error)
         }
     }
 
     @MainActor
     private func revokeOthers() async {
+        operationGeneration &+= 1
+        let generation = operationGeneration
+        isLoading = false
         isRevoking = true
-        defer { isRevoking = false }
+        defer {
+            if operationGeneration == generation { isRevoking = false }
+        }
         do {
             try await manager.revokeOtherDeviceSessions()
+            guard operationGeneration == generation else { return }
             sessions.removeAll { !$0.isCurrent }
             errorMessage = nil
         } catch {
+            guard operationGeneration == generation else { return }
             errorMessage = DeviceManagementErrorCopy.message(for: error)
         }
     }


### PR DESCRIPTION
A delayed device-session reload can restore a revoked session or overwrite newer action feedback. Give reload and revocation operations one generation owner and reject stale completions.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34227629197/job/102065545863). Skipped checks are not claimed as executed proof.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

The claimed behavior is covered at the native protocol, persistence, or client boundary. No visible layout change or measured phone responsiveness improvement is claimed.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
