### PR TITLE
fix(swift-ios): release accepted commands before optional refreshes

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -96,14 +96,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var pendingBootstrapSubmissions: [PendingBootstrapSubmission] = []
     private var pendingTurnSubmissions: [String: PendingTurnSubmission] = [:]
-    private struct AcceptedSendRefresh: Sendable {
+    private struct AcceptedCommandRefresh: Sendable {
         let id: UUID
         let client: T3Client
         let generation: Int
         let task: Task<Void, Never>
         var pending = false
+        var needsDetail: Bool
     }
-    private var acceptedSendRefreshes: [String: AcceptedSendRefresh] = [:]
+    private var acceptedCommandRefreshes: [String: AcceptedCommandRefresh] = [:]
     private var approvalRoutes: [String: PendingRequestRoute] = [:]
     private var inputRoutes: [String: PendingRequestRoute] = [:]
     private var relayDeviceSessionIDs: Set<String> = []
@@ -223,7 +224,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailCatchUpTask?.cancel()
         detailPublishTask?.cancel()
         projectFaviconRefreshTasks.values.forEach { $0.cancel() }
-        acceptedSendRefreshes.values.forEach { $0.task.cancel() }
+        acceptedCommandRefreshes.values.forEach { $0.task.cancel() }
         continuation.finish()
     }
 
@@ -472,7 +473,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
-            cancelAcceptedSendRefreshes(environmentID: id)
+            cancelAcceptedCommandRefreshes(environmentID: id)
             environmentConnectionStates[id] = .disconnected
             environmentConnectionDetails[id] = nil
             environmentClients[id] = nil
@@ -491,7 +492,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if environment?.kind == .managedDPoP {
             try await runtime.revokeCredential(id: id)
         }
-        cancelAcceptedSendRefreshes(environmentID: id)
+        cancelAcceptedCommandRefreshes(environmentID: id)
         try await runtime.remove(id: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)
