### PR TITLE
fix(swift-ios): recover missing completed thread replies

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1872,6 +1872,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             activeThreadSequence = cached.sequence
             activeThreadPage = cached.page
             detail.page = cached.page
+            if latestDetails[route.uiID]?.page != detail.page {
+                publish(detail, threadID: route.uiID, renderCacheIsSource: true)
+            }
             markThreadCacheRecentlyUsed(route.uiID)
             startDetailStream(route, warmConnectionID: warmConnectionID)
             if let shell = shellsByEnvironmentID[environment.id] {
@@ -4859,6 +4862,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else if rawThread.latestTurn?.turnId == completed.turnId,
                   rawThread.latestTurn?.state == completed.state,
                   rawThread.latestTurn?.completedAt == completed.completedAt,
+                  rawThread.messages.contains(where: {
+                      $0.role == "assistant" && $0.turnId == completed.turnId && !$0.streaming
+                  }),
                   !rawThread.messages.contains(where: {
                       $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
                   }) {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1869,7 +1869,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             detail.page = cached.page
             markThreadCacheRecentlyUsed(route.uiID)
             startDetailStream(route, warmConnectionID: warmConnectionID)
-            return detail
+            if let shell = shellsByEnvironmentID[environment.id] {
+                synchronizeActiveDetail(with: shell, environment: environment)
+            }
+            return latestDetails[route.uiID] ?? detail
         }
         continuation.yield(.threadSync(id: route.uiID, state: .catchingUp))
         let snapshot: OrchestrationThreadDetailSnapshot
@@ -4788,10 +4791,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         guard activeThreadEnvironmentID == environment.id,
               let threadID = activeThreadID,
               let wireID = threadWireIDs[threadID],
-              let shellThread = shell.threads.first(where: { $0.id == wireID }),
-              var detail = latestDetails[threadID] else {
+              let shellThread = shell.threads.first(where: { $0.id == wireID }) else {
             return
         }
+        repairMissingCompletedTurn(shellThread, sequence: shell.snapshotSequence, threadID: threadID)
+        guard var detail = latestDetails[threadID] else { return }
 
         let backgroundLiveness = shellThread.backgroundLiveness
         let backgroundWorkIsActive = backgroundLiveness == .working
@@ -4826,6 +4830,33 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             : 0
         guard latestDetails[threadID] != detail else { return }
         publish(detail, threadID: threadID, renderCacheIsSource: true)
+    }
+
+    private func repairMissingCompletedTurn(
+        _ shellThread: OrchestrationThreadShell, sequence: Int, threadID: String
+    ) {
+        guard let rawThread = activeRawThread,
+              sequence > (activeThreadSequence ?? .min),
+              let completed = shellThread.latestTurn, completed.state == "completed",
+              let route = try? threadRoute(for: threadID) else { return }
+        if let messageID = completed.assistantMessageId {
+            if let message = rawThread.messages.first(where: { $0.id == messageID }),
+               !message.streaming { return }
+        } else if rawThread.latestTurn?.turnId == completed.turnId,
+                  rawThread.latestTurn?.state == completed.state,
+                  rawThread.latestTurn?.completedAt == completed.completedAt,
+                  !rawThread.messages.contains(where: {
+                      $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
+                  }) {
+            return
+        }
+
+        // Keep rendered partial text while requiring a snapshot that includes
+        // the shell's completion. Later detail events advance this same floor.
+        flushDetailPublish(route)
+        activeRawThread = nil
+        activeThreadSequence = sequence
+        scheduleDetailRefresh(threadID: threadID, client: route.client, force: true)
     }
 
     /// Thread-only shell changes stay granular so Home does not replace and

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -52,6 +52,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private let aggregateRefreshSleep: @Sendable (Duration) async throws -> Void
     private let environmentShellTimeoutInterval: TimeInterval
     private let threadSnapshotTimeoutInterval: TimeInterval
+    private let detailPublicationSleep: @Sendable () async throws -> Void
     private let catchUpDelay: @Sendable () async throws -> Void
     private let threadRetryDelay: @Sendable (Int) async throws -> Void
     private let aggregateEnvironmentLoader: @Sendable (EnvironmentRuntime) async throws -> [Environment]
@@ -155,6 +156,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         },
         environmentShellTimeoutInterval: TimeInterval = 6,
         threadSnapshotTimeoutInterval: TimeInterval = 8,
+        detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(80))
+        },
         catchUpDelay: @escaping @Sendable () async throws -> Void = {
             try await Task.sleep(for: .seconds(2))
         },
@@ -195,6 +199,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         self.aggregateRefreshSleep = aggregateRefreshSleep
         self.environmentShellTimeoutInterval = environmentShellTimeoutInterval
         self.threadSnapshotTimeoutInterval = threadSnapshotTimeoutInterval
+        self.detailPublicationSleep = detailPublicationSleep
         self.catchUpDelay = catchUpDelay
         self.threadRetryDelay = threadRetryDelay
         self.aggregateEnvironmentLoader = aggregateEnvironmentLoader
@@ -4263,7 +4268,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 scheduleDetailRefresh(threadID: route.uiID, client: route.client, force: true)
             }
         }
