### PR TITLE
fix(swift-ios): resolve transcript prefetches by snapshot identity

### DIFF
--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -1327,6 +1327,20 @@ enum FeatureComposerDraftRestoration {
     }
 }
 
+enum TranscriptPrefetchIdentity {
+    static func messageIDs(
+        at indexPaths: [IndexPath],
+        snapshotItemIDs: [String],
+        reservedItemIDs: Set<String>
+    ) -> [String] {
+        return indexPaths.compactMap { indexPath in
+            guard snapshotItemIDs.indices.contains(indexPath.item) else { return nil }
+            let itemID = snapshotItemIDs[indexPath.item]
+            return reservedItemIDs.contains(itemID) ? nil : itemID
+        }
+    }
+}
+
 /// A recycled transcript surface. SwiftUI still owns each message's rendering,
 /// while UIKit keeps offscreen messages out of the active view hierarchy.
 private struct FeatureTranscriptCollectionView: UIViewRepresentable {
@@ -1815,8 +1829,16 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             _ collectionView: UICollectionView,
             prefetchItemsAt indexPaths: [IndexPath]
         ) {
-            for indexPath in indexPaths where orderedIDs.indices.contains(indexPath.item) {
-                let messageID = orderedIDs[indexPath.item]
+            guard let dataSource else { return }
+            let messageIDs = TranscriptPrefetchIdentity.messageIDs(
+                at: indexPaths,
+                snapshotItemIDs: dataSource.snapshot().itemIdentifiers,
+                reservedItemIDs: [
+                    FeatureTranscriptCollectionView.loadEarlierID,
+                    FeatureTranscriptCollectionView.workingIndicatorID,
+                ]
+            )
+            for messageID in messageIDs {
                 guard markdownPrefetches[messageID] == nil,
                       let message = messagesByID[messageID],
                       !message.text.isEmpty,
@@ -1847,9 +1869,15 @@ private struct FeatureTranscriptCollectionView: UIViewRepresentable {
             _ collectionView: UICollectionView,
             cancelPrefetchingForItemsAt indexPaths: [IndexPath]
         ) {
-            let messageIDs = indexPaths.compactMap { indexPath in
-                orderedIDs.indices.contains(indexPath.item) ? orderedIDs[indexPath.item] : nil
-            }
+            guard let dataSource else { return }
+            let messageIDs = TranscriptPrefetchIdentity.messageIDs(
+                at: indexPaths,
+                snapshotItemIDs: dataSource.snapshot().itemIdentifiers,
+                reservedItemIDs: [
+                    FeatureTranscriptCollectionView.loadEarlierID,
+                    FeatureTranscriptCollectionView.workingIndicatorID,
+                ]
+            )
             cancelMarkdownPrefetches(for: Set(messageIDs))
         }
 

--- a/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/TranscriptViewportGeometryTests.swift
@@ -6,6 +6,17 @@ import UIKit
 @Suite("Transcript viewport anchoring")
 struct TranscriptViewportGeometryTests {
     @Test
+    func transcriptPrefetchUsesTheVisibleSnapshotWhenLoadEarlierIsPresent() {
+        let ids = TranscriptPrefetchIdentity.messageIDs(
+            at: [IndexPath(item: 1, section: 0), IndexPath(item: 2, section: 0)],
+            snapshotItemIDs: ["__t3-load-earlier__", "message-1", "message-2"],
+            reservedItemIDs: ["__t3-load-earlier__", "__t3-working-indicator__"]
+        )
+
+        #expect(ids == ["message-1", "message-2"])
+    }
+
+    @Test
     func firstLoadedTranscriptAnchorsToLatestMessage() {
         let empty = TranscriptViewportGeometry(
             contentHeight: 0,


### PR DESCRIPTION
Transcript prefetch indexes include reserved collection rows and can therefore point at the wrong message. Resolve prefetch and cancellation through the actual diffable-data-source snapshot, excluding reserved item IDs.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34226727571/job/102062549902). Skipped checks are not claimed as executed proof.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Verification scope: The native transcriptPrefetchUsesTheVisibleSnapshotWhenLoadEarlierIsPresent regression passed on this head. Both prefetch and cancellation now resolve through the diffable snapshot and exclude reserved items; no rendering or measured speedup claim is made. The native CI job linked above contains the passing receipts. The tests exercise the protocol, state, or accessibility-value boundary changed here.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
