### PR TITLE
fix(swift-ios): preserve remote source-control paths

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2698,7 +2698,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
         let key = NativeSourceControlMonitorKey(
             environmentID: route.environmentID,
-            workingDirectory: URL(fileURLWithPath: context.cwd).standardizedFileURL.path
+            workingDirectory: context.cwd
         )
         let subscriberID = UUID()
         let monitor: NativeSourceControlMonitor

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -24,7 +24,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
                 ),
                 host: "two.example"
             )
-            let snapshot = try await fixture.hydratedSnapshot()
+            let snapshot = try await fixture.client.initialSnapshot()
             let thread = try XCTUnwrap(snapshot.threads.first { $0.environmentID == "two" })
             let monitor = Task {
                 for await _ in client.sourceControlStatusEvents(threadID: thread.id) {}
@@ -33,8 +33,9 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             let request = await server.nextSourceControlDirectory()
             XCTAssertEqual(request.host, "two.example")
             XCTAssertEqual(request.cwd, path)
-            await client.disconnect()
+            monitor.cancel()
             await monitor.value
+            await client.disconnect()
         }
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -5,6 +5,39 @@ import XCTest
 
 @MainActor
 final class NativeMultiEnvironmentTests: XCTestCase {
+    func testSourceControlMonitorPreservesTheRemoteWorkingDirectory() async throws {
+        for path in [#"C:\work\My Repo"#, #"\\server\share\repo"#, "/srv/my repo"] {
+            let server = MultiEnvironmentConfigurationServer()
+            let fixture = try await Self.makeFixture(
+                webSocketConnector: MultiEnvironmentConfigurationConnector(server: server)
+            )
+            let client = fixture.client
+            let directory = fixture.directory
+            addTeardownBlock {
+                await client.disconnect()
+                try? FileManager.default.removeItem(at: directory)
+            }
+            await fixture.transport.setShell(
+                multiEnvironmentShell(
+                    projectID: "project-two", threadID: "thread-two", title: "Remote work",
+                    workspaceRoot: path
+                ),
+                host: "two.example"
+            )
+            let snapshot = try await fixture.hydratedSnapshot()
+            let thread = try XCTUnwrap(snapshot.threads.first { $0.environmentID == "two" })
+            let monitor = Task {
+                for await _ in client.sourceControlStatusEvents(threadID: thread.id) {}
+            }
+            defer { monitor.cancel() }
+            let request = await server.nextSourceControlDirectory()
+            XCTAssertEqual(request.host, "two.example")
+            XCTAssertEqual(request.cwd, path)
+            await client.disconnect()
+            await monitor.value
+        }
+    }
+
     func testProviderCatalogueUsesStableProviderAndModelIdentities() {
         let normalized = NativeFeatureClient.normalizedProviders([
             FeatureProvider(
@@ -1579,6 +1612,8 @@ private struct UnavailableMultiEnvironmentWebSocketConnector: WebSocketConnectin
 }
 
 private actor MultiEnvironmentConfigurationServer {
+    private var sourceControlDirectories: [(host: String, cwd: String)] = []
+    private var sourceControlWaiters: [CheckedContinuation<(host: String, cwd: String), Never>] = []
     private var settingsByHost: [String: [String: JSONValue]] = [:]
     private var settingsUpdateHosts: [String] = []
     private let restartSupportHosts: Set<String>
@@ -1588,6 +1623,10 @@ private actor MultiEnvironmentConfigurationServer {
     }
 
     func updatedHosts() -> [String] { settingsUpdateHosts }
+    func nextSourceControlDirectory() async -> (host: String, cwd: String) {
+        if !sourceControlDirectories.isEmpty { return sourceControlDirectories.removeFirst() }
+        return await withCheckedContinuation { sourceControlWaiters.append($0) }
+    }
     func settings(host: String) -> [String: JSONValue] { settingsByHost[host] ?? [:] }
 
     func response(to request: JSONValue, host: String) throws -> JSONValue? {
@@ -1595,6 +1634,16 @@ private actor MultiEnvironmentConfigurationServer {
               case let .number(id)? = request["id"] else { return nil }
         let value: JSONValue
         switch tag {
+        case RPCMethod.subscribeVCSStatus.rawValue:
+            guard let cwd = request["payload"]?["cwd"]?.stringValue else {
+                throw URLError(.badServerResponse)
+            }
+            if sourceControlWaiters.isEmpty {
+                sourceControlDirectories.append((host, cwd))
+            } else {
+                sourceControlWaiters.removeFirst().resume(returning: (host, cwd))
+            }
+            return nil
         case RPCMethod.subscribeServerConfig.rawValue:
             return .object([
                 "_tag": .string("Chunk"), "requestId": .number(id),
@@ -1809,7 +1858,8 @@ func multiEnvironmentShell(
     snapshotSequence: Int = 1,
     settledOverride: String? = nil,
     settledAt: String? = nil,
-    titleRegeneration: ThreadTitleRegeneration? = nil
+    titleRegeneration: ThreadTitleRegeneration? = nil,
+    workspaceRoot: String? = nil
 ) -> OrchestrationShellSnapshot {
     let timestamp = "2026-07-31T12:00:00.000Z"
     let model = ModelSelection(instanceId: providerID, model: modelID)
@@ -1819,7 +1869,7 @@ func multiEnvironmentShell(
             OrchestrationProject(
                 id: projectID,
                 title: title,
-                workspaceRoot: "/work/\(projectID)",
+                workspaceRoot: workspaceRoot ?? "/work/\(projectID)",
                 repositoryIdentity: repositoryIdentity,
                 defaultModelSelection: model,
                 scripts: [],


### PR DESCRIPTION
Source-control status subscriptions must send the working directory exactly as supplied by the remote environment. Preserve Windows drive paths, UNC paths, and POSIX paths instead of applying the iPhone's local path normalization.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34279272956/job/102239835831). Skipped checks are not claimed as executed proof.

The native remote-path regression passed for Windows drive paths, UNC paths, and POSIX paths (1 test, exit 0). The earlier cleanup deadlock was reproduced and corrected.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

The claimed behavior is covered at the native protocol, persistence, or client boundary. No visible layout change or measured phone responsiveness improvement is claimed.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
