### PR TITLE
fix(swift-ios): expose pull request refresh failures

### DIFF
--- a/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
+++ b/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
@@ -398,7 +398,7 @@ public struct PullRequestsView: View {
             List {
                 if let errorMessage = model.errorMessage {
                     FeatureRefreshFailureRow(message: errorMessage) {
-                        Task { await model.load() }
+                        Task { await model.load(invalidate: true) }
                     }
                 }
 

--- a/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
+++ b/apps/swift-ios/Features/PullRequests/PullRequestsView.swift
@@ -396,6 +396,12 @@ public struct PullRequestsView: View {
             ContentUnavailableView("Couldn’t load pull requests", systemImage: "exclamationmark.triangle", description: Text(error))
         } else {
             List {
+                if let errorMessage = model.errorMessage {
+                    FeatureRefreshFailureRow(message: errorMessage) {
+                        Task { await model.load() }
+                    }
+                }
+
                 ForEach(model.environments.filter { $0.errorMessage != nil }) { environment in
                     Label {
                         VStack(alignment: .leading, spacing: 2) {

--- a/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
+++ b/apps/swift-ios/Features/Shared/FeatureRefreshFailureRow.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FeatureRefreshFailureRow: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(T3Colors.warning)
+            Text(message)
+                .font(T3Typography.supporting)
+                .foregroundStyle(T3Colors.textSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button("Retry", action: retry)
+                .font(T3Typography.control.weight(.semibold))
+        }
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/PullRequestDiffTests.swift
@@ -184,6 +184,27 @@ struct PullRequestPaginationTests {
     }
 
     @Test
+    func failedRefreshKeepsLoadedRowsAndReportsTheFailure() async {
+        let client = PullRequestPaginationClientStub()
+        client.firstPages = [page(environmentID: "studio", numbers: [3])]
+        let model = PullRequestsModel(client: client)
+        await model.load()
+
+        client.initialLoadFailure = PullRequestPaginationClientStub.Failure.offline
+        await model.load(invalidate: true)
+
+        #expect(model.rows.map(\.entry.number) == [3])
+        #expect(model.errorMessage == "This computer is offline.")
+
+        client.initialLoadFailure = nil
+        client.firstPages = [page(environmentID: "studio", numbers: [4])]
+        await model.load(invalidate: true)
+
+        #expect(model.rows.map(\.entry.number) == [4])
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test
     func stalePaginationCannotReplaceANewerReload() async {
         let client = PullRequestPaginationClientStub()
         client.firstPages = [page(
@@ -285,6 +306,7 @@ private final class PullRequestPaginationClientStub: FeatureClient {
     var firstPages: [FeaturePullRequestEnvironmentList] = []
     var targetedPages: [String: FeaturePullRequestEnvironmentList] = [:]
     var failedEnvironmentIDs: Set<String> = []
+    var initialLoadFailure: (any Error)?
     var initialRequests: [PullRequestListInput] = []
     var targetedRequests: [TargetedRequest] = []
     var beforeTargetedResponse:
@@ -294,6 +316,7 @@ private final class PullRequestPaginationClientStub: FeatureClient {
         -> [FeaturePullRequestEnvironmentList]
     {
         initialRequests.append(input)
+        if let initialLoadFailure { throw initialLoadFailure }
         return firstPages
     }
 


### PR DESCRIPTION
Refreshing a pull-request inbox that already has rows can fail silently: the error was only shown when the list was empty, so a failed refresh left stale rows with no feedback.

The inbox now keeps its rows and shows a refresh-failure row with a Retry action. Retry reloads with cache invalidation, matching pull-to-refresh and the toolbar refresh button, so a retry can't "succeed" by returning the cached list.

Verification:
- New focused test `PullRequestPaginationTests/failedRefreshKeepsLoadedRowsAndReportsTheFailure`: a failed invalidating refresh keeps loaded rows and sets the error; a successful retry replaces rows and clears it. `-only-testing:T3CodeTests/PullRequestPaginationTests` passed 5/5 on an iPhone 16 Pro Simulator (isolated DerivedData, exit 0).
- Current-head GitHub checks.

Integrated view evidence (captured at `2014b21b4`, actual `PullRequestsView`, iPhone 17 Pro Simulator, iOS 26.5, dark mode). The later Retry change only adds cache invalidation, so what's on screen is unchanged. Baseline `93ca26695` hides the failure; candidate keeps content, shows the error and Retry, and Retry loads the recovered title and removes the error.

![PR inbox: hidden failure before; retained inbox and Retry after — still-state comparison](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-comparison.gif)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-before.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-after.png)

Before (base):

![Before: PR inbox hides the refresh failure](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-before-interaction-v2.gif)

After:

![After: retained inbox with refresh-failure row and Retry](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-interaction.gif)

[Baseline recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-before-clean.mp4) · [Candidate recording](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-after-clean.mp4) · [Provenance](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/inbox-media-receipt.json)

Scope: SwiftUI mobile only. The React Native client and web are not touched.

Independent cross-provider review was skipped for this revision (Codex weekly quota below threshold). No maintainer approval is claimed.

Coordination trace: T3 thread 645b38b0-d8e1-4659-a527-329b3a3c92a3

Model and harness: GPT-6 / Codex (original change); Claude Opus 5 / Claude Code (test and retry follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