-        if serverConfigsByEnvironmentID[route.environmentID]?.threadResumeCompletionMarker != true {
+        if !detailWasSynchronized,
+           serverConfigsByEnvironmentID[route.environmentID]?.threadResumeCompletionMarker != true {
             markDetailSynchronized(route)
         }
     }
@@ -4275,8 +4281,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         pendingDetailRenderMutations.formUnion(mutation)
         guard detailPublishTask == nil else { return }
         let streamGeneration = detailStreamGeneration
+        let sleep = detailPublicationSleep
         detailPublishTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(80))
+            do { try await sleep() } catch { return }
             guard let self else { return }
             guard !Task.isCancelled,
                   self.detailStreamGeneration == streamGeneration,
@@ -4799,22 +4806,26 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
         let backgroundLiveness = shellThread.backgroundLiveness
         let backgroundWorkIsActive = backgroundLiveness == .working
-        let sessionIsLive = shellThread.session?.status == "starting"
-            || shellThread.session?.status == "running"
-        detail.thread.state = Self.resolveThreadState(
-            latestTurn: shellThread.latestTurn,
-            session: shellThread.session,
-            hasApprovals: !detail.approvals.isEmpty,
-            hasUserInput: !detail.userInputs.isEmpty,
-            backgroundLiveness: backgroundLiveness
-        )
-        detail.thread.workingStartedAt = workingStartedAt(
-            latestTurn: shellThread.latestTurn,
-            session: shellThread.session,
-            backgroundWorkIsActive: backgroundWorkIsActive,
-            fallbackUpdatedAt: shellThread.updatedAt
-        )
-        if shell.snapshotSequence >= (activeThreadSequence ?? .min) {
+        let shellMetadataIsCurrent = shell.snapshotSequence >= (activeThreadSequence ?? .min)
+        let latestTurn = shellMetadataIsCurrent ? shellThread.latestTurn : activeRawThread?.latestTurn
+        let session = shellMetadataIsCurrent ? shellThread.session : activeRawThread?.session
+        let sessionIsLive = session?.status == "starting" || session?.status == "running"
+        if shellMetadataIsCurrent || activeRawThread != nil {
+            detail.thread.state = Self.resolveThreadState(
+                latestTurn: latestTurn,
+                session: session,
+                hasApprovals: !detail.approvals.isEmpty,
+                hasUserInput: !detail.userInputs.isEmpty,
+                backgroundLiveness: backgroundLiveness
+            )
+            detail.thread.workingStartedAt = workingStartedAt(
+                latestTurn: latestTurn,
+                session: session,
+                backgroundWorkIsActive: backgroundWorkIsActive,
+                fallbackUpdatedAt: shellThread.updatedAt
+            )
+        }
+        if shellMetadataIsCurrent {
             applyShellMetadataAuthority(from: shellThread, to: &detail.thread)
             if let compaction = detailRenderCaches[threadID]?.compaction {
                 detail.isCompacting = compaction.isActive(
@@ -4836,20 +4847,28 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         _ shellThread: OrchestrationThreadShell, sequence: Int, threadID: String
     ) {
         guard let rawThread = activeRawThread,
-              sequence > (activeThreadSequence ?? .min),
+              sequence >= (activeThreadSequence ?? .min),
               let completed = shellThread.latestTurn, completed.state == "completed",
               let route = try? threadRoute(for: threadID) else { return }
         if let messageID = completed.assistantMessageId {
             if let message = rawThread.messages.first(where: { $0.id == messageID }),
-               !message.streaming { return }
+               !message.streaming {
+                flushDetailPublish(route)
+                return
+            }
         } else if rawThread.latestTurn?.turnId == completed.turnId,
                   rawThread.latestTurn?.state == completed.state,
                   rawThread.latestTurn?.completedAt == completed.completedAt,
                   !rawThread.messages.contains(where: {
                       $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
                   }) {
+            flushDetailPublish(route)
             return
         }
+
+        // Equal-cursor completion may flush final content, but only a newer
+        // shell can prove that detail is missing and require HTTP repair.
+        guard sequence > (activeThreadSequence ?? .min) else { return }
 
         // Keep rendered partial text while requiring a snapshot that includes
         // the shell's completion. Later detail events advance this same floor.

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -165,21 +165,18 @@ final class NativeThreadCatchUpTests: XCTestCase {
 
     func testDelayedCompletedShellPreservesNewerRunningDetailAndBackgroundLiveness() async throws {
         for background: String? in [nil, "working"] {
-            let receipts = AsyncStream<Int>.makeStream()
-            let fixture = try await CatchUpFixture.make(aggregateRefreshReceipt: { receipt in
-                if case let .shellApplied("one", sequence) = receipt { receipts.continuation.yield(sequence) }
-            })
+            let fixture = try await CatchUpFixture.make()
             defer { fixture.cleanUp() }
             do {
                 var requests = fixture.requests.makeAsyncIterator()
-                var applied = receipts.stream.makeAsyncIterator()
+                var events = fixture.client.events().makeAsyncIterator()
                 let shell = try await nextShellRequest(&requests)
-                try await shell.completeShell(sequence: 10, assistantMessageID: nil)
-                while let sequence = await applied.next(isolation: #isolation) {
-                    if sequence == 10 { break }
+                try await shell.completeShell(sequence: 10, assistantMessageID: nil, title: "Shell 10")
+                while let event = await events.next(isolation: #isolation) {
+                    if case let .snapshot(snapshot) = event,
+                       snapshot.threads.contains(where: { $0.id == fixture.firstID && $0.title == "Shell 10" }) { break }
                 }
                 try Task.checkCancellation()
-                var events = fixture.client.events().makeAsyncIterator()
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
                 try await detail.synchronize()
@@ -197,14 +194,22 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 XCTAssertEqual(latest?.thread.state, .working)
                 let startedAt = try XCTUnwrap(latest?.thread.workingStartedAt)
                 try await shell.completeShell(
-                    sequence: 11, assistantMessageID: nil, backgroundLiveness: background
+                    sequence: 11, assistantMessageID: nil, backgroundLiveness: background, title: "Shell 11"
                 )
-                while let sequence = await applied.next(isolation: #isolation) {
-                    if sequence == 11 { break }
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        latest = value
+                        XCTAssertEqual(value.thread.state, .working)
+                        XCTAssertEqual(value.thread.workingStartedAt, startedAt)
+                    default: break
+                    }
+                    if case let .snapshot(snapshot) = event,
+                       snapshot.threads.contains(where: { $0.id == fixture.firstID && $0.title == "Shell 11" }) { break }
                 }
                 try Task.checkCancellation()
-                // The applied shell receipt orders this explicit detail marker
-                // after any detail publication caused by the delayed shell.
+                // The published shell title proves that the delayed shell was applied
+                // before this detail marker.
                 try await detail.synchronize()
                 while let event = await events.next(isolation: #isolation) {
                     switch event {
@@ -1324,7 +1329,6 @@ private struct CatchUpFixture {
     static func make(
         completionMarker: Bool? = true,
         activities: [OrchestrationActivity] = [],
-        aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
         detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
             try await Task.sleep(for: .milliseconds(80))
         },
@@ -1351,18 +1355,15 @@ private struct CatchUpFixture {
                 requests: requests.continuation, completionMarker: completionMarker
             )
         )
-        let readiness = CatchUpBootstrapReadiness()
         let client = NativeFeatureClient(
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
-            aggregateRefreshReceipt: { readiness.record($0); aggregateRefreshReceipt($0) },
             detailPublicationSleep: detailPublicationSleep,
             catchUpDelay: { try await delay.wait() },
             threadRetryDelay: threadRetryDelay
         )
         _ = try await client.initialSnapshot()
-        try await readiness.wait()
         return Self(client: client, http: http, requests: requests.stream, delay: delay, directory: directory)
     }
 
@@ -1500,8 +1501,8 @@ private struct CatchUpRequest: Sendable {
     let payload: JSONValue
     let socket: CatchUpSocket
 
-    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil, backgroundLiveness: String? = nil) async throws {
-        let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: "First")
+    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil, backgroundLiveness: String? = nil, title: String = "First") async throws {
+        let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: title)
         var thread = try JSONValue.encode(shell.threads[0]).decode([String: JSONValue].self)
         thread["latestTurn"] = catchUpCompletedTurn(assistantMessageID: assistantMessageID)
         thread["activeOrderKey"] = activeOrderKey.map(JSONValue.string)
@@ -1795,41 +1796,6 @@ private func catchUpCompletedTurn(assistantMessageID: String?) -> JSONValue {
         "completedAt": .string("2026-09-02T12:01:00Z"),
         "assistantMessageId": assistantMessageID.map(JSONValue.string) ?? .null,
     ])
-}
-
-/// The detail tests retain their one FeatureEvent consumer. Readiness comes
-/// from applied shell/config receipts and does not drain that event stream.
-@MainActor
-private final class CatchUpBootstrapReadiness {
-    private var hasShell = false
-    private var hasConfig = false
-    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
-
-    func record(_ receipt: NativePassiveShellReceipt) {
-        switch receipt {
-        case .shellApplied(environmentID: "one", sequence: _): hasShell = true
-        case .configurationApplied(environmentID: "one"): hasConfig = true
-        default: break
-        }
-        if hasShell && hasConfig {
-            let pending = waiters.values
-            waiters.removeAll()
-            pending.forEach { $0.resume() }
-        }
-    }
-
-    func wait() async throws {
-        try Task.checkCancellation()
-        guard !hasShell || !hasConfig else { return }
-        let id = UUID()
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { waiters[id] = $0 }
-        } onCancel: {
-            Task { @MainActor [weak self] in
-                self?.waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
-            }
-        }
-    }
 }
 
 private final class CatchUpPublicationClock: Sendable {

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -234,7 +234,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
     }
 
     func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
-        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
+        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming", "no-message-id-completed"] {
             let fixture = try await CatchUpFixture.make()
             defer { fixture.cleanUp() }
             if mode == "streaming" || mode == "no-message-id-streaming" {
@@ -245,7 +245,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
             var events = fixture.client.events().makeAsyncIterator()
             _ = try await fixture.client.loadThread(id: fixture.firstID)
             let detail = try await nextThreadRequest(&requests)
-            if mode == "no-message-id-streaming" {
+            if mode == "no-message-id-streaming" || mode == "no-message-id-completed" {
                 try await detail.completeTurnWithoutMessageID(sequence: 3)
             }
             try await detail.synchronize()
@@ -652,6 +652,34 @@ final class NativeThreadCatchUpTests: XCTestCase {
         XCTAssertTrue(detail.messages.contains { $0.text == "Fresh retry" })
         let reads = await fixture.http.threadRequests
         XCTAssertEqual(reads.count, 2)
+        await fixture.client.disconnect()
+    }
+
+    func testWarmReopenClearsAnInterruptedOlderPageLoadingState() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        await fixture.http.setPage(.init(beforeCursor: "older", hasMore: true, snapshotSequence: 2))
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        let older = Task { try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID) }
+        let held = try await nextHeldRead(&reads)
+        fixture.client.releaseThread(id: fixture.firstID)
+        let restored = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertEqual(restored.page?.isLoading, false)
+        XCTAssertEqual(restored.page?.hasMore, true)
+        held.succeed()
+        _ = try await older.value
+        await fixture.http.holdThreadReads(false)
+        await fixture.http.setPage(.init(beforeCursor: nil, hasMore: false, snapshotSequence: 2))
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 3, "Reopened history must allow another older-page request")
         await fixture.client.disconnect()
     }
 
@@ -1375,6 +1403,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
     private var messages: [OrchestrationMessage] = []
     private var activities: [OrchestrationActivity] = []
     private var completionResponse = false
+    private var responsePage: OrchestrationThreadDetailPage?
     private var sequence = 2
     private var holdsThreadReads = false
     private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
@@ -1406,6 +1435,8 @@ private actor CatchUpHTTPTransport: HTTPTransport {
         self.sequence = sequence
         completionResponse = !streaming
     }
+
+    func setPage(_ page: OrchestrationThreadDetailPage) { responsePage = page }
 
     func holdThreadReads(_ hold: Bool) { holdsThreadReads = hold }
 
@@ -1440,7 +1471,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 thread = try JSONValue.object(object).decode(OrchestrationThread.self)
             }
             value = try .encode(OrchestrationThreadDetailSnapshot(
-                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: snapshot.page
+                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: responsePage ?? snapshot.page
             ))
         }
         let response = (try JSONEncoder.t3.encode(value), HTTPURLResponse(

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -24,6 +24,171 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
+        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
+            let fixture = try await CatchUpFixture.make()
+            defer { fixture.cleanUp() }
+            if mode == "streaming" || mode == "no-message-id-streaming" {
+                await fixture.http.setCompletionResponse(text: "Partial", sequence: 2, streaming: true)
+            }
+            var requests = fixture.requests.makeAsyncIterator()
+            let shell = try await nextShellRequest(&requests)
+            var events = fixture.client.events().makeAsyncIterator()
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let detail = try await nextThreadRequest(&requests)
+            if mode == "no-message-id-streaming" {
+                try await detail.completeTurnWithoutMessageID(sequence: 3)
+            }
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+
+            await fixture.http.setCompletionResponse(text: "Final assistant response", sequence: 10)
+            await fixture.http.holdThreadReads(true)
+            let began = expectation(description: "Completion starts a required snapshot: \(mode)")
+            let waiting = Task { @MainActor in
+                var reads = fixture.http.heldRequests.makeAsyncIterator()
+                let read = await reads.next(isolation: #isolation)
+                if read != nil { began.fulfill() }
+                return read
+            }
+            try await shell.completeShell(sequence: 10, assistantMessageID: mode.hasPrefix("no-message-id") ? nil : "answer-0")
+            // Failure watchdog only: successful progress is signaled by the held HTTP read.
+            await fulfillment(of: [began], timeout: 2)
+            waiting.cancel()
+            guard let read = await waiting.value else {
+                await fixture.client.disconnect()
+                continue
+            }
+            read.succeed()
+            let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(repaired, ["Final assistant response"], mode)
+
+            // The same subscription remains usable after HTTP repair.
+            try await detail.sendMessage(text: "Next response", sequence: 11)
+            try await detail.synchronize()
+            let next = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(next, ["Final assistant response", "Next response"], mode)
+            try await shell.completeShell(
+                sequence: 30, assistantMessageID: mode.hasPrefix("no-message-id") ? nil : "answer-0",
+                activeOrderKey: "already-complete"
+            )
+            while let event = await events.next(isolation: #isolation) {
+                if case .threadSync(fixture.firstID, .catchingUp) = event {
+                    XCTFail("Already-complete detail must not start another repair")
+                }
+                if case let .detail(value) = event, value.thread.activeOrderKey == "already-complete" { break }
+                if case let .detailDelta(value, _) = event, value.thread.activeOrderKey == "already-complete" { break }
+            }
+            let count = await fixture.http.threadRequests.count
+            XCTAssertEqual(count, 2, mode)
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testShellCompletionCoalescesWhileRequiredSnapshotTracksNewerDetailEvents() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        let shell = try await nextShellRequest(&requests)
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setCompletionResponse(text: "Final", sequence: 10)
+        await fixture.http.holdThreadReads(true)
+        let began = expectation(description: "Completion starts required read")
+        let waiting = Task { @MainActor in
+            var reads = fixture.http.heldRequests.makeAsyncIterator()
+            let read = await reads.next(isolation: #isolation)
+            if read != nil { began.fulfill() }
+            return read
+        }
+        try await shell.completeShell(sequence: 10, assistantMessageID: "answer-0")
+        await fulfillment(of: [began], timeout: 2)
+        waiting.cancel()
+        guard let first = await waiting.value else {
+            await fixture.client.disconnect()
+            return
+        }
+        await nextCatchUp(&events, threadID: fixture.firstID)
+
+        // An unrelated shell cursor advance must not invalidate the same completion twice.
+        try await shell.completeShell(sequence: 100, assistantMessageID: "answer-0", activeOrderKey: "completion-seen-again")
+        while let event = await events.next(isolation: #isolation) {
+            if case let .detail(value) = event, value.thread.activeOrderKey == "completion-seen-again" { break }
+            if case let .detailDelta(value, _) = event, value.thread.activeOrderKey == "completion-seen-again" { break }
+        }
+        await fixture.http.setCompletionResponse(text: "Final with newer detail", sequence: 20)
+        try await detail.sendMessage(text: "Final with newer detail", sequence: 20)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        first.succeed()
+        let replacement = try await nextHeldRead(&reads)
+        replacement.succeed()
+        let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(repaired, ["Final with newer detail"])
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 3, "Initial read plus one stale repair and one cursor replacement")
+        await fixture.client.disconnect()
+    }
+
+    func testWarmCachedOpenRepairsAlreadyCompletedShellWithoutAnotherShellEvent() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        let shell = try await nextShellRequest(&requests)
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let first = try await nextThreadRequest(&requests)
+        try await first.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        fixture.client.releaseThread(id: fixture.firstID)
+        try await shell.completeShell(sequence: 10, assistantMessageID: "answer-0", activeOrderKey: "cached-completion")
+        while let event = await events.next(isolation: #isolation) {
+            if case let .thread(value) = event, value.activeOrderKey == "cached-completion" { break }
+            if case let .snapshot(value) = event,
+               value.threads.contains(where: { $0.activeOrderKey == "cached-completion" }) { break }
+        }
+        await fixture.http.setCompletionResponse(text: "Final while closed", sequence: 10)
+        await fixture.http.holdThreadReads(true)
+        let began = expectation(description: "Cached completion starts required read on reopen")
+        let waiting = Task { @MainActor in
+            var reads = fixture.http.heldRequests.makeAsyncIterator()
+            let read = await reads.next(isolation: #isolation)
+            if read != nil { began.fulfill() }
+            return read
+        }
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let resumed = try await nextThreadRequest(&requests)
+        try await resumed.synchronize()
+        await fulfillment(of: [began], timeout: 2)
+        waiting.cancel()
+        guard let read = await waiting.value else {
+            await fixture.client.disconnect()
+            return
+        }
+        // Ignore the warm-cache immediate live receipt preceding the repair.
+        while let event = await events.next(isolation: #isolation) {
+            if case .threadSync(fixture.firstID, .catchingUp) = event { break }
+        }
+        read.succeed()
+        let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(repaired, ["Final while closed"])
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 2)
+        await fixture.client.disconnect()
+    }
+
+    private func nextShellRequest(
+        _ iterator: inout AsyncStream<CatchUpRequest>.Iterator
+    ) async throws -> CatchUpRequest {
+        while let request = await iterator.next(isolation: #isolation) {
+            if request.tag == RPCMethod.subscribeShell.rawValue { return request }
+        }
+        throw CancellationError()
+    }
+
     func testRequestSnapshotsKeepTerminalRequestsClosedAndOtherFailuresRetryable() async throws {
         var activities: [OrchestrationActivity] = []
         for kind in ["approval", "user-input"] {
@@ -978,14 +1143,17 @@ private struct CatchUpFixture {
                 requests: requests.continuation, completionMarker: completionMarker
             )
         )
+        let readiness = CatchUpBootstrapReadiness()
         let client = NativeFeatureClient(
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
+            aggregateRefreshReceipt: { readiness.record($0) },
             catchUpDelay: { try await delay.wait() },
             threadRetryDelay: threadRetryDelay
         )
         _ = try await client.initialSnapshot()
+        try await readiness.wait()
         return Self(client: client, http: http, requests: requests.stream, delay: delay, directory: directory)
     }
 
@@ -996,6 +1164,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
     private(set) var threadRequests: [URLRequest] = []
     private var messages: [OrchestrationMessage] = []
     private var activities: [OrchestrationActivity] = []
+    private var completionResponse = false
     private var sequence = 2
     private var holdsThreadReads = false
     private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
@@ -1017,6 +1186,15 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             catchUpMessage(text, index: index, withImage: withImage)
         }
         self.sequence = sequence
+    }
+
+    func setCompletionResponse(text: String, sequence: Int, streaming: Bool = false) {
+        messages = [OrchestrationMessage(
+            id: "answer-0", role: "assistant", text: text, attachments: [], turnId: "turn-1",
+            streaming: streaming, createdAt: "2026-09-02T12:00:00Z", updatedAt: "2026-09-02T12:00:00Z"
+        )]
+        self.sequence = sequence
+        completionResponse = !streaming
     }
 
     func holdThreadReads(_ hold: Bool) { holdsThreadReads = hold }
@@ -1046,6 +1224,11 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             )
             var thread = snapshot.thread
             thread.activities = activities