@@ -917,7 +918,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func clearEnvironmentState(preserveEnvironmentSnapshots: Bool = false) {
         environmentGeneration &+= 1
-        cancelAcceptedSendRefreshes()
+        cancelAcceptedCommandRefreshes()
         resetDetailRefresh()
         resetDetailStream()
         archivedRefreshTask?.cancel()
@@ -1841,7 +1842,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func loadThread(id: String, fresh: Bool) async throws -> FeatureThreadDetail {
         let route = try threadRoute(for: id)
         if let previous = activeThreadID, previous != route.uiID {
-            cancelAcceptedSendRefreshes(threadID: previous)
+            cancelAcceptedCommandRefreshes(threadID: previous)
         }
         let client = route.client
         let environment = client.environment
@@ -1985,7 +1986,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func releaseThread(id: String) {
-        cancelAcceptedSendRefreshes(threadID: id)
+        cancelAcceptedCommandRefreshes(threadID: id)
         guard activeThreadID == id else { return }
         retainActiveThread()
         resetDetailRefresh()
@@ -2146,38 +2147,48 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if pendingTurnSubmissions[route.uiID]?.identity == pending.identity {
             pendingTurnSubmissions[route.uiID] = nil
         }
-        scheduleAcceptedSendRefresh(threadID: route.uiID, client: client, generation: generation)
+        scheduleAcceptedCommandRefresh(threadID: route.uiID, client: client, generation: generation)
     }
 
-    /// Acceptance unlocks the composer immediately. Retain HTTP convergence
-    /// separately for connections whose live events have not caught up yet.
-    private func scheduleAcceptedSendRefresh(threadID: String, client: T3Client, generation: Int) {
-        if let current = acceptedSendRefreshes[threadID],
-           current.client === client, current.generation == generation {
-            acceptedSendRefreshes[threadID]?.pending = true
+    /// Complete accepted commands without waiting for optional reads. A send
+    /// needs detail and shell recovery; Stop retains its shell-only refresh.
+    private func scheduleAcceptedCommandRefresh(
+        threadID: String, client: T3Client, generation: Int, refreshDetail: Bool = true
+    ) {
+        guard isKnownClient(client, environmentID: client.environment.id, generation: generation) else {
             return
         }
-        cancelAcceptedSendRefreshes(threadID: threadID)
+        if let current = acceptedCommandRefreshes[threadID],
+           current.client === client, current.generation == generation {
+            acceptedCommandRefreshes[threadID]?.pending = true
+            acceptedCommandRefreshes[threadID]?.needsDetail = current.needsDetail || refreshDetail
+            return
+        }
+        cancelAcceptedCommandRefreshes(threadID: threadID)
         let id = UUID()
         let task = Task { [weak self] in
-            while self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true {
-                self?.acceptedSendRefreshes[threadID]?.pending = false
-                try? await self?.refreshThread(id: threadID, client: client)
-                guard self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true else { break }
+            while self?.isCurrentAcceptedCommandRefresh(threadID: threadID, id: id) == true {
+                let needsDetail = self?.acceptedCommandRefreshes[threadID]?.needsDetail == true
+                self?.acceptedCommandRefreshes[threadID]?.needsDetail = false
+                self?.acceptedCommandRefreshes[threadID]?.pending = false
+                if needsDetail {
+                    try? await self?.refreshThread(id: threadID, client: client)
+                }
+                guard self?.isCurrentAcceptedCommandRefresh(threadID: threadID, id: id) == true else { break }
                 try? await self?.refresh(client: client)
-                guard self?.acceptedSendRefreshes[threadID]?.pending == true else { break }
+                guard self?.acceptedCommandRefreshes[threadID]?.pending == true else { break }
             }
-            if self?.acceptedSendRefreshes[threadID]?.id == id {
-                self?.acceptedSendRefreshes[threadID] = nil
+            if self?.acceptedCommandRefreshes[threadID]?.id == id {
+                self?.acceptedCommandRefreshes[threadID] = nil
             }
         }
-        acceptedSendRefreshes[threadID] = AcceptedSendRefresh(
-            id: id, client: client, generation: generation, task: task
+        acceptedCommandRefreshes[threadID] = AcceptedCommandRefresh(
+            id: id, client: client, generation: generation, task: task, needsDetail: refreshDetail
         )
     }
 
-    private func isCurrentAcceptedSendRefresh(threadID: String, id: UUID) -> Bool {
-        guard !Task.isCancelled, let refresh = acceptedSendRefreshes[threadID], refresh.id == id else {
+    private func isCurrentAcceptedCommandRefresh(threadID: String, id: UUID) -> Bool {
+        guard !Task.isCancelled, let refresh = acceptedCommandRefreshes[threadID], refresh.id == id else {
             return false
         }
         return isKnownClient(
@@ -2185,12 +2196,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
-    private func cancelAcceptedSendRefreshes(threadID: String? = nil, environmentID: String? = nil) {
-        for (key, refresh) in acceptedSendRefreshes {
+    private func cancelAcceptedCommandRefreshes(threadID: String? = nil, environmentID: String? = nil) {
+        for (key, refresh) in acceptedCommandRefreshes {
             guard threadID.map({ $0 == key }) ?? true,
                   environmentID.map({ $0 == refresh.client.environment.id }) ?? true else { continue }
             refresh.task.cancel()
-            acceptedSendRefreshes[key] = nil
+            acceptedCommandRefreshes[key] = nil
         }
     }
 
@@ -2207,12 +2218,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func cancelTurn(threadID: String) async throws {
         let route = try threadRoute(for: threadID)
+        let generation = environmentGeneration
         let turnID = shellsByEnvironmentID[route.environmentID]?.threads
             .first(where: { $0.id == route.wireID })?
             .latestTurn?
             .turnId
         _ = try await route.client.interrupt(threadID: route.wireID, turnID: turnID)
-        try? await refresh(client: route.client)
+        scheduleAcceptedCommandRefresh(
+            threadID: route.uiID, client: route.client, generation: generation, refreshDetail: false
+        )
     }
 
     func resolveApproval(id: String, decision: FeatureApprovalDecision) async throws {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -96,6 +96,14 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var pendingBootstrapSubmissions: [PendingBootstrapSubmission] = []
     private var pendingTurnSubmissions: [String: PendingTurnSubmission] = [:]
+    private struct AcceptedSendRefresh: Sendable {
+        let id: UUID
+        let client: T3Client
+        let generation: Int
+        let task: Task<Void, Never>
+        var pending = false
+    }
+    private var acceptedSendRefreshes: [String: AcceptedSendRefresh] = [:]
     private var approvalRoutes: [String: PendingRequestRoute] = [:]
     private var inputRoutes: [String: PendingRequestRoute] = [:]
     private var relayDeviceSessionIDs: Set<String> = []
@@ -215,6 +223,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailCatchUpTask?.cancel()
         detailPublishTask?.cancel()
         projectFaviconRefreshTasks.values.forEach { $0.cancel() }
+        acceptedSendRefreshes.values.forEach { $0.task.cancel() }
         continuation.finish()
     }
 
@@ -463,6 +472,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
+            cancelAcceptedSendRefreshes(environmentID: id)
             environmentConnectionStates[id] = .disconnected
             environmentConnectionDetails[id] = nil
             environmentClients[id] = nil
@@ -481,6 +491,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if environment?.kind == .managedDPoP {
             try await runtime.revokeCredential(id: id)
         }
+        cancelAcceptedSendRefreshes(environmentID: id)
         try await runtime.remove(id: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)
@@ -906,6 +917,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func clearEnvironmentState(preserveEnvironmentSnapshots: Bool = false) {
         environmentGeneration &+= 1
+        cancelAcceptedSendRefreshes()
         resetDetailRefresh()
         resetDetailStream()
         archivedRefreshTask?.cancel()
@@ -1828,6 +1840,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func loadThread(id: String, fresh: Bool) async throws -> FeatureThreadDetail {
         let route = try threadRoute(for: id)
+        if let previous = activeThreadID, previous != route.uiID {
+            cancelAcceptedSendRefreshes(threadID: previous)
+        }
         let client = route.client
         let environment = client.environment
         let generation = environmentGeneration
@@ -1970,6 +1985,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func releaseThread(id: String) {
+        cancelAcceptedSendRefreshes(threadID: id)
         guard activeThreadID == id else { return }
         retainActiveThread()
         resetDetailRefresh()
@@ -2130,11 +2146,52 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if pendingTurnSubmissions[route.uiID]?.identity == pending.identity {
             pendingTurnSubmissions[route.uiID] = nil
         }
-        // Live sync reconciles these snapshots. Refreshes are opportunistic
-        // after the accepted command so transient reads cannot invite a
-        // duplicate user turn.
-        try? await refreshThread(id: route.uiID, client: client)
-        try? await refresh(client: client)
+        scheduleAcceptedSendRefresh(threadID: route.uiID, client: client, generation: generation)
+    }
+
+    /// Acceptance unlocks the composer immediately. Retain HTTP convergence
+    /// separately for connections whose live events have not caught up yet.
+    private func scheduleAcceptedSendRefresh(threadID: String, client: T3Client, generation: Int) {
+        if let current = acceptedSendRefreshes[threadID],
+           current.client === client, current.generation == generation {
+            acceptedSendRefreshes[threadID]?.pending = true
+            return
+        }
+        cancelAcceptedSendRefreshes(threadID: threadID)
+        let id = UUID()
+        let task = Task { [weak self] in
+            while self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true {
+                self?.acceptedSendRefreshes[threadID]?.pending = false
+                try? await self?.refreshThread(id: threadID, client: client)
+                guard self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true else { break }
+                try? await self?.refresh(client: client)
+                guard self?.acceptedSendRefreshes[threadID]?.pending == true else { break }
+            }
+            if self?.acceptedSendRefreshes[threadID]?.id == id {
+                self?.acceptedSendRefreshes[threadID] = nil
+            }
+        }
+        acceptedSendRefreshes[threadID] = AcceptedSendRefresh(
+            id: id, client: client, generation: generation, task: task
+        )
+    }
+
+    private func isCurrentAcceptedSendRefresh(threadID: String, id: UUID) -> Bool {
+        guard !Task.isCancelled, let refresh = acceptedSendRefreshes[threadID], refresh.id == id else {
+            return false
+        }
+        return isKnownClient(
+            refresh.client, environmentID: refresh.client.environment.id, generation: refresh.generation
+        )
+    }
+
+    private func cancelAcceptedSendRefreshes(threadID: String? = nil, environmentID: String? = nil) {
+        for (key, refresh) in acceptedSendRefreshes {
+            guard threadID.map({ $0 == key }) ?? true,
+                  environmentID.map({ $0 == refresh.client.environment.id }) ?? true else { continue }
+            refresh.task.cancel()
+            acceptedSendRefreshes[key] = nil
+        }
     }
 
     private func messageWasCommitted(

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -265,7 +265,7 @@ final class NativeRetryIdentityTests: XCTestCase {
         defer { settingsStore.removePersistentDomain(forName: settingsSuite) }
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settingsStore)
         let seed = try await client.initialSnapshot()
-        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        let recorder = AcceptedCommandSnapshotRecorder(seed: seed, events: client.events())
         defer { recorder.stop() }
         let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
@@ -314,7 +314,7 @@ final class NativeRetryIdentityTests: XCTestCase {
             )!
         )
         let seed = try await client.initialSnapshot()
-        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        let recorder = AcceptedCommandSnapshotRecorder(seed: seed, events: client.events())
         defer { recorder.stop() }
         _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
@@ -379,7 +379,7 @@ final class NativeRetryIdentityTests: XCTestCase {
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
         let seed = try await client.initialSnapshot()
-        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        let recorder = AcceptedCommandSnapshotRecorder(seed: seed, events: client.events())
         defer { recorder.stop() }
         let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         XCTAssertEqual(initial.threads.first?.runtimeMode, .approvalRequired)
@@ -491,7 +491,7 @@ final class NativeRetryIdentityTests: XCTestCase {
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
         let seed = try await client.initialSnapshot()
-        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        let recorder = AcceptedCommandSnapshotRecorder(seed: seed, events: client.events())
         defer { recorder.stop() }
         _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
@@ -1379,4 +1379,73 @@ private actor AcceptedSendSocket: WebSocketConnection {
         if let receiver { self.receiver = nil; receiver.resume(returning: data) }
         else { queued.append(data) }
     }
+}
+
+@MainActor
+private final class AcceptedCommandSnapshotRecorder {
+    private(set) var history: [FeatureSnapshot]
+    private var task: Task<Void, Never>?
+    private var waiters: [UUID: (@MainActor (FeatureSnapshot) -> Bool, CheckedContinuation<FeatureSnapshot, Error>)] = [:]
+    private var finished = false
+
+    init(seed: FeatureSnapshot, events: AsyncStream<FeatureEvent>) {
+        history = [seed]
+        task = Task { [weak self] in
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                guard let self else { break }
+                switch event {
+                case let .snapshot(snapshot): self.record(snapshot)
+                case let .thread(thread):
+                    guard var snapshot = self.history.last else { continue }
+                    if let index = snapshot.threads.firstIndex(where: { $0.id == thread.id }) {
+                        snapshot.threads[index] = thread
+                    } else { snapshot.threads.append(thread) }
+                    self.record(snapshot)
+                case let .threadRemoved(id):
+                    guard var snapshot = self.history.last else { continue }
+                    snapshot.threads.removeAll { $0.id == id }
+                    self.record(snapshot)
+                default: break
+                }
+            }
+            self?.stop()
+        }
+    }
+
+    func record(_ snapshot: FeatureSnapshot) {
+        history.append(snapshot)
+        let ready = waiters.filter { $0.value.0(snapshot) }
+        for (id, waiter) in ready {
+            waiters[id] = nil
+            waiter.1.resume(returning: snapshot)
+        }
+    }
+
+    func wait(_ predicate: @escaping @MainActor (FeatureSnapshot) -> Bool) async throws -> FeatureSnapshot {
+        try Task.checkCancellation()
+        if let snapshot = history.last, predicate(snapshot) { return snapshot }
+        guard !finished else { throw CancellationError() }
+        let id = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters[id] = (predicate, continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.waiters.removeValue(forKey: id)?.1.resume(throwing: CancellationError())
+            }
+        }
+    }
+
+    func stop() {
+        finished = true
+        task?.cancel()
+        task = nil
+        let pending = waiters.values
+        waiters.removeAll()
+        pending.forEach { $0.1.resume(throwing: CancellationError()) }
+    }
+
+    deinit { task?.cancel() }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -5,39 +5,6 @@ import XCTest
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
-    func testLateStopAcknowledgementCannotCancelReplacementGenerationRefresh() async throws {
-        let fixture = try await AcceptedSendFixture.make(includePeer: true)
-        addTeardownBlock { await fixture.cleanUp() }
-        var acknowledgements = fixture.socket.heldInterrupts.makeAsyncIterator()
-        var reads = fixture.transport.heldReads.makeAsyncIterator()
-        await fixture.socket.holdInterruptAcknowledgements()
-        let stopping = Task { try await fixture.client.cancelTurn(threadID: fixture.threadID) }
-        addTeardownBlock {
-            await fixture.socket.releaseInterruptAcknowledgements()
-            _ = await stopping.result
-        }
-        guard await acknowledgements.next() != nil else { throw CancellationError() }
-
-        _ = try await fixture.runtime.activate(id: "accepted-peer")
-        _ = try await fixture.client.initialSnapshot()
-        await fixture.transport.holdFollowups(includeShell: false)
-        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Replacement generation", selection: nil)
-        let replacementRead = await reads.next()
-        let replacement = try XCTUnwrap(replacementRead)
-        XCTAssertTrue(replacement.path.hasPrefix("/api/orchestration/threads/"))
-
-        await fixture.socket.releaseInterruptAcknowledgements()
-        try await stopping.value
-        let marker = "Replacement generation published its uniquely held response"
-        XCTAssertNotEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
-        await fixture.transport.release(replacement.id, detailMessage: marker)
-        try await AcceptedSendDetailReceipt(
-            model: fixture.model, threadID: fixture.threadID, expectedMessage: marker
-        ).wait()
-        XCTAssertEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
-        let commands = await fixture.socket.commands
-        XCTAssertEqual(commands.map { $0["type"]?.stringValue }, ["thread.turn.interrupt", "thread.turn.start"])
-    }
 
     func testRejectedStopPropagatesRemoteError() async throws {
         let fixture = try await AcceptedSendFixture.make()

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -5,6 +5,160 @@ import XCTest
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
+    func testLateStopAcknowledgementCannotCancelReplacementGenerationRefresh() async throws {
+        let fixture = try await AcceptedSendFixture.make(includePeer: true)
+        addTeardownBlock { await fixture.cleanUp() }
+        var acknowledgements = fixture.socket.heldInterrupts.makeAsyncIterator()
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.socket.holdInterruptAcknowledgements()
+        let stopping = Task { try await fixture.client.cancelTurn(threadID: fixture.threadID) }
+        addTeardownBlock {
+            await fixture.socket.releaseInterruptAcknowledgements()
+            _ = await stopping.result
+        }
+        guard await acknowledgements.next() != nil else { throw CancellationError() }
+
+        _ = try await fixture.runtime.activate(id: "accepted-peer")
+        _ = try await fixture.client.initialSnapshot()
+        await fixture.transport.holdFollowups(includeShell: false)
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Replacement generation", selection: nil)
+        let replacementRead = await reads.next()
+        let replacement = try XCTUnwrap(replacementRead)
+        XCTAssertTrue(replacement.path.hasPrefix("/api/orchestration/threads/"))
+
+        await fixture.socket.releaseInterruptAcknowledgements()
+        try await stopping.value
+        let marker = "Replacement generation published its uniquely held response"
+        XCTAssertNotEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
+        await fixture.transport.release(replacement.id, detailMessage: marker)
+        try await AcceptedSendDetailReceipt(
+            model: fixture.model, threadID: fixture.threadID, expectedMessage: marker
+        ).wait()
+        XCTAssertEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.map { $0["type"]?.stringValue }, ["thread.turn.interrupt", "thread.turn.start"])
+    }
+
+    func testRejectedStopPropagatesRemoteError() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        await fixture.transport.holdFollowups()
+        let before = await fixture.transport.snapshotReadCount
+        await fixture.socket.rejectInterruptAcknowledgements()
+        do {
+            try await fixture.client.cancelTurn(threadID: fixture.threadID)
+            XCTFail("Rejected interrupt must remain a command error")
+        } catch let error as RPCError {
+            guard case .remote("Stop rejected by fixture") = error else { throw error }
+        }
+        // These counters cover the command-return boundary only; they are
+        // not a proof that no mistakenly queued future task could read later.
+        let after = await fixture.transport.snapshotReadCount
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(after, before)
+        XCTAssertEqual(pending, 0)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands.first?["type"]?.stringValue, "thread.turn.interrupt")
+    }
+
+    func testStopDuringHeldSendDetailPreservesDetailAndShellRecovery() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Send before Stop", selection: nil)
+        let firstRead = await reads.next()
+        let detail = try XCTUnwrap(firstRead)
+        XCTAssertTrue(detail.path.hasPrefix("/api/orchestration/threads/"))
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let count = await fixture.transport.heldCount
+        XCTAssertEqual(count, 1)
+        let detailStillPending = await fixture.transport.isPending(detail.id)
+        XCTAssertTrue(detailStillPending)
+        await fixture.transport.release(detail.id)
+        let nextRead = await reads.next()
+        let shell = try XCTUnwrap(nextRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+        await fixture.transport.release(shell.id)
+        let trailingRead = await reads.next()
+        let trailing = try XCTUnwrap(trailingRead)
+        XCTAssertEqual(trailing.path, "/api/orchestration/shell", "Stop requests shell repair without discarding or repeating the send detail repair")
+        await fixture.client.disconnect()
+        let cancelled = await cancellations.next()
+        XCTAssertEqual(cancelled, trailing.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2)
+    }
+
+    func testAcceptedStopCompletesBeforeOptionalShellReadFinishes() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        let completed = expectation(description: "Accepted Stop completes without snapshot reads")
+        let stopping = Task {
+            await fixture.model.cancelTurn(threadID: fixture.threadID)
+            completed.fulfill()
+        }
+        let read = await reads.next()
+        XCTAssertEqual(read?.path, "/api/orchestration/shell")
+        await fulfillment(of: [completed], timeout: 2)
+        XCTAssertFalse(fixture.model.isPerformingAction)
+
+        await fixture.transport.failFollowups()
+        await stopping.value
+        XCTAssertNil(fixture.model.errorMessage)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands.first?["type"]?.stringValue, "thread.turn.interrupt")
+    }
+
+    func testSendDuringStopRefreshRetainsItsDetailRefresh() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let shellRead = await reads.next()
+        let shell = try XCTUnwrap(shellRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "After Stop", selection: nil)
+        let heldCount = await fixture.transport.heldCount
+        XCTAssertEqual(heldCount, 1)
+        await fixture.transport.release(shell.id)
+        let detailRead = await reads.next()
+        let detail = try XCTUnwrap(detailRead)
+        XCTAssertTrue(detail.path.hasPrefix("/api/orchestration/threads/"))
+
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, detail.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2)
+    }
+
+    func testDisconnectCancelsStopRefreshWithoutAnotherInterrupt() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let read = await reads.next()
+        let held = try XCTUnwrap(read)
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, held.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(pending, 0)
+    }
+
     func testAcceptedSendCompletesOutboxBeforeOptionalReadsFinish() async throws {
         let fixture = try await AcceptedSendFixture.make()
         addTeardownBlock { await fixture.cleanUp() }
@@ -920,8 +1074,9 @@ private struct AcceptedSendFixture {
     let outbox: FeatureOutboxStore
     let transport: AcceptedSendHTTPTransport
     let socket: AcceptedSendSocket
+    let runtime: EnvironmentRuntime
 
-    static func make() async throws -> Self {
+    static func make(includePeer: Bool = false) async throws -> Self {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-accepted-send-\(UUID().uuidString)")
         let environment = Environment(
@@ -930,15 +1085,23 @@ private struct AcceptedSendFixture {
             webSocketBaseURL: URL(string: "wss://accepted-send.example")!
         )
         let store = EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json"))
-        try await store.save([environment])
+        let peer = Environment(
+            id: "accepted-peer", label: "Accepted peer",
+            httpBaseURL: URL(string: "https://accepted-peer.example")!,
+            webSocketBaseURL: URL(string: "wss://accepted-peer.example")!
+        )
+        try await store.save(includePeer ? [environment, peer] : [environment])
         try await store.setActiveEnvironment(id: environment.id)
         let transport = AcceptedSendHTTPTransport()
         let socket = AcceptedSendSocket()
         let runtime = EnvironmentRuntime(
             environmentStore: store,
-            credentialStore: InMemoryCredentialStore(credentials: [environment.id: EnvironmentCredential(accessToken: "fixture-token")]),
+            credentialStore: InMemoryCredentialStore(credentials: [
+                environment.id: EnvironmentCredential(accessToken: "fixture-token"),
+                peer.id: EnvironmentCredential(accessToken: "fixture-peer-token"),
+            ]),
             httpTransport: transport,
-            webSocketConnector: AcceptedSendConnector(socket: socket)
+            webSocketConnector: AcceptedSendConnector(socket: socket, peer: AcceptedSendSocket())
         )
         let settingsName = "t3-accepted-send-\(UUID().uuidString)"
         let client = NativeFeatureClient(
@@ -951,11 +1114,11 @@ private struct AcceptedSendFixture {
         let modelTask = Task { await model.start() }
         do {
             try await AcceptedSendRootReadiness(model: model).wait()
-            let threadID = try XCTUnwrap(model.snapshot.threads.first?.id)
+            let threadID = FeatureScopedID.thread(environmentID: environment.id, wireID: "thread-existing")
             _ = await model.detail(for: threadID)
             return Self(modelTask: modelTask, directory: directory, threadID: threadID,
                         settingsName: settingsName, client: client, model: model,
-                        outbox: outbox, transport: transport, socket: socket)
+                        outbox: outbox, transport: transport, socket: socket, runtime: runtime)
         } catch {
             modelTask.cancel()
             await client.disconnect()
@@ -1014,6 +1177,48 @@ private final class AcceptedSendRootReadiness {
     }
 }
 
+@MainActor
+private final class AcceptedSendDetailReceipt {
+    private let model: FeatureRootModel
+    private let threadID: String
+    private let expectedMessage: String
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(model: FeatureRootModel, threadID: String, expectedMessage: String) {
+        self.model = model
+        self.threadID = threadID
+        self.expectedMessage = expectedMessage
+    }
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                self.continuation = continuation
+                observe()
+            }
+        } onCancel: {
+            Task { @MainActor in self.finish(CancellationError()) }
+        }
+    }
+
+    private func observe() {
+        guard continuation != nil else { return }
+        let ready = withObservationTracking {
+            model.details[threadID]?.messages.last?.text == expectedMessage
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.observe() }
+        }
+        if ready { finish(nil) }
+    }
+
+    private func finish(_ error: Error?) {
+        guard let pending = continuation else { return }
+        continuation = nil
+        if let error { pending.resume(throwing: error) } else { pending.resume() }
+    }
+}
+
 private actor AcceptedSendHTTPTransport: HTTPTransport {
     struct HeldRead: Sendable {
         let id: UUID
@@ -1023,9 +1228,12 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
     nonisolated let cancellations: AsyncStream<UUID>
     private let reads: AsyncStream<HeldRead>.Continuation
     private let cancelled: AsyncStream<UUID>.Continuation
+    private(set) var snapshotReadCount = 0
+    private var holdsShell = true
     private var holds = false
     private var fails = false
     private var pending: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var detailMessages: [UUID: String] = [:]
 
     init() {
         (heldReads, reads) = AsyncStream.makeStream()
@@ -1040,9 +1248,12 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
         guard path == "/api/orchestration/shell" || path.hasPrefix("/api/orchestration/threads/") else {
             throw URLError(.unsupportedURL)
         }
+        snapshotReadCount += 1
         if fails { throw URLError(.networkConnectionLost) }
-        if holds {
+        var heldID: UUID?
+        if holds && (holdsShell || path != "/api/orchestration/shell") {
             let id = UUID()
+            heldID = id
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
@@ -1053,19 +1264,39 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
                 Task { await self.cancel(id) }
             }
         }
-        let data = if path == "/api/orchestration/shell" {
-            try JSONEncoder.t3.encode(retryShellSnapshot())
+        let data: Data
+        if path == "/api/orchestration/shell" {
+            data = try JSONEncoder.t3.encode(retryShellSnapshot())
         } else {
-            try JSONEncoder.t3.encode(retryEmptyThreadDetail(id: request.url!.lastPathComponent))
+            let snapshot = retryEmptyThreadDetail(id: request.url!.lastPathComponent)
+            if let heldID, let text = detailMessages.removeValue(forKey: heldID) {
+                var thread = try JSONValue.encode(snapshot.thread).decode([String: JSONValue].self)
+                thread["messages"] = .array([.object([
+                    "id": .string("replacement-generation-message"), "role": .string("assistant"),
+                    "text": .string(text), "turnId": .null, "streaming": .bool(false),
+                    "attachments": .array([]), "createdAt": .string("2026-07-30T12:00:00.000Z"),
+                    "updatedAt": .string("2026-07-30T12:00:00.000Z"),
+                ])])
+                data = try JSONEncoder.t3.encode(OrchestrationThreadDetailSnapshot(
+                    snapshotSequence: 99,
+                    thread: try JSONValue.object(thread).decode(OrchestrationThread.self)
+                ))
+            } else { data = try JSONEncoder.t3.encode(snapshot) }
         }
         return (data, retryHTTPResponse(request))
     }
 
     var heldCount: Int { pending.count }
 
-    func holdFollowups() { holds = true }
+    func isPending(_ id: UUID) -> Bool { pending[id] != nil }
 
-    func release(_ id: UUID) { pending.removeValue(forKey: id)?.resume() }
+    func holdFollowups(includeShell: Bool = true) { holds = true; holdsShell = includeShell }
+
+    func release(_ id: UUID, detailMessage: String? = nil) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        if let detailMessage { detailMessages[id] = detailMessage }
+        continuation.resume()
+    }
 
     func failFollowups() {
         fails = true
@@ -1084,10 +1315,28 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
 
 private struct AcceptedSendConnector: WebSocketConnecting {
     let socket: AcceptedSendSocket
-    func connect(to _: URL) -> any WebSocketConnection { socket }
+    let peer: AcceptedSendSocket
+    func connect(to url: URL) -> any WebSocketConnection {
+        url.host == "accepted-peer.example" ? peer : socket
+    }
 }
 
 private actor AcceptedSendSocket: WebSocketConnection {
+    nonisolated let heldInterrupts: AsyncStream<Void>
+    private let interruptReceipts: AsyncStream<Void>.Continuation
+    private var holdsInterrupts = false
+    private var rejectsInterrupts = false
+    private var pendingInterruptResponses: [Data] = []
+
+    init() { (heldInterrupts, interruptReceipts) = AsyncStream.makeStream() }
+    func holdInterruptAcknowledgements() { holdsInterrupts = true }
+    func rejectInterruptAcknowledgements() { rejectsInterrupts = true }
+    func releaseInterruptAcknowledgements() {
+        holdsInterrupts = false
+        let responses = pendingInterruptResponses
+        pendingInterruptResponses.removeAll()
+        responses.forEach { enqueue($0) }
+    }
     private(set) var commands: [JSONValue] = []
     private var queued: [Data] = []
     private var receiver: CheckedContinuation<Data, Error>?
@@ -1100,10 +1349,19 @@ private actor AcceptedSendSocket: WebSocketConnection {
             enqueue(response)
         } else if tag == RPCMethod.dispatchCommand.rawValue, let payload = request["payload"] {
             commands.append(payload)
-            enqueue(try JSONEncoder.t3.encode(JSONValue.object([
-                "_tag": .string("Exit"), "requestId": request["id"]!,
-                "exit": .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
-            ])))
+            let isInterrupt = payload["type"]?.stringValue == "thread.turn.interrupt"
+            let exit: JSONValue = isInterrupt && rejectsInterrupts
+                ? .object(["_tag": .string("Failure"), "cause": .array([
+                    .object(["_tag": .string("Fail"), "error": .object(["message": .string("Stop rejected by fixture")])]),
+                ])])
+                : .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
+            let response = try JSONEncoder.t3.encode(JSONValue.object([
+                "_tag": .string("Exit"), "requestId": request["id"]!, "exit": exit,
+            ]))
+            if isInterrupt && holdsInterrupts {
+                pendingInterruptResponses.append(response)
+                interruptReceipts.yield(())
+            } else { enqueue(response) }
         }
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -1,9 +1,86 @@
 import Foundation
+import Observation
 import XCTest
 @testable import T3Code
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
+    func testAcceptedSendCompletesOutboxBeforeOptionalReadsFinish() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        let completed = expectation(description: "Accepted send completes without snapshot reads")
+        let sending = Task {
+            let sent = await fixture.model.sendMessage(threadID: fixture.threadID, text: "Accepted now", selection: nil)
+            completed.fulfill()
+            return sent
+        }
+        _ = await reads.next()
+        await fulfillment(of: [completed], timeout: 2)
+        let queued = try await fixture.outbox.submissions()
+        XCTAssertTrue(queued.isEmpty, "Acknowledgement must retire the outbox while optional reads are held.")
+        XCTAssertFalse(fixture.model.isPerformingAction)
+
+        await fixture.transport.failFollowups()
+        let sent = await sending.value
+        XCTAssertTrue(sent, "Optional read failures cannot turn acceptance into a failed send.")
+        XCTAssertNil(fixture.model.errorMessage)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(fixture.model.details[fixture.threadID]?.messages.last?.state, .complete)
+        await fixture.client.disconnect()
+    }
+
+    func testAcceptedSendRefreshesCoalesceAndCancelWhenThreadCloses() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "First", selection: nil)
+        let firstRead = await reads.next()
+        let first = try XCTUnwrap(firstRead)
+        XCTAssertTrue(first.path.hasPrefix("/api/orchestration/threads/"))
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Second", selection: nil)
+        let heldCount = await fixture.transport.heldCount
+        XCTAssertEqual(heldCount, 1, "A second acceptance must coalesce behind the current read.")
+
+        await fixture.transport.release(first.id)
+        let shellRead = await reads.next()
+        let shell = try XCTUnwrap(shellRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+        await fixture.transport.release(shell.id)
+        let trailingRead = await reads.next()
+        let trailing = try XCTUnwrap(trailingRead)
+        XCTAssertTrue(trailing.path.hasPrefix("/api/orchestration/threads/"))
+        fixture.client.releaseThread(id: fixture.threadID)
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, trailing.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2, "Read reconciliation must never redispatch a command.")
+        await fixture.transport.failFollowups()
+        await fixture.client.disconnect()
+    }
+
+    func testDisconnectCancelsAcceptedSendRefreshWithoutAnotherCommand() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Accepted before disconnect", selection: nil)
+        let heldRead = await reads.next()
+        let held = try XCTUnwrap(heldRead)
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, held.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(pending, 0)
+    }
+
     func testSavedSettingsSurviveAConnectionRepublish() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-native-settings-republish-\(UUID().uuidString)")
@@ -33,28 +110,21 @@ final class NativeRetryIdentityTests: XCTestCase {
         let settingsStore = UserDefaults(suiteName: settingsSuite)!
         defer { settingsStore.removePersistentDomain(forName: settingsSuite) }
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settingsStore)
-        let initial = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
         var updated = initial.settings
         updated.textSize = FeatureTextSizeAdjustment(steps: 2)
         updated.codeSize = FeatureTextSizeAdjustment(steps: -1)
         try await client.saveSettings(updated)
-        var events = client.events().makeAsyncIterator()
-
         await connection.failReceive()
-
-        var receivedRepublish = false
-        while let event = await events.next() {
-            guard case let .snapshot(snapshot) = event,
-                  snapshot.connection.state == .reconnecting else {
-                continue
-            }
-            XCTAssertEqual(snapshot.settings.textSize.steps, 2)
-            XCTAssertEqual(snapshot.settings.codeSize.steps, -1)
-            receivedRepublish = true
-            break
+        let snapshot = try await recorder.wait {
+            $0.connection.state == .reconnecting && $0.settings.textSize.steps == 2
         }
-        XCTAssertTrue(receivedRepublish)
+        XCTAssertEqual(snapshot.settings.textSize.steps, 2)
+        XCTAssertEqual(snapshot.settings.codeSize.steps, -1)
         await client.disconnect()
     }
 
@@ -89,7 +159,10 @@ final class NativeRetryIdentityTests: XCTestCase {
                 suiteName: "t3-native-concurrent-retry-\(UUID().uuidString)"
             )!
         )
-        _ = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
         await transport.rejectShellReads()
 
@@ -151,7 +224,10 @@ final class NativeRetryIdentityTests: XCTestCase {
             suiteName: "t3-native-retry-\(UUID().uuidString)"
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
-        let initial = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         XCTAssertEqual(initial.threads.first?.runtimeMode, .approvalRequired)
         XCTAssertEqual(initial.threads.first?.interactionMode, .standard)
         await connection.waitUntilConnected()
@@ -260,7 +336,10 @@ final class NativeRetryIdentityTests: XCTestCase {
             suiteName: "t3-native-partial-\(UUID().uuidString)"
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
-        _ = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
 
         let identity = FeatureSubmissionIdentity(
@@ -828,4 +907,218 @@ private func retryDispatchCommand(from request: URLRequest) throws -> JSONValue 
         throw URLError(.cannotDecodeContentData)
     }
     return try JSONDecoder.t3.decode(JSONValue.self, from: body)
+}
+
+@MainActor
+private struct AcceptedSendFixture {
+    let modelTask: Task<Void, Never>
+    let directory: URL
+    let threadID: String
+    let settingsName: String
+    let client: NativeFeatureClient
+    let model: FeatureRootModel
+    let outbox: FeatureOutboxStore
+    let transport: AcceptedSendHTTPTransport
+    let socket: AcceptedSendSocket
+
+    static func make() async throws -> Self {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-accepted-send-\(UUID().uuidString)")
+        let environment = Environment(
+            id: "accepted-send", label: "Accepted send",
+            httpBaseURL: URL(string: "https://accepted-send.example")!,
+            webSocketBaseURL: URL(string: "wss://accepted-send.example")!
+        )
+        let store = EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json"))
+        try await store.save([environment])
+        try await store.setActiveEnvironment(id: environment.id)
+        let transport = AcceptedSendHTTPTransport()
+        let socket = AcceptedSendSocket()
+        let runtime = EnvironmentRuntime(
+            environmentStore: store,
+            credentialStore: InMemoryCredentialStore(credentials: [environment.id: EnvironmentCredential(accessToken: "fixture-token")]),
+            httpTransport: transport,
+            webSocketConnector: AcceptedSendConnector(socket: socket)
+        )
+        let settingsName = "t3-accepted-send-\(UUID().uuidString)"
+        let client = NativeFeatureClient(
+            runtime: runtime, settingsStore: UserDefaults(suiteName: settingsName)!,
+            fallbackPollingInitialDelay: .seconds(3600), aggregateRefreshInterval: .seconds(3600),
+            aggregateIdleRefreshInterval: .seconds(3600)
+        )
+        let outbox = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let model = FeatureRootModel(client: client, outboxStore: outbox)
+        let modelTask = Task { await model.start() }
+        do {
+            try await AcceptedSendRootReadiness(model: model).wait()
+            let threadID = try XCTUnwrap(model.snapshot.threads.first?.id)
+            _ = await model.detail(for: threadID)
+            return Self(modelTask: modelTask, directory: directory, threadID: threadID,
+                        settingsName: settingsName, client: client, model: model,
+                        outbox: outbox, transport: transport, socket: socket)
+        } catch {
+            modelTask.cancel()
+            await client.disconnect()
+            await modelTask.value
+            UserDefaults.standard.removePersistentDomain(forName: settingsName)
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
+    }
+
+    func cleanUp() async {
+        modelTask.cancel()
+        await client.disconnect()
+        await modelTask.value
+        UserDefaults.standard.removePersistentDomain(forName: settingsName)
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+@MainActor
+private final class AcceptedSendRootReadiness {
+    private let model: FeatureRootModel
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(model: FeatureRootModel) { self.model = model }
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                self.continuation = continuation
+                observe()
+            }
+        } onCancel: {
+            Task { @MainActor in self.finish(CancellationError()) }
+        }
+    }
+
+    private func observe() {
+        guard continuation != nil else { return }
+        let ready = withObservationTracking {
+            !model.isLoading
+                && model.snapshot.projects.contains { $0.id == FeatureScopedID.project(environmentID: "accepted-send", wireID: "project-1") }
+                && model.snapshot.threads.contains { $0.id == FeatureScopedID.thread(environmentID: "accepted-send", wireID: "thread-existing") }
+                && model.snapshot.environments.first(where: { $0.id == "accepted-send" })?.connectionState == .connected
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.observe() }
+        }
+        if ready { finish(nil) }
+    }
+
+    private func finish(_ error: Error?) {
+        guard let pending = continuation else { return }
+        continuation = nil
+        if let error { pending.resume(throwing: error) } else { pending.resume() }
+    }
+}
+
+private actor AcceptedSendHTTPTransport: HTTPTransport {
+    struct HeldRead: Sendable {
+        let id: UUID
+        let path: String
+    }
+    nonisolated let heldReads: AsyncStream<HeldRead>
+    nonisolated let cancellations: AsyncStream<UUID>
+    private let reads: AsyncStream<HeldRead>.Continuation
+    private let cancelled: AsyncStream<UUID>.Continuation
+    private var holds = false
+    private var fails = false
+    private var pending: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    init() {
+        (heldReads, reads) = AsyncStream.makeStream()
+        (cancellations, cancelled) = AsyncStream.makeStream()
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let path = request.url?.path ?? ""
+        if path == "/api/auth/websocket-ticket" {
+            return (Data(#"{"ticket":"fixture-ticket","expiresAt":"2026-09-07T12:05:00Z"}"#.utf8), retryHTTPResponse(request))
+        }
+        guard path == "/api/orchestration/shell" || path.hasPrefix("/api/orchestration/threads/") else {
+            throw URLError(.unsupportedURL)
+        }
+        if fails { throw URLError(.networkConnectionLost) }
+        if holds {
+            let id = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                    pending[id] = continuation
+                    reads.yield(HeldRead(id: id, path: path))
+                }
+            } onCancel: {
+                Task { await self.cancel(id) }
+            }
+        }
+        let data = if path == "/api/orchestration/shell" {
+            try JSONEncoder.t3.encode(retryShellSnapshot())
+        } else {
+            try JSONEncoder.t3.encode(retryEmptyThreadDetail(id: request.url!.lastPathComponent))
+        }
+        return (data, retryHTTPResponse(request))
+    }
+
+    var heldCount: Int { pending.count }
+
+    func holdFollowups() { holds = true }
+
+    func release(_ id: UUID) { pending.removeValue(forKey: id)?.resume() }
+
+    func failFollowups() {
+        fails = true
+        holds = false
+        let waiting = pending.values
+        pending.removeAll()
+        waiting.forEach { $0.resume(throwing: URLError(.networkConnectionLost)) }
+    }
+
+    private func cancel(_ id: UUID) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: CancellationError())
+        cancelled.yield(id)
+    }
+}
+
+private struct AcceptedSendConnector: WebSocketConnecting {
+    let socket: AcceptedSendSocket
+    func connect(to _: URL) -> any WebSocketConnection { socket }
+}
+
+private actor AcceptedSendSocket: WebSocketConnection {
+    private(set) var commands: [JSONValue] = []
+    private var queued: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+
+    func send(_ data: Data) throws {
+        let request = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        let tag = request["tag"]?.stringValue
+        if tag == RPCMethod.serverGetConfig.rawValue || tag == RPCMethod.subscribeServerConfig.rawValue,
+           let response = try retryConfigResponse(for: request) {
+            enqueue(response)
+        } else if tag == RPCMethod.dispatchCommand.rawValue, let payload = request["payload"] {
+            commands.append(payload)
+            enqueue(try JSONEncoder.t3.encode(JSONValue.object([
+                "_tag": .string("Exit"), "requestId": request["id"]!,
+                "exit": .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
+            ])))
+        }
+    }
+
+    func receive() async throws -> Data {
+        if !queued.isEmpty { return queued.removeFirst() }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        receiver?.resume(throwing: CancellationError())
+        receiver = nil
+    }
+
+    private func enqueue(_ data: Data) {
+        if let receiver { self.receiver = nil; receiver.resume(returning: data) }
+        else { queued.append(data) }
+    }
 }


### PR DESCRIPTION
Accepted Send and Stop commands keep their UI actions waiting for optional HTTP reads. Release the accepted action immediately and let a generation-owned refresh reconcile the thread separately. Coalesce overlapping Send/Stop refresh requirements without replaying the command.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34281258377/job/102246288840). Skipped checks are not claimed as executed proof.

All 12 standalone command-acknowledgement/retry XCTest cases passed (exit 0). The old-environment late-ack regression relies on the later live-bootstrap connection lifetime and remains covered in the dependent chain.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Verification scope: Native tests passed with optional HTTP reads held while accepted Send/Stop completes. They verify outbox completion, refresh coalescing, cancellation on close/disconnect, and absence of command replay. The direct PR excludes a test requiring the later passive-live lifetime; that test remains in the dependent chain. The native CI job linked above contains the passing receipts. The tests exercise the protocol, state, or accessibility-value boundary changed here.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
