### PR TITLE
fix(swift-ios): retain directory listings after refresh failures

### DIFF
--- a/apps/swift-ios/Features/Files/FeatureFilesView.swift
+++ b/apps/swift-ios/Features/Files/FeatureFilesView.swift
@@ -59,6 +59,7 @@ private struct FeatureFileDirectoryView: View {
     @State private var includesHidden = false
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var loadGeneration = FeatureAsyncGeneration()
 
     var body: some View {
         Group {
@@ -71,18 +72,37 @@ private struct FeatureFileDirectoryView: View {
                     systemImage: "folder.badge.questionmark",
                     description: Text(errorMessage)
                 )
-            } else if filteredEntries.isEmpty {
+            } else if filteredEntries.isEmpty, errorMessage == nil {
                 ContentUnavailableView(
                     searchText.isEmpty ? "Empty folder" : "No matches",
                     systemImage: "folder",
                     description: Text(searchText.isEmpty ? "This folder has no visible files." : "Try another search.")
                 )
             } else {
-                List(filteredEntries) { entry in
-                    NavigationLink {
-                        destination(for: entry)
-                    } label: {
-                        FeatureFileRow(entry: entry)
+                List {
+                    if let errorMessage {
+                        FeatureRefreshFailureRow(message: errorMessage) {
+                            Task { await load() }
+                        }
+                    }
+                    if filteredEntries.isEmpty {
+                        ContentUnavailableView(
+                            searchText.isEmpty ? "Empty folder" : "No matches",
+                            systemImage: "folder",
+                            description: Text(
+                                searchText.isEmpty
+                                    ? "The last successful refresh found no visible files."
+                                    : "Try another search."
+                            )
+                        )
+                        .listRowBackground(Color.clear)
+                    }
+                    ForEach(filteredEntries) { entry in
+                        NavigationLink {
+                            destination(for: entry)
+                        } label: {
+                            FeatureFileRow(entry: entry)
+                        }
                     }
                 }
                 .listStyle(.plain)
@@ -137,12 +157,18 @@ private struct FeatureFileDirectoryView: View {
     }
 
     private func load() async {
+        let generation = loadGeneration.begin()
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            if loadGeneration.accepts(generation) { isLoading = false }
+        }
         do {
-            entries = try await client.listFiles(threadID: threadID, path: path)
+            let loaded = try await client.listFiles(threadID: threadID, path: path)
+            guard loadGeneration.accepts(generation) else { return }
+            entries = loaded
             errorMessage = nil
         } catch {
+            guard loadGeneration.accepts(generation) else { return }
             errorMessage = error.localizedDescription
         }
     }

--- a/apps/swift-ios/Features/Shared/FeatureAsyncGeneration.swift
+++ b/apps/swift-ios/Features/Shared/FeatureAsyncGeneration.swift
@@ -1,0 +1,12 @@
+struct FeatureAsyncGeneration {
+    private var value: UInt64 = 0
+
+    mutating func begin() -> UInt64 {
+        value &+= 1
+        return value
+    }
+
+    func accepts(_ generation: UInt64) -> Bool {
+        generation == value
+    }
+}

--- a/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
+++ b/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FeatureRefreshFailureRow: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(T3Colors.warning)
+            Text(message)
+                .font(T3Typography.supporting)
+                .foregroundStyle(T3Colors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button("Retry", action: retry)
+                .font(T3Typography.control.weight(.semibold))
+        }
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/FeatureAsyncGenerationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureAsyncGenerationTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import T3Code
+
+struct FeatureAsyncGenerationTests {
+    @Test
+    func asyncGenerationRejectsAnOlderCompletionAfterANewerOperationBegins() {
+        var generation = FeatureAsyncGeneration()
+        let staleLoad = generation.begin()
+        let mutation = generation.begin()
+
+        #expect(!generation.accepts(staleLoad))
+        #expect(generation.accepts(mutation))
+    }
+
+}


### PR DESCRIPTION
Directory refresh failures can be hidden by cached entries or filtered empty states. Retain the last successful listing, show a contextual error and Retry action, and reject older load completions after a newer refresh begins.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34227631707/job/102065554632). Skipped checks are not claimed as executed proof.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Integrated view verification: actual `FeatureFilesView`, dark mode, iPhone 17 Pro Simulator iOS 26.5, 390×844 hosted viewport. Synthetic client returns two entries, then fails refresh, then returns a new third file. Baseline `93ca26695` hides the second-request failure; candidate `ef5e8cb63` retains entries and exposes error/Retry. Filtering to no matches retains the error. Retry clears it and loads `recovered.txt`. Both hosted tests passed 1 test, exit 0 and asserted exactly 3 client calls. This exercises actual view controls with fixture responses, not a live server.

Still-state comparison of the same failed refresh (actual screenshots, 3.5 seconds each):

![Directory refresh: hidden failure before; retained entries and Retry after — still-state comparison](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-comparison.gif)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-before.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-after.png)

Before (base), full recorded sequence at 12 fps and real-time playback:

![Before: Directory refresh: hidden failure before; retained entries and Retry after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-before-interaction-v2.gif)

After (candidate), full recorded sequence at 12 fps and real-time playback:

![After: Directory refresh: hidden failure before; retained entries and Retry after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-after-interaction.gif)

[Baseline recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-before-clean.mp4) · [Candidate clean recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-after-clean.mp4) · [Captioned recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-after-annotated.mp4) · [Provenance and editing receipt](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/files-media-receipt.json)

Visual review: inspected the before/after images and recorded interaction states at 390 px width against current head `ef5e8cb63`. The demonstrated UI is unchanged from the labeled capture revisions; retained content, recovery controls, spacing, and text are legible. This is the author’s visual assessment, not maintainer approval.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