+            if completionResponse {
+                var object = try JSONValue.encode(thread).decode([String: JSONValue].self)
+                object["latestTurn"] = catchUpCompletedTurn(assistantMessageID: "answer-0")
+                thread = try JSONValue.object(object).decode(OrchestrationThread.self)
+            }
             value = try .encode(OrchestrationThreadDetailSnapshot(
                 snapshotSequence: snapshot.snapshotSequence, thread: thread, page: snapshot.page
             ))
@@ -1107,6 +1290,34 @@ private struct CatchUpRequest: Sendable {
     let id: Int
     let payload: JSONValue
     let socket: CatchUpSocket
+
+    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil) async throws {
+        let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: "First")
+        var thread = try JSONValue.encode(shell.threads[0]).decode([String: JSONValue].self)
+        thread["latestTurn"] = catchUpCompletedTurn(assistantMessageID: assistantMessageID)
+        thread["activeOrderKey"] = activeOrderKey.map(JSONValue.string)
+        let snapshot = OrchestrationShellSnapshot(
+            snapshotSequence: sequence, projects: shell.projects,
+            threads: [try JSONValue.object(thread).decode(OrchestrationThreadShell.self)], updatedAt: shell.updatedAt
+        )
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("snapshot"), "snapshot": try .encode(snapshot),
+        ])])
+    }
+
+    func completeTurnWithoutMessageID(sequence: Int) async throws {
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("event"), "event": .object([
+                "type": .string("thread.turn-diff-completed"), "sequence": .number(Double(sequence)),
+                "occurredAt": .string("2026-09-02T12:01:00Z"), "payload": .object([
+                    "threadId": payload["threadId"]!, "turnId": .string("turn-1"),
+                    "checkpointTurnCount": .number(1), "checkpointRef": .string("refs/t3/checkpoints/turn-1"),
+                    "status": .string("ready"), "files": .array([]),
+                    "completedAt": .string("2026-09-02T12:01:00Z"), "assistantMessageId": .null,
+                ]),
+            ]),
+        ])])
+    }
 
     func terminate(_ failure: CatchUpStreamFailure) async throws {
         switch failure {
@@ -1324,5 +1535,50 @@ private actor CatchUpDelay {
     }
     private func cancel(_ id: UUID) {
         waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+    }
+}
+
+private func catchUpCompletedTurn(assistantMessageID: String?) -> JSONValue {
+    .object([
+        "turnId": .string("turn-1"), "state": .string("completed"),
+        "requestedAt": .string("2026-09-02T12:00:00Z"),
+        "startedAt": .string("2026-09-02T12:00:00Z"),
+        "completedAt": .string("2026-09-02T12:01:00Z"),
+        "assistantMessageId": assistantMessageID.map(JSONValue.string) ?? .null,
+    ])
+}
+
+/// The detail tests retain their one FeatureEvent consumer. Readiness comes
+/// from applied shell/config receipts and does not drain that event stream.
+@MainActor
+private final class CatchUpBootstrapReadiness {
+    private var hasShell = false
+    private var hasConfig = false
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    func record(_ receipt: NativePassiveShellReceipt) {
+        switch receipt {
+        case .shellApplied(environmentID: "one", sequence: _): hasShell = true
+        case .configurationApplied(environmentID: "one"): hasConfig = true
+        default: break
+        }
+        if hasShell && hasConfig {
+            let pending = waiters.values
+            waiters.removeAll()
+            pending.forEach { $0.resume() }
+        }
+    }
+
+    func wait() async throws {
+        try Task.checkCancellation()
+        guard !hasShell || !hasConfig else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { waiters[id] = $0 }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+            }
+        }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -37,6 +37,11 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                // HTTP readiness can precede installation of the subscription's
+                // connection UUID. Establish this stream's own live boundary
+                // before counting the already-synchronized burst publications.
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 100, includeMarker: true)
                 var publications = 0
                 var sawLive = false
