### PR TITLE
fix(swift-ios): retain review content during refresh failures

### DIFF
--- a/apps/swift-ios/Features/Review/FeatureReviewView.swift
+++ b/apps/swift-ios/Features/Review/FeatureReviewView.swift
@@ -9,6 +9,7 @@ public struct FeatureReviewView: View {
     @State private var review: FeatureReview?
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var loadGeneration = FeatureAsyncGeneration()
 
     public init(client: any FeatureClient, threadID: String) {
         self.client = client
@@ -52,6 +53,14 @@ public struct FeatureReviewView: View {
 
     private func reviewList(_ review: FeatureReview) -> some View {
         List {
+            if let errorMessage {
+                Section {
+                    FeatureRefreshFailureRow(message: errorMessage) {
+                        Task { await load() }
+                    }
+                }
+            }
+
             Section {
                 HStack {
                     VStack(alignment: .leading, spacing: 3) {
@@ -99,12 +108,18 @@ public struct FeatureReviewView: View {
     }
 
     private func load() async {
+        let generation = loadGeneration.begin()
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            if loadGeneration.accepts(generation) { isLoading = false }
+        }
         do {
-            review = try await client.loadReview(threadID: threadID)
+            let loaded = try await client.loadReview(threadID: threadID)
+            guard loadGeneration.accepts(generation) else { return }
+            review = loaded
             errorMessage = nil
         } catch {
+            guard loadGeneration.accepts(generation) else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -192,6 +207,8 @@ private struct FeatureDiffView: View {
 
     @State private var renderedLines: [FeatureDiffLine]
     @State private var isHydrating = false
+    @State private var hydrationError: String?
+    @State private var hydrationGeneration = FeatureAsyncGeneration()
     @State private var selectedLine: FeatureReviewLineSelection?
     @State private var isCommenting = false
     @State private var comment = ""
@@ -211,6 +228,15 @@ private struct FeatureDiffView: View {
             if renderedLines.isEmpty, isHydrating {
                 ProgressView("Loading full diff…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let hydrationError, renderedLines.isEmpty {
+                ContentUnavailableView {
+                    Label("Couldn’t load this diff", systemImage: "exclamationmark.circle")
+                } description: {
+                    Text(hydrationError)
+                } actions: {
+                    Button("Try again") { Task { await hydrate() } }
+                        .buttonStyle(.borderedProminent)
+                }
             } else if renderedLines.isEmpty {
                 ContentUnavailableView(
                     file.change == .binary ? "Binary file" : "Diff unavailable",
@@ -256,6 +282,16 @@ private struct FeatureDiffView: View {
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if isCommenting {
                 commentComposer
+            }
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if let hydrationError, !renderedLines.isEmpty {
+                FeatureRefreshFailureRow(message: hydrationError) {
+                    Task { await hydrate() }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(T3Colors.surface)
             }
         }
         .task(id: file.id) { await hydrate() }
@@ -389,15 +425,27 @@ private struct FeatureDiffView: View {
     }
 
     private func hydrate() async {
+        let generation = hydrationGeneration.begin()
+        hydrationError = nil
         isHydrating = true
-        defer { isHydrating = false }
-        guard let contents = try? await client.loadReviewFileContents(
-            threadID: threadID,
-            file: file
-        ) else {
-            return
+        defer {
+            if hydrationGeneration.accepts(generation) { isHydrating = false }
         }
-        renderedLines = FeatureFullDiffHydrator.lines(for: file, contents: contents)
+        do {
+            guard let contents = try await client.loadReviewFileContents(
+                threadID: threadID,
+                file: file
+            ) else {
+                return
+            }
+            guard hydrationGeneration.accepts(generation) else { return }
+            renderedLines = FeatureFullDiffHydrator.lines(for: file, contents: contents)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard hydrationGeneration.accepts(generation) else { return }
+            hydrationError = error.localizedDescription
+        }
     }
 
     private func sendComment() {

--- a/apps/swift-ios/Features/Shared/FeatureAsyncGeneration.swift
+++ b/apps/swift-ios/Features/Shared/FeatureAsyncGeneration.swift
@@ -1,0 +1,12 @@
+struct FeatureAsyncGeneration {
+    private var value: UInt64 = 0
+
+    mutating func begin() -> UInt64 {
+        value &+= 1
+        return value
+    }
+
+    func accepts(_ generation: UInt64) -> Bool {
+        generation == value
+    }
+}

--- a/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
+++ b/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FeatureRefreshFailureRow: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(T3Colors.warning)
+            Text(message)
+                .font(T3Typography.supporting)
+                .foregroundStyle(T3Colors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button("Retry", action: retry)
+                .font(T3Typography.control.weight(.semibold))
+        }
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/FeatureAsyncGenerationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureAsyncGenerationTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import T3Code
+
+struct FeatureAsyncGenerationTests {
+    @Test
+    func asyncGenerationRejectsAnOlderCompletionAfterANewerOperationBegins() {
+        var generation = FeatureAsyncGeneration()
+        let staleLoad = generation.begin()
+        let mutation = generation.begin()
+
+        #expect(!generation.accepts(staleLoad))
+        #expect(generation.accepts(mutation))
+    }
+
+}


### PR DESCRIPTION
A transient review refresh can erase previously loaded content or hide the failure. Keep the last valid review content available and show a contextual Retry action.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34227637911/job/102065576138). Skipped checks are not claimed as executed proof.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Integrated view verification: actual `FeatureReviewView` on iPhone 17 Pro Simulator, iOS 26.5, dark mode, 390×844 hosted viewport. The same fixture succeeds, fails the next refresh, then returns a distinct recovered title. Baseline `93ca26695` hides the failure; candidate `f2f427606` retains content, displays error/Retry, and Retry loads the recovered title and removes the error. Both scenarios asserted exactly 3 client reads; the baseline capture suite passed 3 tests and this candidate passed 1 test (exit 0). Fixture responses exercise real view controls; live-server transport behavior is covered separately by native tests.

Still-state comparison of the failed refresh (actual screenshots, 3.5 seconds each):

![Review refresh: hidden failure before; retained review and Retry after — still-state comparison](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-comparison.gif)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-before.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-after.png)

Before (base), full recorded sequence at 12 fps and real-time playback:

![Before: Review refresh: hidden failure before; retained review and Retry after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-before-interaction-v2.gif)

After (candidate), full recorded sequence at 12 fps and real-time playback:

![After: Review refresh: hidden failure before; retained review and Retry after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-interaction.gif)

[Baseline recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-before-clean.mp4) · [Candidate clean recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-after-clean.mp4) · [Captioned recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-after-annotated.mp4) · [Provenance](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/review-media-receipt.json)

Visual review: inspected the before/after images and recorded interaction states at 390 px width against current head `f2f427606`. The demonstrated UI is unchanged from the labeled capture revisions; retained content, recovery controls, spacing, and text are legible. This is the author’s visual assessment, not maintainer approval.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
