### PR TITLE
fix(web): keep sidebar scroll position when pinning threads

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -708,8 +708,9 @@ function SidebarContent({
         className="h-auto min-h-0 flex-1"
       >
         <div
+          // Reordered rows must not pull the viewport to their new position.
           className={cn(
-            "flex w-full min-w-0 flex-col gap-2 group-data-[collapsible=icon]:overflow-hidden",
+            "flex w-full min-w-0 flex-col gap-2 [overflow-anchor:none] group-data-[collapsible=icon]:overflow-hidden",
             className,
           )}
           data-sidebar="content"

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -29,6 +29,9 @@ the thread opens and the files are attached in its composer, ready for
 your next message. The same per-message file limits apply as when attaching
 files directly; see [Attach files](./composer.md#attach-files).
 
+On web and desktop, pinning or unpinning a thread keeps the sidebar at your current
+scroll position instead of following the thread to its new place in the list.
+
 Pinning does not prevent automatic settlement. Settling a thread removes its pin.
 
 On web and desktop, drag a thread between sections to change its state. Drag a thread up into


### PR DESCRIPTION
## What Changed

Pinning a visible thread partway down the sidebar can jump the entire list to the top. Exclude the sidebar content from browser scroll anchoring so pinning and unpinning preserve the scroll position. The existing row animation and explicit search navigation continue to work.

## Why

The unified list introduced in #9731 retains a thread's DOM row while moving it between sections. Browser scroll anchoring can follow that row into Pinned. This is a side effect of the section move, rather than an intentional scroll request. The fix is scoped to the shared sidebar content; transcript scroll behavior is unaffected.

## UI Changes

Same disposable Harbor project, 40 threads with fixed active ordering, dark theme, 1280×800 browser viewport, and the same thread/menu action. Base `7220dfe2c`; candidate `0e4544cc7`. Menu opening uses the real DOM handler, and a normal preview click pins through the real backend.

**Before: sidebar scrollTop jumps from 1,000 px to 0 px.**

![Before: pinning Harbor task 27 jumps the list to Pinned](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/before.gif)

**After: sidebar scrollTop stays at 1,000 px.**

![After: pinning Harbor task 27 preserves the sidebar scroll position](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/after.gif)

GIFs crop the sidebar and sample at 20 fps. Only idle lead-in is trimmed; the action and settled result retain their original speed. They illustrate the jump, not animation smoothness. Relative age labels advance between captures.

[Before recording](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/before-clean.mp4) · [After recording](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/after-clean.mp4) · [Annotated before](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/before-annotated.mp4) · [Annotated after](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/after-annotated.mp4)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/before-clean.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-sidebar-pin-20260908/after-clean.png)

## Verification

Current head `e048caf6c` is rebased onto `b5d89038a`. The documentation conflict preserves upstream file-drop instructions and this scroll-position note. The anchoring fix itself is unchanged. The recordings above retain their original revision labels; the same browser pin scenario was freshly repeated on the rebased head with the new upstream scroll-fade-padding behavior: **1,000 → 1,000 px**. Focused tests (21), web typecheck, scoped lint and formatting were repeated after rebase.

- `cd apps/web && vp test run src/components/ui/sidebar.test.tsx src/components/Sidebar.motion.test.ts`: 21 tests pass.
- `cd apps/web && vp run typecheck`: passes.
- Scoped lint and formatting pass; lint reports the existing `Math.random` purity warning in SidebarMenuSkeleton.
- Full browser client: reproduced the base jump twice; candidate pin preserved 1,000 px, unpin preserved 0 px, ordinary scrolling reached 700 px, and keyboard search advanced to the next result. No running row animations remained after the candidate pin.

The real scroll regression was checked in Chromium; the existing unit tests do not emulate browser scroll anchoring. Electron shares this sidebar but its native shell/context menu was not separately exercised. Grouped sidebar, React Native, and SwiftUI were not independently exercised; no native client code or wire contracts change.

Independent review was attempted with `claude -p --model claude-opus-5 --effort high --tools '' --output-format json` against the frozen diff and project coding standards. It exited 1 on expired OAuth before any model ran; no independent review occurred. Local review found no actionable issues in the two-file change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented and verified with GPT-6 in the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the sidebar from jumping to a different scroll position when threads are pinned or unpinned.

- **Documentation**
  - Clarified that pinning or unpinning threads preserves the sidebar’s current scroll position on web and desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->