@@ -83,6 +88,8 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 1, includeMarker: false)
                 guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
                 await clock.release()
@@ -125,6 +132,8 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 var entries = clock.entries.makeAsyncIterator()
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.synchronize()
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 1, includeMarker: false)
                 guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -24,6 +24,201 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testLegacyBurstCoalescesUntilExplicitMarker() async throws {
+        for capability: Bool? in [nil, false] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: capability, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var events = fixture.client.events().makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 100, includeMarker: true)
+                var publications = 0
+                var sawLive = false
+                var finalText: String?
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        publications += 1
+                        finalText = value.messages.last?.text
+                    case .threadSync(fixture.firstID, .live):
+                        XCTAssertEqual(publications, 1)
+                        XCTAssertEqual(finalText, String(repeating: "x", count: 100))
+                        sawLive = true
+                        break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(sawLive)
+                XCTAssertEqual(finalText, String(repeating: "x", count: 100))
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await clock.release()
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testLegacyMarkerlessFinalPublishesWhenClockReleases() async throws {
+        for capability: Bool? in [nil, false] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: capability, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var events = fixture.client.events().makeAsyncIterator()
+                var entries = clock.entries.makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 1, includeMarker: false)
+                guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
+                await clock.release()
+                var foundFinal = false
+                while let event = await events.next(isolation: #isolation) {
+                    if case .threadSync(fixture.firstID, .live) = event {
+                        XCTFail("An already live legacy event must not emit another live status")
+                    }
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        XCTAssertEqual(value.messages.last?.text, "x")
+                        foundFinal = true
+                    default: continue
+                    }
+                    if foundFinal { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(foundFinal)
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testLegacyBufferedFinalPrecedesShellDone() async throws {
+        for shellSequence in [3, 10] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: nil, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                let shell = try await nextShellRequest(&requests)
+                var events = fixture.client.events().makeAsyncIterator()
+                var entries = clock.entries.makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 1, includeMarker: false)
+                guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
+                try await shell.completeShell(sequence: shellSequence, assistantMessageID: "burst-message")
+                var reachedDone = false
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        if value.thread.state == .completed {
+                            XCTAssertEqual(value.messages.last?.text, "x")
+                            reachedDone = true
+                        }
+                    default: continue
+                    }
+                    if reachedDone { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(reachedDone)
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await clock.release()
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testDelayedCompletedShellPreservesNewerRunningDetailAndBackgroundLiveness() async throws {
+        for background: String? in [nil, "working"] {
+            let receipts = AsyncStream<Int>.makeStream()
+            let fixture = try await CatchUpFixture.make(aggregateRefreshReceipt: { receipt in
+                if case let .shellApplied("one", sequence) = receipt { receipts.continuation.yield(sequence) }
+            })
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var applied = receipts.stream.makeAsyncIterator()
+                let shell = try await nextShellRequest(&requests)
+                try await shell.completeShell(sequence: 10, assistantMessageID: nil)
+                while let sequence = await applied.next(isolation: #isolation) {
+                    if sequence == 10 { break }
+                }
+                try Task.checkCancellation()
+                var events = fixture.client.events().makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.runningTurnSnapshot(sequence: 12)
+                var latest: FeatureThreadDetail?
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _): latest = value
+                    case .threadSync(fixture.firstID, .live): break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                XCTAssertEqual(latest?.thread.state, .working)
+                let startedAt = try XCTUnwrap(latest?.thread.workingStartedAt)
+                try await shell.completeShell(
+                    sequence: 11, assistantMessageID: nil, backgroundLiveness: background
+                )
+                while let sequence = await applied.next(isolation: #isolation) {
+                    if sequence == 11 { break }
+                }
+                try Task.checkCancellation()
+                // The applied shell receipt orders this explicit detail marker
+                // after any detail publication caused by the delayed shell.
+                try await detail.synchronize()
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        latest = value
+                        XCTAssertEqual(value.thread.state, .working)
+                        XCTAssertEqual(value.thread.workingStartedAt, startedAt)
+                    case .threadSync(fixture.firstID, .live): break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertEqual(latest?.thread.state, .working)
+                XCTAssertEqual(latest?.backgroundWorkIsActive, background == "working")
+            } catch {
+                await fixture.client.disconnect()
+                throw error
+            }
+            await fixture.client.disconnect()
+        }
+    }
+
     func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
         for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
             let fixture = try await CatchUpFixture.make()
