### PR TITLE
fix(swift-ios): preserve queued messages during incomplete hydration

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1719,7 +1719,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             switch error {
             case .invalidResponse:
                 return true
-            case .status, .missingCredential, .incompatibleCredential,
+            case .status, .threadNotFound, .missingCredential, .incompatibleCredential,
                  .managedAuthorizationUnavailable, .unauthenticatedSession:
                 return false
             }
@@ -1820,6 +1820,36 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailCacheRecency.removeAll { $0 == route.uiID }
         await emitCachedSnapshot(for: route.environmentID)
         try? await refresh(client: route.client, includeArchived: true)
+    }
+
+    func recoverQueuedThread(environmentID: String, wireID: String) async throws -> FeatureThread? {
+        guard let client = environmentClients[environmentID], client.environment.isEnabled else {
+            throw URLError(.notConnectedToInternet)
+        }
+        let generation = environmentGeneration
+        let supportsPagination = serverConfigsByEnvironmentID[environmentID]?
+            .threadSnapshotPagination == true
+        do {
+            let snapshot = try await client.threadSnapshot(
+                id: wireID,
+                turnLimit: supportsPagination ? 1 : nil
+            )
+            guard isKnownClient(client, environmentID: environmentID, generation: generation) else {
+                throw CancellationError()
+            }
+            guard snapshot.thread.id == wireID else { throw HTTPError.invalidResponse }
+            registerProvisionalThread(wireID: wireID, environmentID: environmentID)
+            return mapThread(snapshot.thread, environment: client.environment)
+        } catch {
+            guard isKnownClient(client, environmentID: environmentID, generation: generation) else {
+                throw CancellationError()
+            }
+            if let httpError = error as? HTTPError,
+               case .threadNotFound = httpError {
+                return nil
+            }
+            throw error
+        }
     }
 
     func loadThread(id: String) async throws -> FeatureThreadDetail {
@@ -2062,16 +2092,17 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let client = route.client
         let environmentID = route.environmentID
         let generation = environmentGeneration
-        guard let shellThread = shellsByEnvironmentID[environmentID]?.threads
-            .first(where: { $0.id == route.wireID }) else {
+        // Durable submissions carry their runtime mode. Their thread may have
+        // been recovered directly while the sidebar inventory is still partial.
+        let shellRuntimeMode = shellsByEnvironmentID[environmentID]?.threads
+            .first(where: { $0.id == route.wireID }).map { mapRuntimeMode($0.runtimeMode) }
+        guard let effectiveRuntimeMode = requestedRuntimeMode ?? shellRuntimeMode else {
             throw NativeFeatureClientError.threadNotFound
         }
         let model = selection.map(coreModelSelection)
         let uploads = try makeUploadAttachments(attachments)
         if !uploads.isEmpty { _ = try await client.serverConfig() }
-        let runtimeMode = coreRuntimeMode(
-            requestedRuntimeMode ?? mapRuntimeMode(shellThread.runtimeMode)
-        )
+        let runtimeMode = coreRuntimeMode(effectiveRuntimeMode)
         let interactionMode = InteractionMode.default
         let signature = TurnSubmissionSignature(
             text: text,

--- a/apps/swift-ios/Core/HTTP.swift
+++ b/apps/swift-ios/Core/HTTP.swift
@@ -102,6 +102,7 @@ public enum HTTPRequestPolicy {
 public enum HTTPError: LocalizedError, Sendable {
     case invalidResponse
     case status(Int, message: String, traceID: String?)
+    case threadNotFound(message: String, traceID: String?)
     case missingCredential
     case incompatibleCredential
     case managedAuthorizationUnavailable
@@ -113,6 +114,8 @@ public enum HTTPError: LocalizedError, Sendable {
             "The server returned an invalid response."
         case let .status(status, message, traceID):
             traceID.map { "\(message) (trace \($0))" } ?? "\(message) (HTTP \(status))"
+        case let .threadNotFound(message, traceID):
+            traceID.map { "\(message) (trace \($0))" } ?? "\(message) (HTTP 404)"
         case .missingCredential:
             "This environment has no saved credential."
         case .incompatibleCredential:
@@ -189,6 +192,7 @@ enum DPoPFailurePresentation {
 }
 
 struct EnvironmentErrorBody: Decodable {
+    let code: String?
     let message: String?
     let reason: String?
     let dpopFailureReason: DPoPFailureReason?
@@ -621,6 +625,10 @@ public actor EnvironmentAPI {
                 )
             } else {
                 message = body?.message ?? body?.reason ?? "Environment request failed."
+            }
+            if response.statusCode == 404, body?.code == "not_found",
+               body?.reason == "thread_not_found" {
+                throw HTTPError.threadNotFound(message: message, traceID: body?.traceId)
             }
             throw HTTPError.status(
                 response.statusCode,

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -1390,13 +1390,7 @@ public final class FeatureRootModel {
             }
 
             guard snapshot.threads.contains(where: { $0.id == submission.threadID }) else {
-                if pendingThreadsByID[submission.threadID] != nil {
-                    pendingSubmissionsByID[submission.id] = submission
-                } else if isEnvironmentConnected(submission.environmentID) {
-                    await discardRestoredSubmission(submission)
-                } else {
-                    pendingSubmissionsByID[submission.id] = submission
-                }
+                pendingSubmissionsByID[submission.id] = submission
                 continue
             }
             pendingSubmissionsByID[submission.id] = submission
@@ -1716,6 +1710,36 @@ public final class FeatureRootModel {
                     needsRetry = true
                 }
                 continue
+            }
+            let awaitingCreation = pendingSubmissionsByID.values.contains {
+                $0.creation != nil && $0.threadID == submission.threadID
+            }
+            if submission.creation == nil, !awaitingCreation,
+               !snapshot.threads.contains(where: { $0.id == submission.threadID }),
+               isEnvironmentConnected(submission.environmentID) {
+                do {
+                    let recovered = try await client.recoverQueuedThread(
+                        environmentID: submission.environmentID,
+                        wireID: submission.identity.threadID
+                    )
+                    guard !Task.isCancelled, outboxGeneration == generation else { return false }
+                    guard pendingSubmissionsByID[submission.id] != nil else { continue }
+                    guard let recovered else {
+                        if !(await discardQueuedSubmission(submission)) { needsRetry = true }
+                        continue
+                    }
+                    guard recovered.id == submission.threadID,
+                          recovered.environmentID == submission.environmentID else {
+                        needsRetry = true
+                        continue
+                    }
+                    upsert(recovered)
+                } catch {
+                    guard !Task.isCancelled, outboxGeneration == generation else { return false }
+                    // Lookup/auth/transport failures are not evidence that the thread was deleted.
+                    needsRetry = true
+                    continue
+                }
             }
             var policySnapshot = snapshot
             if pendingThreadsByID[submission.threadID] != nil {

--- a/apps/swift-ios/Features/Shared/FeatureClient.swift
+++ b/apps/swift-ios/Features/Shared/FeatureClient.swift
@@ -74,6 +74,9 @@ public protocol FeatureClient: AnyObject {
     func deleteThread(id: String) async throws
 
     func loadThread(id: String) async throws -> FeatureThreadDetail
+    /// Looks up a queued thread independently of the partially hydrated sidebar.
+    /// `nil` means the owning server explicitly reported thread_not_found.
+    func recoverQueuedThread(environmentID: String, wireID: String) async throws -> FeatureThread?
     func loadThread(id: String, fresh: Bool) async throws -> FeatureThreadDetail
     func loadEarlierThreadTurns(id: String) async throws -> FeatureThreadDetail?
     func releaseThread(id: String)
@@ -245,6 +248,10 @@ public protocol FeatureClient: AnyObject {
 }
 
 public extension FeatureClient {
+    func recoverQueuedThread(environmentID: String, wireID: String) async throws -> FeatureThread? {
+        throw URLError(.resourceUnavailable)
+    }
+
     func serverPreferences(environmentID: String) async throws -> ServerSettingsSnapshot {
         throw FeatureCapabilityUnavailable("Server preferences")
     }

--- a/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
+++ b/apps/swift-ios/Features/Shared/FeatureOutboxStore.swift
@@ -220,8 +220,9 @@ public enum FeatureOutboxPolicy {
             return .wait
         }
         guard thread != nil else {
-            // A fully synchronized environment proves the thread was deleted.
-            return isConnected ? .discard : .wait
+            // Connected snapshots can omit archived threads while hydration is pending.
+            // The owning server must confirm deletion before the outbox removes a message.
+            return .wait
         }
         guard isConnected else { return .wait }
         return .send

--- a/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureOutboxStoreTests.swift
@@ -325,7 +325,7 @@ struct FeatureOutboxStoreTests {
         var followUp = creation
         followUp.creation = nil
         snapshot.threads = []
-        #expect(FeatureOutboxPolicy.decision(for: followUp, snapshot: snapshot) == .discard)
+        #expect(FeatureOutboxPolicy.decision(for: followUp, snapshot: snapshot) == .wait)
         #expect(
             FeatureOutboxPolicy.decision(
                 for: followUp,

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -3740,6 +3740,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var startedWorktreePath: String?
     var startedFromOrigin = false
     var createThreadCallCount = 0
+    var sentIdentities: [FeatureSubmissionIdentity] = []
     var sendMessageCallCount = 0
     var sentRuntimeModes: [FeatureRuntimeMode] = []
     var setRuntimeModeCalls: [FeatureRuntimeMode] = []
@@ -3943,9 +3944,10 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         selection: FeatureSelection?,
         runtimeMode: FeatureRuntimeMode,
         attachments _: [FeatureUploadAttachment],
-        identity _: FeatureSubmissionIdentity
+        identity: FeatureSubmissionIdentity
     ) async throws {
         sentRuntimeModes.append(runtimeMode)
+        sentIdentities.append(identity)
         try await sendMessage(threadID: threadID, text: text, selection: selection)
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -10,6 +10,163 @@ import XCTest
 @Suite("Feature root model")
 struct FeatureRootModelTests {
     @Test
+    func queuedArchivedFollowUpWaitsForLookupThenSendsWithStableIdentity() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-outbox-recovery-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let threadID = FeatureScopedID.thread(environmentID: "studio", wireID: "archived-thread")
+        let submission = FeatureQueuedSubmission(
+            environmentID: "studio",
+            identity: FeatureSubmissionIdentity(threadID: "archived-thread"),
+            threadID: threadID,
+            text: "Keep my offline follow-up",
+            selection: nil,
+            runtimeMode: .fullAccess,
+            interactionMode: .standard,
+            attachments: []
+        )
+        try await store.enqueue(submission)
+        let started = AsyncStream<Void>.makeStream()
+        let response = AsyncStream<FeatureThread>.makeStream()
+        let sent = AsyncStream<Void>.makeStream()
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [.init(id: "studio", name: "Studio", endpoint: "https://studio.example",
+                                 isActive: true, connectionState: .connected)]
+        )
+        client.queuedThreadRecovery = { environmentID, wireID in
+            #expect(environmentID == "studio")
+            #expect(wireID == "archived-thread")
+            started.continuation.yield(())
+            var iterator = response.stream.makeAsyncIterator()
+            guard let value = await iterator.next() else { throw CancellationError() }
+            return value
+        }
+        client.beforeSendMessage = { sent.continuation.yield(()) }
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        let task = Task { await model.start() }
+        defer {
+            response.continuation.finish()
+            started.continuation.finish()
+            sent.continuation.finish()
+            client.finishEvents()
+            task.cancel()
+        }
+        var startedIterator = started.stream.makeAsyncIterator()
+        _ = await startedIterator.next()
+        #expect(try await store.submissions() == [submission])
+        #expect(client.sendMessageCallCount == 0)
+        response.continuation.yield(FeatureThread(
+            id: threadID, wireID: "archived-thread", projectID: "project", environmentID: "studio",
+            title: "Archived", isArchived: true
+        ))
+        var sentIterator = sent.stream.makeAsyncIterator()
+        _ = await sentIterator.next()
+        #expect(client.sendMessageCallCount == 1)
+        #expect(client.sentIdentities == [submission.identity])
+        #expect(model.snapshot.threads.contains(where: { $0.id == threadID && $0.isArchived }))
+        await model.disconnect()
+        client.finishEvents()
+        await task.value
+    }
+
+    @Test(arguments: [false, true])
+    func queuedRecoveryDiscardsOnlyAuthoritativelyMissingThreads(confirmsDeletion: Bool) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-outbox-deletion-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        func submission(_ wireID: String, at time: TimeInterval) -> FeatureQueuedSubmission {
+            FeatureQueuedSubmission(
+                environmentID: "studio",
+                identity: FeatureSubmissionIdentity(threadID: wireID, createdAt: Date(timeIntervalSince1970: time)),
+                threadID: FeatureScopedID.thread(environmentID: "studio", wireID: wireID),
+                text: "Retain unless deletion is confirmed", selection: nil,
+                runtimeMode: .fullAccess, interactionMode: .standard, attachments: []
+            )
+        }
+        let first = submission("missing", at: 1)
+        let second = submission("held", at: 2)
+        try await store.enqueue(first)
+        try await store.enqueue(second)
+        let reachedSecond = AsyncStream<Void>.makeStream()
+        let response = AsyncStream<FeatureThread>.makeStream()
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [
+                .init(id: "other", name: "Other", endpoint: "https://other.example", isActive: true,
+                      connectionState: .connected),
+                .init(id: "studio", name: "Studio", endpoint: "https://studio.example", isActive: false,
+                      connectionState: .connected),
+            ]
+        )
+        client.queuedThreadRecovery = { environmentID, wireID in
+            #expect(environmentID == "studio")
+            if wireID == "missing" {
+                if confirmsDeletion { return nil }
+                throw URLError(.userAuthenticationRequired)
+            }
+            #expect(wireID == "held")
+            reachedSecond.continuation.yield(())
+            var iterator = response.stream.makeAsyncIterator()
+            return await iterator.next()
+        }
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        let task = Task { await model.start() }
+        defer {
+            response.continuation.finish()
+            reachedSecond.continuation.finish()
+            client.finishEvents()
+            task.cancel()
+        }
+        var iterator = reachedSecond.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        // Reaching the next queued lookup proves that the first result was handled.
+        let remaining = try await store.submissions()
+        #expect(Set(remaining.map(\.id)) == Set((confirmsDeletion ? [second] : [first, second]).map(\.id)))
+        await model.disconnect()
+        // Cancellation of the second lookup must not turn its nil response into deletion.
+        #expect(try await store.submissions().contains(where: { $0.id == second.id }))
+        #expect(client.sendMessageCallCount == 0)
+        client.finishEvents()
+        await task.value
+    }
+
+    @Test
+    func queuedMessageSurvivesConnectedSnapshotBeforeArchivedInventoryArrives() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-outbox-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let submission = FeatureQueuedSubmission(
+            environmentID: "studio",
+            identity: FeatureSubmissionIdentity(threadID: "archived-thread"),
+            threadID: FeatureScopedID.thread(environmentID: "studio", wireID: "archived-thread"),
+            text: "Keep my offline follow-up",
+            selection: nil,
+            runtimeMode: .fullAccess,
+            interactionMode: .standard,
+            attachments: []
+        )
+        try await store.enqueue(submission)
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [.init(id: "studio", name: "Studio", endpoint: "https://studio.example",
+                                 isActive: true, connectionState: .connected)]
+        )
+        client.finishEvents()
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.start()
+        await model.disconnect()
+        #expect(try await store.submissions() == [submission])
+        #expect(client.sendMessageCallCount == 0)
+    }
+
+    @Test
     func transcriptSkillPillsUseTheThreadWorkspaceCatalog() async {
         let skill = FeatureProviderSkill(name: "project-only", displayName: "Project only")
         var provider = FeatureProvider(
@@ -3600,6 +3757,12 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var beforeSendMessage: (() throws -> Void)?
     var beforeSaveSettings: (@MainActor () async throws -> Void)?
     var loadThreadError: (any Error)?
+    var queuedThreadRecovery: ((String, String) async throws -> FeatureThread?)?
+
+    func recoverQueuedThread(environmentID: String, wireID: String) async throws -> FeatureThread? {
+        guard let queuedThreadRecovery else { throw URLError(.resourceUnavailable) }
+        return try await queuedThreadRecovery(environmentID, wireID)
+    }
     var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
     var preuploadHandler: ((FeatureUploadAttachment, String) async throws -> FeatureUploadedAttachmentReference?)?
     var beforeLoadThreadReturn: (() async -> Void)?

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -11,7 +11,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             await fixture.client.disconnect()
             try? FileManager.default.removeItem(at: fixture.directory)
         }
-        _ = try await fixture.hydratedSnapshot()
+        _ = try await fixture.client.initialSnapshot()
         let wireID = "queued-archived"
         let archived = multiEnvironmentDetail(
             projectID: "project-two", threadID: wireID, archivedAt: "2026-07-31T12:00:00.000Z"
@@ -41,7 +41,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             await fixture.client.disconnect()
             try? FileManager.default.removeItem(at: fixture.directory)
         }
-        _ = try await fixture.hydratedSnapshot()
+        _ = try await fixture.client.initialSnapshot()
         let cases = [
             (404, #"{"code":"not_found","reason":"thread_not_found"}"#, true),
             (404, #"{"message":"Proxy route missing"}"#, false),
@@ -67,7 +67,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
                 await fixture.client.disconnect()
                 try? FileManager.default.removeItem(at: fixture.directory)
             }
-            _ = try await fixture.hydratedSnapshot()
+            _ = try await fixture.client.initialSnapshot()
             if deleted {
                 await fixture.transport.setQueuedRecoveryResponse(
                     status: 404, body: #"{"code":"not_found","reason":"thread_not_found"}"#
@@ -1409,7 +1409,7 @@ private actor BlockingRuntimeCloseConnection: WebSocketConnection {
 }
 
 private actor RuntimeReplacementHTTPTransport: HTTPTransport {
-    func data(for request: URLRequest) throws -> (Data, HTTPURLResponse) {
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         guard request.url?.path == "/api/auth/websocket-ticket" else {
             throw URLError(.unsupportedURL)
         }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -1409,7 +1409,7 @@ private actor BlockingRuntimeCloseConnection: WebSocketConnection {
 }
 
 private actor RuntimeReplacementHTTPTransport: HTTPTransport {
-    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+    func data(for request: URLRequest) throws -> (Data, HTTPURLResponse) {
         guard request.url?.path == "/api/auth/websocket-ticket" else {
             throw URLError(.unsupportedURL)
         }
@@ -1593,7 +1593,7 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
         hostsDroppingNextCreateReply.insert(host)
     }
 
-    func data(for request: URLRequest) throws -> (Data, HTTPURLResponse) {
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let host = request.url?.host ?? ""
         let path = request.url?.path ?? ""
         if path == "/api/orchestration/shell" {

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -5,6 +5,91 @@ import XCTest
 
 @MainActor
 final class NativeMultiEnvironmentTests: XCTestCase {
+    func testQueuedRecoveryRoutesAndSendsWithoutSidebarMembership() async throws {
+        let fixture = try await Self.makeFixture()
+        addTeardownBlock {
+            await fixture.client.disconnect()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        _ = try await fixture.hydratedSnapshot()
+        let wireID = "queued-archived"
+        let archived = multiEnvironmentDetail(
+            projectID: "project-two", threadID: wireID, archivedAt: "2026-07-31T12:00:00.000Z"
+        )
+        await fixture.transport.setDetail(archived, host: "two.example")
+        let thread = try await fixture.client.recoverQueuedThread(environmentID: "two", wireID: wireID)
+        XCTAssertEqual(thread?.environmentID, "two")
+        XCTAssertEqual(thread?.wireID, wireID)
+        XCTAssertEqual(thread?.isArchived, true)
+        let identity = FeatureSubmissionIdentity(threadID: wireID)
+        try await fixture.client.sendMessage(
+            threadID: XCTUnwrap(thread).id, text: "Recovered follow-up", selection: nil,
+            runtimeMode: .fullAccess, attachments: [], identity: identity
+        )
+        let requests = await fixture.transport.queuedRecoveryRequests()
+        XCTAssertTrue(requests.contains { $0 == "two.example/api/orchestration/threads/queued-archived" })
+        let dispatches = await fixture.transport.dispatchRecords()
+        let send = try XCTUnwrap(dispatches.last)
+        XCTAssertEqual(send.host, "two.example")
+        XCTAssertEqual(send.command["threadId"]?.stringValue, wireID)
+        XCTAssertEqual(send.command["commandId"]?.stringValue, identity.commandID)
+    }
+
+    func testQueuedRecoveryRecognizesOnlyStructuredThreadDeletion() async throws {
+        let fixture = try await Self.makeFixture()
+        addTeardownBlock {
+            await fixture.client.disconnect()
+            try? FileManager.default.removeItem(at: fixture.directory)
+        }
+        _ = try await fixture.hydratedSnapshot()
+        let cases = [
+            (404, #"{"code":"not_found","reason":"thread_not_found"}"#, true),
+            (404, #"{"message":"Proxy route missing"}"#, false),
+            (404, #"{"code":"other","reason":"thread_not_found"}"#, false),
+            (403, #"{"code":"not_found","reason":"thread_not_found"}"#, false),
+        ]
+        for (status, body, deleted) in cases {
+            await fixture.transport.setQueuedRecoveryResponse(status: status, body: body)
+            do {
+                let thread = try await fixture.client.recoverQueuedThread(environmentID: "two", wireID: "queued-archived")
+                XCTAssertTrue(deleted, "An unrecognized HTTP error must propagate")
+                XCTAssertNil(thread)
+            } catch {
+                XCTAssertFalse(deleted, "Structured deletion should return nil: \(error)")
+            }
+        }
+    }
+
+    func testQueuedRecoveryRejectsBothLateSuccessAndLateDeletionAfterDisconnect() async throws {
+        for deleted in [false, true] {
+            let fixture = try await Self.makeFixture()
+            addTeardownBlock {
+                await fixture.client.disconnect()
+                try? FileManager.default.removeItem(at: fixture.directory)
+            }
+            _ = try await fixture.hydratedSnapshot()
+            if deleted {
+                await fixture.transport.setQueuedRecoveryResponse(
+                    status: 404, body: #"{"code":"not_found","reason":"thread_not_found"}"#
+                )
+            }
+            let gate = PassiveRequestGate()
+            await fixture.transport.holdQueuedRecovery(gate)
+            let lookup = Task {
+                try await fixture.client.recoverQueuedThread(environmentID: "two", wireID: "queued-archived")
+            }
+            await gate.waitUntilEntered()
+            await fixture.client.disconnect()
+            await gate.release()
+            do {
+                _ = try await lookup.value
+                XCTFail("A stale lookup cannot authorize sending or deletion")
+            } catch is CancellationError {
+                // The environment generation, not response contents, owns this completion.
+            }
+        }
+    }
+
     func testProviderCatalogueUsesStableProviderAndModelIdentities() {
         let normalized = NativeFeatureClient.normalizedProviders([
             FeatureProvider(
@@ -1446,6 +1531,17 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
     private var shellReadCounts: [String: Int] = [:]
     private var dispatched: [MultiEnvironmentDispatchRecord] = []
     private var hostsDroppingNextCreateReply = Set<String>()
+    private var queuedResponse: (Int, Data)?
+    private var queuedGate: PassiveRequestGate?
+    private var queuedRequests: [String] = []
+
+    func setQueuedRecoveryResponse(status: Int, body: String) {
+        queuedResponse = (status, Data(body.utf8))
+    }
+
+    func holdQueuedRecovery(_ gate: PassiveRequestGate) { queuedGate = gate }
+    func queuedRecoveryRequests() -> [String] { queuedRequests }
+
 
     init(shells: [String: OrchestrationShellSnapshot]) {
         self.shells = shells
@@ -1513,6 +1609,18 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
         }
         if path.hasPrefix("/api/orchestration/threads/") {
             let threadID = request.url?.lastPathComponent.removingPercentEncoding ?? "thread"
+            if threadID == "queued-archived" {
+                queuedRequests.append(host + path)
+                let response = queuedResponse
+                if let gate = queuedGate {
+                    queuedGate = nil
+                    await gate.enter()
+                }
+                if let (status, data) = response {
+                    return (data, HTTPURLResponse(url: request.url!, statusCode: status,
+                                                  httpVersion: "HTTP/1.1", headerFields: nil)!)
+                }
+            }
             if let data = detailData[host]?[threadID] {
                 return (data, multiEnvironmentResponse(request))
             }
@@ -1864,6 +1972,7 @@ func multiEnvironmentDetail(
     projectID: String,
     threadID: String,
     snapshotSequence: Int = 2,
+    archivedAt: String? = nil,
     settledOverride: String? = nil,
     settledAt: String? = nil,
     messages: [OrchestrationMessage] = []
@@ -1883,7 +1992,7 @@ func multiEnvironmentDetail(
             latestTurn: nil,
             createdAt: timestamp,
             updatedAt: timestamp,
-            archivedAt: nil,
+            archivedAt: archivedAt,
             settledOverride: settledOverride,
             settledAt: settledAt,
             snoozedUntil: nil,
@@ -1905,4 +2014,50 @@ private func multiEnvironmentResponse(_ request: URLRequest) -> HTTPURLResponse 
         httpVersion: "HTTP/1.1",
         headerFields: ["Content-Type": "application/json"]
     )!
+}
+
+private actor PassiveRequestGate {
+    private var cancellableEntryWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var entered = false
+    private var released = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    var isHeld: Bool { entered && !released }
+
+    func enter() async {
+        entered = true
+        let pending = cancellableEntryWaiters.values
+        cancellableEntryWaiters.removeAll()
+        pending.forEach { $0.resume() }
+        entryWaiters.forEach { $0.resume() }
+        entryWaiters.removeAll()
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilEnteredCancellable() async throws {
+        try Task.checkCancellation()
+        guard !entered else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { cancellableEntryWaiters[id] = $0 }
+        } onCancel: {
+            Task { await self.cancelEntryWaiter(id) }
+        }
+    }
+
+    private func cancelEntryWaiter(_ id: UUID) {
+        cancellableEntryWaiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        releaseWaiters.forEach { $0.resume() }
+        releaseWaiters.removeAll()
+    }
 }


### PR DESCRIPTION
A queued message can be discarded when its thread is absent from a partially hydrated sidebar. Ask its owning server for authoritative thread state and discard only an explicit thread_not_found response. Preserve queued content after other failures and reject stale lookup completions after disconnect.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34280699053/job/102244464032). Skipped checks are not claimed as executed proof.

3 native queued-recovery tests and 88 root-model Swift Testing cases passed (91 tests, exit 0).

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Verification scope: Native protocol tests passed for sending without sidebar membership, accepting only structured thread deletion, and rejecting late success/deletion after disconnect. Root-model tests also preserve queued content across incomplete hydration. These exercise the queue and owning-server boundaries; no new row presentation is introduced. The native CI job linked above contains the passing receipts. The tests exercise the protocol, state, or accessibility-value boundary changed here.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
