### PR TITLE
fix(swift-ios): keep share confirmations readable at large text sizes

### DIFF
--- a/apps/swift-ios/Extensions/Share/ShareViewController.swift
+++ b/apps/swift-ios/Extensions/Share/ShareViewController.swift
@@ -45,6 +45,8 @@ final class T3ShareViewController: UIViewController {
 }
 
 struct T3ShareExtensionView: View {
+    @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     enum Phase: Equatable {
         case ready
         case saving
@@ -60,19 +62,10 @@ struct T3ShareExtensionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ZStack {
-                Text("T3 Code")
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                HStack {
-                    Button("Cancel", action: cancel)
-                        .foregroundStyle(.secondary)
-                        .disabled(isSaving)
-                    Spacer()
-                }
-            }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 15)
+            header
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 15)
 
             Divider()
 
@@ -96,7 +89,7 @@ struct T3ShareExtensionView: View {
                 .padding(.horizontal, 28)
                 .padding(.vertical, 24)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
 
             Button(action: primaryAction) {
                 Text(primaryTitle)
@@ -114,6 +107,37 @@ struct T3ShareExtensionView: View {
             .padding(.bottom, 18)
         }
         .background(Color(uiColor: .systemBackground).ignoresSafeArea())
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 8) {
+                headerTitle
+                cancelButton
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            ZStack {
+                headerTitle
+                HStack {
+                    cancelButton
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    private var headerTitle: some View {
+        Text("T3 Code")
+            .font(.headline)
+            .foregroundStyle(.primary)
+    }
+
+    private var cancelButton: some View {
+        Button("Cancel", action: cancel)
+            .foregroundStyle(.secondary)
+            .disabled(isSaving)
     }
 
     private var isSaving: Bool {

--- a/apps/swift-ios/Extensions/Share/ShareViewController.swift
+++ b/apps/swift-ios/Extensions/Share/ShareViewController.swift
@@ -48,7 +48,7 @@ struct T3ShareExtensionView: View {
     enum Phase: Equatable {
         case ready
         case saving
-        case saved(imageCount: Int)
+        case saved(attachmentCount: Int)
         case failed(message: String)
     }
 
@@ -60,47 +60,51 @@ struct T3ShareExtensionView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                Button("Cancel", action: cancel)
-                    .foregroundStyle(.secondary)
-                    .disabled(isSaving)
-                Spacer()
+            ZStack {
                 Text("T3 Code")
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(.headline)
                     .foregroundStyle(.primary)
-                Spacer()
-                Color.clear.frame(width: 52, height: 1)
+                HStack {
+                    Button("Cancel", action: cancel)
+                        .foregroundStyle(.secondary)
+                        .disabled(isSaving)
+                    Spacer()
+                }
             }
             .padding(.horizontal, 18)
             .padding(.vertical, 15)
 
             Divider()
 
-            VStack(spacing: 14) {
-                Image(systemName: phaseSymbol)
-                    .font(.system(size: 32, weight: .medium))
-                    .foregroundStyle(phaseTint)
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(.system(size: 22, weight: .bold))
-                    .foregroundStyle(.primary)
-                    .multilineTextAlignment(.center)
-                Text(message)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .lineSpacing(3)
+            ScrollView {
+                VStack(spacing: 14) {
+                    Image(systemName: phaseSymbol)
+                        .font(.title.weight(.medium))
+                        .foregroundStyle(phaseTint)
+                        .accessibilityHidden(true)
+                    Text(title)
+                        .font(.title2.bold())
+                        .foregroundStyle(.primary)
+                        .multilineTextAlignment(.center)
+                    Text(message)
+                        .font(.body.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(3)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 24)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(.horizontal, 28)
-            .padding(.vertical, 24)
 
             Button(action: primaryAction) {
                 Text(primaryTitle)
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.headline)
                     .foregroundStyle(Color(uiColor: .systemBackground))
                     .frame(maxWidth: .infinity)
-                    .frame(height: 50)
+                    .frame(minHeight: 50)
+                    .padding(.vertical, 2)
                     .background(Color(uiColor: .label), in: RoundedRectangle(cornerRadius: 13))
             }
             .buttonStyle(.plain)
@@ -131,10 +135,10 @@ struct T3ShareExtensionView: View {
             "Text, links, and up to eight files will be waiting in the native composer."
         case .saving:
             "Keeping a durable copy so nothing gets lost."
-        case let .saved(imageCount):
-            imageCount == 0
+        case let .saved(attachmentCount):
+            attachmentCount == 0
                 ? "Open T3 Code to choose a project and send it."
-                : "Saved \(imageCount) image\(imageCount == 1 ? "" : "s"). Open T3 Code to choose a project."
+                : "Saved \(attachmentCount) attachment\(attachmentCount == 1 ? "" : "s"). Open T3 Code to choose a project."
         case let .failed(message):
             message
         }
@@ -173,7 +177,7 @@ struct T3ShareExtensionView: View {
             Task {
                 do {
                     let envelope = try await save()
-                    phase = .saved(imageCount: envelope.images.count + envelope.files.count)
+                    phase = .saved(attachmentCount: envelope.images.count + envelope.files.count)
                 } catch {
                     phase = .failed(
                         message: (error as? LocalizedError)?.errorDescription


### PR DESCRIPTION
The share-extension confirmation uses fixed text sizes and a fixed content area that can clip at large accessibility sizes. Use semantic text styles, scrollable content, and a growing action button. Name the saved total as attachments so shared files are not reported as images.

Verification: the final native capture test passed (1 test, exit 0), including exactly one save and one completion callback. Current-head CI passes, including [native tests](https://github.com/pingdotgg/t3code/actions/runs/34287388936/job/102266013401).

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Visual verification: baseline `93ca26695` and candidate `7667b8e86` use the actual share view source in a native Simulator test host, accessibility5, dark mode, 390 × 844. The fixture returns two files. The candidate scales text, separates header controls, scrolls the confirmation, and keeps Done reachable. Save and completion callbacks are asserted. This tests the actual view with mocked callbacks; it does not claim a share-extension process or storage integration test.

Actual before/after stills, held for 3.5 seconds each; not a motion or latency measurement. The candidate poster is the settled saved state before scrolling, extracted from the existing current-head recording; the video shows the remaining text through scrolling and the Done action.

![Current saved state at accessibility5, before scrolling](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-after-v3.png)

![Share confirmation at accessibility5: fixed-size before; scalable and scrollable after — still-state comparison](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-comparison-v3.gif)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-before-v3.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-after-v3.png)

Before (base), full recorded sequence at 12 fps and real-time playback:

![Before: Share confirmation at accessibility5: fixed-size before; scalable and scrollable after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-before-interaction-v2.gif)

After (candidate), full recorded sequence at 12 fps and real-time playback:

![After: Share confirmation at accessibility5: fixed-size before; scalable and scrollable after](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-interaction.gif)

[Before video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-before-clean.mp4) · [Clean candidate video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-after-clean.mp4) · [Annotated candidate video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-after-annotated.mp4) · [Evidence receipt](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/share-media-receipt.json)

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