@@ -1118,8 +1313,12 @@ private struct CatchUpFixture {
     var secondID: String { FeatureScopedID.thread(environmentID: "one", wireID: "second") }
 
     static func make(
-        completionMarker: Bool = true,
+        completionMarker: Bool? = true,
         activities: [OrchestrationActivity] = [],
+        aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
+        detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(80))
+        },
         threadRetryDelay: @escaping @Sendable (Int) async throws -> Void = { _ in
             try await Task.sleep(for: .milliseconds(250))
         }
@@ -1148,7 +1347,8 @@ private struct CatchUpFixture {
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
-            aggregateRefreshReceipt: { readiness.record($0) },
+            aggregateRefreshReceipt: { readiness.record($0); aggregateRefreshReceipt($0) },
+            detailPublicationSleep: detailPublicationSleep,
             catchUpDelay: { try await delay.wait() },
             threadRetryDelay: threadRetryDelay
         )
@@ -1275,7 +1475,7 @@ private func catchUpMessage(
 
 private struct CatchUpConnector: WebSocketConnecting {
     let requests: AsyncStream<CatchUpRequest>.Continuation
-    let completionMarker: Bool
+    let completionMarker: Bool?
     func connect(to url: URL) async throws -> any WebSocketConnection {
         CatchUpSocket(requests: requests, completionMarker: completionMarker)
     }
@@ -1291,11 +1491,12 @@ private struct CatchUpRequest: Sendable {
     let payload: JSONValue
     let socket: CatchUpSocket
 
-    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil) async throws {
+    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil, backgroundLiveness: String? = nil) async throws {
         let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: "First")
         var thread = try JSONValue.encode(shell.threads[0]).decode([String: JSONValue].self)
         thread["latestTurn"] = catchUpCompletedTurn(assistantMessageID: assistantMessageID)
         thread["activeOrderKey"] = activeOrderKey.map(JSONValue.string)
+        thread["backgroundLiveness"] = backgroundLiveness.map(JSONValue.string)
         let snapshot = OrchestrationShellSnapshot(
             snapshotSequence: sequence, projects: shell.projects,
             threads: [try JSONValue.object(thread).decode(OrchestrationThreadShell.self)], updatedAt: shell.updatedAt
@@ -1373,6 +1574,44 @@ private struct CatchUpRequest: Sendable {
         ])])
     }
 
+    func runningTurnSnapshot(sequence: Int) async throws {
+        let snapshot = multiEnvironmentDetail(
+            projectID: "project", threadID: payload["threadId"]!.stringValue!, snapshotSequence: sequence
+        )
+        var thread = try JSONValue.encode(snapshot.thread).decode([String: JSONValue].self)
+        thread["latestTurn"] = .object([
+            "turnId": .string("turn-2"), "state": .string("running"),
+            "requestedAt": .string("2026-09-02T12:02:00Z"),
+            "startedAt": .string("2026-09-02T12:02:00Z"),
+            "completedAt": .null, "assistantMessageId": .null,
+        ])
+        let updated = OrchestrationThreadDetailSnapshot(
+            snapshotSequence: sequence, thread: try JSONValue.object(thread).decode(OrchestrationThread.self)
+        )
+        try await socket.chunk(id: id, values: [
+            .object(["kind": .string("snapshot"), "snapshot": try .encode(updated)]),
+        ])
+    }
+
+    func sendBurst(count: Int, includeMarker: Bool) async throws {
+        var values: [JSONValue] = (1...count).map { index in
+            .object([
+                "kind": .string("event"), "event": .object([
+                    "type": .string("thread.message-sent"), "sequence": .number(Double(index + 2)),
+                    "occurredAt": .string("2026-09-02T12:00:00Z"), "payload": .object([
+                        "threadId": payload["threadId"]!, "messageId": .string("burst-message"),
+                        "role": .string("assistant"), "text": .string(index < count ? "x" : String(repeating: "x", count: count)),
+                        "streaming": .bool(index < count),
+                        "createdAt": .string("2026-09-02T12:00:00Z"),
+                        "updatedAt": .string("2026-09-02T12:00:00Z"),
+                    ]),
+                ]),
+            ])
+        }
+        if includeMarker { values.append(.object(["kind": .string("synchronized")])) }
+        try await socket.chunk(id: id, values: values)
+    }
+
     func sendMessage(text: String, sequence: Int) async throws {
         try await socket.chunk(id: id, values: [.object([
             "kind": .string("event"), "event": .object([
@@ -1390,13 +1629,13 @@ private struct CatchUpRequest: Sendable {
 
 private actor CatchUpSocket: WebSocketConnection {
     let requests: AsyncStream<CatchUpRequest>.Continuation
-    let completionMarker: Bool
+    let completionMarker: Bool?
     private(set) var assetRequestCount = 0
     private var pending: [Data] = []
     private var receiver: CheckedContinuation<Data, any Error>?
     private var closed = false
 
-    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool) {
+    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool?) {
         self.requests = requests
         self.completionMarker = completionMarker
     }
@@ -1410,11 +1649,12 @@ private actor CatchUpSocket: WebSocketConnection {
         guard let tag = request["tag"]?.stringValue, case let .number(id) = request["id"] else { return }
         if tag == RPCMethod.assetsCreateURL.rawValue { assetRequestCount += 1 }
         if tag == RPCMethod.subscribeServerConfig.rawValue {
+            var config: [String: JSONValue] = [
+                "providers": .array([]), "threadSnapshotPagination": .bool(true),
+            ]
+            if let completionMarker { config["threadResumeCompletionMarker"] = .bool(completionMarker) }
             try chunk(id: Int(id), values: [.object([
-                "type": .string("snapshot"), "config": .object([
-                    "providers": .array([]), "threadSnapshotPagination": .bool(true),
-                    "threadResumeCompletionMarker": .bool(completionMarker),
-                ]),
+                "type": .string("snapshot"), "config": .object(config),
             ])])
         }
         requests.yield(.init(tag: tag, id: Int(id), payload: request["payload"]!, socket: self))
@@ -1581,4 +1821,23 @@ private final class CatchUpBootstrapReadiness {
             }
         }
     }
+}
+
+private final class CatchUpPublicationClock: Sendable {
+    private let gate = CatchUpDelay()
+    private let receipt: AsyncStream<Void>.Continuation
+    let entries: AsyncStream<Void>
+
+    init() {
+        let pair = AsyncStream<Void>.makeStream()
+        entries = pair.stream
+        receipt = pair.continuation
+    }
+
+    func wait() async throws {
+        receipt.yield(())
+        try await gate.wait()
+    }
+
+    func release() async { await gate.release() }
 }


### PR DESCRIPTION
A shell can report completion while the selected transcript still lacks the final reply or displays streaming text. Require an authoritative detail snapshot without closing the live subscription, preserve newer detail state against stale shell metadata, and avoid repeatedly publishing already-synchronized legacy bursts.

Verification: all current-head GitHub checks pass, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34279880847/job/102241820491). Skipped checks are not claimed as executed proof.

The completion tests now use observable upstream snapshot events instead of a receipt type supplied only by the later bootstrap PR. Current-head native CI passes.

Delivery: direct.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Verification scope: Native tests passed for missing or streaming final replies, completion while required snapshots are held, newer running details against delayed shell completion, and warm cached opens. Tests assert authoritative replacement while preserving the live subscription. The native CI job linked above contains the passing receipts. The tests exercise the protocol, state, or accessibility-value boundary changed here.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
