### PR TITLE
fix(swift-ios): retain thread subscriptions across navigation

### DIFF
--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -599,7 +599,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             credential: savedCredential
         )
         await adoptEnvironment(environment, client: managedClient)
-        startAggregateRefresh(managedClient)
         do {
             try await refresh(client: managedClient)
         } catch {
@@ -612,6 +611,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             )
             publish(snapshot)
         }
+        startAggregateRefresh(managedClient)
         startPolling(managedClient)
     }
 

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -310,7 +310,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         }
         guard bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         let environment = activeClient.environment
-        guard await adoptEnvironment(environment, client: activeClient) else { throw CancellationError() }
+        guard try await adoptEnvironment(environment, client: activeClient) else { throw CancellationError() }
         guard bootstrapID == foregroundBootstrapID,
               isCurrentSession(client: activeClient, generation: environmentGeneration) else {
             throw CancellationError()
@@ -539,7 +539,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else {
             pairedClient = try await runtime.pair(url: endpoint, clientLabel: "T3 Code Swift")
         }
-        guard await adoptEnvironment(pairedClient.environment, client: pairedClient) else { throw CancellationError() }
+        guard try await adoptEnvironment(pairedClient.environment, client: pairedClient) else { throw CancellationError() }
         startAggregateRefresh(pairedClient)
         startPolling(pairedClient)
     }
@@ -604,7 +604,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             environment,
             credential: savedCredential
         )
-        guard await adoptEnvironment(environment, client: managedClient) else { throw CancellationError() }
+        guard try await adoptEnvironment(environment, client: managedClient) else { throw CancellationError() }
         do {
             try await refresh(client: managedClient)
         } catch {
@@ -1066,11 +1066,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private func adoptEnvironment(
         _ environment: Environment,
         client newClient: T3Client
-    ) async -> Bool {
+    ) async throws -> Bool {
         let bootstrapID = foregroundBootstrapID
         let generation = environmentGeneration
         let adoptedConnectionID = await newClient.currentConnectionID()
-        let selectedClient = try? await runtime.activeClient()
+        let selectedClient = try await runtime.activeClient()
         guard bootstrapID == foregroundBootstrapID, generation == environmentGeneration,
               selectedClient === newClient, selectedClient?.environment == environment else { return false }
         cancelAggregateRefresh()

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -453,6 +453,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func resumeAfterBackground(reconnect: Bool) async {
         isForeground = true
+        if client == nil {
+            if let snapshot = try? await initialSnapshot(), isForeground {
+                continuation.yield(.snapshot(snapshot))
+            }
+            return
+        }
         if let client { startAggregateRefresh(client) }
         let sessionGeneration = environmentGeneration
         let selectedRoute = activeThreadID.flatMap { try? threadRoute(for: $0) }
@@ -5302,6 +5308,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let bootstrapID = foregroundBootstrapID
         let sourceSequence = shellsByEnvironmentID[environment.id]?.snapshotSequence
         let authorityRevision = activeHTTPAuthorityRevision
+        // Archive RPC can establish the first socket. Bind the subsequent shell
+        // read to that socket instead of treating its creation as replacement.
+        let archivedShell = includeArchived ? try? await client.archivedShellSnapshot() : nil
         let connectionID = await client.currentConnectionID()
         guard !Task.isCancelled, bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         let shell = try await client.shellSnapshot()
@@ -5309,9 +5318,6 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
               isKnownClient(client, environmentID: environment.id, generation: generation) else {
             throw CancellationError()
         }
-        // Optional archive work cannot carry a pre-reload shell through another
-        // suspension and then establish authority in the replacement bootstrap.
-        let archivedShell = includeArchived ? try? await client.archivedShellSnapshot() : nil
         let currentConnectionID = await client.currentConnectionID()
         guard !Task.isCancelled, bootstrapID == foregroundBootstrapID,
               isKnownClient(client, environmentID: environment.id, generation: generation),

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1132,6 +1132,13 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func clearEnvironmentState(preserveEnvironmentSnapshots: Bool = false) {
+        activeHydrationTask?.cancel()
+        activeHydrationTask = nil
+        activeHydrationID = nil
+        activeHydrationPending = false
+        activeHTTPAuthorityRevision &+= 1
+        activeHasHydrated = false
+        activeStreamIsAuthoritative = false
         environmentGeneration &+= 1
         cancelAcceptedCommandRefreshes()
         resetDetailRefresh()

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -310,7 +310,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         }
         guard bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         let environment = activeClient.environment
-        await adoptEnvironment(environment, client: activeClient)
+        guard await adoptEnvironment(environment, client: activeClient) else { throw CancellationError() }
         guard bootstrapID == foregroundBootstrapID,
               isCurrentSession(client: activeClient, generation: environmentGeneration) else {
             throw CancellationError()
@@ -539,7 +539,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else {
             pairedClient = try await runtime.pair(url: endpoint, clientLabel: "T3 Code Swift")
         }
-        await adoptEnvironment(pairedClient.environment, client: pairedClient)
+        guard await adoptEnvironment(pairedClient.environment, client: pairedClient) else { throw CancellationError() }
         startAggregateRefresh(pairedClient)
         startPolling(pairedClient)
     }
@@ -604,7 +604,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             environment,
             credential: savedCredential
         )
-        await adoptEnvironment(environment, client: managedClient)
+        guard await adoptEnvironment(environment, client: managedClient) else { throw CancellationError() }
         do {
             try await refresh(client: managedClient)
         } catch {
@@ -669,12 +669,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
+        try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
             shellConnectionIDsByEnvironmentID[id] = nil
             aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
-        }
-        try await runtime.setEnabled(id: id, enabled: enabled)
-        if !enabled {
             cancelAcceptedCommandRefreshes(environmentID: id)
             environmentConnectionStates[id] = .disconnected
             environmentConnectionDetails[id] = nil
@@ -689,15 +687,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func removeEnvironment(id: String) async throws {
-        shellConnectionIDsByEnvironmentID[id] = nil
-        aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
         let removesActiveEnvironment = activeEnvironment?.id == id
         let environment = try await runtime.environments().first { $0.id == id }
         if environment?.kind == .managedDPoP {
             try await runtime.revokeCredential(id: id)
         }
-        cancelAcceptedCommandRefreshes(environmentID: id)
         try await runtime.remove(id: id)
+        shellConnectionIDsByEnvironmentID[id] = nil
+        aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
+        cancelAcceptedCommandRefreshes(environmentID: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)
         }
@@ -1068,20 +1066,20 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private func adoptEnvironment(
         _ environment: Environment,
         client newClient: T3Client
-    ) async {
+    ) async -> Bool {
+        let bootstrapID = foregroundBootstrapID
+        let generation = environmentGeneration
+        let adoptedConnectionID = await newClient.currentConnectionID()
+        let selectedClient = try? await runtime.activeClient()
+        guard bootstrapID == foregroundBootstrapID, generation == environmentGeneration,
+              selectedClient === newClient, selectedClient?.environment == environment else { return false }
         cancelAggregateRefresh()
         if activeEnvironment?.id == environment.id, client === newClient {
             activeEnvironment = environment
             environmentClients[environment.id] = newClient
             latestShell = shellsByEnvironmentID[environment.id]
-            return
+            return true
         }
-        let bootstrapID = foregroundBootstrapID
-        let generation = environmentGeneration
-        let adoptedConnectionID = await newClient.currentConnectionID()
-        let selectedEnvironment = try? await runtime.activeEnvironment()
-        guard bootstrapID == foregroundBootstrapID, generation == environmentGeneration,
-              selectedEnvironment == environment else { return }
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
         shellReconciliationTask?.cancel()
@@ -1106,6 +1104,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         latestShell = shellsByEnvironmentID[environment.id]
         // Runtime owns shared transports. The former inbox client may now
         // serve a passive shell or a selected detail, so adoption does not close it.
+        return true
     }
 
     private func clearActiveEnvironment(disconnectClient: Bool = true) async {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -2094,6 +2094,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             activeThreadSequence = cached.sequence
             activeThreadPage = cached.page
             detail.page = cached.page
+            if latestDetails[route.uiID]?.page != detail.page {
+                publish(detail, threadID: route.uiID, renderCacheIsSource: true)
+            }
             markThreadCacheRecentlyUsed(route.uiID)
             startDetailStream(route, warmConnectionID: warmConnectionID)
             if let shell = shellsByEnvironmentID[environment.id] {
@@ -5667,6 +5670,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } else if rawThread.latestTurn?.turnId == completed.turnId,
                   rawThread.latestTurn?.state == completed.state,
                   rawThread.latestTurn?.completedAt == completed.completedAt,
+                  rawThread.messages.contains(where: {
+                      $0.role == "assistant" && $0.turnId == completed.turnId && !$0.streaming
+                  }),
                   !rawThread.messages.contains(where: {
                       $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
                   }) {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -116,6 +116,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private var activeHydrationID: UUID?
     private var activeHydrationPending = false
     private var activeHTTPAuthorityRevision = 0
+    private var shellConnectionIDsByEnvironmentID: [String: UUID] = [:]
     private var activeShellConnectionID: UUID?
     private var activeShellEpochHasSnapshot = false
     private var activeHasHydrated = false
@@ -373,6 +374,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         activeShellEpochHasSnapshot = true
         activeHasHydrated = true
         if socketAuthoritative {
+            shellConnectionIDsByEnvironmentID[client.environment.id] = activeShellConnectionID
             activeStreamIsAuthoritative = true
             activeHTTPAuthorityRevision &+= 1
             activeHydrationPending = false
@@ -616,7 +618,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
-        if !enabled { aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel() }
+        if !enabled {
+            shellConnectionIDsByEnvironmentID[id] = nil
+            aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
+        }
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
             environmentConnectionStates[id] = .disconnected
@@ -632,6 +637,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func removeEnvironment(id: String) async throws {
+        shellConnectionIDsByEnvironmentID[id] = nil
         aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
         let removesActiveEnvironment = activeEnvironment?.id == id
         let environment = try await runtime.environments().first { $0.id == id }
@@ -1017,6 +1023,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             latestShell = shellsByEnvironmentID[environment.id]
             return
         }
+        let bootstrapID = foregroundBootstrapID
+        let generation = environmentGeneration
+        let adoptedConnectionID = await newClient.currentConnectionID()
+        let selectedEnvironment = try? await runtime.activeEnvironment()
+        guard bootstrapID == foregroundBootstrapID, generation == environmentGeneration,
+              selectedEnvironment == environment else { return }
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
         configurationTask?.cancel()
@@ -1027,8 +1039,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         aggregateRefreshTask = nil
         aggregateRefreshID = nil
         archivedRefreshTask = nil
-        activeShellConnectionID = nil
-        activeShellEpochHasSnapshot = false
+        // A passive snapshot is authoritative for adoption only while its
+        // exact socket is still current. A replacement socket starts a new epoch.
+        activeShellConnectionID = adoptedConnectionID
+        activeShellEpochHasSnapshot = adoptedConnectionID != nil
+            && shellConnectionIDsByEnvironmentID[environment.id] == adoptedConnectionID
         clearEnvironmentState(preserveEnvironmentSnapshots: true)
         activeEnvironment = environment
         client = newClient
@@ -1073,6 +1088,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         latestServerConfig = nil
         if !preserveEnvironmentSnapshots {
             environmentClients.removeAll()
+            shellConnectionIDsByEnvironmentID.removeAll()
             shellsByEnvironmentID.removeAll()
             shellProjectionCache.removeAll()
             indexedShellMembership = nil
@@ -3626,6 +3642,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     return
                 }
                 self.lastShellEventAt = nil
+                self.shellConnectionIDsByEnvironmentID[activeClient.environment.id] = nil
                 if self.activeStreamIsAuthoritative {
                     self.activeHTTPAuthorityRevision &+= 1
                 }
@@ -3914,6 +3931,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     guard owns(environment), epoch == state.epoch,
                           authority == state.authorityRevision, connectionID == currentConnection,
                           !state.isLive else { continue }
+                    // A validated HTTP snapshot remains in this socket's cache
+                    // epoch without claiming that the live stream is complete.
+                    if shell != nil { owner?.shellConnectionIDsByEnvironmentID[environment.id] = connectionID }
                     // The first authoritative response in this subscription epoch
                     // may reset a cache left over from a restarted server.
                     interval = applyShell(
@@ -3973,6 +3993,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
         func markStreamPaused(_ environment: Environment) {
             guard let owner, owns(environment) else { return }
+            owner.shellConnectionIDsByEnvironmentID[environment.id] = nil
             owner.environmentConnectionStates[environment.id] = .reconnecting
             owner.environmentConnectionDetails[environment.id] = "Live updates paused. Refreshing over HTTP."
             schedulePublication(environment.id)
@@ -3998,6 +4019,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                         environmentID: environment.id, wireID: removed.id
                     ))
                 }
+                owner.shellConnectionIDsByEnvironmentID[environment.id] = state.connectionID
                 state.authorityRevision &+= 1
                 state.cacheEpoch = state.epoch
                 state.isLive = true
@@ -4881,6 +4903,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ) {
         let savedIDs = Set(savedEnvironments.map(\.id))
         environmentClients = environmentClients.filter { savedIDs.contains($0.key) }
+        shellConnectionIDsByEnvironmentID = shellConnectionIDsByEnvironmentID.filter { savedIDs.contains($0.key) }
         shellsByEnvironmentID = shellsByEnvironmentID.filter { savedIDs.contains($0.key) }
         shellProjectionCache = shellProjectionCache.filter { savedIDs.contains($0.key) }
         serverConfigsByEnvironmentID = serverConfigsByEnvironmentID.filter {
@@ -5238,6 +5261,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             archivedShellThreadsByEnvironmentID[sourceEnvironment.id] = Dictionary(
                 uniqueKeysWithValues: archivedShell.threads.map { ($0.id, $0) }
             )
+        }
+        if let refreshGuard {
+            shellConnectionIDsByEnvironmentID[sourceEnvironment.id] = refreshGuard.connectionID
         }
         shellsByEnvironmentID[sourceEnvironment.id] = shell
         if markSourceConnected {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -50,6 +50,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private let aggregateIdleRefreshInterval: Duration
     private let aggregateFailureRefreshInterval: Duration
     private let aggregateRefreshSleep: @Sendable (Duration) async throws -> Void
+    private let aggregateRefreshReceipt: @MainActor @Sendable (NativePassiveShellReceipt) -> Void
+    private let aggregateStreamRetrySleep: @Sendable (String, Duration) async throws -> Void
+    private let aggregatePublishSleep: @Sendable () async throws -> Void
+    private let aggregatePeerRefreshSleep: @Sendable (String, Duration) async throws -> Void
     private let environmentShellTimeoutInterval: TimeInterval
     private let threadSnapshotTimeoutInterval: TimeInterval
     private let catchUpDelay: @Sendable () async throws -> Void
@@ -107,11 +111,25 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private var terminalSnapshots: [TerminalKey: FeatureTerminalSnapshot] = [:]
     // Keep versions unique when a terminal cache is evicted or an environment reconnects.
     private var terminalLifecycleVersion = 0
+    private var foregroundBootstrapID = UUID()
+    private var activeHydrationTask: Task<Void, Never>?
+    private var activeHydrationID: UUID?
+    private var activeHydrationPending = false
+    private var activeHTTPAuthorityRevision = 0
+    private var activeShellConnectionID: UUID?
+    private var activeShellEpochHasSnapshot = false
+    private var activeHasHydrated = false
+    private var activeStreamIsAuthoritative = false
     private var pollingTask: Task<Void, Never>?
     private var fallbackPollingTask: Task<Void, Never>?
     private var configurationTask: Task<Void, Never>?
     private var aggregateRefreshTask: Task<Void, Never>?
     private var aggregateRefreshID: UUID?
+    private var aggregatePublishTask: Task<Void, Never>?
+    private var isForeground = true
+    private(set) var aggregateRefreshWorkers: [
+        String: (environment: Environment, task: Task<Void, Never>)
+    ] = [:]
     private var shellPublishTask: Task<Void, Never>?
     private var archivedRefreshTask: Task<Void, Never>?
     private var detailRefreshTask: Task<Void, Never>?
@@ -153,6 +171,16 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         aggregateRefreshSleep: @escaping @Sendable (Duration) async throws -> Void = {
             try await Task.sleep(for: $0)
         },
+        aggregatePeerRefreshSleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
+        aggregateStreamRetrySleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
+        aggregatePublishSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(250))
+        },
+        aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
         environmentShellTimeoutInterval: TimeInterval = 6,
         threadSnapshotTimeoutInterval: TimeInterval = 8,
         catchUpDelay: @escaping @Sendable () async throws -> Void = {
@@ -192,6 +220,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         self.aggregateRefreshInterval = aggregateRefreshInterval
         self.aggregateIdleRefreshInterval = aggregateIdleRefreshInterval
         self.aggregateFailureRefreshInterval = aggregateFailureRefreshInterval
+        self.aggregateRefreshReceipt = aggregateRefreshReceipt
+        self.aggregateStreamRetrySleep = aggregateStreamRetrySleep
+        self.aggregatePublishSleep = aggregatePublishSleep
+        self.aggregatePeerRefreshSleep = aggregatePeerRefreshSleep
         self.aggregateRefreshSleep = aggregateRefreshSleep
         self.environmentShellTimeoutInterval = environmentShellTimeoutInterval
         self.threadSnapshotTimeoutInterval = threadSnapshotTimeoutInterval
@@ -204,10 +236,13 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     deinit {
+        activeHydrationTask?.cancel()
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
         configurationTask?.cancel()
         aggregateRefreshTask?.cancel()
+        aggregatePublishTask?.cancel()
+        aggregateRefreshWorkers.values.forEach { $0.task.cancel() }
         shellPublishTask?.cancel()
         archivedRefreshTask?.cancel()
         detailRefreshTask?.cancel()
@@ -219,44 +254,159 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func initialSnapshot() async throws -> FeatureSnapshot {
+        beginForegroundBootstrap()
+        let bootstrapID = foregroundBootstrapID
         let environments = try await runtime.environments()
+        guard bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         guard let activeClient = try await runtime.activeClient() else {
-            await clearActiveEnvironment()
+            await clearActiveEnvironment(disconnectClient: false)
             let snapshot = disconnectedSnapshot(environments: environments)
             latestSnapshot = snapshot
             return snapshot
         }
-        // The runtime actor can change its active selection at any suspension
-        // point. Derive both values from one client so the snapshot cannot pair
-        // one environment with another environment's connection.
+        guard bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         let environment = activeClient.environment
-
         await adoptEnvironment(environment, client: activeClient)
-        let generation = environmentGeneration
-        let loads = await loadEnvironmentShells(environments.filter(\.isEnabled))
-        guard isCurrentSession(client: activeClient, generation: generation) else {
+        guard bootstrapID == foregroundBootstrapID,
+              isCurrentSession(client: activeClient, generation: environmentGeneration) else {
             throw CancellationError()
         }
-        reconcileEnvironmentLoads(loads, savedEnvironments: environments)
+        reconcileEnvironmentLoads([], savedEnvironments: environments)
+        for saved in environments where saved.isEnabled {
+            environmentConnectionStates[saved.id] = .reconnecting
+            environmentConnectionDetails[saved.id] = nil
+        }
         latestShell = shellsByEnvironmentID[environment.id]
-        startPolling(activeClient)
-        let activeIsReachable = loads.contains {
-            $0.environment.id == environment.id && $0.shell != nil
-        }
-        if activeIsReachable {
-            scheduleArchivedRefresh(client: activeClient, environment: environment)
-        }
         let snapshot = makeSnapshot(
-            environments: environments,
-            activeEnvironment: environment,
-            connectionState: activeIsReachable ? .connected : .disconnected,
-            connectionDetail: activeIsReachable ? nil : "That server is currently unreachable."
+            environments: environments, activeEnvironment: environment,
+            connectionState: .reconnecting
         )
         latestSnapshot = snapshot
+        // No suspension after assigning the seed: the root installs it before
+        // it consumes buffered hydration events through its single iterator.
+        if isForeground {
+            startPolling(activeClient)
+            requestActiveShellHydration(activeClient, bootstrapID: bootstrapID)
+            startAggregateRefresh(activeClient, refreshImmediately: true)
+        }
         return snapshot
     }
 
+    private func beginForegroundBootstrap() {
+        foregroundBootstrapID = UUID()
+        activeHydrationTask?.cancel()
+        activeHydrationTask = nil
+        activeHydrationID = nil
+        activeHydrationPending = false
+        activeHTTPAuthorityRevision &+= 1
+        activeHasHydrated = false
+        activeStreamIsAuthoritative = false
+        pollingTask?.cancel()
+        fallbackPollingTask?.cancel()
+        configurationTask?.cancel()
+        archivedRefreshTask?.cancel()
+        archivedRefreshTask = nil
+        shellPublishTask?.cancel()
+        shellPublishTask = nil
+        cancelAggregateRefresh()
+    }
+
+    private func isCurrentForeground(_ client: T3Client, generation: Int, bootstrapID: UUID) -> Bool {
+        !Task.isCancelled && isForeground && foregroundBootstrapID == bootstrapID
+            && isCurrentSession(client: client, generation: generation)
+    }
+
+    /// Bootstrap, fallback polling, and unknown stream events share one HTTP
+    /// request owner. An invalidated request drains before its pending repair.
+    private func requestActiveShellHydration(_ activeClient: T3Client, bootstrapID: UUID, force: Bool = false) {
+        let generation = environmentGeneration
+        guard isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) else { return }
+        guard activeHydrationTask == nil else {
+            if force { activeHydrationPending = true }
+            return
+        }
+        let requestID = UUID()
+        let revision = activeHTTPAuthorityRevision
+        let runtime = runtime
+        let timeout = environmentShellTimeoutInterval
+        activeHydrationID = requestID
+        activeHydrationPending = false
+        activeHydrationTask = Task { [weak self] in
+            let shell = try? await activeClient.shellSnapshot(timeoutInterval: timeout)
+            let environments = try? await runtime.environments()
+            guard let self else { return }
+            defer { self.aggregateRefreshReceipt(.httpFinished(environmentID: activeClient.environment.id)) }
+            guard self.activeHydrationID == requestID,
+                  self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID)
+            else { return }
+            self.activeHydrationTask = nil
+            self.activeHydrationID = nil
+            guard let environments, environments.contains(activeClient.environment),
+                  activeClient.environment.isEnabled else { return }
+            if revision == self.activeHTTPAuthorityRevision {
+                if let shell {
+                    self.activeHydrationPending = false
+                    self.acceptActiveShell(shell, client: activeClient, environments: environments,
+                                           socketAuthoritative: false, connectHeader: false)
+                } else {
+                    self.emitConnection(
+                        self.activeHasHydrated ? .reconnecting : .disconnected,
+                        detail: "Server unreachable. Retrying automatically."
+                    )
+                }
+            }
+            if self.activeHydrationPending && !self.activeStreamIsAuthoritative {
+                self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID)
+            }
+        }
+    }
+
+    private func acceptActiveShell(
+        _ candidate: OrchestrationShellSnapshot, client: T3Client,
+        environments: [Environment], socketAuthoritative: Bool, connectHeader: Bool
+    ) {
+        let shell: OrchestrationShellSnapshot
+        if activeShellEpochHasSnapshot, let cached = latestShell,
+           cached.snapshotSequence > candidate.snapshotSequence { shell = cached }
+        else { shell = candidate }
+        let firstHydration = !activeHasHydrated
+        activeShellEpochHasSnapshot = true
+        activeHasHydrated = true
+        if socketAuthoritative {
+            activeStreamIsAuthoritative = true
+            activeHTTPAuthorityRevision &+= 1
+            activeHydrationPending = false
+            lastShellEventAt = .now
+        }
+        let removed = Set(shellsByEnvironmentID[client.environment.id]?.threads.map(\.id) ?? [])
+            .subtracting(shell.threads.map(\.id))
+        for id in removed {
+            clearRemovedThreadDetail(FeatureScopedID.thread(environmentID: client.environment.id, wireID: id))
+        }
+        latestShell = shell
+        shellsByEnvironmentID[client.environment.id] = shell
+        environmentConnectionStates[client.environment.id] = .connected
+        environmentConnectionDetails[client.environment.id] = nil
+        rebuildEntityIndexes(environments)
+        synchronizeActiveDetail(with: shell, environment: client.environment)
+        guard let activeEnvironment else { return }
+        publish(makeSnapshot(
+            environments: environments, activeEnvironment: activeEnvironment,
+            connectionState: connectHeader ? .connected : (latestSnapshot?.connection.state ?? .reconnecting),
+            connectionDetail: connectHeader ? nil : latestSnapshot?.connection.detail
+        ))
+        aggregateRefreshReceipt(.shellApplied(environmentID: client.environment.id, sequence: shell.snapshotSequence))
+        if firstHydration { scheduleArchivedRefresh(client: client, environment: client.environment) }
+    }
+
+    func suspendForBackground() {
+        isForeground = false
+        beginForegroundBootstrap()
+    }
+
     func resumeAfterBackground(reconnect: Bool) async {
+        isForeground = true
+        if let client { startAggregateRefresh(client) }
         let sessionGeneration = environmentGeneration
         let selectedRoute = activeThreadID.flatMap { try? threadRoute(for: $0) }
         detailWasSynchronized = false
@@ -281,7 +431,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             }
         }
         guard sessionGeneration == environmentGeneration else { return }
-        if let client { startPolling(client) }
+        if let client {
+            startPolling(client)
+            requestActiveShellHydration(client, bootstrapID: foregroundBootstrapID)
+        }
         if let selectedRoute, activeThreadID == selectedRoute.uiID,
            isKnownClient(selectedRoute.client, environmentID: selectedRoute.environmentID, generation: sessionGeneration) {
             resetDetailRefresh()
@@ -334,6 +487,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             pairedClient = try await runtime.pair(url: endpoint, clientLabel: "T3 Code Swift")
         }
         await adoptEnvironment(pairedClient.environment, client: pairedClient)
+        startAggregateRefresh(pairedClient)
         startPolling(pairedClient)
     }
 
@@ -398,6 +552,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             credential: savedCredential
         )
         await adoptEnvironment(environment, client: managedClient)
+        startAggregateRefresh(managedClient)
         do {
             try await refresh(client: managedClient)
         } catch {
@@ -461,6 +616,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
+        if !enabled { aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel() }
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
             environmentConnectionStates[id] = .disconnected
@@ -476,6 +632,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func removeEnvironment(id: String) async throws {
+        aggregateRefreshWorkers.removeValue(forKey: id)?.task.cancel()
         let removesActiveEnvironment = activeEnvironment?.id == id
         let environment = try await runtime.environments().first { $0.id == id }
         if environment?.kind == .managedDPoP {
@@ -853,18 +1010,16 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         _ environment: Environment,
         client newClient: T3Client
     ) async {
+        cancelAggregateRefresh()
         if activeEnvironment?.id == environment.id, client === newClient {
             activeEnvironment = environment
             environmentClients[environment.id] = newClient
             latestShell = shellsByEnvironmentID[environment.id]
-            startAggregateRefresh(newClient)
             return
         }
-        let previousClient = client
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
         configurationTask?.cancel()
-        aggregateRefreshTask?.cancel()
         archivedRefreshTask?.cancel()
         pollingTask = nil
         fallbackPollingTask = nil
@@ -872,23 +1027,24 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         aggregateRefreshTask = nil
         aggregateRefreshID = nil
         archivedRefreshTask = nil
+        activeShellConnectionID = nil
+        activeShellEpochHasSnapshot = false
         clearEnvironmentState(preserveEnvironmentSnapshots: true)
         activeEnvironment = environment
         client = newClient
         environmentClients[environment.id] = newClient
         latestShell = shellsByEnvironmentID[environment.id]
-        if let previousClient, previousClient !== newClient {
-            await previousClient.disconnect()
-        }
-        startAggregateRefresh(newClient)
+        // Runtime owns shared transports. The former inbox client may now
+        // serve a passive shell or a selected detail, so adoption does not close it.
     }
 
     private func clearActiveEnvironment(disconnectClient: Bool = true) async {
+        beginForegroundBootstrap()
         let previousClient = client
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
         configurationTask?.cancel()
-        aggregateRefreshTask?.cancel()
+        cancelAggregateRefresh()
         archivedRefreshTask?.cancel()
         pollingTask = nil
         fallbackPollingTask = nil
@@ -3392,64 +3548,67 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         fallbackPollingTask?.cancel()
         configurationTask?.cancel()
         let generation = environmentGeneration
+        let bootstrapID = foregroundBootstrapID
+        let streamRetrySleep = aggregateStreamRetrySleep
         pollingTask = Task { [weak self] in
             while !Task.isCancelled,
-                self?.isCurrentSession(client: activeClient, generation: generation) == true
+                self?.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) == true
             {
                 do {
                     await activeClient.connect()
                     guard
-                        self?.isCurrentSession(
-                            client: activeClient,
-                            generation: generation
-                        ) == true
+                        self?.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) == true
                     else {
                         return
                     }
-                    let sequence = self?.latestShell?.snapshotSequence
-                    let events = await activeClient.shellEventBatches(after: sequence, reconnect: false)
+                    let subscription = try await activeClient.shellEventBatchesOnCurrentConnection()
+                    guard self?.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) == true
+                    else { return }
+                    if let previous = self?.activeShellConnectionID, previous != subscription.connectionID {
+                        self?.activeShellEpochHasSnapshot = false
+                        self?.activeHTTPAuthorityRevision &+= 1
+                        self?.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID, force: true)
+                    }
+                    self?.activeShellConnectionID = subscription.connectionID
+                    let events = subscription.events
                     // Re-bind self per event instead of holding it strongly across
                     // the indefinite stream, so the client can deinit mid-stream.
-                    for try await batch in events {
+                    shellEvents: for try await batch in events {
                         guard !Task.isCancelled,
                             let self,
-                            self.isCurrentSession(
-                                client: activeClient,
-                                generation: generation
-                            )
+                            self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID)
                         else {
                             break
                         }
-                        self.lastShellEventAt = .now
-                        self.emitConnection(.connected)
+                        let environments = try await self.runtime.environments()
+                        let connectionID = await activeClient.currentConnectionID()
+                        guard self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID),
+                              connectionID == subscription.connectionID,
+                              environments.contains(activeClient.environment) else { break }
                         var deltas: [ShellStreamItem] = []
                         for item in batch {
-                            switch item {
-                            case let .snapshot(shell):
-                                await self.consume(deltas: deltas, client: activeClient, generation: generation)
-                                deltas.removeAll(keepingCapacity: true)
-                                await self.consume(
-                                    shell: shell,
-                                    client: activeClient,
-                                    generation: generation,
-                                    refreshActiveThread: true
-                                )
-                            case .projectUpserted, .projectRemoved, .threadUpserted, .threadRemoved:
-                                deltas.append(item)
-                            case .refreshRequired:
-                                await self.consume(deltas: deltas, client: activeClient, generation: generation)
-                                deltas.removeAll(keepingCapacity: true)
-                                if let shell = try? await activeClient.shellSnapshot() {
-                                    await self.consume(
-                                        shell: shell,
-                                        client: activeClient,
-                                        generation: generation,
-                                        refreshActiveThread: true
-                                    )
-                                }
-                            case .synchronized:
-                                break
+                        switch item {
+                        case let .snapshot(shell):
+                            await self.consume(deltas: deltas, client: activeClient, generation: generation)
+                            deltas.removeAll(keepingCapacity: true)
+                            self.acceptActiveShell(shell, client: activeClient, environments: environments,
+                                                   socketAuthoritative: true, connectHeader: true)
+                        case .projectUpserted, .projectRemoved, .threadUpserted, .threadRemoved:
+                            guard self.activeStreamIsAuthoritative else {
+                                self.activeHTTPAuthorityRevision &+= 1
+                                self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID, force: true)
+                                break shellEvents
                             }
+                            deltas.append(item)
+                        case .refreshRequired:
+                            self.activeStreamIsAuthoritative = false
+                            self.activeHTTPAuthorityRevision &+= 1
+                            self.emitConnection(.reconnecting, detail: "Refreshing environment data.")
+                            self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID, force: true)
+                            break shellEvents
+                        case .synchronized:
+                            break
+                        }
                         }
                         await self.consume(deltas: deltas, client: activeClient, generation: generation)
                     }
@@ -3462,16 +3621,21 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
                 guard !Task.isCancelled,
                     let self,
-                    self.isCurrentSession(client: activeClient, generation: generation)
+                    self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID)
                 else {
                     return
                 }
                 self.lastShellEventAt = nil
+                if self.activeStreamIsAuthoritative {
+                    self.activeHTTPAuthorityRevision &+= 1
+                }
+                self.activeStreamIsAuthoritative = false
+                self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID, force: true)
                 self.emitConnection(
                     .reconnecting,
                     detail: "Live updates paused. Refreshing over HTTP."
                 )
-                do { try await Task.sleep(for: .milliseconds(250)) } catch { return }
+                do { try await streamRetrySleep(activeClient.environment.id, .seconds(20)) } catch { return }
             }
         }
         let fallbackPollingInitialDelay = fallbackPollingInitialDelay
@@ -3484,49 +3648,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             }
             while !Task.isCancelled {
                 guard let self,
-                      self.isCurrentSession(
-                          client: activeClient,
-                          generation: generation
-                      ) else {
+                      self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) else {
                     return
                 }
-                let socketIsSynchronized =
-                    await activeClient.liveConnectionActive()
-                    && self.lastShellEventAt != nil
-                if !socketIsSynchronized {
-                    self.emitConnection(
-                        .reconnecting,
-                        detail: "Live updates reconnecting. Refreshing over HTTP."
-                    )
-                    do {
-                        let shell = try await activeClient.shellSnapshot()
-                        guard !Task.isCancelled,
-                              self.isCurrentSession(
-                                  client: activeClient,
-                                  generation: generation
-                              ) else {
-                            return
-                        }
-                        await self.consumeFallbackShell(
-                            shell: shell,
-                            client: activeClient,
-                            generation: generation
-                        )
-                    } catch is CancellationError {
-                        return
-                    } catch {
-                        guard !Task.isCancelled,
-                              self.isCurrentSession(
-                                  client: activeClient,
-                                  generation: generation
-                              ) else {
-                            return
-                        }
-                        self.emitConnection(
-                            .reconnecting,
-                            detail: "Server unreachable. Retrying automatically."
-                        )
-                    }
+                if !self.activeStreamIsAuthoritative {
+                    self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID)
                 }
                 do {
                     try await Task.sleep(for: fallbackPollingInterval)
@@ -3540,10 +3666,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 for try await event in await activeClient.serverConfigEvents() {
                     guard !Task.isCancelled,
                           let self,
-                          self.isCurrentSession(
-                              client: activeClient,
-                              generation: generation
-                          ) else {
+                          self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID) else {
                         break
                     }
                     switch event {
@@ -3605,11 +3728,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     case .unrelated:
                         continue
                     }
-                    if let shell = self.latestShell {
-                        await self.emitSnapshot(
-                            shell, client: activeClient, expectedGeneration: generation
-                        )
-                    }
+                    let environments = try await self.runtime.environments()
+                    guard self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID),
+                          environments.contains(activeClient.environment), let activeEnvironment = self.activeEnvironment
+                    else { return }
+                    self.publish(self.makeSnapshot(
+                        environments: environments, activeEnvironment: activeEnvironment,
+                        connectionState: self.latestSnapshot?.connection.state ?? .reconnecting,
+                        connectionDetail: self.latestSnapshot?.connection.detail
+                    ))
                 }
             } catch is CancellationError {
                 return
@@ -3623,118 +3750,436 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     /// Non-active environments do not hold WebSocket subscriptions. A quiet
     /// HTTP refresh keeps their home rows and reachability useful without
     /// multiplying live streams or creating a high-frequency battery cost.
-    private func startAggregateRefresh(_ activeClient: T3Client) {
+    private func cancelAggregateRefresh() {
         aggregateRefreshTask?.cancel()
-        let generation = environmentGeneration
-        let refreshID = UUID()
-        let fastInterval = aggregateRefreshInterval
-        let idleInterval = aggregateIdleRefreshInterval
-        let failureInterval = aggregateFailureRefreshInterval
-        let sleep = aggregateRefreshSleep
-        let loadEnvironments = aggregateEnvironmentLoader
-        aggregateRefreshID = refreshID
-        aggregateRefreshTask = Task { [weak self] in
-            var nextInterval = fastInterval
-            var failureBackoffs: [String: Duration] = [:]
-            while !Task.isCancelled {
-                let elapsedInterval = nextInterval
+        aggregatePublishTask?.cancel()
+        aggregateRefreshWorkers.values.forEach { $0.task.cancel() }
+        aggregateRefreshWorkers.removeAll()
+        aggregatePublishTask = nil
+        aggregateRefreshID = nil
+    }
+
+    private func startAggregateRefresh(_ activeClient: T3Client, refreshImmediately: Bool = false) {
+        cancelAggregateRefresh()
+        guard isForeground else { return }
+        let context = AggregateRefreshContext(owner: self, activeClient: activeClient, refreshImmediately: refreshImmediately)
+        aggregateRefreshID = context.refreshID
+        aggregateRefreshTask = Task {
+            defer { context.cancelWorkers() }
+            while context.isCurrent {
+                var interval = context.fastInterval
                 do {
-                    try await sleep(nextInterval)
-                } catch {
-                    return
-                }
-                guard let self,
-                      self.aggregateRefreshID == refreshID,
-                      self.isCurrentSession(
-                          client: activeClient,
-                          generation: generation
-                      ),
-                      let activeEnvironment = self.activeEnvironment else {
-                    return
-                }
-                let environments: [Environment]
-                do {
-                    environments = try await loadEnvironments(self.runtime)
+                    let environments = try await context.loadEnvironments(context.runtime)
+                    guard context.isCurrent else { return }
+                    interval = context.reconcileWorkers(environments)
                 } catch is CancellationError where Task.isCancelled {
                     return
                 } catch {
-                    // Persistence can be briefly unavailable while another
-                    // actor atomically replaces the environment document.
-                    // Back off while keeping the loop alive for recovery.
-                    nextInterval = failureInterval
-                    continue
+                    interval = context.failureInterval
                 }
-                guard !Task.isCancelled,
-                      self.aggregateRefreshID == refreshID,
-                      self.isCurrentSession(
-                          client: activeClient,
-                          generation: generation
-                      ) else {
-                    return
-                }
-                let passiveEnvironments = environments.filter {
-                    $0.isEnabled && $0.id != activeEnvironment.id
-                }
-                guard !passiveEnvironments.isEmpty else {
-                    nextInterval = idleInterval
-                    continue
-                }
-                let passiveIDs = Set(passiveEnvironments.map(\.id))
-                failureBackoffs = failureBackoffs.reduce(into: [:]) { result, entry in
-                    guard passiveIDs.contains(entry.key) else { return }
-                    result[entry.key] = max(.zero, entry.value - elapsedInterval)
-                }
-                let refreshableEnvironments = passiveEnvironments.filter {
-                    failureBackoffs[$0.id, default: .zero] <= .zero
-                }
-                guard !refreshableEnvironments.isEmpty else {
-                    nextInterval = fastInterval
-                    continue
-                }
-                let loads = await self.loadEnvironmentShells(refreshableEnvironments)
-                guard !Task.isCancelled,
-                      self.aggregateRefreshID == refreshID,
-                      self.isCurrentSession(
-                          client: activeClient,
-                          generation: generation
-                      ) else {
-                    return
-                }
-                let shellsChanged = loads.contains { load in
-                    guard let shell = load.shell else { return false }
-                    return shell != self.shellsByEnvironmentID[load.environment.id]
-                }
-                let hasActiveWork = loads.contains { load in
-                    load.shell.map(Self.shellNeedsFrequentAggregateRefresh) == true
-                }
-                for load in loads {
-                    if load.shell == nil {
-                        failureBackoffs[load.environment.id] = failureInterval
-                    } else {
-                        failureBackoffs[load.environment.id] = nil
+                do { try await context.sleep(interval) } catch { return }
+            }
+        }
+    }
+
+    /// A worker retains runtime inputs, never its UI owner across a suspension.
+    /// This lets deinit cancel the exact outstanding shell/catalogue tasks.
+    @MainActor
+    private final class AggregateRefreshContext {
+        weak var owner: NativeFeatureClient?
+        let runtime: EnvironmentRuntime
+        let activeClient: T3Client
+        let generation: Int
+        let refreshID = UUID()
+        let refreshImmediately: Bool
+        let fastInterval: Duration
+        let idleInterval: Duration
+        let failureInterval: Duration
+        let shellTimeout: TimeInterval
+        let sleep: @Sendable (Duration) async throws -> Void
+        let peerSleep: @Sendable (String, Duration) async throws -> Void
+        let loadEnvironments: @Sendable (EnvironmentRuntime) async throws -> [Environment]
+        let streamRetrySleep: @Sendable (String, Duration) async throws -> Void
+        let publishSleep: @Sendable () async throws -> Void
+        let refreshReceipt: @MainActor @Sendable (NativePassiveShellReceipt) -> Void
+        var savedEnvironments: [Environment] = []
+        var dirtyEnvironmentIDs = Set<String>()
+
+        init(owner: NativeFeatureClient, activeClient: T3Client, refreshImmediately: Bool) {
+            self.owner = owner
+            self.refreshImmediately = refreshImmediately
+            runtime = owner.runtime
+            self.activeClient = activeClient
+            generation = owner.environmentGeneration
+            fastInterval = owner.aggregateRefreshInterval
+            idleInterval = owner.aggregateIdleRefreshInterval
+            failureInterval = owner.aggregateFailureRefreshInterval
+            shellTimeout = owner.environmentShellTimeoutInterval
+            sleep = owner.aggregateRefreshSleep
+            peerSleep = owner.aggregatePeerRefreshSleep
+            loadEnvironments = owner.aggregateEnvironmentLoader
+            streamRetrySleep = owner.aggregateStreamRetrySleep
+            publishSleep = owner.aggregatePublishSleep
+            refreshReceipt = owner.aggregateRefreshReceipt
+        }
+
+        var isCurrent: Bool {
+            !Task.isCancelled && owner?.isForeground == true && owner?.aggregateRefreshID == refreshID
+                && owner?.isCurrentSession(client: activeClient, generation: generation) == true
+        }
+
+        func cancelWorkers() {
+            guard let owner, owner.aggregateRefreshID == refreshID else { return }
+            owner.aggregateRefreshWorkers.values.forEach { $0.task.cancel() }
+            owner.aggregateRefreshWorkers.removeAll()
+            owner.aggregatePublishTask?.cancel()
+            owner.aggregatePublishTask = nil
+        }
+
+        func owns(_ environment: Environment) -> Bool {
+            isCurrent && owner?.aggregateRefreshWorkers[environment.id]?.environment == environment
+                && owner?.activeEnvironment?.id != environment.id
+        }
+
+        func reconcileWorkers(_ environments: [Environment]) -> Duration {
+            guard let owner, isCurrent else { return idleInterval }
+            savedEnvironments = environments
+            let passive = environments.filter { $0.isEnabled && $0.id != owner.activeEnvironment?.id }
+            let current = Dictionary(uniqueKeysWithValues: passive.map { ($0.id, $0) })
+            for (id, worker) in owner.aggregateRefreshWorkers where current[id] != worker.environment {
+                worker.task.cancel()
+                owner.aggregateRefreshWorkers[id] = nil
+            }
+            // Prune once per topology check, not once per shell result.
+            owner.reconcileEnvironmentLoads([], savedEnvironments: environments)
+            if owner.latestSnapshot?.environments != environments.map({
+                owner.mapEnvironment($0, activeID: owner.activeEnvironment?.id)
+            }) {
+                owner.publishAggregateSnapshot(environments)
+            }
+            for environment in passive where owner.aggregateRefreshWorkers[environment.id] == nil {
+                let state = PassiveShellState()
+                state.needsHTTP = refreshImmediately || owner.shellsByEnvironmentID[environment.id] == nil
+                let task = Task {
+                    await withTaskGroup(of: Void.self) { group in
+                        group.addTask { await self.refreshShell(environment, state: state) }
+                        group.addTask { await self.followShell(environment, state: state) }
+                        group.addTask { await self.refreshCatalogue(environment) }
                     }
                 }
-                self.reconcileEnvironmentLoads(loads, savedEnvironments: environments)
-                let currentConnection = self.latestSnapshot?.connection
-                    ?? FeatureConnection(
-                        state: .disconnected,
-                        environmentName: activeEnvironment.label,
-                        endpoint: activeEnvironment.httpBaseURL.absoluteString
+                owner.aggregateRefreshWorkers[environment.id] = (environment, task)
+            }
+            if let dirtyID = dirtyEnvironmentIDs.first { schedulePublication(dirtyID) }
+            return passive.isEmpty ? idleInterval : fastInterval
+        }
+
+        /// Revalidate membership after suspension, including endpoint edits.
+        /// Persistence errors retry; removed or disabled peers end their work.
+        func currentEnvironments(for environment: Environment) async throws -> [Environment]? {
+            guard isCurrent else { return nil }
+            let environments = try await runtime.environments()
+            guard isCurrent, environments.contains(environment), environment.isEnabled,
+                  owner?.activeEnvironment?.id != environment.id else { return nil }
+            return environments
+        }
+
+        func refreshShell(_ environment: Environment, state: PassiveShellState) async {
+            var interval = fastInterval
+            while owns(environment) {
+                do {
+                    if state.isLive { await state.waitForRepair() }
+                    if !state.needsHTTP {
+                        let delay = interval
+                        await withTaskGroup(of: Void.self) { group in
+                            group.addTask { try? await self.peerSleep(environment.id, delay) }
+                            group.addTask { await state.waitForRepair() }
+                            _ = await group.next()
+                            group.cancelAll()
+                        }
+                    }
+                    guard owns(environment) else { return }
+                    state.needsHTTP = false
+                    guard !state.isLive else { continue }
+                    guard try await currentEnvironments(for: environment) != nil else { return }
+                    let client = await runtime.client(for: environment)
+                    let epoch = state.epoch
+                    let authority = state.authorityRevision
+                    let connectionID = await client.currentConnectionID()
+                    guard owns(environment), epoch == state.epoch,
+                          authority == state.authorityRevision else { continue }
+                    let shell = try? await client.shellSnapshot(timeoutInterval: shellTimeout)
+                    defer { refreshReceipt(.httpFinished(environmentID: environment.id)) }
+                    let currentConnection = await client.currentConnectionID()
+                    guard let environments = try await currentEnvironments(for: environment) else { return }
+                    guard owns(environment), epoch == state.epoch,
+                          authority == state.authorityRevision, connectionID == currentConnection,
+                          !state.isLive else { continue }
+                    // The first authoritative response in this subscription epoch
+                    // may reset a cache left over from a restarted server.
+                    interval = applyShell(
+                        shell, client: client, environment: environment, saved: environments,
+                        replacingEpoch: state.cacheEpoch != epoch
                     )
-                let snapshot = self.makeSnapshot(
-                    environments: environments,
-                    activeEnvironment: activeEnvironment,
-                    connectionState: currentConnection.state,
-                    connectionDetail: currentConnection.detail
-                )
-                self.publish(snapshot)
-                if shellsChanged || hasActiveWork {
-                    nextInterval = fastInterval
-                } else {
-                    nextInterval = idleInterval
+                    if shell != nil { state.cacheEpoch = epoch }
+                } catch is CancellationError where Task.isCancelled {
+                    return
+                } catch {
+                    interval = failureInterval
                 }
             }
         }
+
+        func followShell(_ environment: Environment, state: PassiveShellState) async {
+            while owns(environment) {
+                do {
+                    guard try await currentEnvironments(for: environment) != nil else { return }
+                    let client = await runtime.client(for: environment)
+                    let subscription = try await client.shellEventsOnCurrentConnection()
+                    guard try await currentEnvironments(for: environment) != nil,
+                          owns(environment) else { return }
+                    if state.connectionID != subscription.connectionID {
+                        let needsRepair = state.connectionID != nil
+                            || owner?.shellsByEnvironmentID[environment.id] == nil
+                        state.connectionID = subscription.connectionID
+                        state.epoch = UUID()
+                        // A fresh bootstrap already read this peer. Its first
+                        // socket attempt need not duplicate that HTTP request.
+                        if needsRepair { state.requestRepair() }
+                    }
+                    let epoch = state.epoch
+                    state.isLive = false
+                    for try await item in subscription.events {
+                        let connectionID = await client.currentConnectionID()
+                        guard owns(environment), epoch == state.epoch,
+                              connectionID == subscription.connectionID else { break }
+                        guard applyStream(item, client: client, environment: environment, state: state)
+                        else { break }
+                    }
+                } catch is CancellationError where Task.isCancelled {
+                    return
+                } catch {
+                    // HTTP recovery belongs to this peer's single fallback loop.
+                }
+                guard owns(environment) else { return }
+                state.isLive = false
+                // A read begun before the stream lost completeness cannot
+                // repair that gap, even if the socket identity is unchanged.
+                state.authorityRevision &+= 1
+                markStreamPaused(environment)
+                state.requestRepair()
+                do { try await streamRetrySleep(environment.id, failureInterval) } catch { return }
+            }
+        }
+
+        func markStreamPaused(_ environment: Environment) {
+            guard let owner, owns(environment) else { return }
+            owner.environmentConnectionStates[environment.id] = .reconnecting
+            owner.environmentConnectionDetails[environment.id] = "Live updates paused. Refreshing over HTTP."
+            schedulePublication(environment.id)
+        }
+
+        func applyStream(
+            _ item: ShellStreamItem, client: T3Client, environment: Environment, state: PassiveShellState
+        ) -> Bool {
+            guard let owner, owns(environment) else { return false }
+            let current = owner.shellsByEnvironmentID[environment.id]
+            let shell: OrchestrationShellSnapshot
+            switch item {
+            case let .snapshot(snapshot):
+                if state.cacheEpoch == state.epoch, let current,
+                   current.snapshotSequence > snapshot.snapshotSequence {
+                    shell = current
+                } else {
+                    shell = snapshot
+                }
+                let remainingIDs = Set(shell.threads.map(\.id))
+                for removed in current?.threads ?? [] where !remainingIDs.contains(removed.id) {
+                    owner.clearRemovedThreadDetail(FeatureScopedID.thread(
+                        environmentID: environment.id, wireID: removed.id
+                    ))
+                }
+                state.authorityRevision &+= 1
+                state.cacheEpoch = state.epoch
+                state.isLive = true
+                state.needsHTTP = false
+            case .synchronized:
+                // A completion marker cannot make an arbitrary cached shell authoritative.
+                return state.isLive
+            case .refreshRequired:
+                return false
+            case .projectUpserted, .projectRemoved, .threadUpserted, .threadRemoved:
+                guard state.isLive, let current else { return false }
+                var projects = current.projects
+                var threads = current.threads
+                let sequence: Int
+                switch item {
+                case let .projectUpserted(nextSequence, project):
+                    sequence = nextSequence
+                    guard sequence > current.snapshotSequence else { return true }
+                    if let index = projects.firstIndex(where: { $0.id == project.id }) {
+                        projects[index] = project
+                    } else { projects.append(project) }
+                case let .projectRemoved(nextSequence, id):
+                    sequence = nextSequence
+                    guard sequence > current.snapshotSequence else { return true }
+                    projects.removeAll { $0.id == id }
+                case let .threadUpserted(nextSequence, thread):
+                    sequence = nextSequence
+                    guard sequence > current.snapshotSequence else { return true }
+                    owner.archivedThreadsByEnvironmentID[environment.id]?.removeAll {
+                        ($0.wireID ?? $0.id) == thread.id
+                    }
+                    if let index = threads.firstIndex(where: { $0.id == thread.id }) {
+                        threads[index] = thread
+                    } else { threads.append(thread) }
+                case let .threadRemoved(nextSequence, id):
+                    sequence = nextSequence
+                    guard sequence > current.snapshotSequence else { return true }
+                    threads.removeAll { $0.id == id }
+                    owner.clearRemovedThreadDetail(FeatureScopedID.thread(
+                        environmentID: environment.id, wireID: id
+                    ))
+                default:
+                    return false
+                }
+                shell = OrchestrationShellSnapshot(
+                    snapshotSequence: sequence, projects: projects, threads: threads, updatedAt: current.updatedAt
+                )
+            }
+            let membershipChanged = current?.projects.map(\.id) != shell.projects.map(\.id)
+                || current?.threads.map(\.id) != shell.threads.map(\.id)
+            owner.shellsByEnvironmentID[environment.id] = shell
+            owner.environmentClients[environment.id] = client
+            owner.environmentConnectionStates[environment.id] = .connected
+            owner.environmentConnectionDetails[environment.id] = nil
+            if membershipChanged { owner.rebuildEntityIndexes(savedEnvironments) }
+            owner.synchronizeActiveDetail(with: shell, environment: environment)
+            refreshReceipt(.shellApplied(environmentID: environment.id, sequence: shell.snapshotSequence))
+            schedulePublication(environment.id)
+            return true
+        }
+
+        func schedulePublication(_ environmentID: String) {
+            guard let owner, isCurrent else { return }
+            dirtyEnvironmentIDs.insert(environmentID)
+            guard owner.aggregatePublishTask == nil else { return }
+            owner.aggregatePublishTask = Task {
+                do { try await self.publishSleep() } catch { return }
+                let environments: [Environment]
+                do { environments = try await self.runtime.environments() }
+                catch {
+                    if self.isCurrent { self.owner?.aggregatePublishTask = nil }
+                    return
+                }
+                guard let owner = self.owner, self.isCurrent else { return }
+                self.savedEnvironments = environments
+                owner.reconcileEnvironmentLoads([], savedEnvironments: environments)
+                let dirty = self.dirtyEnvironmentIDs.filter {
+                    owner.aggregateRefreshWorkers[$0] != nil
+                }
+                self.dirtyEnvironmentIDs.removeAll()
+                owner.aggregatePublishTask = nil
+                guard !dirty.isEmpty else { return }
+                owner.publishAggregateSnapshot(self.savedEnvironments, changedEnvironmentIDs: dirty)
+            }
+        }
+
+        func applyShell(
+            _ shell: OrchestrationShellSnapshot?, client: T3Client,
+            environment: Environment, saved: [Environment], replacingEpoch: Bool = false
+        ) -> Duration {
+            guard let owner, isCurrent else { return failureInterval }
+            let previous = owner.shellsByEnvironmentID[environment.id]
+            let changed = shell.map { $0 != previous } ?? false
+            let membershipChanged = shell.map {
+                $0.projects.map(\.id) != previous?.projects.map(\.id)
+                    || $0.threads.map(\.id) != previous?.threads.map(\.id)
+            } ?? false
+            if replacingEpoch, let shell { owner.shellsByEnvironmentID[environment.id] = shell }
+            owner.applyEnvironmentLoad(EnvironmentShellLoad(
+                environment: environment, client: client, shell: shell, config: nil
+            ))
+            if membershipChanged { owner.rebuildEntityIndexes(saved) }
+            owner.publishAggregateSnapshot(saved, changedEnvironmentIDs: [environment.id])
+            guard let shell else { return failureInterval }
+            return changed || NativeFeatureClient.shellNeedsFrequentAggregateRefresh(shell)
+                ? fastInterval : idleInterval
+        }
+
+        func refreshCatalogue(_ environment: Environment) async {
+            while isCurrent && owner?.serverConfigsByEnvironmentID[environment.id] == nil {
+                do {
+                    guard try await currentEnvironments(for: environment) != nil else { return }
+                    // Never disconnect the shared client if this peer becomes selected.
+                    let probe = await runtime.ephemeralClient(for: environment)
+                    let config = try? await probe.serverConfig()
+                    await probe.disconnect()
+                    guard let environments = try await currentEnvironments(for: environment) else { return }
+                    if let config {
+                        applyCatalogue(config, environment: environment, saved: environments)
+                        return
+                    }
+                } catch is CancellationError where Task.isCancelled {
+                    return
+                } catch {
+                    // Retry a transient environment-document read just like a failed probe.
+                }
+                do { try await Task.sleep(for: failureInterval) } catch { return }
+            }
+        }
+
+        func applyCatalogue(_ config: ServerConfigSnapshot, environment: Environment, saved: [Environment]) {
+            guard let owner, isCurrent else { return }
+            owner.setServerConfig(config, environmentID: environment.id)
+            owner.publishAggregateSnapshot(saved, changedEnvironmentIDs: [environment.id])
+        }
+    }
+
+    @MainActor
+    private final class PassiveShellState {
+        var epoch = UUID()
+        var connectionID: UUID?
+        var cacheEpoch: UUID?
+        var authorityRevision = 0
+        var isLive = false
+        var needsHTTP = false
+        private var waiter: (id: UUID, continuation: CheckedContinuation<Void, Never>)?
+
+        func requestRepair() {
+            needsHTTP = true
+            waiter?.continuation.resume()
+            waiter = nil
+        }
+
+        func waitForRepair() async {
+            guard !needsHTTP else { return }
+            let id = UUID()
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    if Task.isCancelled || needsHTTP { continuation.resume() }
+                    else { waiter = (id, continuation) }
+                }
+            } onCancel: {
+                Task { @MainActor [weak self] in
+                    guard self?.waiter?.id == id else { return }
+                    self?.waiter?.continuation.resume()
+                    self?.waiter = nil
+                }
+            }
+        }
+    }
+
+    private func publishAggregateSnapshot(
+        _ environments: [Environment], changedEnvironmentIDs: Set<String>? = nil
+    ) {
+        guard let activeEnvironment else { return }
+        let connection = latestSnapshot?.connection
+        publish(makeSnapshot(
+            environments: environments, activeEnvironment: activeEnvironment,
+            connectionState: connection?.state ?? .disconnected,
+            connectionDetail: connection?.detail,
+            changedEnvironmentIDs: changedEnvironmentIDs
+        ))
     }
 
     nonisolated private static func shellNeedsFrequentAggregateRefresh(
@@ -3863,20 +4308,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 changedThreadIDs.insert(uiThreadID)
                 shouldRefreshArchived = true
                 threads.removeAll { $0.id == threadID }
-                latestDetails[uiThreadID] = nil
-                detailRenderCaches[uiThreadID] = nil
-                detailCacheRecency.removeAll { $0 == uiThreadID }
-                if activeThreadID == uiThreadID {
-                    resetDetailRefresh()
-                    resetDetailStream()
-                    activeThreadID = nil
-                    activeThreadEnvironmentID = nil
-                    activeRawThread = nil
-                    activeThreadSequence = nil
-                    activeThreadPage = nil
-                    threadHistoryEpoch &+= 1
-                    pendingOlderThreadPage = nil
-                }
+                clearRemovedThreadDetail(uiThreadID)
             case .snapshot, .synchronized, .refreshRequired:
                 continue
             }
@@ -3899,6 +4331,23 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         }
         if let activeThreadID, changedThreadIDs.contains(activeThreadID) {
             scheduleDetailRefresh(threadID: activeThreadID, client: client)
+        }
+    }
+
+    private func clearRemovedThreadDetail(_ uiThreadID: String) {
+        latestDetails[uiThreadID] = nil
+        detailRenderCaches[uiThreadID] = nil
+        detailCacheRecency.removeAll { $0 == uiThreadID }
+        if activeThreadID == uiThreadID {
+            resetDetailRefresh()
+            resetDetailStream()
+            activeThreadID = nil
+            activeThreadEnvironmentID = nil
+            activeRawThread = nil
+            activeThreadSequence = nil
+            activeThreadPage = nil
+            threadHistoryEpoch &+= 1
+            pendingOlderThreadPage = nil
         }
     }
 
@@ -4453,28 +4902,30 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             savedIDs.contains($0.key)
         }
 
-        for load in loads {
-            environmentClients[load.environment.id] = load.client
-            if let config = load.config {
-                setServerConfig(config, environmentID: load.environment.id)
-                if load.environment.id == activeEnvironment?.id {
-                    latestServerConfig = config
-                }
-            }
-            if let shell = load.shell {
-                if shell.snapshotSequence
-                    >= (shellsByEnvironmentID[load.environment.id]?.snapshotSequence ?? .min) {
-                    shellsByEnvironmentID[load.environment.id] = shell
-                }
-                environmentConnectionStates[load.environment.id] = .connected
-                environmentConnectionDetails[load.environment.id] = nil
-            } else {
-                environmentConnectionStates[load.environment.id] = .disconnected
-                environmentConnectionDetails[load.environment.id] =
-                    "That server is currently unreachable."
+        for load in loads { applyEnvironmentLoad(load) }
+        rebuildEntityIndexes(savedEnvironments)
+    }
+
+    private func applyEnvironmentLoad(_ load: EnvironmentShellLoad) {
+        environmentClients[load.environment.id] = load.client
+        if let config = load.config {
+            setServerConfig(config, environmentID: load.environment.id)
+            if load.environment.id == activeEnvironment?.id {
+                latestServerConfig = config
             }
         }
-        rebuildEntityIndexes(savedEnvironments)
+        if let shell = load.shell {
+            if shell.snapshotSequence
+                >= (shellsByEnvironmentID[load.environment.id]?.snapshotSequence ?? .min) {
+                shellsByEnvironmentID[load.environment.id] = shell
+            }
+            environmentConnectionStates[load.environment.id] = .connected
+            environmentConnectionDetails[load.environment.id] = nil
+        } else {
+            environmentConnectionStates[load.environment.id] = .disconnected
+            environmentConnectionDetails[load.environment.id] =
+                "That server is currently unreachable."
+        }
     }
 
     private func newestShell(
@@ -4599,42 +5050,60 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         indexedProvisionalRoutes = provisionalThreadRoutes
     }
 
+    /// A missing expectation means an ordinary publication. A present value
+    /// retains even an absent source cache or socket as an exact expectation.
+    private struct RefreshPublicationGuard {
+        let bootstrapID: UUID
+        let sourceSequence: Int?
+        let connectionID: UUID?
+        let activeAuthorityRevision: Int?
+    }
+
     private func refresh(client: T3Client, includeArchived: Bool = false) async throws {
         let environment = client.environment
         let generation = environmentGeneration
+        let bootstrapID = foregroundBootstrapID
+        let sourceSequence = shellsByEnvironmentID[environment.id]?.snapshotSequence
+        let authorityRevision = activeHTTPAuthorityRevision
+        let connectionID = await client.currentConnectionID()
+        guard !Task.isCancelled, bootstrapID == foregroundBootstrapID else { throw CancellationError() }
         let shell = try await client.shellSnapshot()
-        guard isKnownClient(client, environmentID: environment.id, generation: generation) else {
+        guard !Task.isCancelled, bootstrapID == foregroundBootstrapID,
+              isKnownClient(client, environmentID: environment.id, generation: generation) else {
+            throw CancellationError()
+        }
+        // Optional archive work cannot carry a pre-reload shell through another
+        // suspension and then establish authority in the replacement bootstrap.
+        let archivedShell = includeArchived ? try? await client.archivedShellSnapshot() : nil
+        let currentConnectionID = await client.currentConnectionID()
+        guard !Task.isCancelled, bootstrapID == foregroundBootstrapID,
+              isKnownClient(client, environmentID: environment.id, generation: generation),
+              connectionID == currentConnectionID,
+              sourceSequence == shellsByEnvironmentID[environment.id]?.snapshotSequence,
+              activeEnvironment?.id != environment.id || authorityRevision == activeHTTPAuthorityRevision else {
             throw CancellationError()
         }
         guard shell.snapshotSequence
-            >= (shellsByEnvironmentID[environment.id]?.snapshotSequence ?? .min) else {
-            return
-        }
-        shellsByEnvironmentID[environment.id] = shell
-        if activeEnvironment?.id == environment.id {
-            latestShell = shell
-        }
-        if includeArchived,
-           let archivedShell = try? await client.archivedShellSnapshot(),
-           isKnownClient(client, environmentID: environment.id, generation: generation) {
-            archivedThreadsByEnvironmentID[environment.id] = archivedShell.threads.map {
-                mapThread($0, environment: environment)
-            }
-            archivedShellThreadsByEnvironmentID[environment.id] = Dictionary(
-                uniqueKeysWithValues: archivedShell.threads.map { ($0.id, $0) }
-            )
-        }
-        await emitSnapshot(shell, client: client, expectedGeneration: generation)
+            >= (shellsByEnvironmentID[environment.id]?.snapshotSequence ?? .min) else { return }
+        await emitSnapshot(
+            shell, client: client, expectedGeneration: generation,
+            refreshGuard: RefreshPublicationGuard(
+                bootstrapID: bootstrapID, sourceSequence: sourceSequence, connectionID: connectionID,
+                activeAuthorityRevision: activeEnvironment?.id == environment.id ? authorityRevision : nil
+            ), archivedShell: archivedShell
+        )
     }
 
     private func scheduleArchivedRefresh(client: T3Client, environment: Environment) {
         archivedRefreshTask?.cancel()
         let generation = environmentGeneration
+        let bootstrapID = foregroundBootstrapID
         archivedRefreshTask = Task { [weak self] in
-            guard let self,
-                  let archivedShell = try? await client.archivedShellSnapshot(),
+            guard let self else { return }
+            defer { self.aggregateRefreshReceipt(.archiveFinished(environmentID: environment.id)) }
+            guard let archivedShell = try? await client.archivedShellSnapshot(),
                   !Task.isCancelled,
-                  self.isCurrentSession(client: client, generation: generation) else {
+                  self.isCurrentForeground(client, generation: generation, bootstrapID: bootstrapID) else {
                 return
             }
             self.archivedThreadsByEnvironmentID[environment.id] = archivedShell.threads.map {
@@ -4644,7 +5113,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 uniqueKeysWithValues: archivedShell.threads.map { ($0.id, $0) }
             )
             if let shell = self.latestShell {
-                await self.emitSnapshot(shell, client: client, expectedGeneration: generation)
+                await self.emitSnapshot(shell, client: client, expectedGeneration: generation, markSourceConnected: false)
             }
         }
     }
@@ -4727,16 +5196,32 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         _ shell: OrchestrationShellSnapshot,
         client sourceClient: T3Client,
         expectedGeneration: Int,
+        refreshGuard: RefreshPublicationGuard? = nil,
+        archivedShell: OrchestrationShellSnapshot? = nil,
         markSourceConnected: Bool = true
     ) async {
         let sourceEnvironment = sourceClient.environment
         guard !Task.isCancelled,
+              refreshGuard.map({
+                  $0.bootstrapID == foregroundBootstrapID
+                      && $0.sourceSequence == shellsByEnvironmentID[sourceEnvironment.id]?.snapshotSequence
+                      && ($0.activeAuthorityRevision.map { $0 == activeHTTPAuthorityRevision } ?? true)
+              }) ?? true,
               let environment = activeEnvironment,
               isKnownClient(
                   sourceClient, environmentID: sourceEnvironment.id, generation: expectedGeneration
               ) else { return }
         let environments = (try? await runtime.environments()) ?? [environment]
+        // The metadata await can outlive the socket too. Read its identity last,
+        // then validate all expectations together before any cache mutation.
+        let currentConnectionID = refreshGuard == nil ? nil : await sourceClient.currentConnectionID()
         guard !Task.isCancelled,
+              refreshGuard.map({ $0.connectionID == currentConnectionID }) ?? true,
+              refreshGuard.map({
+                  $0.bootstrapID == foregroundBootstrapID
+                      && $0.sourceSequence == shellsByEnvironmentID[sourceEnvironment.id]?.snapshotSequence
+                      && ($0.activeAuthorityRevision.map { $0 == activeHTTPAuthorityRevision } ?? true)
+              }) ?? true,
               isKnownClient(
                   sourceClient, environmentID: sourceEnvironment.id, generation: expectedGeneration
               ),
@@ -4746,6 +5231,14 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                   >= (shellsByEnvironmentID[sourceEnvironment.id]?.snapshotSequence ?? .min) else {
             return
         }
+        if let archivedShell {
+            archivedThreadsByEnvironmentID[sourceEnvironment.id] = archivedShell.threads.map {
+                mapThread($0, environment: sourceEnvironment)
+            }
+            archivedShellThreadsByEnvironmentID[sourceEnvironment.id] = Dictionary(
+                uniqueKeysWithValues: archivedShell.threads.map { ($0.id, $0) }
+            )
+        }
         shellsByEnvironmentID[sourceEnvironment.id] = shell
         if markSourceConnected {
             environmentConnectionStates[sourceEnvironment.id] = .connected
@@ -4753,6 +5246,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         }
         if sourceEnvironment.id == environment.id {
             latestShell = shell
+            if markSourceConnected {
+                activeHasHydrated = true
+                activeShellEpochHasSnapshot = true
+                activeHTTPAuthorityRevision &+= 1
+            }
         }
         rebuildEntityIndexes(environments)
         synchronizeActiveDetail(
@@ -4762,8 +5260,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let connectionState: FeatureConnection.State
         let connectionDetail: String?
         if sourceEnvironment.id == environment.id, markSourceConnected {
-            connectionState = .connected
-            connectionDetail = nil
+            connectionState = activeStreamIsAuthoritative ? .connected : .reconnecting
+            connectionDetail = activeStreamIsAuthoritative ? nil
+                : latestSnapshot?.connection.detail ?? "Live updates reconnecting. Refreshing over HTTP."
         } else {
             connectionState = latestSnapshot?.connection.state
                 ?? environmentConnectionStates[environment.id]
@@ -5051,14 +5550,29 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         environments: [Environment],
         activeEnvironment: Environment,
         connectionState: FeatureConnection.State,
-        connectionDetail: String? = nil
+        connectionDetail: String? = nil,
+        changedEnvironmentIDs: Set<String>? = nil
     ) -> FeatureSnapshot {
         let enabledEnvironments = environments.filter(\.isEnabled)
         let enabledIDs = Set(enabledEnvironments.map(\.id))
         shellProjectionCache = shellProjectionCache.filter { enabledIDs.contains($0.key) }
         var threads: [FeatureThread] = []
         var projects: [FeatureProject] = []
+        let previousThreads = changedEnvironmentIDs == nil ? [:]
+            : Dictionary(grouping: latestSnapshot?.threads ?? [], by: \.environmentID)
+        let previousProjects = changedEnvironmentIDs == nil ? [:]
+            : Dictionary(grouping: latestSnapshot?.projects ?? [], by: \.environmentID)
+        let previousEnvironments = Dictionary(uniqueKeysWithValues:
+            (latestSnapshot?.environments ?? []).map { ($0.id, $0) }
+        )
         for environment in enabledEnvironments {
+            if let changedEnvironmentIDs, !changedEnvironmentIDs.contains(environment.id),
+               previousEnvironments[environment.id]
+                == mapEnvironment(environment, activeID: activeEnvironment.id) {
+                threads.append(contentsOf: previousThreads[environment.id] ?? [])
+                projects.append(contentsOf: previousProjects[environment.id] ?? [])
+                continue
+            }
             // Take ownership while updating so the cache does not copy its
             // retained arrays when one row changes.
             var projection = shellProjectionCache.removeValue(forKey: environment.id)
@@ -5125,6 +5639,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let providersByEnvironment = enabledEnvironments.reduce(
             into: [String: [FeatureProvider]]()
         ) { catalogues, environment in
+            if let changedEnvironmentIDs, !changedEnvironmentIDs.contains(environment.id),
+               let previous = latestSnapshot?.providersByEnvironment?[environment.id] {
+                catalogues[environment.id] = previous
+                return
+            }
             guard let shell = shellsByEnvironmentID[environment.id] else { return }
             catalogues[environment.id] = mapProviders(
                 environmentID: environment.id,
@@ -6188,6 +6707,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             providerCatalogCache[environmentID] = nil
         }
         serverConfigsByEnvironmentID[environmentID] = config
+        aggregateRefreshReceipt(.configurationApplied(environmentID: environmentID))
     }
 
     private func mapProviders(
@@ -7808,4 +8328,12 @@ private enum NativeFeatureClientError: LocalizedError {
             "Couldn't check the remote status. Try reloading."
         }
     }
+}
+
+/// Deterministic receipts at the passive transport/publication boundary.
+enum NativePassiveShellReceipt: Sendable {
+    case shellApplied(environmentID: String, sequence: Int)
+    case httpFinished(environmentID: String)
+    case configurationApplied(environmentID: String)
+    case archiveFinished(environmentID: String)
 }

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -5336,16 +5336,28 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         } ?? []
         let retainedUsers = pendingUsers + loadedUsers
         let retainedIDs = Set(retainedUsers.map(\.id))
-        let retainedAnchor = retainedUsers.first?.id
-        let expandedHistory = retainedUsers.count > Self.initialThreadUserTurnLimit
+        let retainedPage = activeThreadPage
+        let retainedThreads = reconcile ? [activeRawThread, pendingHistory?.snapshot.thread].compactMap { $0 } : []
+        let retainedMessageIDs = Set(retainedThreads.flatMap { $0.messages.map(\.id) })
+        let retainedActivityIDs = Set(retainedThreads.flatMap { $0.activities.map(\.id) })
+        let retainedCheckpointTurns = Set(retainedThreads.flatMap { $0.checkpoints.map(\.turnId) })
         let turnLimit = max(Self.initialThreadUserTurnLimit, retainedUsers.count)
 
         func ownsReconciliationExtent() -> Bool {
             !reconcile || (
                 pendingOlderThreadPage == pendingHistory
+                    && threadHistoryEpoch == historyEpoch
+                    && activeThreadPage == retainedPage
                     && (activeThreadPage?.isLoading != true || pendingHistory != nil)
                     && loadedAnchor == activeRawThread?.messages.first(where: { $0.role == "user" })?.id
             )
+        }
+        func coversRetainedHistory(_ thread: OrchestrationThread) -> Bool {
+            // A server page can hit its raw-turn cap before reaching even one
+            // user row. Preserve every loaded collection, not just user anchors.
+            retainedMessageIDs.isSubset(of: Set(thread.messages.map(\.id)))
+                && retainedActivityIDs.isSubset(of: Set(thread.activities.map(\.id)))
+                && retainedCheckpointTurns.isSubset(of: Set(thread.checkpoints.map(\.turnId)))
         }
         func additionalTailUsers(in thread: OrchestrationThread) -> Int? {
             let users = thread.messages.filter { $0.role == "user" }
@@ -5369,8 +5381,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 || snapshot.snapshotSequence == activeThreadSequence || snapshot.thread == current {
             return
         }
-        if reconcile, expandedHistory, snapshot.page?.hasMore == true,
-           !snapshot.thread.messages.contains(where: { $0.id == retainedAnchor }) {
+        if reconcile, snapshot.page?.hasMore == true,
+           !coversRetainedHistory(snapshot.thread) {
             if let added = additionalTailUsers(in: snapshot.thread), added > 0 {
                 // One extra user turn needs one extra slot, not an automatic
                 // page of older history. Do not keep expanding a moving head.
@@ -5383,8 +5395,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 guard additionalTailUsers(in: snapshot.thread) == added else { return }
             }
             if snapshot.page?.hasMore == true,
-               !snapshot.thread.messages.contains(where: { $0.id == retainedAnchor }) {
-                // A deleted boundary or disjoint gap gets one full read. Never
+               !coversRetainedHistory(snapshot.thread) {
+                // Missing retained rows or a raw-turn cap get one full read. Never
                 // resurrect old rows by unioning them into a rewound thread.
                 snapshot = try await client.threadSnapshot(
                     id: route.wireID, timeoutInterval: threadSnapshotTimeoutInterval

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -1869,7 +1869,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             detail.page = cached.page
             markThreadCacheRecentlyUsed(route.uiID)
             startDetailStream(route, warmConnectionID: warmConnectionID)
-            return detail
+            if let shell = shellsByEnvironmentID[environment.id] {
+                synchronizeActiveDetail(with: shell, environment: environment)
+            }
+            return latestDetails[route.uiID] ?? detail
         }
         continuation.yield(.threadSync(id: route.uiID, state: .catchingUp))
         let snapshot: OrchestrationThreadDetailSnapshot
@@ -4788,10 +4791,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         guard activeThreadEnvironmentID == environment.id,
               let threadID = activeThreadID,
               let wireID = threadWireIDs[threadID],
-              let shellThread = shell.threads.first(where: { $0.id == wireID }),
-              var detail = latestDetails[threadID] else {
+              let shellThread = shell.threads.first(where: { $0.id == wireID }) else {
             return
         }
+        repairMissingCompletedTurn(shellThread, sequence: shell.snapshotSequence, threadID: threadID)
+        guard var detail = latestDetails[threadID] else { return }
 
         let backgroundLiveness = shellThread.backgroundLiveness
         let backgroundWorkIsActive = backgroundLiveness == .working
@@ -4826,6 +4830,33 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             : 0
         guard latestDetails[threadID] != detail else { return }
         publish(detail, threadID: threadID, renderCacheIsSource: true)
+    }
+
+    private func repairMissingCompletedTurn(
+        _ shellThread: OrchestrationThreadShell, sequence: Int, threadID: String
+    ) {
+        guard let rawThread = activeRawThread,
+              sequence > (activeThreadSequence ?? .min),
+              let completed = shellThread.latestTurn, completed.state == "completed",
+              let route = try? threadRoute(for: threadID) else { return }
+        if let messageID = completed.assistantMessageId {
+            if let message = rawThread.messages.first(where: { $0.id == messageID }),
+               !message.streaming { return }
+        } else if rawThread.latestTurn?.turnId == completed.turnId,
+                  rawThread.latestTurn?.state == completed.state,
+                  rawThread.latestTurn?.completedAt == completed.completedAt,
+                  !rawThread.messages.contains(where: {
+                      $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
+                  }) {
+            return
+        }
+
+        // Keep rendered partial text while requiring a snapshot that includes
+        // the shell's completion. Later detail events advance this same floor.
+        flushDetailPublish(route)
+        activeRawThread = nil
+        activeThreadSequence = sequence
+        scheduleDetailRefresh(threadID: threadID, client: route.client, force: true)
     }
 
     /// Thread-only shell changes stay granular so Home does not replace and

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -51,6 +51,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private let projectFaviconStore: FeatureProjectFaviconStore
     private let fallbackPollingInitialDelay: Duration
     private let fallbackPollingInterval: Duration
+    private static let shellReconciliationInterval: Duration = .seconds(30)
+    private let shellReconciliationSleep: @Sendable (String, Duration) async throws -> Void
     private let aggregateRefreshInterval: Duration
     private let aggregateIdleRefreshInterval: Duration
     private let aggregateFailureRefreshInterval: Duration
@@ -141,6 +143,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private var activeStreamIsAuthoritative = false
     private var pollingTask: Task<Void, Never>?
     private var fallbackPollingTask: Task<Void, Never>?
+    private var shellReconciliationTask: Task<Void, Never>?
     private var configurationTask: Task<Void, Never>?
     private var aggregateRefreshTask: Task<Void, Never>?
     private var aggregateRefreshID: UUID?
@@ -187,6 +190,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         projectFaviconStore: FeatureProjectFaviconStore = FeatureProjectFaviconStore(),
         fallbackPollingInitialDelay: Duration = .seconds(3),
         fallbackPollingInterval: Duration = .seconds(2),
+        shellReconciliationSleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
         aggregateRefreshInterval: Duration = NativeFeatureClient.defaultAggregateRefreshInterval,
         aggregateIdleRefreshInterval: Duration = NativeFeatureClient.defaultAggregateIdleRefreshInterval,
         aggregateFailureRefreshInterval: Duration = NativeFeatureClient.defaultAggregateFailureRefreshInterval,
@@ -247,6 +253,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         self.projectFaviconStore = projectFaviconStore
         self.fallbackPollingInitialDelay = fallbackPollingInitialDelay
         self.fallbackPollingInterval = fallbackPollingInterval
+        self.shellReconciliationSleep = shellReconciliationSleep
         self.aggregateRefreshInterval = aggregateRefreshInterval
         self.aggregateIdleRefreshInterval = aggregateIdleRefreshInterval
         self.aggregateFailureRefreshInterval = aggregateFailureRefreshInterval
@@ -274,6 +281,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         activeHydrationTask?.cancel()
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
+        shellReconciliationTask?.cancel()
         configurationTask?.cancel()
         aggregateRefreshTask?.cancel()
         aggregatePublishTask?.cancel()
@@ -339,6 +347,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         activeStreamIsAuthoritative = false
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
+        shellReconciliationTask?.cancel()
         configurationTask?.cancel()
         archivedRefreshTask?.cancel()
         archivedRefreshTask = nil
@@ -384,7 +393,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     self.activeHydrationPending = false
                     self.acceptActiveShell(shell, client: activeClient, environments: environments,
                                            socketAuthoritative: false, connectHeader: false)
-                } else {
+                } else if !self.activeStreamIsAuthoritative {
                     self.emitConnection(
                         self.activeHasHydrated ? .reconnecting : .disconnected,
                         detail: "Server unreachable. Retrying automatically."
@@ -1069,10 +1078,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
               selectedEnvironment == environment else { return }
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
+        shellReconciliationTask?.cancel()
         configurationTask?.cancel()
         archivedRefreshTask?.cancel()
         pollingTask = nil
         fallbackPollingTask = nil
+        shellReconciliationTask = nil
         configurationTask = nil
         aggregateRefreshTask = nil
         aggregateRefreshID = nil
@@ -1096,11 +1107,13 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let previousClient = client
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
+        shellReconciliationTask?.cancel()
         configurationTask?.cancel()
         cancelAggregateRefresh()
         archivedRefreshTask?.cancel()
         pollingTask = nil
         fallbackPollingTask = nil
+        shellReconciliationTask = nil
         configurationTask = nil
         aggregateRefreshTask = nil
         aggregateRefreshID = nil
@@ -3662,6 +3675,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private func startPolling(_ activeClient: T3Client) {
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
+        shellReconciliationTask?.cancel()
         configurationTask?.cancel()
         let generation = environmentGeneration
         let bootstrapID = foregroundBootstrapID
@@ -3771,11 +3785,25 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 if !self.activeStreamIsAuthoritative {
                     self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID)
                 }
-                do {
-                    try await Task.sleep(for: fallbackPollingInterval)
-                } catch {
-                    return
-                }
+                do { try await Task.sleep(for: fallbackPollingInterval) }
+                catch { return }
+            }
+        }
+        let reconciliationSleep = shellReconciliationSleep
+        shellReconciliationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                // Ping health cannot prove shell completeness. Keep the faster
+                // outage fallback independent of this quiet reconciliation.
+                do { try await reconciliationSleep(activeClient.environment.id, Self.shellReconciliationInterval) }
+                catch { return }
+                guard let self,
+                      self.isCurrentForeground(activeClient, generation: generation, bootstrapID: bootstrapID)
+                else { return }
+                guard self.activeStreamIsAuthoritative else { continue }
+                self.requestActiveShellHydration(activeClient, bootstrapID: bootstrapID)
+                // One owner coalesces all HTTP requests. The next interval starts
+                // after this read drains, including failures and supersession.
+                await self.activeHydrationTask?.value
             }
         }
         configurationTask = Task { [weak self] in
@@ -3915,6 +3943,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let shellTimeout: TimeInterval
         let sleep: @Sendable (Duration) async throws -> Void
         let peerSleep: @Sendable (String, Duration) async throws -> Void
+        let reconciliationSleep: @Sendable (String, Duration) async throws -> Void
         let loadEnvironments: @Sendable (EnvironmentRuntime) async throws -> [Environment]
         let streamRetrySleep: @Sendable (String, Duration) async throws -> Void
         let publishSleep: @Sendable () async throws -> Void
@@ -3934,6 +3963,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             shellTimeout = owner.environmentShellTimeoutInterval
             sleep = owner.aggregateRefreshSleep
             peerSleep = owner.aggregatePeerRefreshSleep
+            reconciliationSleep = owner.shellReconciliationSleep
             loadEnvironments = owner.aggregateEnvironmentLoader
             streamRetrySleep = owner.aggregateStreamRetrySleep
             publishSleep = owner.aggregatePublishSleep
@@ -4004,19 +4034,27 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             var interval = fastInterval
             while owns(environment) {
                 do {
-                    if state.isLive { await state.waitForRepair() }
-                    if !state.needsHTTP {
+                    let wasLive = state.isLive
+                    if wasLive || !state.needsHTTP {
                         let delay = interval
                         await withTaskGroup(of: Void.self) { group in
-                            group.addTask { try? await self.peerSleep(environment.id, delay) }
-                            group.addTask { await state.waitForRepair() }
+                            group.addTask {
+                                if wasLive {
+                                    try? await self.reconciliationSleep(environment.id, NativeFeatureClient.shellReconciliationInterval)
+                                } else {
+                                    try? await self.peerSleep(environment.id, delay)
+                                }
+                            }
+                            group.addTask { await state.waitForRepair(untilLive: !wasLive) }
                             _ = await group.next()
                             group.cancelAll()
                         }
                     }
                     guard owns(environment) else { return }
+                    // A newly authoritative snapshot starts the quiet cadence;
+                    // it must not turn a fallback wake-up into a duplicate read.
+                    if !wasLive && state.isLive { continue }
                     state.needsHTTP = false
-                    guard !state.isLive else { continue }
                     guard try await currentEnvironments(for: environment) != nil else { return }
                     let client = await runtime.client(for: environment)
                     let epoch = state.epoch
@@ -4029,8 +4067,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                     let currentConnection = await client.currentConnectionID()
                     guard let environments = try await currentEnvironments(for: environment) else { return }
                     guard owns(environment), epoch == state.epoch,
-                          authority == state.authorityRevision, connectionID == currentConnection,
-                          !state.isLive else { continue }
+                          authority == state.authorityRevision, connectionID == currentConnection else { continue }
+                    // HTTP failure alone says nothing about the connected stream.
+                    if shell == nil && state.isLive { continue }
                     // A validated HTTP snapshot remains in this socket's cache
                     // epoch without claiming that the live stream is complete.
                     if shell != nil { owner?.shellConnectionIDsByEnvironmentID[environment.id] = connectionID }
@@ -4122,8 +4161,10 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 owner.shellConnectionIDsByEnvironmentID[environment.id] = state.connectionID
                 state.authorityRevision &+= 1
                 state.cacheEpoch = state.epoch
+                let wasLive = state.isLive
                 state.isLive = true
                 state.needsHTTP = false
+                if !wasLive { state.wakeWaiter() }
             case .synchronized:
                 // A completion marker cannot make an arbitrary cached shell authoritative.
                 return state.isLive
@@ -4269,16 +4310,20 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
         func requestRepair() {
             needsHTTP = true
+            wakeWaiter()
+        }
+
+        func wakeWaiter() {
             waiter?.continuation.resume()
             waiter = nil
         }
 
-        func waitForRepair() async {
-            guard !needsHTTP else { return }
+        func waitForRepair(untilLive: Bool = false) async {
+            guard !needsHTTP, !(untilLive && isLive) else { return }
             let id = UUID()
             await withTaskCancellationHandler {
                 await withCheckedContinuation { continuation in
-                    if Task.isCancelled || needsHTTP { continuation.resume() }
+                    if Task.isCancelled || needsHTTP || (untilLive && isLive) { continuation.resume() }
                     else { waiter = (id, continuation) }
                 }
             } onCancel: {
@@ -5375,10 +5420,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             throw CancellationError()
         }
         guard ownsReconciliationExtent() else { return }
+        // A later delivered cursor does not prove that every earlier row arrived.
+        // Independent HTTP repair must compare content, even at an equal watermark.
         if reconcile, pendingHistory == nil, let current = activeRawThread,
            snapshot.snapshotSequence >= (activeThreadSequence ?? 0),
-           snapshot.page?.threadSequence.map({ $0 <= (activeThreadSequence ?? 0) }) == true
-                || snapshot.snapshotSequence == activeThreadSequence || snapshot.thread == current {
+           snapshot.thread == current {
             return
         }
         if reconcile, snapshot.page?.hasMore == true,

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -96,14 +96,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var pendingBootstrapSubmissions: [PendingBootstrapSubmission] = []
     private var pendingTurnSubmissions: [String: PendingTurnSubmission] = [:]
-    private struct AcceptedSendRefresh: Sendable {
+    private struct AcceptedCommandRefresh: Sendable {
         let id: UUID
         let client: T3Client
         let generation: Int
         let task: Task<Void, Never>
         var pending = false
+        var needsDetail: Bool
     }
-    private var acceptedSendRefreshes: [String: AcceptedSendRefresh] = [:]
+    private var acceptedCommandRefreshes: [String: AcceptedCommandRefresh] = [:]
     private var approvalRoutes: [String: PendingRequestRoute] = [:]
     private var inputRoutes: [String: PendingRequestRoute] = [:]
     private var relayDeviceSessionIDs: Set<String> = []
@@ -223,7 +224,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailCatchUpTask?.cancel()
         detailPublishTask?.cancel()
         projectFaviconRefreshTasks.values.forEach { $0.cancel() }
-        acceptedSendRefreshes.values.forEach { $0.task.cancel() }
+        acceptedCommandRefreshes.values.forEach { $0.task.cancel() }
         continuation.finish()
     }
 
@@ -472,7 +473,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
-            cancelAcceptedSendRefreshes(environmentID: id)
+            cancelAcceptedCommandRefreshes(environmentID: id)
             environmentConnectionStates[id] = .disconnected
             environmentConnectionDetails[id] = nil
             environmentClients[id] = nil
@@ -491,7 +492,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if environment?.kind == .managedDPoP {
             try await runtime.revokeCredential(id: id)
         }
-        cancelAcceptedSendRefreshes(environmentID: id)
+        cancelAcceptedCommandRefreshes(environmentID: id)
         try await runtime.remove(id: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)
@@ -917,7 +918,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func clearEnvironmentState(preserveEnvironmentSnapshots: Bool = false) {
         environmentGeneration &+= 1
-        cancelAcceptedSendRefreshes()
+        cancelAcceptedCommandRefreshes()
         resetDetailRefresh()
         resetDetailStream()
         archivedRefreshTask?.cancel()
@@ -1841,7 +1842,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func loadThread(id: String, fresh: Bool) async throws -> FeatureThreadDetail {
         let route = try threadRoute(for: id)
         if let previous = activeThreadID, previous != route.uiID {
-            cancelAcceptedSendRefreshes(threadID: previous)
+            cancelAcceptedCommandRefreshes(threadID: previous)
         }
         let client = route.client
         let environment = client.environment
@@ -1985,7 +1986,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func releaseThread(id: String) {
-        cancelAcceptedSendRefreshes(threadID: id)
+        cancelAcceptedCommandRefreshes(threadID: id)
         guard activeThreadID == id else { return }
         retainActiveThread()
         resetDetailRefresh()
@@ -2146,38 +2147,48 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if pendingTurnSubmissions[route.uiID]?.identity == pending.identity {
             pendingTurnSubmissions[route.uiID] = nil
         }
-        scheduleAcceptedSendRefresh(threadID: route.uiID, client: client, generation: generation)
+        scheduleAcceptedCommandRefresh(threadID: route.uiID, client: client, generation: generation)
     }
 
-    /// Acceptance unlocks the composer immediately. Retain HTTP convergence
-    /// separately for connections whose live events have not caught up yet.
-    private func scheduleAcceptedSendRefresh(threadID: String, client: T3Client, generation: Int) {
-        if let current = acceptedSendRefreshes[threadID],
-           current.client === client, current.generation == generation {
-            acceptedSendRefreshes[threadID]?.pending = true
+    /// Complete accepted commands without waiting for optional reads. A send
+    /// needs detail and shell recovery; Stop retains its shell-only refresh.
+    private func scheduleAcceptedCommandRefresh(
+        threadID: String, client: T3Client, generation: Int, refreshDetail: Bool = true
+    ) {
+        guard isKnownClient(client, environmentID: client.environment.id, generation: generation) else {
             return
         }
-        cancelAcceptedSendRefreshes(threadID: threadID)
+        if let current = acceptedCommandRefreshes[threadID],
+           current.client === client, current.generation == generation {
+            acceptedCommandRefreshes[threadID]?.pending = true
+            acceptedCommandRefreshes[threadID]?.needsDetail = current.needsDetail || refreshDetail
+            return
+        }
+        cancelAcceptedCommandRefreshes(threadID: threadID)
         let id = UUID()
         let task = Task { [weak self] in
-            while self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true {
-                self?.acceptedSendRefreshes[threadID]?.pending = false
-                try? await self?.refreshThread(id: threadID, client: client)
-                guard self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true else { break }
+            while self?.isCurrentAcceptedCommandRefresh(threadID: threadID, id: id) == true {
+                let needsDetail = self?.acceptedCommandRefreshes[threadID]?.needsDetail == true
+                self?.acceptedCommandRefreshes[threadID]?.needsDetail = false
+                self?.acceptedCommandRefreshes[threadID]?.pending = false
+                if needsDetail {
+                    try? await self?.refreshThread(id: threadID, client: client)
+                }
+                guard self?.isCurrentAcceptedCommandRefresh(threadID: threadID, id: id) == true else { break }
                 try? await self?.refresh(client: client)
-                guard self?.acceptedSendRefreshes[threadID]?.pending == true else { break }
+                guard self?.acceptedCommandRefreshes[threadID]?.pending == true else { break }
             }
-            if self?.acceptedSendRefreshes[threadID]?.id == id {
-                self?.acceptedSendRefreshes[threadID] = nil
+            if self?.acceptedCommandRefreshes[threadID]?.id == id {
+                self?.acceptedCommandRefreshes[threadID] = nil
             }
         }
-        acceptedSendRefreshes[threadID] = AcceptedSendRefresh(
-            id: id, client: client, generation: generation, task: task
+        acceptedCommandRefreshes[threadID] = AcceptedCommandRefresh(
+            id: id, client: client, generation: generation, task: task, needsDetail: refreshDetail
         )
     }
 
-    private func isCurrentAcceptedSendRefresh(threadID: String, id: UUID) -> Bool {
-        guard !Task.isCancelled, let refresh = acceptedSendRefreshes[threadID], refresh.id == id else {
+    private func isCurrentAcceptedCommandRefresh(threadID: String, id: UUID) -> Bool {
+        guard !Task.isCancelled, let refresh = acceptedCommandRefreshes[threadID], refresh.id == id else {
             return false
         }
         return isKnownClient(
@@ -2185,12 +2196,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         )
     }
 
-    private func cancelAcceptedSendRefreshes(threadID: String? = nil, environmentID: String? = nil) {
-        for (key, refresh) in acceptedSendRefreshes {
+    private func cancelAcceptedCommandRefreshes(threadID: String? = nil, environmentID: String? = nil) {
+        for (key, refresh) in acceptedCommandRefreshes {
             guard threadID.map({ $0 == key }) ?? true,
                   environmentID.map({ $0 == refresh.client.environment.id }) ?? true else { continue }
             refresh.task.cancel()
-            acceptedSendRefreshes[key] = nil
+            acceptedCommandRefreshes[key] = nil
         }
     }
 
@@ -2207,12 +2218,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func cancelTurn(threadID: String) async throws {
         let route = try threadRoute(for: threadID)
+        let generation = environmentGeneration
         let turnID = shellsByEnvironmentID[route.environmentID]?.threads
             .first(where: { $0.id == route.wireID })?
             .latestTurn?
             .turnId
         _ = try await route.client.interrupt(threadID: route.wireID, turnID: turnID)
-        try? await refresh(client: route.client)
+        scheduleAcceptedCommandRefresh(
+            threadID: route.uiID, client: route.client, generation: generation, refreshDetail: false
+        )
     }
 
     func resolveApproval(id: String, decision: FeatureApprovalDecision) async throws {

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -96,6 +96,14 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var pendingBootstrapSubmissions: [PendingBootstrapSubmission] = []
     private var pendingTurnSubmissions: [String: PendingTurnSubmission] = [:]
+    private struct AcceptedSendRefresh: Sendable {
+        let id: UUID
+        let client: T3Client
+        let generation: Int
+        let task: Task<Void, Never>
+        var pending = false
+    }
+    private var acceptedSendRefreshes: [String: AcceptedSendRefresh] = [:]
     private var approvalRoutes: [String: PendingRequestRoute] = [:]
     private var inputRoutes: [String: PendingRequestRoute] = [:]
     private var relayDeviceSessionIDs: Set<String> = []
@@ -215,6 +223,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailCatchUpTask?.cancel()
         detailPublishTask?.cancel()
         projectFaviconRefreshTasks.values.forEach { $0.cancel() }
+        acceptedSendRefreshes.values.forEach { $0.task.cancel() }
         continuation.finish()
     }
 
@@ -463,6 +472,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     func setEnvironmentEnabled(id: String, enabled: Bool) async throws {
         try await runtime.setEnabled(id: id, enabled: enabled)
         if !enabled {
+            cancelAcceptedSendRefreshes(environmentID: id)
             environmentConnectionStates[id] = .disconnected
             environmentConnectionDetails[id] = nil
             environmentClients[id] = nil
@@ -481,6 +491,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if environment?.kind == .managedDPoP {
             try await runtime.revokeCredential(id: id)
         }
+        cancelAcceptedSendRefreshes(environmentID: id)
         try await runtime.remove(id: id)
         if removesActiveEnvironment {
             await clearActiveEnvironment(disconnectClient: false)
@@ -906,6 +917,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     private func clearEnvironmentState(preserveEnvironmentSnapshots: Bool = false) {
         environmentGeneration &+= 1
+        cancelAcceptedSendRefreshes()
         resetDetailRefresh()
         resetDetailStream()
         archivedRefreshTask?.cancel()
@@ -1828,6 +1840,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
     func loadThread(id: String, fresh: Bool) async throws -> FeatureThreadDetail {
         let route = try threadRoute(for: id)
+        if let previous = activeThreadID, previous != route.uiID {
+            cancelAcceptedSendRefreshes(threadID: previous)
+        }
         let client = route.client
         let environment = client.environment
         let generation = environmentGeneration
@@ -1970,6 +1985,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func releaseThread(id: String) {
+        cancelAcceptedSendRefreshes(threadID: id)
         guard activeThreadID == id else { return }
         retainActiveThread()
         resetDetailRefresh()
@@ -2130,11 +2146,52 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         if pendingTurnSubmissions[route.uiID]?.identity == pending.identity {
             pendingTurnSubmissions[route.uiID] = nil
         }
-        // Live sync reconciles these snapshots. Refreshes are opportunistic
-        // after the accepted command so transient reads cannot invite a
-        // duplicate user turn.
-        try? await refreshThread(id: route.uiID, client: client)
-        try? await refresh(client: client)
+        scheduleAcceptedSendRefresh(threadID: route.uiID, client: client, generation: generation)
+    }
+
+    /// Acceptance unlocks the composer immediately. Retain HTTP convergence
+    /// separately for connections whose live events have not caught up yet.
+    private func scheduleAcceptedSendRefresh(threadID: String, client: T3Client, generation: Int) {
+        if let current = acceptedSendRefreshes[threadID],
+           current.client === client, current.generation == generation {
+            acceptedSendRefreshes[threadID]?.pending = true
+            return
+        }
+        cancelAcceptedSendRefreshes(threadID: threadID)
+        let id = UUID()
+        let task = Task { [weak self] in
+            while self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true {
+                self?.acceptedSendRefreshes[threadID]?.pending = false
+                try? await self?.refreshThread(id: threadID, client: client)
+                guard self?.isCurrentAcceptedSendRefresh(threadID: threadID, id: id) == true else { break }
+                try? await self?.refresh(client: client)
+                guard self?.acceptedSendRefreshes[threadID]?.pending == true else { break }
+            }
+            if self?.acceptedSendRefreshes[threadID]?.id == id {
+                self?.acceptedSendRefreshes[threadID] = nil
+            }
+        }
+        acceptedSendRefreshes[threadID] = AcceptedSendRefresh(
+            id: id, client: client, generation: generation, task: task
+        )
+    }
+
+    private func isCurrentAcceptedSendRefresh(threadID: String, id: UUID) -> Bool {
+        guard !Task.isCancelled, let refresh = acceptedSendRefreshes[threadID], refresh.id == id else {
+            return false
+        }
+        return isKnownClient(
+            refresh.client, environmentID: refresh.client.environment.id, generation: refresh.generation
+        )
+    }
+
+    private func cancelAcceptedSendRefreshes(threadID: String? = nil, environmentID: String? = nil) {
+        for (key, refresh) in acceptedSendRefreshes {
+            guard threadID.map({ $0 == key }) ?? true,
+                  environmentID.map({ $0 == refresh.client.environment.id }) ?? true else { continue }
+            refresh.task.cancel()
+            acceptedSendRefreshes[key] = nil
+        }
     }
 
     private func messageWasCommitted(

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -52,6 +52,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private let aggregateRefreshSleep: @Sendable (Duration) async throws -> Void
     private let environmentShellTimeoutInterval: TimeInterval
     private let threadSnapshotTimeoutInterval: TimeInterval
+    private let detailPublicationSleep: @Sendable () async throws -> Void
     private let catchUpDelay: @Sendable () async throws -> Void
     private let threadRetryDelay: @Sendable (Int) async throws -> Void
     private let aggregateEnvironmentLoader: @Sendable (EnvironmentRuntime) async throws -> [Environment]
@@ -155,6 +156,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         },
         environmentShellTimeoutInterval: TimeInterval = 6,
         threadSnapshotTimeoutInterval: TimeInterval = 8,
+        detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(80))
+        },
         catchUpDelay: @escaping @Sendable () async throws -> Void = {
             try await Task.sleep(for: .seconds(2))
         },
@@ -195,6 +199,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         self.aggregateRefreshSleep = aggregateRefreshSleep
         self.environmentShellTimeoutInterval = environmentShellTimeoutInterval
         self.threadSnapshotTimeoutInterval = threadSnapshotTimeoutInterval
+        self.detailPublicationSleep = detailPublicationSleep
         self.catchUpDelay = catchUpDelay
         self.threadRetryDelay = threadRetryDelay
         self.aggregateEnvironmentLoader = aggregateEnvironmentLoader
@@ -4263,7 +4268,8 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 scheduleDetailRefresh(threadID: route.uiID, client: route.client, force: true)
             }
         }
-        if serverConfigsByEnvironmentID[route.environmentID]?.threadResumeCompletionMarker != true {
+        if !detailWasSynchronized,
+           serverConfigsByEnvironmentID[route.environmentID]?.threadResumeCompletionMarker != true {
             markDetailSynchronized(route)
         }
     }
@@ -4275,8 +4281,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         pendingDetailRenderMutations.formUnion(mutation)
         guard detailPublishTask == nil else { return }
         let streamGeneration = detailStreamGeneration
+        let sleep = detailPublicationSleep
         detailPublishTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(80))
+            do { try await sleep() } catch { return }
             guard let self else { return }
             guard !Task.isCancelled,
                   self.detailStreamGeneration == streamGeneration,
@@ -4799,22 +4806,26 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
 
         let backgroundLiveness = shellThread.backgroundLiveness
         let backgroundWorkIsActive = backgroundLiveness == .working
-        let sessionIsLive = shellThread.session?.status == "starting"
-            || shellThread.session?.status == "running"
-        detail.thread.state = Self.resolveThreadState(
-            latestTurn: shellThread.latestTurn,
-            session: shellThread.session,
-            hasApprovals: !detail.approvals.isEmpty,
-            hasUserInput: !detail.userInputs.isEmpty,
-            backgroundLiveness: backgroundLiveness
-        )
-        detail.thread.workingStartedAt = workingStartedAt(
-            latestTurn: shellThread.latestTurn,
-            session: shellThread.session,
-            backgroundWorkIsActive: backgroundWorkIsActive,
-            fallbackUpdatedAt: shellThread.updatedAt
-        )
-        if shell.snapshotSequence >= (activeThreadSequence ?? .min) {
+        let shellMetadataIsCurrent = shell.snapshotSequence >= (activeThreadSequence ?? .min)
+        let latestTurn = shellMetadataIsCurrent ? shellThread.latestTurn : activeRawThread?.latestTurn
+        let session = shellMetadataIsCurrent ? shellThread.session : activeRawThread?.session
+        let sessionIsLive = session?.status == "starting" || session?.status == "running"
+        if shellMetadataIsCurrent || activeRawThread != nil {
+            detail.thread.state = Self.resolveThreadState(
+                latestTurn: latestTurn,
+                session: session,
+                hasApprovals: !detail.approvals.isEmpty,
+                hasUserInput: !detail.userInputs.isEmpty,
+                backgroundLiveness: backgroundLiveness
+            )
+            detail.thread.workingStartedAt = workingStartedAt(
+                latestTurn: latestTurn,
+                session: session,
+                backgroundWorkIsActive: backgroundWorkIsActive,
+                fallbackUpdatedAt: shellThread.updatedAt
+            )
+        }
+        if shellMetadataIsCurrent {
             applyShellMetadataAuthority(from: shellThread, to: &detail.thread)
             if let compaction = detailRenderCaches[threadID]?.compaction {
                 detail.isCompacting = compaction.isActive(
@@ -4836,20 +4847,28 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         _ shellThread: OrchestrationThreadShell, sequence: Int, threadID: String
     ) {
         guard let rawThread = activeRawThread,
-              sequence > (activeThreadSequence ?? .min),
+              sequence >= (activeThreadSequence ?? .min),
               let completed = shellThread.latestTurn, completed.state == "completed",
               let route = try? threadRoute(for: threadID) else { return }
         if let messageID = completed.assistantMessageId {
             if let message = rawThread.messages.first(where: { $0.id == messageID }),
-               !message.streaming { return }
+               !message.streaming {
+                flushDetailPublish(route)
+                return
+            }
         } else if rawThread.latestTurn?.turnId == completed.turnId,
                   rawThread.latestTurn?.state == completed.state,
                   rawThread.latestTurn?.completedAt == completed.completedAt,
                   !rawThread.messages.contains(where: {
                       $0.role == "assistant" && $0.turnId == completed.turnId && $0.streaming
                   }) {
+            flushDetailPublish(route)
             return
         }
+
+        // Equal-cursor completion may flush final content, but only a newer
+        // shell can prove that detail is missing and require HTTP repair.
+        guard sequence > (activeThreadSequence ?? .min) else { return }
 
         // Keep rendered partial text while requiring a snapshot that includes
         // the shell's completion. Later detail events advance this same floor.

--- a/apps/swift-ios/App/NativeFeatureClient.swift
+++ b/apps/swift-ios/App/NativeFeatureClient.swift
@@ -21,6 +21,11 @@ private struct T3ConnectManagedCleanupError: LocalizedError {
     }
 }
 
+enum NativeSelectedThreadReconciliationReceipt: Equatable {
+    case finished(threadID: String)
+    case deferred(threadID: String)
+}
+
 /// Composes the transport-focused Core layer with the UI-focused Features layer.
 @MainActor
 final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
@@ -58,6 +63,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private let threadSnapshotTimeoutInterval: TimeInterval
     private let detailPublicationSleep: @Sendable () async throws -> Void
     private let catchUpDelay: @Sendable () async throws -> Void
+    private let selectedThreadReconciliationSleep: @Sendable (Duration) async throws -> Void
+    private let selectedThreadReconciliationNow: @MainActor @Sendable () -> ContinuousClock.Instant
+    private let selectedThreadReconciliationReceipt: @MainActor @Sendable (NativeSelectedThreadReconciliationReceipt) -> Void
     private let threadRetryDelay: @Sendable (Int) async throws -> Void
     private let aggregateEnvironmentLoader: @Sendable (EnvironmentRuntime) async throws -> [Environment]
     private let stream: AsyncStream<FeatureEvent>
@@ -143,6 +151,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     ] = [:]
     private var shellPublishTask: Task<Void, Never>?
     private var archivedRefreshTask: Task<Void, Never>?
+    private var selectedThreadReconciliationTask: Task<Void, Never>?
+    private var selectedThreadReconciliationRefreshGeneration: Int?
+    private var selectedThreadLastProgressAt: ContinuousClock.Instant?
     private var detailRefreshTask: Task<Void, Never>?
     private var detailStreamTask: Task<Void, Never>?
     private var detailCatchUpTask: Task<Void, Never>?
@@ -200,6 +211,11 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         catchUpDelay: @escaping @Sendable () async throws -> Void = {
             try await Task.sleep(for: .seconds(2))
         },
+        selectedThreadReconciliationSleep: @escaping @Sendable (Duration) async throws -> Void = {
+            try await Task.sleep(for: $0)
+        },
+        selectedThreadReconciliationNow: @escaping @MainActor @Sendable () -> ContinuousClock.Instant = { .now },
+        selectedThreadReconciliationReceipt: @escaping @MainActor @Sendable (NativeSelectedThreadReconciliationReceipt) -> Void = { _ in },
         threadRetryDelay: @escaping @Sendable (Int) async throws -> Void = { attempt in
             try await Task.sleep(for: .seconds(min(5, 0.25 * pow(2, Double(min(5, attempt - 1))))))
         },
@@ -243,6 +259,9 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         self.threadSnapshotTimeoutInterval = threadSnapshotTimeoutInterval
         self.detailPublicationSleep = detailPublicationSleep
         self.catchUpDelay = catchUpDelay
+        self.selectedThreadReconciliationSleep = selectedThreadReconciliationSleep
+        self.selectedThreadReconciliationNow = selectedThreadReconciliationNow
+        self.selectedThreadReconciliationReceipt = selectedThreadReconciliationReceipt
         self.threadRetryDelay = threadRetryDelay
         self.aggregateEnvironmentLoader = aggregateEnvironmentLoader
         let pair = AsyncStream<FeatureEvent>.makeStream()
@@ -251,6 +270,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     deinit {
+        selectedThreadReconciliationTask?.cancel()
         activeHydrationTask?.cancel()
         pollingTask?.cancel()
         fallbackPollingTask?.cancel()
@@ -417,6 +437,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     func suspendForBackground() {
+        stopSelectedThreadReconciliation()
         isForeground = false
         beginForegroundBootstrap()
     }
@@ -4474,11 +4495,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     private func scheduleDetailRefresh(
         threadID: String,
         client: T3Client,
-        force: Bool = false
+        force: Bool = false,
+        reconcile: Bool = false
     ) {
         guard activeThreadID == threadID,
               activeThreadEnvironmentID == client.environment.id else { return }
-        guard force || detailStreamTask == nil else { return }
+        guard force || reconcile || detailStreamTask == nil else { return }
         if force {
             detailWasSynchronized = false
             // This required read owns recovery now. An older fallback must not
@@ -4496,11 +4518,12 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         detailRefreshGeneration &+= 1
         let generation = detailRefreshGeneration
         let sessionGeneration = environmentGeneration
+        let streamGeneration = detailStreamGeneration
         detailRefreshTask = Task { [weak self] in
             do {
                 // Shell updates can be coalesced. A required replacement cannot
                 // apply more thread events until its snapshot arrives.
-                if !force {
+                if !force && !reconcile {
                     try await Task.sleep(for: .milliseconds(250))
                 }
             } catch {
@@ -4516,11 +4539,15 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                    generation: sessionGeneration
                ) {
                 do {
-                    try await self.refreshThread(id: threadID, client: client)
+                    try await self.refreshThread(
+                        id: threadID, client: client,
+                        expectedStreamGeneration: reconcile ? streamGeneration : nil,
+                        reconcile: reconcile
+                    )
                 } catch is CancellationError {
                     // Closing a thread cancels its read without changing its status.
                 } catch {
-                    if !Task.isCancelled,
+                    if !reconcile, !Task.isCancelled,
                        self.detailRefreshGeneration == generation,
                        self.activeThreadID == threadID,
                        self.activeRawThread == nil || self.detailStreamTask == nil {
@@ -4545,6 +4572,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             id: route.uiID, state: warmConnectionID != nil ? .live : .catchingUp
         ))
         ensureDetailCatchUpFallback(route, generation: streamGeneration)
+        startSelectedThreadReconciliation(route, generation: streamGeneration)
         let retryDelay = threadRetryDelay
         detailStreamTask = Task { [weak self] in
             var failedAttempts = 0
@@ -4669,6 +4697,60 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         continuation.yield(.threadSync(id: route.uiID, state: .failed(message)))
     }
 
+    /// The selected transcript gets a bounded HTTP check even when its socket
+    /// remains healthy but subscription delivery stops. Other threads are untouched.
+    private func startSelectedThreadReconciliation(_ route: NativeThreadRoute, generation: Int) {
+        stopSelectedThreadReconciliation()
+        guard isForeground else { return }
+        selectedThreadLastProgressAt = selectedThreadReconciliationNow()
+        let sessionGeneration = environmentGeneration
+        let sleep = selectedThreadReconciliationSleep
+        selectedThreadReconciliationTask = Task { [weak self] in
+            while !Task.isCancelled {
+                let remaining = self.map { owner in
+                    max(.zero, .seconds(30) - (owner.selectedThreadLastProgressAt ?? owner.selectedThreadReconciliationNow())
+                        .duration(to: owner.selectedThreadReconciliationNow()))
+                } ?? .seconds(30)
+                do { try await sleep(remaining) } catch { return }
+                guard !Task.isCancelled, let self, self.isForeground,
+                      self.environmentGeneration == sessionGeneration,
+                      self.isCurrentDetail(route, generation: generation) else { return }
+                if let progress = self.selectedThreadLastProgressAt,
+                   progress.duration(to: self.selectedThreadReconciliationNow()) < .seconds(30) {
+                    self.selectedThreadReconciliationReceipt(.deferred(threadID: route.uiID))
+                    continue
+                }
+                guard self.detailRefreshTask == nil, self.detailCatchUpTask == nil,
+                      self.acceptedCommandRefreshes[route.uiID] == nil,
+                      self.activeRawThread != nil,
+                      self.activeThreadPage?.isLoading != true || self.pendingOlderThreadPage != nil else {
+                    self.selectedThreadLastProgressAt = self.selectedThreadReconciliationNow()
+                    self.selectedThreadReconciliationReceipt(.deferred(threadID: route.uiID))
+                    continue
+                }
+                self.scheduleDetailRefresh(threadID: route.uiID, client: route.client, reconcile: true)
+                self.selectedThreadReconciliationRefreshGeneration = self.detailRefreshGeneration
+                let refresh = self.detailRefreshTask
+                await refresh?.value
+                guard !Task.isCancelled, self.isForeground,
+                      self.environmentGeneration == sessionGeneration,
+                      self.isCurrentDetail(route, generation: generation) else { return }
+                self.selectedThreadReconciliationRefreshGeneration = nil
+                self.selectedThreadLastProgressAt = self.selectedThreadReconciliationNow()
+                self.selectedThreadReconciliationReceipt(.finished(threadID: route.uiID))
+            }
+        }
+    }
+
+    private func stopSelectedThreadReconciliation() {
+        selectedThreadReconciliationTask?.cancel()
+        selectedThreadReconciliationTask = nil
+        if selectedThreadReconciliationRefreshGeneration == detailRefreshGeneration {
+            resetDetailRefresh()
+        }
+        selectedThreadReconciliationRefreshGeneration = nil
+    }
+
     private func isCurrentDetail(_ route: NativeThreadRoute, generation: Int) -> Bool {
         detailStreamGeneration == generation
             && activeThreadID == route.uiID
@@ -4754,6 +4836,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                subscriptionEpoch < requiredEpoch { return }
             guard snapshot.snapshotSequence >= (activeThreadSequence ?? 0),
                   activeRawThread == nil || snapshot.snapshotSequence > (activeThreadSequence ?? 0) else { return }
+            selectedThreadLastProgressAt = selectedThreadReconciliationNow()
             beginWarmReplayIfNeeded(route)
             resetDetailRefresh()
             detailSnapshotRequiredAfterEpoch = nil
@@ -4791,6 +4874,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
                 return
             }
             guard reduction.sequence > (activeThreadSequence ?? 0) else { return }
+            selectedThreadLastProgressAt = selectedThreadReconciliationNow()
             beginWarmReplayIfNeeded(route)
             switch reduction.result {
             case let .updated(thread):
@@ -4891,6 +4975,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func resetDetailStream() {
+        stopSelectedThreadReconciliation()
         detailStreamGeneration &+= 1
         detailCompletionReceived = false
         detailWasSynchronized = false
@@ -5223,7 +5308,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
     }
 
     private func refreshThread(
-        id: String, client: T3Client, expectedStreamGeneration: Int? = nil
+        id: String, client: T3Client, expectedStreamGeneration: Int? = nil, reconcile: Bool = false
     ) async throws {
         let route = try threadRoute(for: id)
         guard route.client === client else {
@@ -5235,16 +5320,85 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
         let supportsPagination = serverConfigsByEnvironmentID[
             environment.id
         ]?.threadSnapshotPagination == true
-        let snapshot = try await client.threadSnapshot(
+        let loadedUsers = reconcile ? activeRawThread?.messages.filter { $0.role == "user" } ?? [] : []
+        let loadedAnchor = loadedUsers.first?.id
+        let pendingHistory = reconcile ? pendingOlderThreadPage : nil
+        if let pendingHistory {
+            guard pendingHistory.epoch == historyEpoch, pendingHistory.threadID == route.uiID,
+                  pendingHistory.environmentID == route.environmentID,
+                  (pendingHistory.snapshot.page?.threadSequence ?? 0) >= (activeThreadSequence ?? 0) else { return }
+        }
+        let loadedIDs = Set(loadedUsers.map(\.id))
+        // Pending rows determine the requested extent only. The published data
+        // always comes from a new authoritative snapshot, never a cached union.
+        let pendingUsers = pendingHistory?.snapshot.thread.messages.filter {
+            $0.role == "user" && !loadedIDs.contains($0.id)
+        } ?? []
+        let retainedUsers = pendingUsers + loadedUsers
+        let retainedIDs = Set(retainedUsers.map(\.id))
+        let retainedAnchor = retainedUsers.first?.id
+        let expandedHistory = retainedUsers.count > Self.initialThreadUserTurnLimit
+        let turnLimit = max(Self.initialThreadUserTurnLimit, retainedUsers.count)
+
+        func ownsReconciliationExtent() -> Bool {
+            !reconcile || (
+                pendingOlderThreadPage == pendingHistory
+                    && (activeThreadPage?.isLoading != true || pendingHistory != nil)
+                    && loadedAnchor == activeRawThread?.messages.first(where: { $0.role == "user" })?.id
+            )
+        }
+        func additionalTailUsers(in thread: OrchestrationThread) -> Int? {
+            let users = thread.messages.filter { $0.role == "user" }
+            guard let lastKnown = users.lastIndex(where: { retainedIDs.contains($0.id) }) else { return nil }
+            return users.distance(from: users.index(after: lastKnown), to: users.endIndex)
+        }
+        var snapshot = try await client.threadSnapshot(
             id: route.wireID,
-            turnLimit: supportsPagination ? Self.initialThreadUserTurnLimit : nil,
+            turnLimit: supportsPagination ? turnLimit : nil,
             timeoutInterval: threadSnapshotTimeoutInterval
         )
+        guard !Task.isCancelled,
+              expectedStreamGeneration.map({ isCurrentDetail(route, generation: $0) }) ?? true,
+              isKnownClient(client, environmentID: environment.id, generation: generation) else {
+            throw CancellationError()
+        }
+        guard ownsReconciliationExtent() else { return }
+        if reconcile, pendingHistory == nil, let current = activeRawThread,
+           snapshot.snapshotSequence >= (activeThreadSequence ?? 0),
+           snapshot.page?.threadSequence.map({ $0 <= (activeThreadSequence ?? 0) }) == true
+                || snapshot.snapshotSequence == activeThreadSequence || snapshot.thread == current {
+            return
+        }
+        if reconcile, expandedHistory, snapshot.page?.hasMore == true,
+           !snapshot.thread.messages.contains(where: { $0.id == retainedAnchor }) {
+            if let added = additionalTailUsers(in: snapshot.thread), added > 0 {
+                // One extra user turn needs one extra slot, not an automatic
+                // page of older history. Do not keep expanding a moving head.
+                snapshot = try await client.threadSnapshot(
+                    id: route.wireID, turnLimit: turnLimit + added,
+                    timeoutInterval: threadSnapshotTimeoutInterval
+                )
+                guard !Task.isCancelled, ownsReconciliationExtent(),
+                      expectedStreamGeneration.map({ isCurrentDetail(route, generation: $0) }) ?? true else { return }
+                guard additionalTailUsers(in: snapshot.thread) == added else { return }
+            }
+            if snapshot.page?.hasMore == true,
+               !snapshot.thread.messages.contains(where: { $0.id == retainedAnchor }) {
+                // A deleted boundary or disjoint gap gets one full read. Never
+                // resurrect old rows by unioning them into a rewound thread.
+                snapshot = try await client.threadSnapshot(
+                    id: route.wireID, timeoutInterval: threadSnapshotTimeoutInterval
+                )
+            }
+        }
         guard !Task.isCancelled,
               isKnownClient(client, environmentID: environment.id, generation: generation),
               expectedStreamGeneration.map({ isCurrentDetail(route, generation: $0) }) ?? true else {
             throw CancellationError()
         }
+        guard ownsReconciliationExtent() else { return }
+        if let pendingWatermark = pendingHistory?.snapshot.page?.threadSequence,
+           snapshot.snapshotSequence < pendingWatermark { return }
         if activeThreadID == route.uiID {
             if activeRawThread == nil, historyEpoch != threadHistoryEpoch {
                 return
@@ -5287,7 +5441,7 @@ final class NativeFeatureClient: FeatureClient, FeatureDeviceManaging,
             wasSynchronized: false,
             connectionID: nil
         )
-        if activeThreadID == route.uiID,
+        if !reconcile, activeThreadID == route.uiID,
            detailCompletionReceived
             || serverConfigsByEnvironmentID[environment.id]?.threadResumeCompletionMarker != true {
             markDetailSynchronized(route)
@@ -8330,7 +8484,7 @@ private struct NativeProjectRoute {
     let client: T3Client
 }
 
-private struct PendingOlderThreadPage {
+private struct PendingOlderThreadPage: Equatable {
     let snapshot: OrchestrationThreadDetailSnapshot
     let epoch: Int
     let threadID: String

--- a/apps/swift-ios/Core/T3Client.swift
+++ b/apps/swift-ios/Core/T3Client.swift
@@ -654,6 +654,29 @@ public actor T3Client {
         )
     }
 
+    /// Passive shells start with a full snapshot on each socket subscription.
+    /// Registering its identity atomically prevents late socket results from
+    /// acquiring authority over a replacement connection.
+    public func shellEventsOnCurrentConnection() async throws -> (
+        events: AsyncThrowingStream<ShellStreamItem, Error>, connectionID: UUID
+    ) {
+        try await rpc.subscribeOnCurrentConnection(
+            RPCMethod.subscribeShell.rawValue,
+            payload: .object(["requestCompletionMarker": .bool(true)]),
+            as: ShellStreamItem.self
+        )
+    }
+
+    public func shellEventBatchesOnCurrentConnection() async throws -> (
+        events: AsyncThrowingStream<[ShellStreamItem], Error>, connectionID: UUID
+    ) {
+        try await rpc.subscribeBatchesOnCurrentConnection(
+            RPCMethod.subscribeShell.rawValue,
+            payload: .object(["requestCompletionMarker": .bool(true)]),
+            as: ShellStreamItem.self
+        )
+    }
+
     public func threadEvents(
         threadID: String,
         after sequence: Int? = nil,

--- a/apps/swift-ios/Core/WebSocketRPC.swift
+++ b/apps/swift-ios/Core/WebSocketRPC.swift
@@ -491,6 +491,25 @@ public actor WebSocketRPCClient {
         }
     }
 
+    public func subscribeBatchesOnCurrentConnection<Value: Decodable & Sendable>(
+        _ tag: String,
+        payload: JSONValue = .object([:]),
+        as type: Value.Type
+    ) async throws -> (events: AsyncThrowingStream<[Value], Error>, connectionID: UUID) {
+        try Task.checkCancellation()
+        start()
+        while true {
+            try Task.checkCancellation()
+            if let id = connectionID {
+                return (
+                    subscribeBatches(tag, payload: payload, reconnect: false, as: type),
+                    id
+                )
+            }
+            _ = try await waitForConnection(after: nil)
+        }
+    }
+
     private func requestRaw(_ tag: String, payload: JSONValue) async throws -> JSONValue {
         start()
         let id = allocateRequestID()

--- a/apps/swift-ios/Features/Chat/ThreadDetailView.swift
+++ b/apps/swift-ios/Features/Chat/ThreadDetailView.swift
@@ -14,6 +14,7 @@ public struct ThreadDetailView: View {
     let submitMessage: (FeatureMessageSubmission) async -> Bool
     let onNavigateBack: () -> Void
     private let draftStore: FeatureComposerDraftStore
+    private let managesThreadPresentation: Bool
 
     @State private var draft = ""
     @State private var selection: FeatureSelection?
@@ -43,20 +44,22 @@ public struct ThreadDetailView: View {
         thread: FeatureThread,
         submitMessage: @escaping (FeatureMessageSubmission) async -> Bool,
         onNavigateBack: @escaping () -> Void = {},
-        draftStore: FeatureComposerDraftStore = .shared
+        draftStore: FeatureComposerDraftStore = .shared,
+        managesThreadPresentation: Bool = true
     ) {
         self.model = model
         self.thread = thread
         self.submitMessage = submitMessage
         self.onNavigateBack = onNavigateBack
         self.draftStore = draftStore
+        self.managesThreadPresentation = managesThreadPresentation
     }
 
     public var body: some View {
         Group {
             if let detail {
                 timeline(detail)
-            } else if isLoading {
+            } else if isOpening {
                 FeatureThreadOpeningView()
             } else {
                 ContentUnavailableView {
@@ -81,9 +84,11 @@ public struct ThreadDetailView: View {
             }
         }
         .task(id: thread.id) {
+            guard managesThreadPresentation else { return }
             isLoading = true
-            _ = await model.detail(for: thread.id, force: true)
-            isLoading = false
+            await model.runThreadPresentation(id: thread.id) {
+                isLoading = false
+            }
         }
         .task(id: thread.id) {
             // A cached thread can already show its composer while the server
@@ -108,7 +113,7 @@ public struct ThreadDetailView: View {
         .onChange(of: threadConnectionState) { _, state in
             if state == .connected,
                case .failed = model.detailLoadStates[thread.id],
-               !isLoading {
+               !isOpening {
                 reloadThread()
             }
         }
@@ -118,7 +123,6 @@ public struct ThreadDetailView: View {
             }
         }
         .onDisappear {
-            model.releaseThread(thread.id)
             persistDraftBeforeLeaving()
         }
         .sheet(item: $toolSurface) { surface in
@@ -264,6 +268,12 @@ public struct ThreadDetailView: View {
         } message: {
             Text(linkedMediaPreviewError ?? "The file could not be opened.")
         }
+    }
+
+    private var isOpening: Bool {
+        if managesThreadPresentation { return isLoading }
+        if case .failed = model.detailLoadStates[thread.id] { return false }
+        return detail == nil || model.detailLoadStates[thread.id] == .loading
     }
 
     private var detail: FeatureThreadDetail? {
@@ -581,10 +591,8 @@ public struct ThreadDetailView: View {
     }
 
     private func reloadThread() {
-        isLoading = true
-        Task {
-            _ = await model.detail(for: thread.id, force: true, fresh: true)
-            isLoading = false
+        if model.refreshThreadPresentation(id: thread.id, onLoaded: { isLoading = false }) {
+            isLoading = true
         }
     }
 
@@ -597,7 +605,7 @@ public struct ThreadDetailView: View {
         ThreadRefreshPresentation.resolve(
             loadState: model.detailLoadStates[thread.id],
             connectionState: threadConnectionState,
-            isOpening: isLoading,
+            isOpening: isOpening,
             syncState: model.threadSyncStates[thread.id]
         )
     }

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -81,6 +81,10 @@ public final class FeatureRootModel {
     private var pendingSettlementMutations: [String: PendingSettlementMutation] = [:]
     private var pendingCompletionSubmissionIDs: Set<String> = []
     private var pendingDiscardSubmissionIDs: Set<String> = []
+    @ObservationIgnored private var activeDetailPresentation: (
+        threadID: String, owner: UUID, lifetime: AsyncStream<Void>.Continuation,
+        refreshTask: Task<Void, Never>?
+    )?
     private var detailRecency: [String] = []
     private var detailLoadGeneration: UInt64 = 0
     private var detailLoadRevisions: [String: UInt64] = [:]
@@ -615,6 +619,55 @@ public final class FeatureRootModel {
         }
     }
 
+    /// Holds selected-thread transport for the owning presentation task, including after loading.
+    func runThreadPresentation(id: String, onLoaded: @MainActor () -> Void = {}) async {
+        guard !Task.isCancelled else { return }
+        if let previous = activeDetailPresentation {
+            releaseThread(previous.threadID)
+        }
+        let owner = UUID()
+        let lifetime = AsyncStream<Void>.makeStream()
+        activeDetailPresentation = (id, owner, lifetime.continuation, nil)
+        await withTaskCancellationHandler {
+            defer { releaseThreadPresentation(id: id, owner: owner) }
+            _ = await detail(for: id, force: true)
+            guard !Task.isCancelled,
+                  activeDetailPresentation?.owner == owner else { return }
+            onLoaded()
+            for await _ in lifetime.stream {}
+        } onCancel: {
+            // Cancellation must release even when the detail read is still suspended.
+            Task { @MainActor [weak self] in
+                self?.releaseThreadPresentation(id: id, owner: owner)
+            }
+        }
+    }
+
+    /// Retries belong to the current presentation and cannot outlive a close or replacement.
+    @discardableResult
+    func refreshThreadPresentation(
+        id: String, fresh: Bool = true, onLoaded: @escaping @MainActor () -> Void = {}
+    ) -> Bool {
+        guard let presentation = activeDetailPresentation, presentation.threadID == id else { return false }
+        presentation.refreshTask?.cancel()
+        let owner = presentation.owner
+        activeDetailPresentation?.refreshTask = Task { [weak self] in
+            guard let self, !Task.isCancelled,
+                  self.activeDetailPresentation?.owner == owner else { return }
+            _ = await self.detail(for: id, force: true, fresh: fresh)
+            guard !Task.isCancelled,
+                  self.activeDetailPresentation?.owner == owner else { return }
+            onLoaded()
+        }
+        return true
+    }
+
+    private func releaseThreadPresentation(id: String, owner: UUID) {
+        guard activeDetailPresentation?.threadID == id,
+              activeDetailPresentation?.owner == owner else { return }
+        releaseThread(id)
+    }
+
     public func detail(for id: String, force: Bool = false, fresh: Bool = false) async -> FeatureThreadDetail? {
         if !force, let cached = details[id] {
             return cached
@@ -693,6 +746,11 @@ public final class FeatureRootModel {
 
     /// Ends any selected-thread transport work when its detail view closes.
     public func releaseThread(_ id: String) {
+        if let presentation = activeDetailPresentation, presentation.threadID == id {
+            activeDetailPresentation = nil
+            presentation.refreshTask?.cancel()
+            presentation.lifetime.finish()
+        }
         client.releaseThread(id: id)
         markDetailRecentlyUsed(id)
         evictOldThreadDetailsIfNeeded()

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -1538,7 +1538,7 @@ public final class FeatureRootModel {
             role: .user,
             text: submission.text,
             createdAt: submission.identity.createdAt,
-            state: pendingCompletionSubmissionIDs.contains(submission.id) ? .complete : .queued,
+            state: .queued,
             attachments: submission.attachments.enumerated().map { index, attachment in
                 FeatureMessageAttachment(
                     id: "\(submission.id)-attachment-\(index)",
@@ -1628,8 +1628,6 @@ public final class FeatureRootModel {
     private func completeQueuedSubmission(_ submission: FeatureQueuedSubmission) async -> Bool {
         pendingCompletionSubmissionIDs.insert(submission.id)
         pendingDiscardSubmissionIDs.remove(submission.id)
-        // Server acceptance is independent of clearing its local durable copy.
-        markQueuedMessageDelivered(submission)
         do {
             try await outboxStore.remove(id: submission.id)
         } catch {
@@ -1640,23 +1638,20 @@ public final class FeatureRootModel {
         pendingSubmissionsByID.removeValue(forKey: submission.id)
         setAttachmentOutboxOwnership(false, for: submission)
         pendingThreadsByID.removeValue(forKey: submission.threadID)
+        markQueuedMessageDelivered(submission)
         outboxRetryAttempt = 0
         return true
     }
 
     private func markQueuedMessageDelivered(_ submission: FeatureQueuedSubmission) {
-        guard var message = details[submission.threadID]?.messages.first(where: {
-            $0.id == submission.identity.messageID
-        }), message.state != .complete else { return }
-        message.state = .complete
         mutateDetail(
             id: submission.threadID,
-            change: .delta(FeatureDetailDelta(changedMessages: [message]))
+            change: .delta(FeatureDetailDelta(changedMessages: []))
         ) { detail in
             guard let index = detail.messages.firstIndex(where: {
                 $0.id == submission.identity.messageID
             }) else { return }
-            detail.messages[index] = message
+            detail.messages[index].state = .complete
         }
     }
 

--- a/apps/swift-ios/Features/Root/FeatureRootModel.swift
+++ b/apps/swift-ios/Features/Root/FeatureRootModel.swift
@@ -135,6 +135,7 @@ public final class FeatureRootModel {
 
     func applicationDidEnterBackground(at date: Date = .now) {
         backgroundedAt = date
+        client.suspendForBackground()
     }
 
     func applicationDidBecomeActive(at date: Date = .now) async {
@@ -1479,7 +1480,7 @@ public final class FeatureRootModel {
             role: .user,
             text: submission.text,
             createdAt: submission.identity.createdAt,
-            state: .queued,
+            state: pendingCompletionSubmissionIDs.contains(submission.id) ? .complete : .queued,
             attachments: submission.attachments.enumerated().map { index, attachment in
                 FeatureMessageAttachment(
                     id: "\(submission.id)-attachment-\(index)",
@@ -1569,6 +1570,8 @@ public final class FeatureRootModel {
     private func completeQueuedSubmission(_ submission: FeatureQueuedSubmission) async -> Bool {
         pendingCompletionSubmissionIDs.insert(submission.id)
         pendingDiscardSubmissionIDs.remove(submission.id)
+        // Server acceptance is independent of clearing its local durable copy.
+        markQueuedMessageDelivered(submission)
         do {
             try await outboxStore.remove(id: submission.id)
         } catch {
@@ -1579,20 +1582,23 @@ public final class FeatureRootModel {
         pendingSubmissionsByID.removeValue(forKey: submission.id)
         setAttachmentOutboxOwnership(false, for: submission)
         pendingThreadsByID.removeValue(forKey: submission.threadID)
-        markQueuedMessageDelivered(submission)
         outboxRetryAttempt = 0
         return true
     }
 
     private func markQueuedMessageDelivered(_ submission: FeatureQueuedSubmission) {
+        guard var message = details[submission.threadID]?.messages.first(where: {
+            $0.id == submission.identity.messageID
+        }), message.state != .complete else { return }
+        message.state = .complete
         mutateDetail(
             id: submission.threadID,
-            change: .delta(FeatureDetailDelta(changedMessages: []))
+            change: .delta(FeatureDetailDelta(changedMessages: [message]))
         ) { detail in
             guard let index = detail.messages.firstIndex(where: {
                 $0.id == submission.identity.messageID
             }) else { return }
-            detail.messages[index].state = .complete
+            detail.messages[index] = message
         }
     }
 

--- a/apps/swift-ios/Features/Shared/FeatureClient.swift
+++ b/apps/swift-ios/Features/Shared/FeatureClient.swift
@@ -10,6 +10,7 @@ public protocol FeatureClient: AnyObject {
     func backgroundSnapshot() async throws -> FeatureSnapshot
     func events() -> AsyncStream<FeatureEvent>
     func resumeAfterBackground(reconnect: Bool) async
+    func suspendForBackground()
 
     func preuploadAttachment(
         _ attachment: FeatureUploadAttachment,
@@ -315,6 +316,8 @@ public extension FeatureClient {
     }
 
     func resumeAfterBackground(reconnect: Bool) async {}
+
+    func suspendForBackground() {}
 
     func preuploadAttachment(
         _ attachment: FeatureUploadAttachment,

--- a/apps/swift-ios/Features/Workspace/WorkspaceThreadSelection.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceThreadSelection.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct WorkspaceThreadSelection: Equatable {
+    private(set) var selectedID: String?
+    private(set) var lastOpenedID: String?
+
+    var highlightedID: String? { selectedID ?? lastOpenedID }
+
+    mutating func open(_ id: String) {
+        selectedID = id
+        lastOpenedID = id
+    }
+
+    func presentedID(isCompact: Bool, showsDetailColumn: Bool) -> String? {
+        isCompact && !showsDetailColumn ? nil : selectedID
+    }
+
+    mutating func reconcilePresentation(isCompact: Bool, showsDetailColumn: Bool) {
+        if isCompact && !showsDetailColumn { close() }
+    }
+
+    mutating func close() {
+        selectedID = nil
+    }
+}

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -17,24 +17,9 @@ struct FeatureWorkspaceNavigationRequest: Equatable, Sendable {
     }
 }
 
-struct WorkspaceThreadSelection: Equatable {
-    private(set) var selectedID: String?
-    private(set) var lastOpenedID: String?
-
-    var highlightedID: String? { selectedID ?? lastOpenedID }
-
-    mutating func open(_ id: String) {
-        selectedID = id
-        lastOpenedID = id
-    }
-
-    mutating func close() {
-        selectedID = nil
-    }
-}
-
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @Bindable var model: FeatureRootModel
     private let navigationRequest: FeatureWorkspaceNavigationRequest?
@@ -130,8 +115,8 @@ public struct WorkspaceView: View {
         }
     }
 
-    public var body: some View {
-        NavigationSplitView(preferredCompactColumn: $preferredCompactColumn) {
+    private var workspaceNavigation: some View {
+        NavigationSplitView(preferredCompactColumn: compactColumnBinding) {
             sidebar
                 .navigationSplitViewColumnWidth(
                     min: T3Metrics.minimumSidebarWidth,
@@ -142,6 +127,17 @@ public struct WorkspaceView: View {
             detail
         }
         .navigationSplitViewStyle(.balanced)
+        .task(id: presentedThreadID) { [id = presentedThreadID] in
+            guard let id else { return }
+            await model.runThreadPresentation(id: id)
+        }
+        .onChange(of: horizontalSizeClass) { _, _ in
+            reconcileThreadPresentation()
+        }
+    }
+
+    public var body: some View {
+        workspaceNavigation
         .sheet(isPresented: $showingNewTask) {
             NewThreadView(
                 model: model,
@@ -329,7 +325,8 @@ public struct WorkspaceView: View {
                 model: model,
                 thread: thread,
                 submitMessage: submitMessage,
-                onNavigateBack: closeSelectedThread
+                onNavigateBack: closeSelectedThread,
+                managesThreadPresentation: false
             )
             .id(id)
         } else {
@@ -626,6 +623,31 @@ public struct WorkspaceView: View {
     private var selectedProjectIsAvailable: Bool {
         guard let selectedProjectID else { return true }
         return model.snapshot.projects.contains { $0.id == selectedProjectID }
+    }
+
+    private var compactColumnBinding: Binding<NavigationSplitViewColumn> {
+        Binding(
+            get: { preferredCompactColumn },
+            set: { column in
+                preferredCompactColumn = column
+                reconcileThreadPresentation()
+            }
+        )
+    }
+
+    private var presentedThreadID: String? {
+        guard let id = threadSelection.presentedID(
+            isCompact: horizontalSizeClass == .compact,
+            showsDetailColumn: preferredCompactColumn == .detail
+        ), model.snapshot.threads.contains(where: { $0.id == id }) else { return nil }
+        return id
+    }
+
+    private func reconcileThreadPresentation() {
+        threadSelection.reconcilePresentation(
+            isCompact: horizontalSizeClass == .compact,
+            showsDetailColumn: preferredCompactColumn == .detail
+        )
     }
 
     private func openThread(_ id: String) {

--- a/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
+++ b/apps/swift-ios/Tests/CoreTests/WebSocketRPCRaceTests.swift
@@ -47,6 +47,38 @@ final class WebSocketRPCRaceTests: XCTestCase {
         await client.stop()
     }
 
+    func testColdBatchedSubscriptionRetainsFailedSocketIdentity() async throws {
+        let connection = SubscriptionTrafficConnection(sendsInvalidSubscriptionValue: true)
+        let connector = GatedConnector(connection: connection)
+        let client = WebSocketRPCClient(
+            connector: connector,
+            endpointProvider: { URL(string: "wss://studio.example/ws")! }
+        )
+        let pending = Task {
+            try await client.subscribeBatchesOnCurrentConnection("thread.events", as: Int.self)
+        }
+        await connector.waitUntilConnectStarted()
+        let beforeConnection = await client.currentConnectionID()
+        XCTAssertNil(beforeConnection)
+        await connector.release()
+        let subscription = try await pending.value
+        var events = subscription.events.makeAsyncIterator()
+        do {
+            _ = try await events.next()
+            XCTFail("The first invalid value must terminate the cold subscription.")
+        } catch is DecodingError {}
+        let failedSocketID = await client.currentConnectionID()
+        XCTAssertEqual(subscription.connectionID, failedSocketID)
+        let waiting = Task { try await client.waitForConnection(after: subscription.connectionID) }
+        _ = try await client.request("server.stillHealthy", as: JSONValue.self)
+        waiting.cancel()
+        do {
+            _ = try await waiting.value
+            XCTFail("The failed socket must not satisfy the wait for its replacement.")
+        } catch is CancellationError {}
+        await client.stop()
+    }
+
     func testColdSubscriptionRetainsFailedSocketIdentity() async throws {
         let connection = SubscriptionTrafficConnection(sendsInvalidSubscriptionValue: true)
         let connector = GatedConnector(connection: connection)

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -9,6 +9,163 @@ import XCTest
 @MainActor
 @Suite("Feature root model")
 struct FeatureRootModelTests {
+    @Test(arguments: [["a", "b", "a"], ["a", "a"]])
+    func presentationTaskReplacementAndCloseReleaseExactlyOnce(threadIDs: [String]) async {
+        let client = FeatureClientStub()
+        let model = FeatureRootModel(client: client)
+        let loaded = AsyncStream<String>.makeStream()
+        var loads = loaded.stream.makeAsyncIterator()
+        var previous: Task<Void, Never>?
+        for id in threadIDs {
+            let next = Task {
+                await model.runThreadPresentation(id: id) { loaded.continuation.yield(id) }
+            }
+            #expect(await loads.next() == id)
+            // Replacement finishes the old lifetime even before SwiftUI cancels its task.
+            await previous?.value
+            previous?.cancel()
+            previous = next
+        }
+        #expect(client.loadedThreadIDs == threadIDs)
+        #expect(client.releasedThreadIDs == Array(threadIDs.dropLast()))
+        previous?.cancel()
+        await previous?.value
+        #expect(client.releasedThreadIDs == threadIDs)
+        loaded.continuation.finish()
+    }
+
+    @Test
+    func cancelledPresentationTaskCannotReplaceVisibleThread() async {
+        let client = FeatureClientStub()
+        let model = FeatureRootModel(client: client)
+        let loaded = AsyncStream<Void>.makeStream()
+        let current = Task {
+            await model.runThreadPresentation(id: "a") { loaded.continuation.yield(()) }
+        }
+        var loads = loaded.stream.makeAsyncIterator()
+        await loads.next()
+        let cancelled = Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            await model.runThreadPresentation(id: "a")
+        }
+        await cancelled.value
+        #expect(client.loadedThreadIDs == ["a"])
+        #expect(client.releasedThreadIDs.isEmpty)
+        current.cancel()
+        await current.value
+        #expect(client.releasedThreadIDs == ["a"])
+        loaded.continuation.finish()
+    }
+
+    @Test(arguments: [false, true])
+    func cancellationReleasesSuspendedPresentationBeforeItsLoadReturns(cancelBeforeReplacement: Bool) async {
+        let client = FeatureClientStub()
+        let model = FeatureRootModel(client: client)
+        let started = AsyncStream<Void>.makeStream()
+        let released = AsyncStream<String>.makeStream()
+        let loaded = AsyncStream<Void>.makeStream()
+        client.onReleaseThread = { released.continuation.yield($0) }
+        var pendingLoad: CheckedContinuation<FeatureThreadDetail, any Error>?
+        client.loadThreadHandler = { _ in
+            try await withCheckedThrowingContinuation { continuation in
+                pendingLoad = continuation
+                started.continuation.yield(())
+            }
+        }
+        var oldLoaded = false
+        let old = Task { await model.runThreadPresentation(id: "a") { oldLoaded = true } }
+        var starts = started.stream.makeAsyncIterator()
+        await starts.next()
+        var releases = released.stream.makeAsyncIterator()
+        if cancelBeforeReplacement {
+            old.cancel()
+            #expect(await releases.next() == "a")
+        }
+        #expect(pendingLoad != nil)
+        #expect(!oldLoaded)
+
+        client.loadThreadHandler = nil
+        let replacement = Task {
+            await model.runThreadPresentation(id: "a") { loaded.continuation.yield(()) }
+        }
+        var loads = loaded.stream.makeAsyncIterator()
+        await loads.next()
+        if !cancelBeforeReplacement {
+            // The old cancellation handler runs only after the same-ID replacement owns transport.
+            old.cancel()
+            #expect(await releases.next() == "a")
+        }
+        pendingLoad?.resume(returning: FeatureThreadDetail(thread: client.createdThread))
+        pendingLoad = nil
+        await old.value
+        #expect(!oldLoaded)
+        #expect(client.releasedThreadIDs == ["a"])
+        replacement.cancel()
+        await replacement.value
+        #expect(client.releasedThreadIDs == ["a", "a"])
+        #expect(client.loadedThreadIDs == ["a", "a"])
+        started.continuation.finish()
+        released.continuation.finish()
+        loaded.continuation.finish()
+    }
+
+    @Test
+    func presentationCloseStillReleasesAfterConnectionReload() async {
+        let client = FeatureClientStub()
+        let model = FeatureRootModel(client: client)
+        let loaded = AsyncStream<Void>.makeStream()
+        let presentation = Task {
+            await model.runThreadPresentation(id: "a") { loaded.continuation.yield(()) }
+        }
+        var loads = loaded.stream.makeAsyncIterator()
+        await loads.next()
+        await model.reloadAfterConnection()
+        presentation.cancel()
+        await presentation.value
+        #expect(client.releasedThreadIDs == ["a"])
+        loaded.continuation.finish()
+    }
+
+    @Test
+    func presentationCloseCancelsRetryAndRejectsLateRetry() async {
+        let client = FeatureClientStub()
+        let model = FeatureRootModel(client: client)
+        let loaded = AsyncStream<Void>.makeStream()
+        let started = AsyncStream<Void>.makeStream()
+        let cancelled = AsyncStream<Void>.makeStream()
+        let presentation = Task {
+            await model.runThreadPresentation(id: "a") { loaded.continuation.yield(()) }
+        }
+        var loads = loaded.stream.makeAsyncIterator()
+        await loads.next()
+        var pendingRetry: CheckedContinuation<FeatureThreadDetail, any Error>?
+        client.loadThreadHandler = { _ in
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    pendingRetry = continuation
+                    started.continuation.yield(())
+                }
+            } onCancel: {
+                cancelled.continuation.yield(())
+            }
+        }
+        #expect(model.refreshThreadPresentation(id: "a"))
+        var retries = started.stream.makeAsyncIterator()
+        await retries.next()
+        presentation.cancel()
+        await presentation.value
+        var cancellations = cancelled.stream.makeAsyncIterator()
+        await cancellations.next()
+        #expect(client.releasedThreadIDs == ["a"])
+        #expect(!model.refreshThreadPresentation(id: "a"))
+        pendingRetry?.resume(throwing: CancellationError())
+        pendingRetry = nil
+        #expect(client.loadedThreadIDs == ["a", "a"])
+        loaded.continuation.finish()
+        started.continuation.finish()
+        cancelled.continuation.finish()
+    }
+
     @Test
     func transcriptSkillPillsUseTheThreadWorkspaceCatalog() async {
         let skill = FeatureProviderSkill(name: "project-only", displayName: "Project only")
@@ -3660,6 +3817,13 @@ private func orchestrationThread(
 
 @MainActor
 private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
+    var loadedThreadIDs: [String] = []
+    var releasedThreadIDs: [String] = []
+    var onReleaseThread: ((String) -> Void)?
+    func releaseThread(id: String) {
+        releasedThreadIDs.append(id)
+        onReleaseThread?(id)
+    }
     var foregroundReconnects: [Bool] = []
     var backgroundSuspends = 0
     func suspendForBackground() { backgroundSuspends += 1 }
@@ -3854,6 +4018,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     }
 
     func loadThread(id: String) async throws -> FeatureThreadDetail {
+        loadedThreadIDs.append(id)
         if let loadThreadError {
             throw loadThreadError
         }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -81,6 +81,7 @@ struct FeatureRootModelTests {
         await model.applicationDidBecomeActive(at: start.addingTimeInterval(10))
         await model.applicationDidBecomeActive(at: start.addingTimeInterval(11))
         #expect(client.foregroundReconnects == [false, true])
+        #expect(client.backgroundSuspends == 2)
     }
 
     @Test
@@ -1691,8 +1692,67 @@ struct FeatureRootModelTests {
         #expect(model.details[thread.id]?.messages.last?.state == .queued)
     }
 
+    @Test(arguments: ["accepted", "cancelled", "network", "rejected"])
+    func queuedMessageWaitsForAcceptance(outcome: String) async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-root-queued-feedback-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let thread = FeatureThread(
+            id: "thread-1", projectID: "project-1", environmentID: "environment-1", title: "Thread"
+        )
+        let client = FeatureClientStub()
+        client.snapshot = FeatureSnapshot(
+            connection: .init(state: .connected),
+            environments: [.init(
+                id: "environment-1", name: "Studio", endpoint: "https://studio.example",
+                isActive: true, connectionState: .connected
+            )],
+            threads: [thread]
+        )
+        client.threadDetail = FeatureThreadDetail(thread: thread)
+        let started = AsyncStream<Void>.makeStream()
+        var response: CheckedContinuation<Void, any Error>?
+        client.beforeSendMessageReturn = {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                response = continuation
+                started.continuation.yield()
+            }
+        }
+        let model = FeatureRootModel(client: client, outboxStore: store)
+        await model.reload()
+        _ = await model.detail(for: thread.id)
+        let send = Task { await model.sendMessage(threadID: thread.id, text: "Queued response", selection: nil) }
+        var requests = started.stream.makeAsyncIterator()
+        await requests.next()
+        #expect(model.details[thread.id]?.messages.last?.state == .queued)
+        #expect(try await store.submissions().count == 1)
+        switch outcome {
+        case "cancelled": response?.resume(throwing: CancellationError())
+        case "network": response?.resume(throwing: URLError(.notConnectedToInternet))
+        case "rejected": response?.resume(throwing: FeatureCapabilityUnavailable("Rejected message"))
+        default: response?.resume()
+        }
+        let sent = await send.value
+        #expect(client.sendMessageCallCount == 1)
+        switch outcome {
+        case "accepted":
+            #expect(sent)
+            #expect(model.details[thread.id]?.messages.last?.state == .complete)
+            #expect(try await store.submissions().isEmpty)
+        case "rejected":
+            #expect(!sent)
+            #expect(model.details[thread.id]?.messages.isEmpty == true)
+            #expect(try await store.submissions().isEmpty)
+        default:
+            #expect(sent, "Ambiguous delivery remains queued for stable-identity retry")
+            #expect(model.details[thread.id]?.messages.last?.state == .queued)
+            #expect(try await store.submissions().count == 1)
+        }
+    }
+
     @Test
-    func failedDeliveryCleanupKeepsTheDurableAndOptimisticSubmission() async throws {
+    func failedDeliveryCleanupKeepsAcceptedStateAndTheDurableSubmission() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-root-completion-failure-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(
@@ -1749,8 +1809,49 @@ struct FeatureRootModelTests {
         #expect(client.sendMessageCallCount == 1)
         #expect(try await store.submissions().count == 1)
         #expect(model.details[thread.id]?.messages.last?.text == "Already delivered")
-        #expect(model.details[thread.id]?.messages.last?.state == .queued)
+        #expect(model.details[thread.id]?.messages.last?.state == .complete)
         #expect(model.errorMessage?.contains("delivered") == true)
+        guard case let .delta(delta) = model.detailRenderUpdates[thread.id]?.change else {
+            Issue.record("Expected accepted message to update the existing timeline row")
+            return
+        }
+        #expect(delta.changedMessages == model.details[thread.id]?.messages)
+        #expect(delta.changedMessages.first?.state == .complete)
+
+        // A stale detail read must retain accepted local feedback while cleanup is pending.
+        _ = await model.detail(for: thread.id, force: true)
+        #expect(model.details[thread.id]?.messages.last?.state == .complete)
+        #expect(client.sendMessageCallCount == 1)
+
+        let accepted = try #require(await store.submissions().first)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o700))], ofItemAtPath: directory.path
+        )
+        client.beforeSendMessage = nil
+        client.sendMessageError = URLError(.notConnectedToInternet)
+        #expect(await model.sendMessage(threadID: thread.id, text: "Retry boundary", selection: nil))
+        client.sendMessageError = nil
+        let retryEntered = AsyncStream<Void>.makeStream()
+        var retryResponse: CheckedContinuation<Void, any Error>?
+        client.beforeSendMessageReturn = {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                retryResponse = continuation
+                retryEntered.continuation.yield()
+            }
+        }
+        // This public boundary cancels the delayed retry and starts the owned drain now.
+        #expect(await model.setEnvironmentEnabled("environment-1", enabled: true))
+        var retries = retryEntered.stream.makeAsyncIterator()
+        await retries.next()
+        // Sorted drain reaches the later message only after completing the accepted copy.
+        #expect(try await store.submissions().allSatisfy { $0.id != accepted.id })
+        #expect(client.sentIdentities.filter { $0.commandID == accepted.identity.commandID }.count == 1)
+        #expect(model.details[thread.id]?.messages.first { $0.id == accepted.identity.messageID }?.state == .complete)
+        retryResponse?.resume(throwing: FeatureCapabilityUnavailable("Sentinel rejected"))
+        // Await the current drain's exit through its existing owner boundary.
+        #expect(await model.setEnvironmentEnabled("environment-1", enabled: true))
+        #expect(try await store.submissions().isEmpty)
+        #expect(client.sentIdentities.filter { $0.commandID == accepted.identity.commandID }.count == 1)
     }
 
     @Test
@@ -3560,6 +3661,8 @@ private func orchestrationThread(
 @MainActor
 private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var foregroundReconnects: [Bool] = []
+    var backgroundSuspends = 0
+    func suspendForBackground() { backgroundSuspends += 1 }
     func resumeAfterBackground(reconnect: Bool) async { foregroundReconnects.append(reconnect) }
     private let eventStream: AsyncStream<FeatureEvent>
     private let eventContinuation: AsyncStream<FeatureEvent>.Continuation
@@ -3584,6 +3687,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var startedFromOrigin = false
     var createThreadCallCount = 0
     var sendMessageCallCount = 0
+    var sentIdentities: [FeatureSubmissionIdentity] = []
     var sentRuntimeModes: [FeatureRuntimeMode] = []
     var setRuntimeModeCalls: [FeatureRuntimeMode] = []
     var cancelTurnCallCount = 0
@@ -3598,6 +3702,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var removedEnvironmentID: String?
     var beforeStartTask: (() async throws -> Void)?
     var beforeSendMessage: (() throws -> Void)?
+    var beforeSendMessageReturn: (() async throws -> Void)?
     var beforeSaveSettings: (@MainActor () async throws -> Void)?
     var loadThreadError: (any Error)?
     var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
@@ -3770,6 +3875,7 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     func sendMessage(threadID: String, text: String, selection: FeatureSelection?) async throws {
         sendMessageCallCount += 1
         try beforeSendMessage?()
+        try await beforeSendMessageReturn?()
         if let sendMessageError { throw sendMessageError }
         sentText = text
     }
@@ -3780,8 +3886,9 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         selection: FeatureSelection?,
         runtimeMode: FeatureRuntimeMode,
         attachments _: [FeatureUploadAttachment],
-        identity _: FeatureSubmissionIdentity
+        identity: FeatureSubmissionIdentity
     ) async throws {
+        sentIdentities.append(identity)
         sentRuntimeModes.append(runtimeMode)
         try await sendMessage(threadID: threadID, text: text, selection: selection)
     }

--- a/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/FeatureRootModelTests.swift
@@ -1849,67 +1849,8 @@ struct FeatureRootModelTests {
         #expect(model.details[thread.id]?.messages.last?.state == .queued)
     }
 
-    @Test(arguments: ["accepted", "cancelled", "network", "rejected"])
-    func queuedMessageWaitsForAcceptance(outcome: String) async throws {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("t3-root-queued-feedback-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let store = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
-        let thread = FeatureThread(
-            id: "thread-1", projectID: "project-1", environmentID: "environment-1", title: "Thread"
-        )
-        let client = FeatureClientStub()
-        client.snapshot = FeatureSnapshot(
-            connection: .init(state: .connected),
-            environments: [.init(
-                id: "environment-1", name: "Studio", endpoint: "https://studio.example",
-                isActive: true, connectionState: .connected
-            )],
-            threads: [thread]
-        )
-        client.threadDetail = FeatureThreadDetail(thread: thread)
-        let started = AsyncStream<Void>.makeStream()
-        var response: CheckedContinuation<Void, any Error>?
-        client.beforeSendMessageReturn = {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                response = continuation
-                started.continuation.yield()
-            }
-        }
-        let model = FeatureRootModel(client: client, outboxStore: store)
-        await model.reload()
-        _ = await model.detail(for: thread.id)
-        let send = Task { await model.sendMessage(threadID: thread.id, text: "Queued response", selection: nil) }
-        var requests = started.stream.makeAsyncIterator()
-        await requests.next()
-        #expect(model.details[thread.id]?.messages.last?.state == .queued)
-        #expect(try await store.submissions().count == 1)
-        switch outcome {
-        case "cancelled": response?.resume(throwing: CancellationError())
-        case "network": response?.resume(throwing: URLError(.notConnectedToInternet))
-        case "rejected": response?.resume(throwing: FeatureCapabilityUnavailable("Rejected message"))
-        default: response?.resume()
-        }
-        let sent = await send.value
-        #expect(client.sendMessageCallCount == 1)
-        switch outcome {
-        case "accepted":
-            #expect(sent)
-            #expect(model.details[thread.id]?.messages.last?.state == .complete)
-            #expect(try await store.submissions().isEmpty)
-        case "rejected":
-            #expect(!sent)
-            #expect(model.details[thread.id]?.messages.isEmpty == true)
-            #expect(try await store.submissions().isEmpty)
-        default:
-            #expect(sent, "Ambiguous delivery remains queued for stable-identity retry")
-            #expect(model.details[thread.id]?.messages.last?.state == .queued)
-            #expect(try await store.submissions().count == 1)
-        }
-    }
-
     @Test
-    func failedDeliveryCleanupKeepsAcceptedStateAndTheDurableSubmission() async throws {
+    func failedDeliveryCleanupKeepsTheDurableAndOptimisticSubmission() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-root-completion-failure-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(
@@ -1966,49 +1907,8 @@ struct FeatureRootModelTests {
         #expect(client.sendMessageCallCount == 1)
         #expect(try await store.submissions().count == 1)
         #expect(model.details[thread.id]?.messages.last?.text == "Already delivered")
-        #expect(model.details[thread.id]?.messages.last?.state == .complete)
+        #expect(model.details[thread.id]?.messages.last?.state == .queued)
         #expect(model.errorMessage?.contains("delivered") == true)
-        guard case let .delta(delta) = model.detailRenderUpdates[thread.id]?.change else {
-            Issue.record("Expected accepted message to update the existing timeline row")
-            return
-        }
-        #expect(delta.changedMessages == model.details[thread.id]?.messages)
-        #expect(delta.changedMessages.first?.state == .complete)
-
-        // A stale detail read must retain accepted local feedback while cleanup is pending.
-        _ = await model.detail(for: thread.id, force: true)
-        #expect(model.details[thread.id]?.messages.last?.state == .complete)
-        #expect(client.sendMessageCallCount == 1)
-
-        let accepted = try #require(await store.submissions().first)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: NSNumber(value: Int16(0o700))], ofItemAtPath: directory.path
-        )
-        client.beforeSendMessage = nil
-        client.sendMessageError = URLError(.notConnectedToInternet)
-        #expect(await model.sendMessage(threadID: thread.id, text: "Retry boundary", selection: nil))
-        client.sendMessageError = nil
-        let retryEntered = AsyncStream<Void>.makeStream()
-        var retryResponse: CheckedContinuation<Void, any Error>?
-        client.beforeSendMessageReturn = {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                retryResponse = continuation
-                retryEntered.continuation.yield()
-            }
-        }
-        // This public boundary cancels the delayed retry and starts the owned drain now.
-        #expect(await model.setEnvironmentEnabled("environment-1", enabled: true))
-        var retries = retryEntered.stream.makeAsyncIterator()
-        await retries.next()
-        // Sorted drain reaches the later message only after completing the accepted copy.
-        #expect(try await store.submissions().allSatisfy { $0.id != accepted.id })
-        #expect(client.sentIdentities.filter { $0.commandID == accepted.identity.commandID }.count == 1)
-        #expect(model.details[thread.id]?.messages.first { $0.id == accepted.identity.messageID }?.state == .complete)
-        retryResponse?.resume(throwing: FeatureCapabilityUnavailable("Sentinel rejected"))
-        // Await the current drain's exit through its existing owner boundary.
-        #expect(await model.setEnvironmentEnabled("environment-1", enabled: true))
-        #expect(try await store.submissions().isEmpty)
-        #expect(client.sentIdentities.filter { $0.commandID == accepted.identity.commandID }.count == 1)
     }
 
     @Test
@@ -3851,7 +3751,6 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var startedFromOrigin = false
     var createThreadCallCount = 0
     var sendMessageCallCount = 0
-    var sentIdentities: [FeatureSubmissionIdentity] = []
     var sentRuntimeModes: [FeatureRuntimeMode] = []
     var setRuntimeModeCalls: [FeatureRuntimeMode] = []
     var cancelTurnCallCount = 0
@@ -3866,7 +3765,6 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     var removedEnvironmentID: String?
     var beforeStartTask: (() async throws -> Void)?
     var beforeSendMessage: (() throws -> Void)?
-    var beforeSendMessageReturn: (() async throws -> Void)?
     var beforeSaveSettings: (@MainActor () async throws -> Void)?
     var loadThreadError: (any Error)?
     var loadThreadHandler: ((String) async throws -> FeatureThreadDetail)?
@@ -4040,7 +3938,6 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
     func sendMessage(threadID: String, text: String, selection: FeatureSelection?) async throws {
         sendMessageCallCount += 1
         try beforeSendMessage?()
-        try await beforeSendMessageReturn?()
         if let sendMessageError { throw sendMessageError }
         sentText = text
     }
@@ -4051,9 +3948,8 @@ private final class FeatureClientStub: FeatureClient, T3ConnectCapable {
         selection: FeatureSelection?,
         runtimeMode: FeatureRuntimeMode,
         attachments _: [FeatureUploadAttachment],
-        identity: FeatureSubmissionIdentity
+        identity _: FeatureSubmissionIdentity
     ) async throws {
-        sentIdentities.append(identity)
         sentRuntimeModes.append(runtimeMode)
         try await sendMessage(threadID: threadID, text: text, selection: selection)
     }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -2751,7 +2751,7 @@ private actor PassiveLiveServer: WebSocketConnecting {
         }
         if value["_tag"]?.stringValue == "Ping" { return .object(["_tag": .string("Pong")]) }
         if value["tag"]?.stringValue == RPCMethod.dispatchCommand.rawValue,
-           value["payload"]?["type"]?.stringValue == "thread.meta.update",
+           ["thread.meta.update", "thread.unarchive"].contains(value["payload"]?["type"]?.stringValue ?? ""),
            case let .number(id)? = value["id"] {
             return .object([
                 "_tag": .string("Exit"), "requestId": .number(id),
@@ -2850,6 +2850,56 @@ private actor PassiveLiveConnection: WebSocketConnection {
 @Suite("Native incremental bootstrap")
 @MainActor
 struct NativeIncrementalBootstrapTests {
+    @Test("Foreground restores bootstrap before a client has been adopted", .timeLimit(.minutes(1)))
+    func foregroundRestartsUnadoptedClient() async throws {
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let recorder = BootstrapSnapshotRecorder(
+            seed: FeatureSnapshot(connection: .init(state: .disconnected)), events: fixture.client.events()
+        )
+        defer { recorder.stop() }
+        fixture.client.suspendForBackground()
+        await fixture.client.resumeAfterBackground(reconnect: false)
+        let restored = try await recorder.wait { $0.threads.contains { $0.environmentID == "one" } }
+        #expect(restored.environments.contains { $0.id == "one" })
+        await fixture.client.disconnect()
+    }
+
+    @Test("An archive refresh reads the current shell after the archive RPC settles", .timeLimit(.minutes(1)))
+    func archiveRefreshReadsShellAfterArchive() async throws {
+        let receipts = PassiveLiveReceipts()
+        let server = PassiveLiveServer()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server, fallbackPollingInitialDelay: .seconds(60),
+            aggregatePublishSleep: {}, aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.hydratedSnapshot()
+        let recorder = try #require(fixture.recorder)
+        try await receipts.waitForArchive("one")
+        let archive = PassiveRequestGate()
+        await server.holdArchive(host: "one.example", gate: archive)
+        let refresh = Task { try await fixture.client.setThreadArchived(id: "thread-one", archived: false) }
+        do {
+            try await archive.waitUntilEnteredCancellable()
+            await fixture.transport.setShell(multiEnvironmentShell(
+                projectID: "project-one", threadID: "thread-one", title: "Current after archive", snapshotSequence: 20
+            ), host: "one.example")
+            await archive.release()
+            try await refresh.value
+            #expect(recorder.history.last?.threads.contains { $0.title == "Current after archive" } == true)
+        } catch {
+            await archive.release()
+            refresh.cancel()
+            _ = try? await refresh.value
+            await fixture.client.disconnect()
+            throw error
+        }
+        await fixture.client.disconnect()
+    }
+
     @Test("Metadata returns while active HTTP and catalogue are held; a healthy peer publishes", .timeLimit(.minutes(1)))
     func heldActiveDoesNotBlockHealthyPeer() async throws {
         let connector = BootstrapHeldConnector()

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -453,7 +453,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "two.example"
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let thread = try XCTUnwrap(snapshot.threads.first { $0.environmentID == "two" })
         XCTAssertTrue(thread.isRegeneratingTitle)
 
@@ -2387,6 +2387,8 @@ struct NativePassiveLiveShellTests {
         let live = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Live", snapshotSequence: 10)
         try await server.snapshot(live, host: "two.example")
         try await receipts.waitForShells("two", count: 1)
+        let initialReadCount = await fixture.transport.shellReadCount(host: "two.example")
+        let initialReceiptCount = receipts.httpCount("two")
         let held = PassiveRequestGate()
         let repaired = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "HTTP repaired", snapshotSequence: 11)
         await fixture.transport.setShell(repaired, host: "two.example")
@@ -2395,15 +2397,15 @@ struct NativePassiveLiveShellTests {
         await held.waitUntilEntered()
         await server.waitForSubscriptions(host: "two.example", count: 2)
         let readCount = await fixture.transport.shellReadCount(host: "two.example")
-        #expect(readCount == 2)
+        #expect(readCount == initialReadCount + 1)
         let probe = ThreadTitleEventProbe(events: fixture.client.events(), threadID: threadID, title: "HTTP repaired")
         probe.start()
         await held.release()
-        try await receipts.waitForHTTP("two", count: 2)
+        try await receipts.waitForHTTP("two", count: initialReceiptCount + 1)
         await probe.waitUntilObserved()
         try await server.snapshot(repaired, host: "two.example")
         try await receipts.waitForShells("two", count: 2)
-        #expect(await fixture.transport.shellReadCount(host: "two.example") == 2)
+        #expect(await fixture.transport.shellReadCount(host: "two.example") == initialReadCount + 1)
         await fixture.client.disconnect()
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -1702,6 +1702,15 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
     func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let host = request.url?.host ?? ""
         let path = request.url?.path ?? ""
+        if path == "/.well-known/t3/environment" {
+            let id = host == "one.example" ? "one" : "two"
+            return (try JSONEncoder.t3.encode(multiEnvironmentDescriptor(
+                environmentID: id, label: id == "one" ? "Left Book" : "Steam Box", pullRequestsAvailable: true
+            )), multiEnvironmentResponse(request))
+        }
+        if path == "/oauth/token" {
+            return (Data(#"{"access_token":"paired-token","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600,"scope":"read write"}"#.utf8), multiEnvironmentResponse(request))
+        }
         if path == "/api/orchestration/shell" {
             shellReadCounts[host, default: 0] += 1
             if let gate = nextShellGates.removeValue(forKey: host), let data = shellData[host] {
@@ -2897,6 +2906,41 @@ private actor PassiveLiveConnection: WebSocketConnection {
 @Suite("Native incremental bootstrap")
 @MainActor
 struct NativeIncrementalBootstrapTests {
+    @Test("Pairing resets the previous environment's hydration and archive lifetime", .timeLimit(.minutes(1)), arguments: [false, true])
+    func pairingReplacesHydrationLifetime(previousHydrated: Bool) async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server, fallbackPollingInitialDelay: .seconds(60),
+            aggregatePublishSleep: {}, aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let held = PassiveRequestGate()
+        if !previousHydrated { await fixture.transport.holdNextShell(host: "one.example", gate: held) }
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        do {
+            if previousHydrated { try await receipts.waitForArchive("one") }
+            else { try await held.waitUntilEnteredCancellable() }
+            await server.waitForSubscriptions(host: "two.example", count: 1)
+            try await fixture.client.pair(endpoint: "https://two.example", token: "fixture-bootstrap")
+            await server.waitForSubscriptions(host: "two.example", count: 2)
+            let shell = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "New active hydration", snapshotSequence: 20)
+            await fixture.transport.setShell(shell, host: "two.example")
+            try await server.upsert(shell.threads[0], sequence: 20, host: "two.example")
+            _ = try await recorder.wait { $0.threads.contains { $0.title == "New active hydration" } }
+            try await receipts.waitForArchive("two")
+            if !previousHydrated { #expect(await held.isHeld) }
+        } catch {
+            await held.release()
+            await fixture.client.disconnect()
+            throw error
+        }
+        await held.release()
+        await fixture.client.disconnect()
+    }
+
     @Test("Foreground restores bootstrap before a client has been adopted", .timeLimit(.minutes(1)))
     func foregroundRestartsUnadoptedClient() async throws {
         let fixture = try await NativeMultiEnvironmentTests.makeFixture(

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -2906,6 +2906,31 @@ private actor PassiveLiveConnection: WebSocketConnection {
 @Suite("Native incremental bootstrap")
 @MainActor
 struct NativeIncrementalBootstrapTests {
+    @Test("Environment-store failures remain visible to the root model")
+    func environmentStoreFailureIsNotCancellation() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let catalog = directory.appendingPathComponent("environments.json")
+        try Data("invalid catalog".utf8).write(to: catalog)
+        let runtime = EnvironmentRuntime(environmentStore: EnvironmentStore(fileURL: catalog),
+                                         credentialStore: InMemoryCredentialStore())
+        let client = NativeFeatureClient(runtime: runtime)
+        do {
+            _ = try await client.initialSnapshot()
+            Issue.record("The invalid catalog unexpectedly loaded")
+        } catch {
+            #expect(error is DecodingError)
+            #expect(!(error is CancellationError))
+        }
+        let model = FeatureRootModel(client: client,
+            outboxStore: FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json")),
+            draftStore: FeatureComposerDraftStore(fileURL: directory.appendingPathComponent("drafts.json")))
+        await model.reload()
+        #expect(model.errorMessage?.isEmpty == false)
+        await model.disconnect()
+    }
+
     @Test("Pairing resets the previous environment's hydration and archive lifetime", .timeLimit(.minutes(1)), arguments: [false, true])
     func pairingReplacesHydrationLifetime(previousHydrated: Bool) async throws {
         let server = PassiveLiveServer()

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -2485,7 +2485,9 @@ struct NativePassiveLiveShellTests {
         let nextWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
         try await fixture.client.removeEnvironment(id: "two")
         await nextWorker.value
-        await server.waitForInterrupts(host: "two.example", count: 2)
+        // Successful removal closes the transport before cancelling the worker.
+        // There is no live socket on which to deliver another Interrupt frame.
+        #expect(await server.latestConnectionIsClosed(host: "two.example"))
         #expect(nextWorker.isCancelled)
         #expect(fixture.client.aggregateRefreshWorkers["two"] == nil)
         let snapshot = try await fixture.client.backgroundSnapshot()
@@ -2850,10 +2852,15 @@ private actor PassiveLiveServer: WebSocketConnecting {
 
     func subscriptionCount(host: String) -> Int { subscriptions[host, default: []].count }
 
+    func latestConnectionIsClosed(host: String) async -> Bool {
+        await subscriptions[host]?.last?.connection.isClosed ?? false
+    }
+
     func closeLatest(host: String) async { await subscriptions[host]?.last?.connection.close() }
 }
 
 private actor PassiveLiveConnection: WebSocketConnection {
+    var isClosed: Bool { closed }
     private let host: String
     private let server: PassiveLiveServer
     private var responses: [Data] = []

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -1222,6 +1222,46 @@ struct NativePassiveThreadRefreshTests {
         await fixture.client.disconnect()
     }
 
+    @Test("Failed environment writes preserve the passive worker", arguments: [false, true])
+    func failedEnvironmentWritePreservesWorker(removal: Bool) async throws {
+        let clock = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            aggregatePeerRefreshSleep: { _, interval in try await clock.sleep(for: interval) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        _ = await clock.waitUntilRequested(count: 1)
+        let worker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        let catalog = fixture.directory.appendingPathComponent("environments.json")
+        let data = try Data(contentsOf: catalog)
+        try FileManager.default.removeItem(at: catalog)
+        try FileManager.default.createDirectory(at: catalog, withIntermediateDirectories: false)
+        do {
+            if removal { try await fixture.client.removeEnvironment(id: "two") }
+            else { try await fixture.client.setEnvironmentEnabled(id: "two", enabled: false) }
+            Issue.record("The blocked catalog write unexpectedly succeeded")
+        } catch {
+            #expect(!worker.isCancelled)
+            #expect(fixture.client.aggregateRefreshWorkers["two"] != nil)
+        }
+        try FileManager.default.removeItem(at: catalog)
+        try data.write(to: catalog)
+        #expect(try await fixture.runtime.environments().contains { $0.id == "two" && $0.isEnabled })
+        let probe = ThreadTitleEventProbe(
+            events: fixture.client.events(),
+            threadID: FeatureScopedID.thread(environmentID: "two", wireID: "thread-two"),
+            title: "Still updating"
+        )
+        probe.start()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Still updating", snapshotSequence: 2
+        ), host: "two.example")
+        await clock.resume()
+        await probe.waitUntilObserved()
+        #expect(probe.didObserveTitle())
+        await fixture.client.disconnect()
+    }
+
     @Test("Removal cancels a held peer and its late response never returns a row", .timeLimit(.minutes(1)))
     func removedPeerCannotPublishLateResponse() async throws {
         let removedClock = ControllableAggregateRefreshSleep()

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Darwin
+import Observation
 import Testing
 import XCTest
 @testable import T3Code
@@ -81,7 +83,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
 
         XCTAssertEqual(Set(snapshot.projects.map(\.environmentID)), ["one", "two"])
         XCTAssertEqual(Set(snapshot.threads.compactMap(\.wireID)), ["thread-one", "thread-two"])
@@ -136,19 +138,19 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testPassiveProviderRefreshKeepsActiveThreadsAndAcceptsTheirNextSequence() async throws {
         let server = MultiEnvironmentConfigurationServer()
         let fixture = try await Self.makeFixture(
-            passiveSequence: 5_000,
+            requireConfiguration: true, passiveSequence: 5_000,
             webSocketConnector: MultiEnvironmentConfigurationConnector(server: server),
             rpcConnectionWaitTimeout: .seconds(1),
             fallbackPollingInitialDelay: .seconds(60),
             aggregateRefreshInterval: .seconds(60)
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         let providers = try await fixture.client.refreshProviders(environmentID: "two")
         XCTAssertEqual(providers.map(\.id), ["codex-two.example"])
 
-        let refreshed = try await fixture.client.initialSnapshot()
+        let refreshed = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             refreshed.threads.filter { $0.environmentID == "one" }.compactMap(\.wireID),
             ["thread-one"]
@@ -174,7 +176,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "one.example"
         )
 
-        let updated = try await fixture.client.initialSnapshot()
+        let updated = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             Set(updated.threads.filter { $0.environmentID == "one" }.compactMap(\.wireID)),
             ["thread-one", "thread-new"]
@@ -188,20 +190,20 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testPassiveEnvironmentSettingsDoNotReplaceActiveThreads() async throws {
         let server = MultiEnvironmentConfigurationServer()
         let fixture = try await Self.makeFixture(
-            passiveSequence: 5_000,
+            requireConfiguration: true, passiveSequence: 5_000,
             webSocketConnector: MultiEnvironmentConfigurationConnector(server: server),
             rpcConnectionWaitTimeout: .seconds(1),
             fallbackPollingInitialDelay: .seconds(60),
             aggregateRefreshInterval: .seconds(60)
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         try await fixture.client.updateServerPreferences(
             environmentID: "two", change: .environmentIcon("mac-mini")
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             snapshot.threads.filter { $0.environmentID == "one" }.compactMap(\.wireID),
             ["thread-one"]
@@ -218,6 +220,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testMachineModelDefaultsRefreshCachedProjectsWithoutChangingOtherEnvironments() async throws {
         let server = MultiEnvironmentConfigurationServer()
         let fixture = try await Self.makeFixture(
+            requireConfiguration: true,
             webSocketConnector: MultiEnvironmentConfigurationConnector(server: server),
             rpcConnectionWaitTimeout: .seconds(1),
             fallbackPollingInitialDelay: .seconds(60),
@@ -232,7 +235,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             snapshotSequence: source.snapshotSequence, projects: [project],
             threads: source.threads, updatedAt: source.updatedAt
         ), host: "two.example")
-        let initial = try await fixture.client.initialSnapshot()
+        let initial = try await fixture.hydratedSnapshot()
         XCTAssertNil(initial.projects.first { $0.environmentID == "two" }?.defaultSelection)
         let localDefault = initial.projects.first { $0.environmentID == "one" }?.defaultSelection
 
@@ -241,13 +244,13 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             try await fixture.client.updateServerPreferences(environmentID: "two", change: .sharedPreferences(.object([
                 "defaultModelSelection": try JSONValue.encode(selection),
             ])))
-            let snapshot = try await fixture.client.initialSnapshot()
+            let snapshot = try await fixture.hydratedSnapshot()
             XCTAssertEqual(snapshot.projects.first { $0.environmentID == "two" }?.defaultSelection?.modelID, model)
             XCTAssertEqual(snapshot.projects.first { $0.environmentID == "one" }?.defaultSelection, localDefault)
         }
 
         await fixture.transport.setShell(source, host: "two.example")
-        let overridden = try await fixture.client.initialSnapshot()
+        let overridden = try await fixture.hydratedSnapshot()
         XCTAssertEqual(overridden.projects.first { $0.environmentID == "two" }?.defaultSelection?.modelID, "gpt-5.6-sol")
         await fixture.client.disconnect()
     }
@@ -255,20 +258,20 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testSharedSettingsFanOutDoesNotReplaceActiveThreads() async throws {
         let server = MultiEnvironmentConfigurationServer()
         let fixture = try await Self.makeFixture(
-            passiveSequence: 5_000,
+            requireConfiguration: true, passiveSequence: 5_000,
             webSocketConnector: MultiEnvironmentConfigurationConnector(server: server),
             rpcConnectionWaitTimeout: .seconds(1),
             fallbackPollingInitialDelay: .seconds(60),
             aggregateRefreshInterval: .seconds(60)
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         try await fixture.client.updateServerPreferences(
             environmentID: "one", change: .defaultThreadEnvMode(.worktree)
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             snapshot.threads.filter { $0.environmentID == "one" }.compactMap(\.wireID),
             ["thread-one"]
@@ -285,13 +288,14 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testRestartPreferenceOnlyReachesComputersThatSupportIt() async throws {
         let server = MultiEnvironmentConfigurationServer(restartSupportHosts: ["one.example"])
         let fixture = try await Self.makeFixture(
+            requireConfiguration: true,
             webSocketConnector: MultiEnvironmentConfigurationConnector(server: server),
             rpcConnectionWaitTimeout: .seconds(1),
             fallbackPollingInitialDelay: .seconds(60),
             aggregateRefreshInterval: .seconds(60)
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         XCTAssertEqual(snapshot.preferencesByEnvironment?["one"]?.continueThreadsAfterServerUpdate, false)
         XCTAssertNil(snapshot.preferencesByEnvironment?["two"]?.continueThreadsAfterServerUpdate)
 
@@ -336,7 +340,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "one.example"
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let thread = try XCTUnwrap(
             snapshot.threads.first(where: { $0.wireID == "thread-one" })
         )
@@ -371,7 +375,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "two.example"
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let thread = try XCTUnwrap(snapshot.threads.first { $0.environmentID == "two" })
         let detail = try await fixture.client.loadThread(id: thread.id)
 
@@ -403,7 +407,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "two.example"
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let thread = try XCTUnwrap(snapshot.threads.first { $0.environmentID == "two" })
         let detail = try await fixture.client.loadThread(id: thread.id)
 
@@ -477,7 +481,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let fixture = try await Self.makeFixture(repositoryIdentity: identity)
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let groups = DailyUXCreationContext.projectGroups(in: snapshot)
 
         XCTAssertEqual(Set(snapshot.projects.compactMap(\.repositoryIdentity?.canonicalKey)), [
@@ -492,15 +496,15 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
         await fixture.transport.setReachable(false, host: "two.example")
 
-        let passiveFailure = try await fixture.client.initialSnapshot()
+        let passiveFailure = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             Set(passiveFailure.threads.compactMap(\.wireID)),
             ["thread-one", "thread-two"]
         )
-        XCTAssertEqual(passiveFailure.connection.state, .connected)
+        XCTAssertEqual(passiveFailure.environments.first { $0.id == "one" }?.connectionState, .connected)
         XCTAssertEqual(
             passiveFailure.environments.first(where: { $0.id == "two" })?.connectionState,
             .disconnected
@@ -509,7 +513,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         await fixture.transport.setReachable(false, host: "one.example")
         await fixture.transport.setReachable(true, host: "two.example")
 
-        let activeFailure = try await fixture.client.initialSnapshot()
+        let activeFailure = try await fixture.hydratedSnapshot()
         XCTAssertEqual(
             Set(activeFailure.threads.compactMap(\.wireID)),
             ["thread-one", "thread-two"]
@@ -526,7 +530,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testCachedShellRowsApplySettlementAndRemoveDeletedRoutes() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let initial = try await fixture.client.initialSnapshot()
+        let initial = try await fixture.hydratedSnapshot()
         let original = try XCTUnwrap(initial.threads.first { $0.environmentID == "two" })
         let updated = multiEnvironmentShell(
             projectID: "project-two", threadID: "thread-two", title: "Remote work",
@@ -535,7 +539,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             settledOverride: "settled", settledAt: "2026-07-31T12:01:00.000Z"
         )
         await fixture.transport.setShell(updated, host: "two.example")
-        let refreshed = try await fixture.client.initialSnapshot()
+        let refreshed = try await fixture.hydratedSnapshot()
         let settled = try XCTUnwrap(refreshed.threads.first { $0.id == original.id })
         XCTAssertEqual(settled.updatedAt, original.updatedAt)
         XCTAssertTrue(settled.isSettled)
@@ -549,7 +553,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             ),
             host: "two.example"
         )
-        let removed = try await fixture.client.initialSnapshot()
+        let removed = try await fixture.hydratedSnapshot()
         XCTAssertFalse(removed.threads.contains { $0.id == original.id })
         XCTAssertEqual(removed.projects.first { $0.environmentID == "two" }?.threadCount, 0)
         do {
@@ -564,7 +568,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testOlderHTTPSnapshotCannotReplaceNewerEnvironmentState() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         let newer = multiEnvironmentShell(
             projectID: "project-one",
@@ -580,7 +584,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             ),
             host: "one.example"
         )
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         let older = multiEnvironmentShell(
             projectID: "project-one",
@@ -597,7 +601,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             host: "one.example"
         )
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
 
         XCTAssertEqual(
             snapshot.threads.first(where: { $0.environmentID == "one" })?.title,
@@ -609,7 +613,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testThreadCreationCannotReplaceNewerEnvironmentStateWithAnOlderShell() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         let newer = multiEnvironmentShell(
             projectID: "project-one",
@@ -625,7 +629,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             ),
             host: "one.example"
         )
-        let current = try await fixture.client.initialSnapshot()
+        let current = try await fixture.hydratedSnapshot()
         let project = try XCTUnwrap(
             current.projects.first(where: { $0.environmentID == "one" })
         )
@@ -650,7 +654,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             title: "Another task",
             selection: nil
         )
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
 
         XCTAssertEqual(
             snapshot.threads.first(where: { $0.wireID == "thread-one" })?.title,
@@ -722,7 +726,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         await loader.waitForCallCount(2)
         let retryCallCount = await loader.callCount
@@ -743,7 +747,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         _ = try await fixture.client.initialSnapshot()
         await loader.waitForCallCount(1)
 
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
 
         await loader.waitForFirstLoadCancellation()
         await loader.waitForCallCount(2)
@@ -756,7 +760,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let fixture = try await Self.makeFixture(duplicateIDs: true)
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         XCTAssertEqual(snapshot.projects.count, 2)
         XCTAssertEqual(snapshot.threads.count, 2)
         XCTAssertEqual(Set(snapshot.projects.map(\.id)).count, 2)
@@ -779,7 +783,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
 
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let remoteProject = try XCTUnwrap(
             snapshot.projects.first(where: { $0.environmentID == "two" })
         )
@@ -812,7 +816,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testPassiveCreateRecoversACommittedThreadAfterItsReplyIsLost() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let snapshot = try await fixture.client.initialSnapshot()
+        let snapshot = try await fixture.hydratedSnapshot()
         let project = try XCTUnwrap(
             snapshot.projects.first(where: { $0.environmentID == "two" })
         )
@@ -837,32 +841,17 @@ final class NativeMultiEnvironmentTests: XCTestCase {
     func testUnarchiveImmediatelyRestoresLiveThreadWhenRefreshIsUnavailable() async throws {
         let fixture = try await Self.makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let initial = try await fixture.client.initialSnapshot()
+        let initial = try await fixture.hydratedSnapshot()
         let thread = try XCTUnwrap(
             initial.threads.first(where: { $0.environmentID == "one" })
         )
-        let events = fixture.client.events()
-        var iterator = events.makeAsyncIterator()
+        let recorder = try XCTUnwrap(fixture.recorder)
         await fixture.transport.setShellReadsEnabled(false, host: "one.example")
-
         try await fixture.client.setThreadArchived(id: thread.id, archived: true)
-        while let event = await iterator.next() {
-            if case let .thread(candidate) = event,
-               candidate.id == thread.id,
-               candidate.isArchived {
-                break
-            }
-        }
+        _ = try await recorder.wait { $0.threads.contains { $0.id == thread.id && $0.isArchived } }
         try await fixture.client.setThreadArchived(id: thread.id, archived: false)
-        var restored: FeatureThread?
-        while let event = await iterator.next() {
-            if case let .thread(candidate) = event,
-               candidate.id == thread.id,
-               !candidate.isArchived {
-                restored = candidate
-                break
-            }
-        }
+        let restoredSnapshot = try await recorder.wait { $0.threads.contains { $0.id == thread.id && !$0.isArchived } }
+        let restored = restoredSnapshot.threads.first { $0.id == thread.id }
 
         XCTAssertEqual(restored?.id, thread.id)
         XCTAssertEqual(restored?.isArchived, false)
@@ -875,7 +864,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             fallbackPollingInterval: .seconds(2)
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        _ = try await fixture.hydratedSnapshot()
         let current = multiEnvironmentShell(
             projectID: "project-one",
             threadID: "thread-one",
@@ -901,23 +890,15 @@ final class NativeMultiEnvironmentTests: XCTestCase {
             ),
             host: "one.example"
         )
-        let events = fixture.client.events()
-        var iterator = events.makeAsyncIterator()
-        var refreshed: FeatureSnapshot?
-        while let event = await iterator.next() {
-            if case let .snapshot(snapshot) = event,
-               snapshot.projects.contains(where: { $0.wireID == addedProject.id }) {
-                refreshed = snapshot
-                break
-            }
-        }
-
-        XCTAssertEqual(refreshed?.connection.state, .reconnecting)
+        let recorder = try XCTUnwrap(fixture.recorder)
+        let refreshed = try await recorder.wait { $0.projects.contains { $0.wireID == addedProject.id } }
+        XCTAssertEqual(refreshed.connection.state, .reconnecting)
         await fixture.client.disconnect()
     }
 
     fileprivate static func makeFixture(
         duplicateIDs: Bool = false,
+        requireConfiguration: Bool = false,
         passiveSequence: Int = 1,
         includeThirdEnvironment: Bool = false,
         repositoryIdentity: RepositoryIdentity? = nil,
@@ -932,6 +913,16 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         aggregateRefreshSleep: @escaping @Sendable (Duration) async throws -> Void = {
             try await Task.sleep(for: $0)
         },
+        aggregatePeerRefreshSleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
+        aggregateStreamRetrySleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
+        aggregatePublishSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(250))
+        },
+        aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
         aggregateEnvironmentLoader: @escaping @Sendable (EnvironmentRuntime) async throws -> [Environment] = {
             try await $0.environments()
         }
@@ -1026,9 +1017,11 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         let settings = UserDefaults(
             suiteName: "t3-native-multi-\(UUID().uuidString)"
         )!
+        let receipts = PassiveLiveReceipts()
         return MultiEnvironmentFixture(
             directory: directory,
             transport: transport,
+            runtime: runtime,
             client: NativeFeatureClient(
                 runtime: runtime,
                 settingsStore: settings,
@@ -1038,8 +1031,15 @@ final class NativeMultiEnvironmentTests: XCTestCase {
                 aggregateIdleRefreshInterval: aggregateIdleRefreshInterval,
                 aggregateFailureRefreshInterval: aggregateFailureRefreshInterval,
                 aggregateRefreshSleep: aggregateRefreshSleep,
+                aggregatePeerRefreshSleep: aggregatePeerRefreshSleep,
+                aggregateStreamRetrySleep: aggregateStreamRetrySleep,
+                aggregatePublishSleep: aggregatePublishSleep,
+                aggregateRefreshReceipt: { receipt in
+                    receipts.record(receipt)
+                    aggregateRefreshReceipt(receipt)
+                },
                 aggregateEnvironmentLoader: aggregateEnvironmentLoader
-            )
+            ), receipts: receipts, requireConfiguration: requireConfiguration
         )
     }
 }
@@ -1054,19 +1054,17 @@ struct NativePassiveThreadRefreshTests {
     func passiveThreadEventsArriveWithinFiveSecondsAndStayFastAfterChanges() async throws {
         let refreshSleep = ControllableAggregateRefreshSleep()
         let fixture = try await NativeMultiEnvironmentTests.makeFixture(
-            aggregateRefreshSleep: {
-                try await refreshSleep.sleep(for: $0)
+            aggregatePeerRefreshSleep: { _, interval in
+                try await refreshSleep.sleep(for: interval)
             }
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        let initial = try await fixture.client.initialSnapshot()
-        let thread = try #require(
-            initial.threads.first(where: { $0.environmentID == "two" })
-        )
+        _ = try await fixture.client.initialSnapshot()
+        let threadID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
         let updatedTitle = "Passive work updated automatically"
         let eventProbe = ThreadTitleEventProbe(
             events: fixture.client.events(),
-            threadID: thread.id,
+            threadID: threadID,
             title: updatedTitle
         )
         eventProbe.start()
@@ -1096,8 +1094,8 @@ struct NativePassiveThreadRefreshTests {
     func passiveRefreshUsesTenSecondsWhenWorkIsUnchanged() async throws {
         let refreshSleep = ControllableAggregateRefreshSleep()
         let fixture = try await NativeMultiEnvironmentTests.makeFixture(
-            aggregateRefreshSleep: {
-                try await refreshSleep.sleep(for: $0)
+            aggregatePeerRefreshSleep: { _, interval in
+                try await refreshSleep.sleep(for: interval)
             }
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
@@ -1111,52 +1109,159 @@ struct NativePassiveThreadRefreshTests {
         await fixture.client.disconnect()
     }
 
-    @Test("A failed passive environment backs off without slowing an active peer")
+    @Test("A failed passive environment backs off without slowing an active peer", .timeLimit(.minutes(1)))
     func failedPassiveEnvironmentBacksOffWithoutSlowingActivePeer() async throws {
-        let refreshSleep = ControllableAggregateRefreshSleep()
+        let healthyClock = ControllableAggregateRefreshSleep()
+        let failedClock = ControllableAggregateRefreshSleep()
         let fixture = try await NativeMultiEnvironmentTests.makeFixture(
             includeThirdEnvironment: true,
-            aggregateRefreshSleep: {
-                try await refreshSleep.sleep(for: $0)
+            aggregatePeerRefreshSleep: { id, interval in
+                try await (id == "two" ? healthyClock : failedClock).sleep(for: interval)
             }
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         _ = try await fixture.client.initialSnapshot()
-        await fixture.transport.setShell(
-            multiEnvironmentShell(
-                projectID: "project-two",
-                threadID: "thread-two",
-                title: "Remote work",
-                providerID: "claudeAgent",
-                modelID: "claude-opus-4-1",
-                backgroundLiveness: .working
-            ),
-            host: "two.example"
-        )
+        _ = await healthyClock.waitUntilRequested(count: 1)
+        _ = await failedClock.waitUntilRequested(count: 1)
         await fixture.transport.setReachable(false, host: "three.example")
-
-        let firstCadence = await refreshSleep.waitUntilRequested(count: 1)
-        #expect(firstCadence == .seconds(5))
-        await refreshSleep.resume()
-        let secondCadence = await refreshSleep.waitUntilRequested(count: 2)
-        #expect(secondCadence == .seconds(5))
-        let initialFailedReadCount = await fixture.transport.shellReadCount(host: "three.example")
-        #expect(initialFailedReadCount == 2)
-
-        for requestCount in 2...4 {
-            await refreshSleep.resume()
-            let cadence = await refreshSleep.waitUntilRequested(count: requestCount + 1)
-            #expect(cadence == .seconds(5))
-            let failedReadCount = await fixture.transport.shellReadCount(host: "three.example")
-            #expect(failedReadCount == 2)
+        await failedClock.resume()
+        let failureCadence = await failedClock.waitUntilRequested(count: 2)
+        #expect(failureCadence == .seconds(20))
+        for count in 2...4 {
+            await healthyClock.resume()
+            _ = await healthyClock.waitUntilRequested(count: count)
+            let failedReads = await fixture.transport.shellReadCount(host: "three.example")
+            #expect(failedReads == 2)
         }
-
-        await refreshSleep.resume()
-        _ = await refreshSleep.waitUntilRequested(count: 6)
-        let retriedReadCount = await fixture.transport.shellReadCount(host: "three.example")
-        #expect(retriedReadCount == 3)
+        await failedClock.resume()
+        _ = await failedClock.waitUntilRequested(count: 3)
+        let retriedReads = await fixture.transport.shellReadCount(host: "three.example")
+        #expect(retriedReads == 3)
         await fixture.client.disconnect()
     }
+
+    @Test("Healthy rows publish twice while a peer shell and optional catalogue remain held", .timeLimit(.minutes(1)))
+    func healthyRowsPublishTwiceWhilePeerAndCatalogueAreHeld() async throws {
+        let healthyClock = ControllableAggregateRefreshSleep()
+        let slowClock = ControllableAggregateRefreshSleep()
+        let connector = GatedPassiveCatalogueConnector()
+        let topologyGate = PassiveRequestGate()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            includeThirdEnvironment: true,
+            webSocketConnector: connector,
+            aggregatePeerRefreshSleep: { id, interval in
+                try await (id == "two" ? healthyClock : slowClock).sleep(for: interval)
+            },
+            aggregateEnvironmentLoader: { runtime in
+                await topologyGate.enter()
+                return try await runtime.environments()
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let healthyID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
+        let heldShell = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "three.example", gate: heldShell)
+        await connector.holdPassiveConnections()
+        await topologyGate.release()
+        await connector.gate.waitUntilEntered()
+        _ = await healthyClock.waitUntilRequested(count: 1)
+        await heldShell.waitUntilEntered()
+        for update in 1...2 {
+            let title = "Healthy update \(update)"
+            let probe = ThreadTitleEventProbe(events: fixture.client.events(), threadID: healthyID, title: title)
+            probe.start()
+            await fixture.transport.setShell(multiEnvironmentShell(
+                projectID: "project-two", threadID: "thread-two", title: title,
+                snapshotSequence: update + 1
+            ), host: "two.example")
+            await healthyClock.resume()
+            await probe.waitUntilObserved()
+            #expect(probe.didObserveTitle())
+            _ = await healthyClock.waitUntilRequested(count: update + 1)
+            #expect(await heldShell.isHeld)
+            #expect(await connector.gate.isHeld)
+        }
+        await fixture.client.disconnect()
+        await heldShell.release()
+        await connector.release()
+    }
+    @Test("A cancelled refresh generation cannot overwrite a restarted peer", .timeLimit(.minutes(1)))
+    func cancelledGenerationCannotOverwriteRestartedPeer() async throws {
+        let clock = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            aggregatePeerRefreshSleep: { _, interval in try await clock.sleep(for: interval) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        _ = await clock.waitUntilRequested(count: 1)
+        let oldWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        let gate = PassiveRequestGate()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Stale generation",
+            snapshotSequence: 999
+        ), host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: gate)
+        await clock.resume()
+        await gate.waitUntilEntered()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Current generation",
+            snapshotSequence: 2
+        ), host: "two.example")
+        _ = try await fixture.client.initialSnapshot()
+        #expect(oldWorker.isCancelled)
+        await gate.release()
+        await oldWorker.value
+        // A stale 999 would survive this read of sequence 2 if it reached the cache.
+        let snapshot = try await fixture.client.backgroundSnapshot()
+        #expect(snapshot.threads.first { $0.environmentID == "two" }?.title == "Current generation")
+        await fixture.client.disconnect()
+    }
+
+    @Test("Removal cancels a held peer and its late response never returns a row", .timeLimit(.minutes(1)))
+    func removedPeerCannotPublishLateResponse() async throws {
+        let removedClock = ControllableAggregateRefreshSleep()
+        let healthyClock = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            includeThirdEnvironment: true,
+            aggregatePeerRefreshSleep: { id, interval in
+                try await (id == "two" ? removedClock : healthyClock).sleep(for: interval)
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let healthyID = FeatureScopedID.thread(environmentID: "three", wireID: "thread-three")
+        let probe = ThreadTitleEventProbe(
+            events: fixture.client.events(), threadID: healthyID, title: "Removal verified"
+        )
+        probe.start()
+        _ = await removedClock.waitUntilRequested(count: 1)
+        _ = await healthyClock.waitUntilRequested(count: 1)
+        let oldWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        let gate = PassiveRequestGate()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Ghost removed row",
+            snapshotSequence: 999
+        ), host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: gate)
+        await removedClock.resume()
+        await gate.waitUntilEntered()
+        try await fixture.client.removeEnvironment(id: "two")
+        #expect(oldWorker.isCancelled)
+        #expect(fixture.client.aggregateRefreshWorkers["two"] == nil)
+        await gate.release()
+        await oldWorker.value
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-three", threadID: "thread-three", title: "Removal verified",
+            snapshotSequence: 2
+        ), host: "three.example")
+        await healthyClock.resume()
+        await probe.waitUntilObserved()
+        #expect(!probe.sawThreadTitle("Ghost removed row"))
+        #expect(!probe.lastEnvironmentIDs.contains("two"))
+        await fixture.client.disconnect()
+    }
+
 }
 
 private actor FailOnceAggregateEnvironmentLoader {
@@ -1341,6 +1446,8 @@ private final class ThreadTitleEventProbe {
     private let threadID: String
     private let title: String
     private var observed = false
+    private var observedTitles = Set<String>()
+    private(set) var lastEnvironmentIDs = Set<String>()
     private var observedWaiters: [CheckedContinuation<Void, Never>] = []
     private var task: Task<Void, Never>?
 
@@ -1356,8 +1463,11 @@ private final class ThreadTitleEventProbe {
             for await event in events {
                 switch event {
                 case let .thread(thread):
+                    observedTitles.insert(thread.title)
                     observed = thread.id == threadID && thread.title == title
                 case let .snapshot(snapshot):
+                    observedTitles.formUnion(snapshot.threads.map(\.title))
+                    lastEnvironmentIDs = Set(snapshot.environments.map(\.id))
                     observed = snapshot.threads.contains {
                         $0.id == self.threadID && $0.title == self.title
                     }
@@ -1372,6 +1482,8 @@ private final class ThreadTitleEventProbe {
             }
         }
     }
+
+    func sawThreadTitle(_ title: String) -> Bool { observedTitles.contains(title) }
 
     func didObserveTitle() -> Bool {
         observed
@@ -1390,6 +1502,7 @@ private final class ThreadTitleEventProbe {
 }
 
 private actor ControllableAggregateRefreshSleep {
+    var requestCount: Int { requestedCadences.count }
     private var requestedCadences: [Duration] = []
     private var requestWaiters: [(
         count: Int,
@@ -1431,10 +1544,43 @@ private actor ControllableAggregateRefreshSleep {
     }
 }
 
-private struct MultiEnvironmentFixture {
+@MainActor
+private final class MultiEnvironmentFixture {
     let directory: URL
     let transport: MultiEnvironmentHTTPTransport
+    let runtime: EnvironmentRuntime
     let client: NativeFeatureClient
+    let receipts: PassiveLiveReceipts
+    let requireConfiguration: Bool
+    private(set) var recorder: BootstrapSnapshotRecorder?
+
+    init(directory: URL, transport: MultiEnvironmentHTTPTransport, runtime: EnvironmentRuntime,
+         client: NativeFeatureClient, receipts: PassiveLiveReceipts, requireConfiguration: Bool) {
+        self.directory = directory
+        self.transport = transport
+        self.runtime = runtime
+        self.client = client
+        self.receipts = receipts
+        self.requireConfiguration = requireConfiguration
+    }
+
+    func hydratedSnapshot() async throws -> FeatureSnapshot {
+        let ids = try await runtime.environments().filter(\.isEnabled).map(\.id)
+        let targets = Dictionary(uniqueKeysWithValues: ids.map { ($0, receipts.httpCount($0) + 1) })
+        let seed = try await client.initialSnapshot()
+        if let recorder { recorder.record(seed) }
+        else { recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events()) }
+        for id in ids {
+            try await receipts.waitForHTTP(id, count: targets[id]!)
+            if requireConfiguration { try await receipts.waitForConfiguration(id) }
+        }
+        return try await recorder!.wait { snapshot in
+            ids.allSatisfy { id in
+                guard let state = snapshot.environments.first(where: { $0.id == id })?.connectionState else { return false }
+                return state == .connected || state == .disconnected
+            }
+        }
+    }
 }
 
 private actor MultiEnvironmentHTTPTransport: HTTPTransport {
@@ -1446,6 +1592,8 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
     private var shellReadCounts: [String: Int] = [:]
     private var dispatched: [MultiEnvironmentDispatchRecord] = []
     private var hostsDroppingNextCreateReply = Set<String>()
+    private var nextShellGates: [String: PassiveRequestGate] = [:]
+    private var nextDispatchGates: [String: PassiveRequestGate] = [:]
 
     init(shells: [String: OrchestrationShellSnapshot]) {
         self.shells = shells
@@ -1497,11 +1645,21 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
         hostsDroppingNextCreateReply.insert(host)
     }
 
-    func data(for request: URLRequest) throws -> (Data, HTTPURLResponse) {
+    func holdNextDispatch(host: String, gate: PassiveRequestGate) { nextDispatchGates[host] = gate }
+
+    func holdNextShell(host: String, gate: PassiveRequestGate) {
+        nextShellGates[host] = gate
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let host = request.url?.host ?? ""
         let path = request.url?.path ?? ""
         if path == "/api/orchestration/shell" {
             shellReadCounts[host, default: 0] += 1
+            if let gate = nextShellGates.removeValue(forKey: host), let data = shellData[host] {
+                await gate.enter()
+                return (data, multiEnvironmentResponse(request))
+            }
         }
         guard reachableHosts.contains(host) else {
             throw URLError(.cannotConnectToHost)
@@ -1532,6 +1690,7 @@ private actor MultiEnvironmentHTTPTransport: HTTPTransport {
             dispatched.append(
                 MultiEnvironmentDispatchRecord(host: host, command: command)
             )
+            if let gate = nextDispatchGates.removeValue(forKey: host) { await gate.enter() }
             if command["type"]?.stringValue == "thread.create",
                hostsDroppingNextCreateReply.remove(host) != nil,
                let projectID = command["projectId"]?.stringValue,
@@ -1905,4 +2064,1148 @@ private func multiEnvironmentResponse(_ request: URLRequest) -> HTTPURLResponse 
         httpVersion: "HTTP/1.1",
         headerFields: ["Content-Type": "application/json"]
     )!
+}
+
+/// Deliberately ignores cancellation to model a transport completing an old read.
+private actor PassiveRequestGate {
+    private var cancellableEntryWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var entered = false
+    private var released = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    var isHeld: Bool { entered && !released }
+
+    func enter() async {
+        entered = true
+        let pending = cancellableEntryWaiters.values
+        cancellableEntryWaiters.removeAll()
+        pending.forEach { $0.resume() }
+        entryWaiters.forEach { $0.resume() }
+        entryWaiters.removeAll()
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilEnteredCancellable() async throws {
+        try Task.checkCancellation()
+        guard !entered else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { cancellableEntryWaiters[id] = $0 }
+        } onCancel: {
+            Task { await self.cancelEntryWaiter(id) }
+        }
+    }
+
+    private func cancelEntryWaiter(_ id: UUID) {
+        cancellableEntryWaiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        releaseWaiters.forEach { $0.resume() }
+        releaseWaiters.removeAll()
+    }
+}
+
+private actor GatedPassiveCatalogueConnector: WebSocketConnecting {
+    private var shouldHold = false
+    let gate = PassiveRequestGate()
+
+    func holdPassiveConnections() { shouldHold = true }
+
+    func connect(to url: URL) async throws -> any WebSocketConnection {
+        if shouldHold && url.host == "two.example" {
+            return GatedPassiveCatalogueConnection(gate: gate)
+        }
+        throw URLError(.cannotConnectToHost)
+    }
+
+    func release() async { await gate.release() }
+}
+
+private actor GatedPassiveCatalogueConnection: WebSocketConnection {
+    let gate: PassiveRequestGate
+    private var receiver: CheckedContinuation<Data, Error>?
+    private var closed = false
+
+    init(gate: PassiveRequestGate) { self.gate = gate }
+
+    func send(_ data: Data) async throws {
+        let request = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        if request["tag"]?.stringValue != nil { await gate.enter() }
+    }
+
+    func receive() async throws -> Data {
+        if closed { throw CancellationError() }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        closed = true
+        receiver?.resume(throwing: CancellationError())
+        receiver = nil
+    }
+}
+
+@Suite("Native passive live shells")
+@MainActor
+struct NativePassiveLiveShellTests {
+    @Test("Live peer bursts publish together without polling", .timeLimit(.minutes(1)))
+    func livePeerBurstsPublishTogetherWithoutPolling() async throws {
+        let server = PassiveLiveServer()
+        let topology = PassiveRequestGate()
+        let topologyClock = ControllableAggregateRefreshSleep()
+        let clocks = PassiveClockBank()
+        let publication = ControllableAggregateRefreshSleep()
+        let receipts = PassiveLiveReceipts()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            includeThirdEnvironment: true,
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregateRefreshSleep: { try await topologyClock.sleep(for: $0) },
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: { try await publication.sleep(for: .zero) },
+            aggregateRefreshReceipt: { receipts.record($0) },
+            aggregateEnvironmentLoader: { runtime in
+                await topology.enter()
+                return try await runtime.environments()
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let threeID = FeatureScopedID.thread(environmentID: "three", wireID: "thread-three")
+        let heldTwo = PassiveRequestGate()
+        let heldThree = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "two.example", gate: heldTwo)
+        await fixture.transport.holdNextShell(host: "three.example", gate: heldThree)
+        await topology.release()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        await server.waitForSubscriptions(host: "three.example", count: 1)
+        await heldTwo.waitUntilEntered()
+        await heldThree.waitUntilEntered()
+        let shellTwo = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Live base", snapshotSequence: 10)
+        let shellThree = multiEnvironmentShell(projectID: "project-three", threadID: "thread-three", title: "Third base", snapshotSequence: 20)
+        try await server.snapshot(shellTwo, host: "two.example")
+        try await server.snapshot(shellThree, host: "three.example")
+        try await receipts.waitForShells("two", count: 1)
+        try await receipts.waitForShells("three", count: 1)
+        let finalTwo = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Burst final", snapshotSequence: 12)
+        let finalThree = multiEnvironmentShell(projectID: "project-three", threadID: "thread-three", title: "Third final", snapshotSequence: 21)
+        try await server.upsert(finalTwo.threads[0], sequence: 11, host: "two.example")
+        try await server.upsert(finalTwo.threads[0], sequence: 12, host: "two.example")
+        try await server.upsert(finalThree.threads[0], sequence: 21, host: "three.example")
+        try await receipts.waitForShells("two", count: 3)
+        try await receipts.waitForShells("three", count: 2)
+        _ = await publication.waitUntilRequested(count: 1)
+        #expect(await publication.requestCount == 1)
+        let probe = ThreadTitleEventProbe(events: fixture.client.events(), threadID: threeID, title: "Third final")
+        probe.start()
+        await publication.resume()
+        await probe.waitUntilObserved()
+        #expect(probe.sawThreadTitle("Burst final"))
+        #expect(await heldTwo.isHeld)
+        #expect(await heldThree.isHeld)
+        await heldTwo.release()
+        await heldThree.release()
+        try await receipts.waitForHTTP("two", count: 1)
+        try await receipts.waitForHTTP("three", count: 1)
+        let reads = await fixture.transport.shellReadCount(host: "two.example")
+        #expect(reads == 1)
+        let payload = await server.lastPayload(host: "two.example")
+        #expect(payload?["afterSequence"] == nil)
+        await fixture.client.disconnect()
+    }
+
+    @Test("A replacement socket accepts a low sequence and rejects old HTTP", .timeLimit(.minutes(1)))
+    func replacementSocketRejectsOldHTTP() async throws {
+        let server = PassiveLiveServer()
+        let topology = PassiveRequestGate()
+        let clocks = PassiveClockBank()
+        let receipts = PassiveLiveReceipts()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) },
+            aggregateEnvironmentLoader: { runtime in
+                await topology.enter()
+                return try await runtime.environments()
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let oldHTTP = PassiveRequestGate()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Old HTTP", snapshotSequence: 999
+        ), host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: oldHTTP)
+        await topology.release()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        await oldHTTP.waitUntilEntered()
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Old socket", snapshotSequence: 100
+        ), host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
+        await server.closeLatest(host: "two.example")
+        await server.waitForSubscriptions(host: "two.example", count: 2)
+        let fresh = multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Replacement socket", snapshotSequence: 2
+        )
+        await fixture.transport.setShell(fresh, host: "two.example")
+        try await server.snapshot(fresh, host: "two.example")
+        try await receipts.waitForShells("two", count: 2)
+        await oldHTTP.release()
+        try await receipts.waitForHTTP("two", count: 1)
+        let snapshot = try await fixture.client.backgroundSnapshot()
+        #expect(snapshot.threads.first { $0.environmentID == "two" }?.title == "Replacement socket")
+        #expect(receipts.sequences["two"] == [100, 2])
+        let payload = await server.lastPayload(host: "two.example")
+        #expect(payload?["afterSequence"] == nil)
+        await fixture.client.disconnect()
+    }
+
+    @Test("Unknown live events trigger one immediate HTTP repair and recover", .timeLimit(.minutes(1)))
+    func unknownEventRepairsWithoutPollingDelay() async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let threadID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        // Drain the initial repair before making the stream authoritative.
+        try await receipts.waitForHTTP("two", count: 1)
+        let live = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Live", snapshotSequence: 10)
+        try await server.snapshot(live, host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
+        let held = PassiveRequestGate()
+        let repaired = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "HTTP repaired", snapshotSequence: 11)
+        await fixture.transport.setShell(repaired, host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: held)
+        try await server.emit([.object(["kind": .string("future-shell-event")])], host: "two.example")
+        await held.waitUntilEntered()
+        await server.waitForSubscriptions(host: "two.example", count: 2)
+        let readCount = await fixture.transport.shellReadCount(host: "two.example")
+        #expect(readCount == 2)
+        let probe = ThreadTitleEventProbe(events: fixture.client.events(), threadID: threadID, title: "HTTP repaired")
+        probe.start()
+        await held.release()
+        try await receipts.waitForHTTP("two", count: 2)
+        await probe.waitUntilObserved()
+        try await server.snapshot(repaired, host: "two.example")
+        try await receipts.waitForShells("two", count: 2)
+        #expect(await fixture.transport.shellReadCount(host: "two.example") == 2)
+        await fixture.client.disconnect()
+    }
+
+    @Test("Background cancels passive work and foreground replaces subscriptions", .timeLimit(.minutes(1)))
+    func backgroundAndRemovalCancelOwnedSubscriptions() async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let publication = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: { try await publication.sleep(for: .zero) },
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        try await receipts.waitForHTTP("two", count: 1)
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Cached live peer", snapshotSequence: 3
+        ), host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
+        _ = await publication.waitUntilRequested(count: 1)
+        let oldWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        fixture.client.suspendForBackground()
+        await oldWorker.value
+        await server.waitForInterrupts(host: "two.example", count: 1)
+        #expect(fixture.client.aggregateRefreshWorkers.isEmpty)
+        #expect(oldWorker.isCancelled)
+        await fixture.client.resumeAfterBackground(reconnect: false)
+        await server.waitForSubscriptions(host: "two.example", count: 2)
+        let payload = await server.lastPayload(host: "two.example")
+        #expect(payload?["afterSequence"] == nil)
+        let nextWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        try await fixture.client.removeEnvironment(id: "two")
+        await nextWorker.value
+        await server.waitForInterrupts(host: "two.example", count: 2)
+        #expect(nextWorker.isCancelled)
+        #expect(fixture.client.aggregateRefreshWorkers["two"] == nil)
+        let snapshot = try await fixture.client.backgroundSnapshot()
+        #expect(!snapshot.environments.contains { $0.id == "two" })
+        await fixture.client.disconnect()
+    }
+    @Test("Repeated snapshot then stream end waits twenty seconds between subscriptions", .timeLimit(.minutes(1)))
+    func repeatedStreamEndsBackOffWhileHTTPRepairs() async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let retries = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, interval in try await retries.sleep(for: interval) },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        try await receipts.waitForHTTP("two", count: 1)
+        for attempt in 1...3 {
+            try await server.snapshot(multiEnvironmentShell(
+                projectID: "project-two", threadID: "thread-two", title: "Snapshot \(attempt)", snapshotSequence: 10 + attempt
+            ), host: "two.example")
+            try await receipts.waitForShells("two", count: attempt)
+            try await server.finish(host: "two.example")
+            let cadence = await retries.waitUntilRequested(count: attempt)
+            #expect(cadence == .seconds(20))
+            try await receipts.waitForHTTP("two", count: attempt + 1)
+            #expect(await server.subscriptionCount(host: "two.example") == attempt)
+            if attempt < 3 {
+                await retries.resume()
+                await server.waitForSubscriptions(host: "two.example", count: attempt + 1)
+            }
+        }
+        await fixture.client.disconnect()
+    }
+
+    @Test("Selecting a passive environment transfers shell ownership", .timeLimit(.minutes(1)))
+    func activeSwitchTransfersShellOwnership() async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        try await receipts.waitForHTTP("two", count: 1)
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Selected peer", snapshotSequence: 10
+        ), host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
+        let oldWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        _ = try await fixture.runtime.activate(id: "two")
+        let selected = try await fixture.client.initialSnapshot()
+        await oldWorker.value
+        await server.waitForSubscriptions(host: "two.example", count: 2)
+        #expect(oldWorker.isCancelled)
+        #expect(fixture.client.aggregateRefreshWorkers["two"] == nil)
+        #expect(selected.environments.first { $0.isActive }?.id == "two")
+        #expect(selected.threads.first { $0.environmentID == "two" }?.title == "Selected peer")
+        await server.waitForSubscriptions(host: "one.example", count: 2)
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-one", threadID: "thread-one", title: "New passive peer", snapshotSequence: 2
+        ), host: "one.example")
+        try await receipts.waitForShells("one", count: 2)
+        let snapshot = try await fixture.client.backgroundSnapshot()
+        #expect(snapshot.threads.first { $0.environmentID == "two" }?.title == "Selected peer")
+        #expect(snapshot.threads.first { $0.environmentID == "one" }?.title == "New passive peer")
+        await fixture.client.disconnect()
+    }
+
+    @Test("HTTP begun before an unknown same-socket event cannot repair the gap", .timeLimit(.minutes(1)))
+    func sameSocketGapRejectsPreGapHTTP() async throws {
+        let server = PassiveLiveServer()
+        let topology = PassiveRequestGate()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let retries = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, interval in try await retries.sleep(for: interval) },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) },
+            aggregateEnvironmentLoader: { runtime in
+                await topology.enter()
+                return try await runtime.environments()
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let oldRead = PassiveRequestGate()
+        let freshRead = PassiveRequestGate()
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Pre-gap stale HTTP", snapshotSequence: 999
+        ), host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: oldRead)
+        await topology.release()
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        await oldRead.waitUntilEntered()
+        try await server.emit([.object(["kind": .string("unknown-before-baseline")])], host: "two.example")
+        _ = await retries.waitUntilRequested(count: 1)
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Post-gap authoritative HTTP", snapshotSequence: 2
+        ), host: "two.example")
+        await fixture.transport.holdNextShell(host: "two.example", gate: freshRead)
+        await oldRead.release()
+        try await receipts.waitForHTTP("two", count: 1)
+        await freshRead.waitUntilEntered()
+        #expect(await fixture.transport.shellReadCount(host: "two.example") == 2)
+        // If the old 999 was installed, this independent sequence-2 read
+        // cannot undo it and exposes the poisoned cache deterministically.
+        let snapshot = try await fixture.client.backgroundSnapshot()
+        #expect(snapshot.threads.first { $0.environmentID == "two" }?.title == "Post-gap authoritative HTTP")
+        await freshRead.release()
+        try await receipts.waitForHTTP("two", count: 2)
+        await fixture.client.disconnect()
+    }
+
+    @Test("An authoritative peer snapshot removes its selected detail subscription", .timeLimit(.minutes(1)))
+    func fullSnapshotRemovalStopsSelectedPeerDetail() async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clocks = PassiveClockBank()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .seconds(60),
+            aggregatePeerRefreshSleep: { try await clocks.sleep(id: $0, interval: $1) },
+            aggregateStreamRetrySleep: { _, _ in },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.client.initialSnapshot()
+        let threadID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
+        await server.waitForSubscriptions(host: "two.example", count: 1)
+        try await receipts.waitForHTTP("two", count: 1)
+        _ = try await fixture.client.loadThread(id: threadID)
+        await server.waitForSubscriptions(host: "two.example#detail", count: 1)
+        let baseline = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Removed", snapshotSequence: 10)
+        try await server.snapshot(OrchestrationShellSnapshot(
+            snapshotSequence: 10, projects: baseline.projects, threads: [], updatedAt: baseline.updatedAt
+        ), host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
+        await server.waitForInterrupts(host: "two.example#detail", count: 1)
+        #expect(await server.subscriptionCount(host: "one.example") == 1)
+        await fixture.client.disconnect()
+    }
+
+}
+
+@MainActor
+private final class PassiveLiveReceipts {
+    private(set) var sequences: [String: [Int]] = [:]
+    private var counts: [String: Int] = [:]
+    private var waiters: [UUID: (String, Int, CheckedContinuation<Void, Error>)] = [:]
+
+    func record(_ receipt: NativePassiveShellReceipt) {
+        let key: String
+        switch receipt {
+        case let .shellApplied(id, sequence):
+            sequences[id, default: []].append(sequence)
+            key = "shell:" + id
+        case let .httpFinished(id): key = "http:" + id
+        case let .configurationApplied(id): key = "config:" + id
+        case let .archiveFinished(id): key = "archive:" + id
+        }
+        counts[key, default: 0] += 1
+        let ready = waiters.filter { counts[$0.value.0, default: 0] >= $0.value.1 }
+        for (id, waiter) in ready {
+            waiters[id] = nil
+            waiter.2.resume()
+        }
+    }
+
+    func httpCount(_ id: String) -> Int { counts["http:" + id, default: 0] }
+    func waitForShells(_ id: String, count: Int) async throws { try await wait("shell:" + id, count: count) }
+    func waitForHTTP(_ id: String, count: Int) async throws { try await wait("http:" + id, count: count) }
+    func waitForConfiguration(_ id: String) async throws { try await wait("config:" + id, count: 1) }
+    func waitForArchive(_ id: String) async throws { try await wait("archive:" + id, count: 1) }
+
+    private func wait(_ key: String, count: Int) async throws {
+        try Task.checkCancellation()
+        guard counts[key, default: 0] < count else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters[id] = (key, count, continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.waiters.removeValue(forKey: id)?.2.resume(throwing: CancellationError())
+            }
+        }
+    }
+}
+
+private actor PassiveClockBank {
+    private var clocks: [String: ControllableAggregateRefreshSleep] = [:]
+
+    private func clock(_ id: String) -> ControllableAggregateRefreshSleep {
+        if let clock = clocks[id] { return clock }
+        let clock = ControllableAggregateRefreshSleep()
+        clocks[id] = clock
+        return clock
+    }
+
+    func sleep(id: String, interval: Duration) async throws {
+        try await clock(id).sleep(for: interval)
+    }
+
+    func resumeInitial(_ id: String) async {
+        let clock = clock(id)
+        _ = await clock.waitUntilRequested(count: 1)
+        await clock.resume()
+    }
+}
+
+private actor PassiveLiveServer: WebSocketConnecting {
+    struct Subscription: Sendable {
+        let connection: PassiveLiveConnection
+        let requestID: Int
+        let payload: JSONValue?
+    }
+    private let configs = MultiEnvironmentConfigurationServer()
+    private var archiveGates: [String: PassiveRequestGate] = [:]
+    func holdArchive(host: String, gate: PassiveRequestGate) { archiveGates[host] = gate }
+    private var subscriptions: [String: [Subscription]] = [:]
+    private var interrupts: [String: Int] = [:]
+    private var waiters: [(String, Int, Bool, CheckedContinuation<Void, Never>)] = []
+
+    func connect(to url: URL) -> any WebSocketConnection {
+        PassiveLiveConnection(host: url.host ?? "", server: self)
+    }
+
+    func request(_ value: JSONValue, host: String, connection: PassiveLiveConnection) async throws -> JSONValue? {
+        if let tag = value["tag"]?.stringValue,
+           tag == RPCMethod.subscribeShell.rawValue || tag == RPCMethod.subscribeThread.rawValue,
+           case let .number(id)? = value["id"] {
+            let key = tag == RPCMethod.subscribeThread.rawValue ? host + "#detail" : host
+            subscriptions[key, default: []].append(Subscription(connection: connection, requestID: Int(id), payload: value["payload"]))
+            resumeWaiters()
+            return nil
+        }
+        if value["_tag"]?.stringValue == "Interrupt", case let .number(id)? = value["requestId"] {
+            for key in [host, host + "#detail"] where subscriptions[key, default: []].contains(where: {
+                $0.connection === connection && $0.requestID == Int(id)
+            }) {
+                interrupts[key, default: 0] += 1
+            }
+            resumeWaiters()
+        }
+        if value["_tag"]?.stringValue == "Ping" { return .object(["_tag": .string("Pong")]) }
+        if value["tag"]?.stringValue == RPCMethod.getArchivedShellSnapshot.rawValue,
+           let gate = archiveGates.removeValue(forKey: host) { await gate.enter() }
+        return try await configs.response(to: value, host: host)
+    }
+
+    func lastPayload(host: String) -> JSONValue? { subscriptions[host]?.last?.payload }
+
+    func waitForSubscriptions(host: String, count: Int) async { await wait(host: host, count: count, interrupt: false) }
+    func waitForInterrupts(host: String, count: Int) async { await wait(host: host, count: count, interrupt: true) }
+
+    private func count(_ host: String, interrupt: Bool) -> Int {
+        interrupt ? interrupts[host, default: 0] : subscriptions[host, default: []].count
+    }
+
+    private func wait(host: String, count: Int, interrupt: Bool) async {
+        guard self.count(host, interrupt: interrupt) < count else { return }
+        await withCheckedContinuation { waiters.append((host, count, interrupt, $0)) }
+    }
+
+    private func resumeWaiters() {
+        let ready = waiters.filter { count($0.0, interrupt: $0.2) >= $0.1 }
+        waiters.removeAll { count($0.0, interrupt: $0.2) >= $0.1 }
+        ready.forEach { $0.3.resume() }
+    }
+
+    func emit(_ values: [JSONValue], host: String) async throws {
+        guard let subscription = subscriptions[host]?.last else { throw URLError(.notConnectedToInternet) }
+        try await subscription.connection.enqueue(.object([
+            "_tag": .string("Chunk"), "requestId": .number(Double(subscription.requestID)), "values": .array(values),
+        ]))
+    }
+
+    func snapshot(_ shell: OrchestrationShellSnapshot, host: String) async throws {
+        try await emit([.object(["kind": .string("snapshot"), "snapshot": try JSONValue.encode(shell)])], host: host)
+    }
+
+    func upsert(_ thread: OrchestrationThreadShell, sequence: Int, host: String) async throws {
+        try await emit([.object([
+            "kind": .string("thread-upserted"), "sequence": .number(Double(sequence)), "thread": try JSONValue.encode(thread),
+        ])], host: host)
+    }
+
+    func finish(host: String) async throws {
+        guard let subscription = subscriptions[host]?.last else { throw URLError(.notConnectedToInternet) }
+        try await subscription.connection.enqueue(.object([
+            "_tag": .string("Exit"), "requestId": .number(Double(subscription.requestID)),
+            "exit": .object(["_tag": .string("Success"), "value": .null]),
+        ]))
+    }
+
+    func subscriptionCount(host: String) -> Int { subscriptions[host, default: []].count }
+
+    func closeLatest(host: String) async { await subscriptions[host]?.last?.connection.close() }
+}
+
+private actor PassiveLiveConnection: WebSocketConnection {
+    private let host: String
+    private let server: PassiveLiveServer
+    private var responses: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+    private var closed = false
+
+    init(host: String, server: PassiveLiveServer) { self.host = host; self.server = server }
+
+    func send(_ data: Data) async throws {
+        guard !closed else { throw URLError(.networkConnectionLost) }
+        let value = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        if let response = try await server.request(value, host: host, connection: self) { try enqueue(response) }
+    }
+
+    func enqueue(_ value: JSONValue) throws {
+        let data = try JSONEncoder.t3.encode(value)
+        if let receiver { self.receiver = nil; receiver.resume(returning: data) }
+        else { responses.append(data) }
+    }
+
+    func receive() async throws -> Data {
+        guard !closed else { throw URLError(.networkConnectionLost) }
+        if !responses.isEmpty { return responses.removeFirst() }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        closed = true
+        receiver?.resume(throwing: URLError(.networkConnectionLost))
+        receiver = nil
+    }
+}
+
+@Suite("Native incremental bootstrap")
+@MainActor
+struct NativeIncrementalBootstrapTests {
+    @Test("Metadata returns while active HTTP and catalogue are held; a healthy peer publishes", .timeLimit(.minutes(1)))
+    func heldActiveDoesNotBlockHealthyPeer() async throws {
+        let connector = BootstrapHeldConnector()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            includeThirdEnvironment: true, webSocketConnector: connector,
+            rpcConnectionWaitTimeout: .seconds(60), fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let active = PassiveRequestGate()
+        let passive = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "one.example", gate: active)
+        await fixture.transport.holdNextShell(host: "two.example", gate: passive)
+        let seed = try await fixture.client.initialSnapshot()
+        #expect(Set(seed.environments.map(\.id)) == ["one", "two", "three"])
+        #expect(seed.threads.isEmpty)
+        #expect(seed.environments.allSatisfy { $0.connectionState != .connected })
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        try await active.waitUntilEnteredCancellable()
+        try await passive.waitUntilEnteredCancellable()
+        try await connector.gate.waitUntilEnteredCancellable()
+        let healthy = try await recorder.wait { snapshot in
+            snapshot.threads.contains { $0.environmentID == "three" }
+                && snapshot.environments.first { $0.id == "three" }?.connectionState == .connected
+        }
+        #expect(await active.isHeld)
+        #expect(await passive.isHeld)
+        #expect(await connector.gate.isHeld)
+        #expect(healthy.environments.first { $0.id == "one" }?.connectionState != .connected)
+        await active.release()
+        await passive.release()
+        await connector.gate.release()
+        await fixture.client.disconnect()
+    }
+
+    @Test("Catalog and synchronized markers cannot authorize an empty outbox view", .timeLimit(.minutes(1)))
+    func authorityAndRowsPublishTogether() async throws {
+        let receipts = PassiveLiveReceipts()
+        let server = PassiveLiveServer()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server, fallbackPollingInitialDelay: .seconds(60),
+            aggregatePublishSleep: {}, aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let held = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "one.example", gate: held)
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        let submission = FeatureQueuedSubmission(
+            environmentID: "one", identity: .init(threadID: "thread-one"),
+            threadID: FeatureScopedID.thread(environmentID: "one", wireID: "thread-one"),
+            text: "Queued before hydration", selection: nil, runtimeMode: .fullAccess,
+            interactionMode: .standard, attachments: []
+        )
+        #expect(FeatureOutboxPolicy.decision(for: submission, snapshot: seed) == .wait)
+        try await held.waitUntilEnteredCancellable()
+        await server.waitForSubscriptions(host: "one.example", count: 1)
+        try await server.emit([.object(["kind": .string("synchronized")])], host: "one.example")
+        try await receipts.waitForConfiguration("one")
+        let shell = multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Authoritative", snapshotSequence: 10)
+        try await server.snapshot(shell, host: "one.example")
+        let ready = try await recorder.wait { $0.threads.contains { $0.title == "Authoritative" } }
+        #expect(FeatureOutboxPolicy.decision(for: submission, snapshot: ready) == .send)
+        for snapshot in recorder.history {
+            let connected = snapshot.environments.first { $0.id == "one" }?.connectionState == .connected
+            #expect(!connected || snapshot.threads.contains { $0.id == submission.threadID })
+            #expect(FeatureOutboxPolicy.decision(for: submission, snapshot: snapshot) != .discard)
+        }
+        #expect(await held.isHeld)
+        await held.release()
+        await fixture.client.disconnect()
+    }
+
+    @Test("Same-client reload rejects a late old HTTP response and retains cached rows", .timeLimit(.minutes(1)))
+    func reloadRetainsCacheAndRejectsOldRead() async throws {
+        let receipts = PassiveLiveReceipts()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { $0.threads.count == 2 }
+        let old = PassiveRequestGate()
+        await fixture.transport.setShell(multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Stale old request", snapshotSequence: 999), host: "one.example")
+        await fixture.transport.holdNextShell(host: "one.example", gate: old)
+        let cached = try await fixture.client.initialSnapshot()
+        #expect(cached.threads.count == 2)
+        #expect(cached.environments.allSatisfy { $0.connectionState != .connected })
+        try await old.waitUntilEnteredCancellable()
+        await fixture.transport.setShell(multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Current reload", snapshotSequence: 2), host: "one.example")
+        _ = try await fixture.client.initialSnapshot()
+        _ = try await recorder.wait { $0.threads.contains { $0.title == "Current reload" } }
+        await old.release()
+        try await receipts.waitForHTTP("one", count: 3)
+        #expect(!recorder.history.contains { $0.threads.contains { $0.title == "Stale old request" } })
+        await fixture.client.disconnect()
+    }
+
+    @Test("A current HTTP command refresh keeps the live header reconnecting while its rows are ready", .timeLimit(.minutes(1)))
+    func currentHTTPCommandPreservesReconnectingHeader() async throws {
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        do {
+            _ = try await fixture.hydratedSnapshot()
+            let recorder = try #require(fixture.recorder)
+            await fixture.transport.setShell(multiEnvironmentShell(
+                projectID: "project-one", threadID: "thread-one", title: "HTTP command result", snapshotSequence: 2
+            ), host: "one.example")
+            try await fixture.client.renameThread(id: "thread-one", title: "HTTP command result")
+            let updated = try await recorder.wait { $0.threads.contains { $0.title == "HTTP command result" } }
+            #expect(updated.connection.state == .reconnecting)
+            #expect(updated.environments.first { $0.id == "one" }?.connectionState == .connected)
+            #expect(await fixture.transport.dispatchRecords().count == 1)
+        } catch {
+            await fixture.client.disconnect()
+            throw error
+        }
+        await fixture.client.disconnect()
+    }
+
+    @Test("A public rename's old optional shell cannot authorize a replacement bootstrap", .timeLimit(.minutes(1)))
+    func oldCommandRefreshCannotAuthorizeReload() async throws {
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        _ = try await fixture.hydratedSnapshot()
+        let recorder = try #require(fixture.recorder)
+        let oldRead = PassiveRequestGate()
+        let replacementRead = PassiveRequestGate()
+        let stale = multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Old command shell", snapshotSequence: 999)
+        await fixture.transport.setShell(stale, host: "one.example")
+        await fixture.transport.holdNextShell(host: "one.example", gate: oldRead)
+        let command = Task { try await fixture.client.renameThread(id: "thread-one", title: "Rename once") }
+        do {
+            try await oldRead.waitUntilEnteredCancellable()
+            await fixture.transport.setShell(multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Replacement bootstrap", snapshotSequence: 2), host: "one.example")
+            await fixture.transport.holdNextShell(host: "one.example", gate: replacementRead)
+            let seed = try await fixture.client.initialSnapshot()
+            recorder.record(seed)
+            try await replacementRead.waitUntilEnteredCancellable()
+            await oldRead.release()
+            try await command.value
+            #expect(recorder.history.last?.environments.first { $0.id == "one" }?.connectionState != .connected)
+            #expect(!recorder.history.contains { $0.threads.contains { $0.title == "Old command shell" } })
+            await replacementRead.release()
+            _ = try await recorder.wait { $0.threads.contains { $0.title == "Replacement bootstrap" } }
+        } catch {
+            await oldRead.release()
+            await replacementRead.release()
+            command.cancel()
+            _ = try? await command.value
+            await fixture.client.disconnect()
+            throw error
+        }
+        await fixture.client.disconnect()
+    }
+
+    @Test("A cancelled old archive cannot authorize a same-client reload", .timeLimit(.minutes(1)))
+    func oldArchiveCannotAuthorizeReload() async throws {
+        let receipts = PassiveLiveReceipts()
+        let server = PassiveLiveServer()
+        let archive = PassiveRequestGate()
+        await server.holdArchive(host: "one.example", gate: archive)
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server, fallbackPollingInitialDelay: .seconds(60),
+            aggregatePublishSleep: {}, aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { $0.threads.contains { $0.environmentID == "one" } }
+        try await archive.waitUntilEnteredCancellable()
+        let heldShell = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "one.example", gate: heldShell)
+        let reload = try await fixture.client.initialSnapshot()
+        recorder.record(reload)
+        let startIndex = recorder.history.count - 1
+        try await heldShell.waitUntilEnteredCancellable()
+        await archive.release()
+        try await receipts.waitForArchive("one")
+        for snapshot in recorder.history.dropFirst(startIndex) {
+            #expect(snapshot.environments.first { $0.id == "one" }?.connectionState != .connected)
+        }
+        #expect(await heldShell.isHeld)
+        await heldShell.release()
+        await fixture.client.disconnect()
+    }
+
+    @Test("Unknown active events repair once, then a replacement stream delivers deltas", .timeLimit(.minutes(1)))
+    func unknownActiveStreamRepairsAndResubscribes() async throws {
+        let server = PassiveLiveServer()
+        let retries = ControllableAggregateRefreshSleep()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server, fallbackPollingInitialDelay: .seconds(60),
+            aggregateStreamRetrySleep: { id, interval in
+                if id == "one" { try await retries.sleep(for: interval) }
+            }, aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        await server.waitForSubscriptions(host: "one.example", count: 1)
+        let baseline = multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Active live baseline", snapshotSequence: 10)
+        try await server.snapshot(baseline, host: "one.example")
+        _ = try await recorder.wait { $0.threads.contains { $0.title == "Active live baseline" } }
+        let held = PassiveRequestGate()
+        let repaired = multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Active HTTP repaired", snapshotSequence: 20)
+        await fixture.transport.setShell(repaired, host: "one.example")
+        await fixture.transport.holdNextShell(host: "one.example", gate: held)
+        try await server.emit([.object(["kind": .string("unknown-active-event")])], host: "one.example")
+        try await held.waitUntilEnteredCancellable()
+        #expect(await retries.waitUntilRequested(count: 1) == .seconds(20))
+        // These are delivered to the discarded subscription and cannot poison repair.
+        for sequence in 21...23 { try await server.upsert(baseline.threads[0], sequence: sequence, host: "one.example") }
+        await held.release()
+        _ = try await recorder.wait { $0.threads.contains { $0.title == "Active HTTP repaired" } }
+        #expect(await server.subscriptionCount(host: "one.example") == 1)
+        await retries.resume()
+        await server.waitForSubscriptions(host: "one.example", count: 2)
+        try await server.snapshot(repaired, host: "one.example")
+        let delta = multiEnvironmentShell(projectID: "project-one", threadID: "thread-one", title: "Active delta recovered", snapshotSequence: 24)
+        try await server.upsert(delta.threads[0], sequence: 24, host: "one.example")
+        _ = try await recorder.wait { $0.threads.contains { $0.title == "Active delta recovered" } }
+        await fixture.client.disconnect()
+    }
+
+    @Test("A failed initial socket attempt cannot invalidate its independent HTTP read", .timeLimit(.minutes(1)))
+    func failedSocketDoesNotStarveHTTP() async throws {
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let held = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "one.example", gate: held)
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
+        try await held.waitUntilEnteredCancellable()
+        _ = try await recorder.wait { $0.connection.detail == "Live updates paused. Refreshing over HTTP." }
+        await held.release()
+        let ready = try await recorder.wait {
+            $0.environments.first { $0.id == "one" }?.connectionState == .connected
+        }
+        #expect(ready.threads.contains { $0.environmentID == "one" })
+        #expect(await fixture.transport.shellReadCount(host: "one.example") == 1)
+        await fixture.client.disconnect()
+    }
+}
+
+/// One collector per fixture; any number of predicates observe the same snapshots.
+@MainActor
+final class BootstrapSnapshotRecorder {
+    private(set) var history: [FeatureSnapshot]
+    private var task: Task<Void, Never>?
+    private var waiters: [UUID: (@MainActor (FeatureSnapshot) -> Bool, CheckedContinuation<FeatureSnapshot, Error>)] = [:]
+    private var finished = false
+
+    init(seed: FeatureSnapshot, events: AsyncStream<FeatureEvent>) {
+        history = [seed]
+        task = Task { [weak self] in
+            for await event in events {
+                guard !Task.isCancelled else { break }
+                guard let self else { break }
+                switch event {
+                case let .snapshot(snapshot): self.record(snapshot)
+                case let .thread(thread):
+                    guard var snapshot = self.history.last else { continue }
+                    if let index = snapshot.threads.firstIndex(where: { $0.id == thread.id }) {
+                        snapshot.threads[index] = thread
+                    } else { snapshot.threads.append(thread) }
+                    self.record(snapshot)
+                case let .threadRemoved(id):
+                    guard var snapshot = self.history.last else { continue }
+                    snapshot.threads.removeAll { $0.id == id }
+                    self.record(snapshot)
+                default: break
+                }
+            }
+            self?.stop()
+        }
+    }
+
+    func record(_ snapshot: FeatureSnapshot) {
+        history.append(snapshot)
+        let ready = waiters.filter { $0.value.0(snapshot) }
+        for (id, waiter) in ready {
+            waiters[id] = nil
+            waiter.1.resume(returning: snapshot)
+        }
+    }
+
+    func wait(_ predicate: @escaping @MainActor (FeatureSnapshot) -> Bool) async throws -> FeatureSnapshot {
+        try Task.checkCancellation()
+        if let snapshot = history.last, predicate(snapshot) { return snapshot }
+        guard !finished else { throw CancellationError() }
+        let id = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters[id] = (predicate, continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.waiters.removeValue(forKey: id)?.1.resume(throwing: CancellationError())
+            }
+        }
+    }
+
+    func stop() {
+        finished = true
+        task?.cancel()
+        task = nil
+        let pending = waiters.values
+        waiters.removeAll()
+        pending.forEach { $0.1.resume(throwing: CancellationError()) }
+    }
+
+    deinit { task?.cancel() }
+}
+
+private actor BootstrapHeldConnector: WebSocketConnecting {
+    let gate = PassiveRequestGate()
+    func connect(to url: URL) async throws -> any WebSocketConnection {
+        if url.host == "one.example" { await gate.enter() }
+        throw URLError(.cannotConnectToHost)
+    }
+}
+
+@Suite("Native bootstrap durable outbox")
+@MainActor
+struct NativeBootstrapRootOutboxTests {
+    @Test("A persisted follow-up waits through another peer's update and sends once after its owner hydrates", .timeLimit(.minutes(1)))
+    func restoredFollowUpWaitsForOwningShell() async throws {
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let outbox = FeatureOutboxStore(fileURL: fixture.directory.appendingPathComponent("root-outbox.json"))
+        let drafts = FeatureComposerDraftStore(fileURL: fixture.directory.appendingPathComponent("root-drafts.json"))
+        let threadID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
+        let identity = FeatureSubmissionIdentity(threadID: "thread-two", commandID: "bootstrap-root-command", messageID: "bootstrap-root-message")
+        let submission = FeatureQueuedSubmission(
+            environmentID: "two", identity: identity, threadID: threadID,
+            text: "Persisted before the peer loaded", selection: nil,
+            runtimeMode: .fullAccess, interactionMode: .standard, attachments: []
+        )
+        try await outbox.enqueue(submission)
+        let heldShell = PassiveRequestGate()
+        let heldDispatch = PassiveRequestGate()
+        await fixture.transport.holdNextShell(host: "two.example", gate: heldShell)
+        await fixture.transport.holdNextDispatch(host: "two.example", gate: heldDispatch)
+        let model = FeatureRootModel(client: fixture.client, outboxStore: outbox, draftStore: drafts)
+        let run = Task { await model.start() }
+        do {
+        try await heldShell.waitUntilEnteredCancellable()
+        let healthy = RootObservationWaiter {
+            !model.isLoading && model.snapshot.threads.contains { $0.environmentID == "one" }
+        }
+        try await healthy.wait()
+        #expect(model.snapshot.environments.first { $0.id == "two" }?.connectionState != .connected)
+        #expect(try await outbox.submissions().map(\.id) == [submission.id])
+        #expect(await fixture.transport.dispatchRecords().isEmpty)
+        #expect(await heldShell.isHeld)
+
+        await heldShell.release()
+        try await heldDispatch.waitUntilEnteredCancellable()
+        // Load the real detail while acceptance is held; the root attaches its
+        // restored queued message, giving an observable completion after removal.
+        _ = await model.detail(for: threadID)
+        #expect(model.details[threadID]?.messages.first { $0.id == identity.messageID }?.state == .queued)
+        let completed = RootObservationWaiter {
+            model.details[threadID]?.messages.first { $0.id == identity.messageID }?.state == .complete
+        }
+        await heldDispatch.release()
+        try await completed.wait()
+        // Message acceptance may precede durable deletion. Wait for the actual
+        // owned outbox file change, independent of that presentation ordering.
+        try await OwnedOutboxRemovalWaiter(fileURL: fixture.directory.appendingPathComponent("root-outbox.json")).wait()
+        #expect(try await outbox.submissions().isEmpty)
+        let commands = await fixture.transport.dispatchRecords()
+        #expect(commands.count == 1)
+        #expect(commands.first?.host == "two.example")
+        #expect(commands.first?.command["commandId"]?.stringValue == identity.commandID)
+        #expect(commands.first?.command["threadId"]?.stringValue == identity.threadID)
+        #expect(commands.first?.command["message"]?["messageId"]?.stringValue == identity.messageID)
+        #expect(model.errorMessage == nil)
+        } catch {
+            await heldShell.release()
+            await heldDispatch.release()
+            run.cancel()
+            await fixture.client.disconnect()
+            await run.value
+            throw error
+        }
+        await heldShell.release()
+        await heldDispatch.release()
+        run.cancel()
+        await fixture.client.disconnect()
+        await run.value
+    }
+}
+
+/// Observe the root's applied state without taking a second client event iterator.
+@MainActor
+private final class RootObservationWaiter {
+    private let predicate: @MainActor () -> Bool
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(_ predicate: @escaping @MainActor () -> Bool) { self.predicate = predicate }
+
+    func wait() async throws {
+        try Task.checkCancellation()
+        if predicate() { return }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                observe()
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.finish(.failure(CancellationError()))
+            }
+        }
+    }
+
+    private func observe() {
+        guard continuation != nil else { return }
+        let ready = withObservationTracking { predicate() } onChange: { [weak self] in
+            Task { @MainActor in self?.observe() }
+        }
+        if ready { finish(.success(())) }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        let pending = continuation
+        continuation = nil
+        pending?.resume(with: result)
+    }
+}
+
+
+/// The test watches only its owned directory. Atomic store writes replace the
+/// file, so observing the directory avoids retaining an obsolete file inode.
+@MainActor
+private final class OwnedOutboxRemovalWaiter {
+    private let fileURL: URL
+    private var source: DispatchSourceFileSystemObject?
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(fileURL: URL) { self.fileURL = fileURL }
+
+    func wait() async throws {
+        try Task.checkCancellation()
+        let descriptor = open(fileURL.deletingLastPathComponent().path, O_EVTONLY)
+        guard descriptor >= 0 else { throw POSIXError(.EIO) }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor, eventMask: [.write, .rename], queue: .global()
+        )
+        self.source = source
+        source.setCancelHandler { close(descriptor) }
+        source.setEventHandler { [weak self] in
+            Task { @MainActor in self?.check() }
+        }
+        source.resume()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                check()
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in self?.finish(.failure(CancellationError())) }
+        }
+    }
+
+    private func check() {
+        guard continuation != nil else { return }
+        do {
+            let document = try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+            guard let submissions = document?["submissions"] as? [Any] else { throw URLError(.cannotParseResponse) }
+            if submissions.isEmpty { finish(.success(())) }
+        } catch { finish(.failure(error)) }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        let pending = continuation
+        continuation = nil
+        source?.cancel()
+        source = nil
+        pending?.resume(with: result)
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -1578,8 +1578,12 @@ private final class MultiEnvironmentFixture {
             try await receipts.waitForHTTP(id, count: targets[id]!)
             if requireConfiguration { try await receipts.waitForConfiguration(id) }
         }
+        let needsPublishedConfiguration = requireConfiguration
         return try await recorder!.wait { snapshot in
             ids.allSatisfy { id in
+                // The configuration receipt precedes publication. Wait for
+                // the same event consumer to observe settings in its snapshot.
+                if needsPublishedConfiguration && snapshot.preferencesByEnvironment?[id] == nil { return false }
                 guard let state = snapshot.environments.first(where: { $0.id == id })?.connectionState else { return false }
                 return state == .connected || state == .disconnected
             }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -2408,18 +2408,35 @@ struct NativePassiveLiveShellTests {
             aggregateRefreshReceipt: { receipts.record($0) }
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        _ = try await fixture.client.initialSnapshot()
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        defer { recorder.stop() }
         await server.waitForSubscriptions(host: "two.example", count: 1)
         try await receipts.waitForHTTP("two", count: 1)
         try await server.snapshot(multiEnvironmentShell(
             projectID: "project-two", threadID: "thread-two", title: "Selected peer", snapshotSequence: 10
         ), host: "two.example")
         try await receipts.waitForShells("two", count: 1)
+        // A same-socket HTTP refresh must retain the epoch association even
+        // when its complete snapshot is identical to the last socket snapshot.
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Selected peer", snapshotSequence: 10
+        ), host: "two.example")
+        let readsBeforeRename = await fixture.transport.shellReadCount(host: "two.example")
+        try await fixture.client.renameThread(
+            id: FeatureScopedID.thread(environmentID: "two", wireID: "thread-two"), title: "Selected peer"
+        )
+        #expect(await fixture.transport.shellReadCount(host: "two.example") == readsBeforeRename + 1)
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Remote work", snapshotSequence: 1
+        ), host: "two.example")
         let oldWorker = try #require(fixture.client.aggregateRefreshWorkers["two"]?.task)
+        let adoptedHTTPCount = receipts.httpCount("two") + 1
         _ = try await fixture.runtime.activate(id: "two")
         let selected = try await fixture.client.initialSnapshot()
         await oldWorker.value
         await server.waitForSubscriptions(host: "two.example", count: 2)
+        try await receipts.waitForHTTP("two", count: adoptedHTTPCount)
         #expect(oldWorker.isCancelled)
         #expect(fixture.client.aggregateRefreshWorkers["two"] == nil)
         #expect(selected.environments.first { $0.isActive }?.id == "two")
@@ -2432,6 +2449,21 @@ struct NativePassiveLiveShellTests {
         let snapshot = try await fixture.client.backgroundSnapshot()
         #expect(snapshot.threads.first { $0.environmentID == "two" }?.title == "Selected peer")
         #expect(snapshot.threads.first { $0.environmentID == "one" }?.title == "New passive peer")
+
+        // Retaining the adopted socket's sequence must not pin a genuinely
+        // replacement socket to that old high watermark after a server restart.
+        let restarted = multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Restarted active peer", snapshotSequence: 2
+        )
+        await fixture.transport.setShell(restarted, host: "two.example")
+        await server.closeLatest(host: "two.example")
+        await server.waitForSubscriptions(host: "two.example", count: 3)
+        try await server.snapshot(restarted, host: "two.example")
+        let recovered = try await recorder.wait {
+            $0.connection.state == .connected
+                && $0.threads.first { $0.environmentID == "two" }?.title == "Restarted active peer"
+        }
+        #expect(recovered.threads.first { $0.environmentID == "two" }?.title == "Restarted active peer")
         await fixture.client.disconnect()
     }
 
@@ -2502,13 +2534,19 @@ struct NativePassiveLiveShellTests {
         let threadID = FeatureScopedID.thread(environmentID: "two", wireID: "thread-two")
         await server.waitForSubscriptions(host: "two.example", count: 1)
         try await receipts.waitForHTTP("two", count: 1)
+        // HTTP completion can mean a rejected read after the socket epoch
+        // changed. Establish an applied baseline before using its detail route.
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-two", threadID: "thread-two", title: "Before removal", snapshotSequence: 9
+        ), host: "two.example")
+        try await receipts.waitForShells("two", count: 1)
         _ = try await fixture.client.loadThread(id: threadID)
         await server.waitForSubscriptions(host: "two.example#detail", count: 1)
         let baseline = multiEnvironmentShell(projectID: "project-two", threadID: "thread-two", title: "Removed", snapshotSequence: 10)
         try await server.snapshot(OrchestrationShellSnapshot(
             snapshotSequence: 10, projects: baseline.projects, threads: [], updatedAt: baseline.updatedAt
         ), host: "two.example")
-        try await receipts.waitForShells("two", count: 1)
+        try await receipts.waitForShells("two", count: 2)
         await server.waitForInterrupts(host: "two.example#detail", count: 1)
         #expect(await server.subscriptionCount(host: "one.example") == 1)
         await fixture.client.disconnect()
@@ -2618,6 +2656,14 @@ private actor PassiveLiveServer: WebSocketConnecting {
             resumeWaiters()
         }
         if value["_tag"]?.stringValue == "Ping" { return .object(["_tag": .string("Pong")]) }
+        if value["tag"]?.stringValue == RPCMethod.dispatchCommand.rawValue,
+           value["payload"]?["type"]?.stringValue == "thread.meta.update",
+           case let .number(id)? = value["id"] {
+            return .object([
+                "_tag": .string("Exit"), "requestId": .number(id),
+                "exit": .object(["_tag": .string("Success"), "value": try JSONValue.encode(DispatchResult(sequence: 10))]),
+            ])
+        }
         if value["tag"]?.stringValue == RPCMethod.getArchivedShellSnapshot.rawValue,
            let gate = archiveGates.removeValue(forKey: host) { await gate.enter() }
         return try await configs.response(to: value, host: host)
@@ -2947,8 +2993,9 @@ struct NativeIncrementalBootstrapTests {
 
     @Test("A failed initial socket attempt cannot invalidate its independent HTTP read", .timeLimit(.minutes(1)))
     func failedSocketDoesNotStarveHTTP() async throws {
+        let connector = FailedBootstrapAttemptConnector()
         let fixture = try await NativeMultiEnvironmentTests.makeFixture(
-            fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
+            webSocketConnector: connector, fallbackPollingInitialDelay: .seconds(60), aggregatePublishSleep: {}
         )
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let held = PassiveRequestGate()
@@ -2956,14 +3003,20 @@ struct NativeIncrementalBootstrapTests {
         let seed = try await fixture.client.initialSnapshot()
         let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
         defer { recorder.stop() }
+        do {
         try await held.waitUntilEnteredCancellable()
-        _ = try await recorder.wait { $0.connection.detail == "Live updates paused. Refreshing over HTTP." }
+        try await connector.waitForFailure()
         await held.release()
         let ready = try await recorder.wait {
             $0.environments.first { $0.id == "one" }?.connectionState == .connected
         }
         #expect(ready.threads.contains { $0.environmentID == "one" })
         #expect(await fixture.transport.shellReadCount(host: "one.example") == 1)
+        } catch {
+            await held.release()
+            await fixture.client.disconnect()
+            throw error
+        }
         await fixture.client.disconnect()
     }
 }
@@ -3207,5 +3260,24 @@ private final class OwnedOutboxRemovalWaiter {
         source?.cancel()
         source = nil
         pending?.resume(with: result)
+    }
+}
+
+
+/// Observe the failed connector attempt itself: the RPC subscription deliberately
+/// keeps waiting for its first usable socket instead of failing with a UI header.
+private actor FailedBootstrapAttemptConnector: WebSocketConnecting {
+    private let failures = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+
+    func connect(to url: URL) async throws -> any WebSocketConnection {
+        if url.host == "one.example" { failures.continuation.yield(()) }
+        throw URLError(.cannotConnectToHost)
+    }
+
+    func waitForFailure() async throws {
+        try Task.checkCancellation()
+        var iterator = failures.stream.makeAsyncIterator()
+        guard await iterator.next() != nil else { throw CancellationError() }
+        try Task.checkCancellation()
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeMultiEnvironmentTests.swift
@@ -907,6 +907,9 @@ final class NativeMultiEnvironmentTests: XCTestCase {
         rpcConnectionWaitTimeout: Duration = .milliseconds(5),
         fallbackPollingInitialDelay: Duration = .seconds(3),
         fallbackPollingInterval: Duration = .seconds(2),
+        shellReconciliationSleep: @escaping @Sendable (String, Duration) async throws -> Void = { _, interval in
+            try await Task.sleep(for: interval)
+        },
         aggregateRefreshInterval: Duration = NativeFeatureClient.defaultAggregateRefreshInterval,
         aggregateIdleRefreshInterval: Duration = NativeFeatureClient.defaultAggregateIdleRefreshInterval,
         aggregateFailureRefreshInterval: Duration = NativeFeatureClient.defaultAggregateFailureRefreshInterval,
@@ -1027,6 +1030,7 @@ final class NativeMultiEnvironmentTests: XCTestCase {
                 settingsStore: settings,
                 fallbackPollingInitialDelay: fallbackPollingInitialDelay,
                 fallbackPollingInterval: fallbackPollingInterval,
+                shellReconciliationSleep: shellReconciliationSleep,
                 aggregateRefreshInterval: aggregateRefreshInterval,
                 aggregateIdleRefreshInterval: aggregateIdleRefreshInterval,
                 aggregateFailureRefreshInterval: aggregateFailureRefreshInterval,
@@ -2156,6 +2160,90 @@ private actor GatedPassiveCatalogueConnection: WebSocketConnection {
 @Suite("Native passive live shells")
 @MainActor
 struct NativePassiveLiveShellTests {
+    @Test("Silent connected shells reconcile through bounded HTTP", arguments: ["one", "two"], [false, true])
+    func silentConnectedShellReconciles(environmentID: String, disconnect: Bool) async throws {
+        let server = PassiveLiveServer()
+        let receipts = PassiveLiveReceipts()
+        let clock = SilentShellClock()
+        let fixture = try await NativeMultiEnvironmentTests.makeFixture(
+            webSocketConnector: server,
+            fallbackPollingInitialDelay: .zero,
+            fallbackPollingInterval: .milliseconds(1),
+            shellReconciliationSleep: { id, interval in
+                if id == environmentID { try await clock.sleep(interval) }
+                else { try await Task.sleep(for: interval) }
+            },
+            aggregatePublishSleep: {},
+            aggregateRefreshReceipt: { receipts.record($0) }
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let seed = try await fixture.client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: fixture.client.events())
+        let host = environmentID + ".example"
+        let threadID = "thread-" + environmentID
+        try await receipts.waitForHTTP(environmentID, count: 1)
+        await server.waitForSubscriptions(host: host, count: 1)
+        try await server.snapshot(multiEnvironmentShell(
+            projectID: "project-" + environmentID, threadID: threadID,
+            title: "Live seed", snapshotSequence: 10
+        ), host: host)
+        _ = try await recorder.wait { $0.threads.contains { $0.title == "Live seed" } }
+        let reads = await fixture.transport.shellReadCount(host: host)
+        await fixture.transport.setShell(multiEnvironmentShell(
+            projectID: "project-" + environmentID, threadID: threadID,
+            title: "HTTP repaired silent shell", snapshotSequence: 11
+        ), host: host)
+        let held = PassiveRequestGate()
+        let operation = Task { @MainActor in
+            try await clock.waitForRequest()
+            #expect(await clock.intervals == [.seconds(30)])
+            #expect(await fixture.transport.shellReadCount(host: host) == reads)
+            await clock.advance()
+            _ = try await recorder.wait { $0.threads.contains { $0.title == "HTTP repaired silent shell" } }
+            #expect(await fixture.transport.shellReadCount(host: host) == reads + 1)
+            try await clock.waitForRequest(2)
+            await fixture.transport.holdNextShell(host: host, gate: held)
+            await clock.advance()
+            try await held.waitUntilEnteredCancellable()
+            #expect(await clock.intervals.count == 2)
+            #expect(await fixture.transport.shellReadCount(host: host) == reads + 2)
+            let completions = receipts.httpCount(environmentID)
+            try await server.snapshot(multiEnvironmentShell(
+                projectID: "project-" + environmentID, threadID: threadID,
+                title: "Newer live shell", snapshotSequence: 20
+            ), host: host)
+            _ = try await recorder.wait { $0.threads.contains { $0.title == "Newer live shell" } }
+            await held.release()
+            try await receipts.waitForHTTP(environmentID, count: completions + 1)
+            try await clock.waitForRequest(3)
+            #expect(recorder.history.last?.threads.contains { $0.title == "Newer live shell" } == true)
+            #expect(await fixture.transport.shellReadCount(host: host) == reads + 2)
+            // A failed quiet check neither disconnects the live stream nor
+            // retries until another full reconciliation interval has elapsed.
+            await fixture.transport.setShellReadsEnabled(false, host: host)
+            await clock.advance()
+            try await clock.waitForRequest(4)
+            #expect(await fixture.transport.shellReadCount(host: host) == reads + 3)
+            #expect(recorder.history.last?.environments.first { $0.id == environmentID }?.connectionState == .connected)
+            #expect(await clock.intervals == Array(repeating: .seconds(30), count: 4))
+            if disconnect { await fixture.client.disconnect() }
+            else { fixture.client.suspendForBackground() }
+            try await clock.waitForCancellation()
+            #expect(await fixture.transport.shellReadCount(host: host) == reads + 3)
+        }
+        // Failure watchdog only; successful verification advances an explicit clock.
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(3))
+            if !Task.isCancelled { operation.cancel() }
+        }
+        do { try await operation.value }
+        catch { Issue.record("Silent connected shell never scheduled or applied its HTTP repair: \(error)") }
+        watchdog.cancel()
+        await held.release()
+        recorder.stop()
+        await fixture.client.disconnect()
+    }
+
     @Test("Live peer bursts publish together without polling", .timeLimit(.minutes(1)))
     func livePeerBurstsPublishTogetherWithoutPolling() async throws {
         let server = PassiveLiveServer()
@@ -3279,5 +3367,48 @@ private actor FailedBootstrapAttemptConnector: WebSocketConnecting {
         var iterator = failures.stream.makeAsyncIterator()
         guard await iterator.next() != nil else { throw CancellationError() }
         try Task.checkCancellation()
+    }
+}
+
+private actor SilentShellClock {
+    private(set) var intervals: [Duration] = []
+    private let cancelled = PassiveRequestGate()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var requestWaiters: [UUID: (Int, CheckedContinuation<Void, Error>)] = [:]
+
+    func sleep(_ interval: Duration) async throws {
+        intervals.append(interval)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()) }
+                else {
+                    self.continuation = continuation
+                    let ready = requestWaiters.filter { intervals.count >= $0.value.0 }
+                    for (id, waiter) in ready {
+                        requestWaiters[id] = nil
+                        waiter.1.resume()
+                    }
+                }
+            }
+        } onCancel: { Task { await self.cancel() } }
+    }
+    func waitForRequest(_ count: Int = 1) async throws {
+        try Task.checkCancellation()
+        guard intervals.count < count else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { requestWaiters[id] = (count, $0) }
+        } onCancel: { Task { await self.cancelWaiter(id) } }
+    }
+    private func cancelWaiter(_ id: UUID) {
+        requestWaiters.removeValue(forKey: id)?.1.resume(throwing: CancellationError())
+    }
+    func advance() { continuation?.resume(); continuation = nil }
+    func waitForCancellation() async throws { try await cancelled.waitUntilEnteredCancellable() }
+    func cancel() async {
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
+        await cancelled.release()
+        await cancelled.enter()
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -5,6 +5,160 @@ import XCTest
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
+    func testLateStopAcknowledgementCannotCancelReplacementGenerationRefresh() async throws {
+        let fixture = try await AcceptedSendFixture.make(includePeer: true)
+        addTeardownBlock { await fixture.cleanUp() }
+        var acknowledgements = fixture.socket.heldInterrupts.makeAsyncIterator()
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.socket.holdInterruptAcknowledgements()
+        let stopping = Task { try await fixture.client.cancelTurn(threadID: fixture.threadID) }
+        addTeardownBlock {
+            await fixture.socket.releaseInterruptAcknowledgements()
+            _ = await stopping.result
+        }
+        guard await acknowledgements.next() != nil else { throw CancellationError() }
+
+        _ = try await fixture.runtime.activate(id: "accepted-peer")
+        _ = try await fixture.client.initialSnapshot()
+        await fixture.transport.holdFollowups(includeShell: false)
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Replacement generation", selection: nil)
+        let replacementRead = await reads.next()
+        let replacement = try XCTUnwrap(replacementRead)
+        XCTAssertTrue(replacement.path.hasPrefix("/api/orchestration/threads/"))
+
+        await fixture.socket.releaseInterruptAcknowledgements()
+        try await stopping.value
+        let marker = "Replacement generation published its uniquely held response"
+        XCTAssertNotEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
+        await fixture.transport.release(replacement.id, detailMessage: marker)
+        try await AcceptedSendDetailReceipt(
+            model: fixture.model, threadID: fixture.threadID, expectedMessage: marker
+        ).wait()
+        XCTAssertEqual(fixture.model.details[fixture.threadID]?.messages.last?.text, marker)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.map { $0["type"]?.stringValue }, ["thread.turn.interrupt", "thread.turn.start"])
+    }
+
+    func testRejectedStopPropagatesRemoteError() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        await fixture.transport.holdFollowups()
+        let before = await fixture.transport.snapshotReadCount
+        await fixture.socket.rejectInterruptAcknowledgements()
+        do {
+            try await fixture.client.cancelTurn(threadID: fixture.threadID)
+            XCTFail("Rejected interrupt must remain a command error")
+        } catch let error as RPCError {
+            guard case .remote("Stop rejected by fixture") = error else { throw error }
+        }
+        // These counters cover the command-return boundary only; they are
+        // not a proof that no mistakenly queued future task could read later.
+        let after = await fixture.transport.snapshotReadCount
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(after, before)
+        XCTAssertEqual(pending, 0)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands.first?["type"]?.stringValue, "thread.turn.interrupt")
+    }
+
+    func testStopDuringHeldSendDetailPreservesDetailAndShellRecovery() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Send before Stop", selection: nil)
+        let firstRead = await reads.next()
+        let detail = try XCTUnwrap(firstRead)
+        XCTAssertTrue(detail.path.hasPrefix("/api/orchestration/threads/"))
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let count = await fixture.transport.heldCount
+        XCTAssertEqual(count, 1)
+        let detailStillPending = await fixture.transport.isPending(detail.id)
+        XCTAssertTrue(detailStillPending)
+        await fixture.transport.release(detail.id)
+        let nextRead = await reads.next()
+        let shell = try XCTUnwrap(nextRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+        await fixture.transport.release(shell.id)
+        let trailingRead = await reads.next()
+        let trailing = try XCTUnwrap(trailingRead)
+        XCTAssertEqual(trailing.path, "/api/orchestration/shell", "Stop requests shell repair without discarding or repeating the send detail repair")
+        await fixture.client.disconnect()
+        let cancelled = await cancellations.next()
+        XCTAssertEqual(cancelled, trailing.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2)
+    }
+
+    func testAcceptedStopCompletesBeforeOptionalShellReadFinishes() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        let completed = expectation(description: "Accepted Stop completes without snapshot reads")
+        let stopping = Task {
+            await fixture.model.cancelTurn(threadID: fixture.threadID)
+            completed.fulfill()
+        }
+        let read = await reads.next()
+        XCTAssertEqual(read?.path, "/api/orchestration/shell")
+        await fulfillment(of: [completed], timeout: 2)
+        XCTAssertFalse(fixture.model.isPerformingAction)
+
+        await fixture.transport.failFollowups()
+        await stopping.value
+        XCTAssertNil(fixture.model.errorMessage)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(commands.first?["type"]?.stringValue, "thread.turn.interrupt")
+    }
+
+    func testSendDuringStopRefreshRetainsItsDetailRefresh() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let shellRead = await reads.next()
+        let shell = try XCTUnwrap(shellRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "After Stop", selection: nil)
+        let heldCount = await fixture.transport.heldCount
+        XCTAssertEqual(heldCount, 1)
+        await fixture.transport.release(shell.id)
+        let detailRead = await reads.next()
+        let detail = try XCTUnwrap(detailRead)
+        XCTAssertTrue(detail.path.hasPrefix("/api/orchestration/threads/"))
+
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, detail.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2)
+    }
+
+    func testDisconnectCancelsStopRefreshWithoutAnotherInterrupt() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.cancelTurn(threadID: fixture.threadID)
+        let read = await reads.next()
+        let held = try XCTUnwrap(read)
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, held.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(pending, 0)
+    }
+
     func testAcceptedSendCompletesOutboxBeforeOptionalReadsFinish() async throws {
         let fixture = try await AcceptedSendFixture.make()
         addTeardownBlock { await fixture.cleanUp() }
@@ -920,8 +1074,9 @@ private struct AcceptedSendFixture {
     let outbox: FeatureOutboxStore
     let transport: AcceptedSendHTTPTransport
     let socket: AcceptedSendSocket
+    let runtime: EnvironmentRuntime
 
-    static func make() async throws -> Self {
+    static func make(includePeer: Bool = false) async throws -> Self {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-accepted-send-\(UUID().uuidString)")
         let environment = Environment(
@@ -930,15 +1085,23 @@ private struct AcceptedSendFixture {
             webSocketBaseURL: URL(string: "wss://accepted-send.example")!
         )
         let store = EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json"))
-        try await store.save([environment])
+        let peer = Environment(
+            id: "accepted-peer", label: "Accepted peer",
+            httpBaseURL: URL(string: "https://accepted-peer.example")!,
+            webSocketBaseURL: URL(string: "wss://accepted-peer.example")!
+        )
+        try await store.save(includePeer ? [environment, peer] : [environment])
         try await store.setActiveEnvironment(id: environment.id)
         let transport = AcceptedSendHTTPTransport()
         let socket = AcceptedSendSocket()
         let runtime = EnvironmentRuntime(
             environmentStore: store,
-            credentialStore: InMemoryCredentialStore(credentials: [environment.id: EnvironmentCredential(accessToken: "fixture-token")]),
+            credentialStore: InMemoryCredentialStore(credentials: [
+                environment.id: EnvironmentCredential(accessToken: "fixture-token"),
+                peer.id: EnvironmentCredential(accessToken: "fixture-peer-token"),
+            ]),
             httpTransport: transport,
-            webSocketConnector: AcceptedSendConnector(socket: socket)
+            webSocketConnector: AcceptedSendConnector(socket: socket, peer: AcceptedSendSocket())
         )
         let settingsName = "t3-accepted-send-\(UUID().uuidString)"
         let client = NativeFeatureClient(
@@ -951,11 +1114,11 @@ private struct AcceptedSendFixture {
         let modelTask = Task { await model.start() }
         do {
             try await AcceptedSendRootReadiness(model: model).wait()
-            let threadID = try XCTUnwrap(model.snapshot.threads.first?.id)
+            let threadID = FeatureScopedID.thread(environmentID: environment.id, wireID: "thread-existing")
             _ = await model.detail(for: threadID)
             return Self(modelTask: modelTask, directory: directory, threadID: threadID,
                         settingsName: settingsName, client: client, model: model,
-                        outbox: outbox, transport: transport, socket: socket)
+                        outbox: outbox, transport: transport, socket: socket, runtime: runtime)
         } catch {
             modelTask.cancel()
             await client.disconnect()
@@ -1014,6 +1177,48 @@ private final class AcceptedSendRootReadiness {
     }
 }
 
+@MainActor
+private final class AcceptedSendDetailReceipt {
+    private let model: FeatureRootModel
+    private let threadID: String
+    private let expectedMessage: String
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(model: FeatureRootModel, threadID: String, expectedMessage: String) {
+        self.model = model
+        self.threadID = threadID
+        self.expectedMessage = expectedMessage
+    }
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                self.continuation = continuation
+                observe()
+            }
+        } onCancel: {
+            Task { @MainActor in self.finish(CancellationError()) }
+        }
+    }
+
+    private func observe() {
+        guard continuation != nil else { return }
+        let ready = withObservationTracking {
+            model.details[threadID]?.messages.last?.text == expectedMessage
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.observe() }
+        }
+        if ready { finish(nil) }
+    }
+
+    private func finish(_ error: Error?) {
+        guard let pending = continuation else { return }
+        continuation = nil
+        if let error { pending.resume(throwing: error) } else { pending.resume() }
+    }
+}
+
 private actor AcceptedSendHTTPTransport: HTTPTransport {
     struct HeldRead: Sendable {
         let id: UUID
@@ -1023,9 +1228,12 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
     nonisolated let cancellations: AsyncStream<UUID>
     private let reads: AsyncStream<HeldRead>.Continuation
     private let cancelled: AsyncStream<UUID>.Continuation
+    private(set) var snapshotReadCount = 0
+    private var holdsShell = true
     private var holds = false
     private var fails = false
     private var pending: [UUID: CheckedContinuation<Void, Error>] = [:]
+    private var detailMessages: [UUID: String] = [:]
 
     init() {
         (heldReads, reads) = AsyncStream.makeStream()
@@ -1040,9 +1248,12 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
         guard path == "/api/orchestration/shell" || path.hasPrefix("/api/orchestration/threads/") else {
             throw URLError(.unsupportedURL)
         }
+        snapshotReadCount += 1
         if fails { throw URLError(.networkConnectionLost) }
-        if holds {
+        var heldID: UUID?
+        if holds && (holdsShell || path != "/api/orchestration/shell") {
             let id = UUID()
+            heldID = id
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
@@ -1053,19 +1264,39 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
                 Task { await self.cancel(id) }
             }
         }
-        let data = if path == "/api/orchestration/shell" {
-            try JSONEncoder.t3.encode(retryShellSnapshot())
+        let data: Data
+        if path == "/api/orchestration/shell" {
+            data = try JSONEncoder.t3.encode(retryShellSnapshot())
         } else {
-            try JSONEncoder.t3.encode(retryEmptyThreadDetail(id: request.url!.lastPathComponent))
+            let snapshot = retryEmptyThreadDetail(id: request.url!.lastPathComponent)
+            if let heldID, let text = detailMessages.removeValue(forKey: heldID) {
+                var thread = try JSONValue.encode(snapshot.thread).decode([String: JSONValue].self)
+                thread["messages"] = .array([.object([
+                    "id": .string("replacement-generation-message"), "role": .string("assistant"),
+                    "text": .string(text), "turnId": .null, "streaming": .bool(false),
+                    "attachments": .array([]), "createdAt": .string("2026-07-30T12:00:00.000Z"),
+                    "updatedAt": .string("2026-07-30T12:00:00.000Z"),
+                ])])
+                data = try JSONEncoder.t3.encode(OrchestrationThreadDetailSnapshot(
+                    snapshotSequence: 99,
+                    thread: try JSONValue.object(thread).decode(OrchestrationThread.self)
+                ))
+            } else { data = try JSONEncoder.t3.encode(snapshot) }
         }
         return (data, retryHTTPResponse(request))
     }
 
     var heldCount: Int { pending.count }
 
-    func holdFollowups() { holds = true }
+    func isPending(_ id: UUID) -> Bool { pending[id] != nil }
 
-    func release(_ id: UUID) { pending.removeValue(forKey: id)?.resume() }
+    func holdFollowups(includeShell: Bool = true) { holds = true; holdsShell = includeShell }
+
+    func release(_ id: UUID, detailMessage: String? = nil) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        if let detailMessage { detailMessages[id] = detailMessage }
+        continuation.resume()
+    }
 
     func failFollowups() {
         fails = true
@@ -1084,10 +1315,28 @@ private actor AcceptedSendHTTPTransport: HTTPTransport {
 
 private struct AcceptedSendConnector: WebSocketConnecting {
     let socket: AcceptedSendSocket
-    func connect(to _: URL) -> any WebSocketConnection { socket }
+    let peer: AcceptedSendSocket
+    func connect(to url: URL) -> any WebSocketConnection {
+        url.host == "accepted-peer.example" ? peer : socket
+    }
 }
 
 private actor AcceptedSendSocket: WebSocketConnection {
+    nonisolated let heldInterrupts: AsyncStream<Void>
+    private let interruptReceipts: AsyncStream<Void>.Continuation
+    private var holdsInterrupts = false
+    private var rejectsInterrupts = false
+    private var pendingInterruptResponses: [Data] = []
+
+    init() { (heldInterrupts, interruptReceipts) = AsyncStream.makeStream() }
+    func holdInterruptAcknowledgements() { holdsInterrupts = true }
+    func rejectInterruptAcknowledgements() { rejectsInterrupts = true }
+    func releaseInterruptAcknowledgements() {
+        holdsInterrupts = false
+        let responses = pendingInterruptResponses
+        pendingInterruptResponses.removeAll()
+        responses.forEach { enqueue($0) }
+    }
     private(set) var commands: [JSONValue] = []
     private var queued: [Data] = []
     private var receiver: CheckedContinuation<Data, Error>?
@@ -1100,10 +1349,19 @@ private actor AcceptedSendSocket: WebSocketConnection {
             enqueue(response)
         } else if tag == RPCMethod.dispatchCommand.rawValue, let payload = request["payload"] {
             commands.append(payload)
-            enqueue(try JSONEncoder.t3.encode(JSONValue.object([
-                "_tag": .string("Exit"), "requestId": request["id"]!,
-                "exit": .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
-            ])))
+            let isInterrupt = payload["type"]?.stringValue == "thread.turn.interrupt"
+            let exit: JSONValue = isInterrupt && rejectsInterrupts
+                ? .object(["_tag": .string("Failure"), "cause": .array([
+                    .object(["_tag": .string("Fail"), "error": .object(["message": .string("Stop rejected by fixture")])]),
+                ])])
+                : .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
+            let response = try JSONEncoder.t3.encode(JSONValue.object([
+                "_tag": .string("Exit"), "requestId": request["id"]!, "exit": exit,
+            ]))
+            if isInterrupt && holdsInterrupts {
+                pendingInterruptResponses.append(response)
+                interruptReceipts.yield(())
+            } else { enqueue(response) }
         }
     }
 

--- a/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeRetryIdentityTests.swift
@@ -1,9 +1,86 @@
 import Foundation
+import Observation
 import XCTest
 @testable import T3Code
 
 @MainActor
 final class NativeRetryIdentityTests: XCTestCase {
+    func testAcceptedSendCompletesOutboxBeforeOptionalReadsFinish() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        let completed = expectation(description: "Accepted send completes without snapshot reads")
+        let sending = Task {
+            let sent = await fixture.model.sendMessage(threadID: fixture.threadID, text: "Accepted now", selection: nil)
+            completed.fulfill()
+            return sent
+        }
+        _ = await reads.next()
+        await fulfillment(of: [completed], timeout: 2)
+        let queued = try await fixture.outbox.submissions()
+        XCTAssertTrue(queued.isEmpty, "Acknowledgement must retire the outbox while optional reads are held.")
+        XCTAssertFalse(fixture.model.isPerformingAction)
+
+        await fixture.transport.failFollowups()
+        let sent = await sending.value
+        XCTAssertTrue(sent, "Optional read failures cannot turn acceptance into a failed send.")
+        XCTAssertNil(fixture.model.errorMessage)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        XCTAssertEqual(fixture.model.details[fixture.threadID]?.messages.last?.state, .complete)
+        await fixture.client.disconnect()
+    }
+
+    func testAcceptedSendRefreshesCoalesceAndCancelWhenThreadCloses() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "First", selection: nil)
+        let firstRead = await reads.next()
+        let first = try XCTUnwrap(firstRead)
+        XCTAssertTrue(first.path.hasPrefix("/api/orchestration/threads/"))
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Second", selection: nil)
+        let heldCount = await fixture.transport.heldCount
+        XCTAssertEqual(heldCount, 1, "A second acceptance must coalesce behind the current read.")
+
+        await fixture.transport.release(first.id)
+        let shellRead = await reads.next()
+        let shell = try XCTUnwrap(shellRead)
+        XCTAssertEqual(shell.path, "/api/orchestration/shell")
+        await fixture.transport.release(shell.id)
+        let trailingRead = await reads.next()
+        let trailing = try XCTUnwrap(trailingRead)
+        XCTAssertTrue(trailing.path.hasPrefix("/api/orchestration/threads/"))
+        fixture.client.releaseThread(id: fixture.threadID)
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, trailing.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 2, "Read reconciliation must never redispatch a command.")
+        await fixture.transport.failFollowups()
+        await fixture.client.disconnect()
+    }
+
+    func testDisconnectCancelsAcceptedSendRefreshWithoutAnotherCommand() async throws {
+        let fixture = try await AcceptedSendFixture.make()
+        addTeardownBlock { await fixture.cleanUp() }
+        var reads = fixture.transport.heldReads.makeAsyncIterator()
+        var cancellations = fixture.transport.cancellations.makeAsyncIterator()
+        await fixture.transport.holdFollowups()
+        try await fixture.client.sendMessage(threadID: fixture.threadID, text: "Accepted before disconnect", selection: nil)
+        let heldRead = await reads.next()
+        let held = try XCTUnwrap(heldRead)
+        await fixture.client.disconnect()
+        let cancelledID = await cancellations.next()
+        XCTAssertEqual(cancelledID, held.id)
+        let commands = await fixture.socket.commands
+        XCTAssertEqual(commands.count, 1)
+        let pending = await fixture.transport.heldCount
+        XCTAssertEqual(pending, 0)
+    }
+
     func testSavedSettingsSurviveAConnectionRepublish() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("t3-native-settings-republish-\(UUID().uuidString)")
@@ -33,28 +110,21 @@ final class NativeRetryIdentityTests: XCTestCase {
         let settingsStore = UserDefaults(suiteName: settingsSuite)!
         defer { settingsStore.removePersistentDomain(forName: settingsSuite) }
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settingsStore)
-        let initial = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
         var updated = initial.settings
         updated.textSize = FeatureTextSizeAdjustment(steps: 2)
         updated.codeSize = FeatureTextSizeAdjustment(steps: -1)
         try await client.saveSettings(updated)
-        var events = client.events().makeAsyncIterator()
-
         await connection.failReceive()
-
-        var receivedRepublish = false
-        while let event = await events.next() {
-            guard case let .snapshot(snapshot) = event,
-                  snapshot.connection.state == .reconnecting else {
-                continue
-            }
-            XCTAssertEqual(snapshot.settings.textSize.steps, 2)
-            XCTAssertEqual(snapshot.settings.codeSize.steps, -1)
-            receivedRepublish = true
-            break
+        let snapshot = try await recorder.wait {
+            $0.connection.state == .reconnecting && $0.settings.textSize.steps == 2
         }
-        XCTAssertTrue(receivedRepublish)
+        XCTAssertEqual(snapshot.settings.textSize.steps, 2)
+        XCTAssertEqual(snapshot.settings.codeSize.steps, -1)
         await client.disconnect()
     }
 
@@ -89,7 +159,10 @@ final class NativeRetryIdentityTests: XCTestCase {
                 suiteName: "t3-native-concurrent-retry-\(UUID().uuidString)"
             )!
         )
-        _ = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
         await transport.rejectShellReads()
 
@@ -151,7 +224,10 @@ final class NativeRetryIdentityTests: XCTestCase {
             suiteName: "t3-native-retry-\(UUID().uuidString)"
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
-        let initial = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        let initial = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         XCTAssertEqual(initial.threads.first?.runtimeMode, .approvalRequired)
         XCTAssertEqual(initial.threads.first?.interactionMode, .standard)
         await connection.waitUntilConnected()
@@ -260,7 +336,10 @@ final class NativeRetryIdentityTests: XCTestCase {
             suiteName: "t3-native-partial-\(UUID().uuidString)"
         )!
         let client = NativeFeatureClient(runtime: runtime, settingsStore: settings)
-        _ = try await client.initialSnapshot()
+        let seed = try await client.initialSnapshot()
+        let recorder = BootstrapSnapshotRecorder(seed: seed, events: client.events())
+        defer { recorder.stop() }
+        _ = try await recorder.wait { !$0.projects.isEmpty && !$0.threads.isEmpty }
         await connection.waitUntilConnected()
 
         let identity = FeatureSubmissionIdentity(
@@ -828,4 +907,218 @@ private func retryDispatchCommand(from request: URLRequest) throws -> JSONValue 
         throw URLError(.cannotDecodeContentData)
     }
     return try JSONDecoder.t3.decode(JSONValue.self, from: body)
+}
+
+@MainActor
+private struct AcceptedSendFixture {
+    let modelTask: Task<Void, Never>
+    let directory: URL
+    let threadID: String
+    let settingsName: String
+    let client: NativeFeatureClient
+    let model: FeatureRootModel
+    let outbox: FeatureOutboxStore
+    let transport: AcceptedSendHTTPTransport
+    let socket: AcceptedSendSocket
+
+    static func make() async throws -> Self {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("t3-accepted-send-\(UUID().uuidString)")
+        let environment = Environment(
+            id: "accepted-send", label: "Accepted send",
+            httpBaseURL: URL(string: "https://accepted-send.example")!,
+            webSocketBaseURL: URL(string: "wss://accepted-send.example")!
+        )
+        let store = EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json"))
+        try await store.save([environment])
+        try await store.setActiveEnvironment(id: environment.id)
+        let transport = AcceptedSendHTTPTransport()
+        let socket = AcceptedSendSocket()
+        let runtime = EnvironmentRuntime(
+            environmentStore: store,
+            credentialStore: InMemoryCredentialStore(credentials: [environment.id: EnvironmentCredential(accessToken: "fixture-token")]),
+            httpTransport: transport,
+            webSocketConnector: AcceptedSendConnector(socket: socket)
+        )
+        let settingsName = "t3-accepted-send-\(UUID().uuidString)"
+        let client = NativeFeatureClient(
+            runtime: runtime, settingsStore: UserDefaults(suiteName: settingsName)!,
+            fallbackPollingInitialDelay: .seconds(3600), aggregateRefreshInterval: .seconds(3600),
+            aggregateIdleRefreshInterval: .seconds(3600)
+        )
+        let outbox = FeatureOutboxStore(fileURL: directory.appendingPathComponent("outbox.json"))
+        let model = FeatureRootModel(client: client, outboxStore: outbox)
+        let modelTask = Task { await model.start() }
+        do {
+            try await AcceptedSendRootReadiness(model: model).wait()
+            let threadID = try XCTUnwrap(model.snapshot.threads.first?.id)
+            _ = await model.detail(for: threadID)
+            return Self(modelTask: modelTask, directory: directory, threadID: threadID,
+                        settingsName: settingsName, client: client, model: model,
+                        outbox: outbox, transport: transport, socket: socket)
+        } catch {
+            modelTask.cancel()
+            await client.disconnect()
+            await modelTask.value
+            UserDefaults.standard.removePersistentDomain(forName: settingsName)
+            try? FileManager.default.removeItem(at: directory)
+            throw error
+        }
+    }
+
+    func cleanUp() async {
+        modelTask.cancel()
+        await client.disconnect()
+        await modelTask.value
+        UserDefaults.standard.removePersistentDomain(forName: settingsName)
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+@MainActor
+private final class AcceptedSendRootReadiness {
+    private let model: FeatureRootModel
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(model: FeatureRootModel) { self.model = model }
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                self.continuation = continuation
+                observe()
+            }
+        } onCancel: {
+            Task { @MainActor in self.finish(CancellationError()) }
+        }
+    }
+
+    private func observe() {
+        guard continuation != nil else { return }
+        let ready = withObservationTracking {
+            !model.isLoading
+                && model.snapshot.projects.contains { $0.id == FeatureScopedID.project(environmentID: "accepted-send", wireID: "project-1") }
+                && model.snapshot.threads.contains { $0.id == FeatureScopedID.thread(environmentID: "accepted-send", wireID: "thread-existing") }
+                && model.snapshot.environments.first(where: { $0.id == "accepted-send" })?.connectionState == .connected
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in self?.observe() }
+        }
+        if ready { finish(nil) }
+    }
+
+    private func finish(_ error: Error?) {
+        guard let pending = continuation else { return }
+        continuation = nil
+        if let error { pending.resume(throwing: error) } else { pending.resume() }
+    }
+}
+
+private actor AcceptedSendHTTPTransport: HTTPTransport {
+    struct HeldRead: Sendable {
+        let id: UUID
+        let path: String
+    }
+    nonisolated let heldReads: AsyncStream<HeldRead>
+    nonisolated let cancellations: AsyncStream<UUID>
+    private let reads: AsyncStream<HeldRead>.Continuation
+    private let cancelled: AsyncStream<UUID>.Continuation
+    private var holds = false
+    private var fails = false
+    private var pending: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    init() {
+        (heldReads, reads) = AsyncStream.makeStream()
+        (cancellations, cancelled) = AsyncStream.makeStream()
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let path = request.url?.path ?? ""
+        if path == "/api/auth/websocket-ticket" {
+            return (Data(#"{"ticket":"fixture-ticket","expiresAt":"2026-09-07T12:05:00Z"}"#.utf8), retryHTTPResponse(request))
+        }
+        guard path == "/api/orchestration/shell" || path.hasPrefix("/api/orchestration/threads/") else {
+            throw URLError(.unsupportedURL)
+        }
+        if fails { throw URLError(.networkConnectionLost) }
+        if holds {
+            let id = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    if Task.isCancelled { continuation.resume(throwing: CancellationError()); return }
+                    pending[id] = continuation
+                    reads.yield(HeldRead(id: id, path: path))
+                }
+            } onCancel: {
+                Task { await self.cancel(id) }
+            }
+        }
+        let data = if path == "/api/orchestration/shell" {
+            try JSONEncoder.t3.encode(retryShellSnapshot())
+        } else {
+            try JSONEncoder.t3.encode(retryEmptyThreadDetail(id: request.url!.lastPathComponent))
+        }
+        return (data, retryHTTPResponse(request))
+    }
+
+    var heldCount: Int { pending.count }
+
+    func holdFollowups() { holds = true }
+
+    func release(_ id: UUID) { pending.removeValue(forKey: id)?.resume() }
+
+    func failFollowups() {
+        fails = true
+        holds = false
+        let waiting = pending.values
+        pending.removeAll()
+        waiting.forEach { $0.resume(throwing: URLError(.networkConnectionLost)) }
+    }
+
+    private func cancel(_ id: UUID) {
+        guard let continuation = pending.removeValue(forKey: id) else { return }
+        continuation.resume(throwing: CancellationError())
+        cancelled.yield(id)
+    }
+}
+
+private struct AcceptedSendConnector: WebSocketConnecting {
+    let socket: AcceptedSendSocket
+    func connect(to _: URL) -> any WebSocketConnection { socket }
+}
+
+private actor AcceptedSendSocket: WebSocketConnection {
+    private(set) var commands: [JSONValue] = []
+    private var queued: [Data] = []
+    private var receiver: CheckedContinuation<Data, Error>?
+
+    func send(_ data: Data) throws {
+        let request = try JSONDecoder.t3.decode(JSONValue.self, from: data)
+        let tag = request["tag"]?.stringValue
+        if tag == RPCMethod.serverGetConfig.rawValue || tag == RPCMethod.subscribeServerConfig.rawValue,
+           let response = try retryConfigResponse(for: request) {
+            enqueue(response)
+        } else if tag == RPCMethod.dispatchCommand.rawValue, let payload = request["payload"] {
+            commands.append(payload)
+            enqueue(try JSONEncoder.t3.encode(JSONValue.object([
+                "_tag": .string("Exit"), "requestId": request["id"]!,
+                "exit": .object(["_tag": .string("Success"), "value": .object(["sequence": .number(2)])])
+            ])))
+        }
+    }
+
+    func receive() async throws -> Data {
+        if !queued.isEmpty { return queued.removeFirst() }
+        return try await withCheckedThrowingContinuation { receiver = $0 }
+    }
+
+    func close() {
+        receiver?.resume(throwing: CancellationError())
+        receiver = nil
+    }
+
+    private func enqueue(_ data: Data) {
+        if let receiver { self.receiver = nil; receiver.resume(returning: data) }
+        else { queued.append(data) }
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -848,23 +848,6 @@ final class NativeThreadCatchUpTests: XCTestCase {
         XCTAssertFalse(urls[4].contains("turnLimit="))
     }
 
-    func testStaleDetailReplaySkipsReductionOnlyAfterEnvelopeValidation() throws {
-        let thread = multiEnvironmentDetail(
-            projectID: "project", threadID: "first", snapshotSequence: 2, messages: []
-        ).thread
-        let event = replayMessage(sequence: 2, text: "Duplicate")
-        let ordinary = NativeThreadDetailReducer.apply(event, to: thread)
-        guard case .updated = ordinary.result else {
-            return XCTFail("The control must exercise a real message reduction.")
-        }
-        let skipped = NativeThreadDetailReducer.apply(event, to: thread, afterSequence: 2)
-        XCTAssertEqual(skipped.sequence, 2)
-        guard case .unchanged = skipped.result, case .none = skipped.renderMutation else {
-            return XCTFail("A validated stale event must bypass message reduction.")
-        }
-        let newer = NativeThreadDetailReducer.apply(event, to: thread, afterSequence: 1)
-        guard case .updated = newer.result else { return XCTFail("New events must still reduce.") }
-    }
 
     func testOnlyMessageQuestionsCanBeDismissed() async throws {
         let fixture = try await CatchUpFixture.make(activities: [

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -1073,7 +1073,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
     }
 
     func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
-        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
+        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming", "no-message-id-completed"] {
             let fixture = try await CatchUpFixture.make()
             defer { fixture.cleanUp() }
             if mode == "streaming" || mode == "no-message-id-streaming" {
@@ -1084,7 +1084,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
             var events = fixture.client.events().makeAsyncIterator()
             _ = try await fixture.client.loadThread(id: fixture.firstID)
             let detail = try await nextThreadRequest(&requests)
-            if mode == "no-message-id-streaming" {
+            if mode == "no-message-id-streaming" || mode == "no-message-id-completed" {
                 try await detail.completeTurnWithoutMessageID(sequence: 3)
             }
             try await detail.synchronize()
@@ -1491,6 +1491,34 @@ final class NativeThreadCatchUpTests: XCTestCase {
         XCTAssertTrue(detail.messages.contains { $0.text == "Fresh retry" })
         let reads = await fixture.http.threadRequests
         XCTAssertEqual(reads.count, 2)
+        await fixture.client.disconnect()
+    }
+
+    func testWarmReopenClearsAnInterruptedOlderPageLoadingState() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        await fixture.http.setPage(.init(beforeCursor: "older", hasMore: true, snapshotSequence: 2))
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let stream = try await nextThreadRequest(&requests)
+        try await stream.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        let older = Task { try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID) }
+        let held = try await nextHeldRead(&reads)
+        fixture.client.releaseThread(id: fixture.firstID)
+        let restored = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertEqual(restored.page?.isLoading, false)
+        XCTAssertEqual(restored.page?.hasMore, true)
+        held.succeed()
+        _ = try await older.value
+        await fixture.http.holdThreadReads(false)
+        await fixture.http.setPage(.init(beforeCursor: nil, hasMore: false, snapshotSequence: 2))
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 3, "Reopened history must allow another older-page request")
         await fixture.client.disconnect()
     }
 
@@ -2259,6 +2287,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
     private var activities: [OrchestrationActivity] = []
     private var completionResponse = false
     private var runningResponse = false
+    private var responsePage: OrchestrationThreadDetailPage?
     private var sequence = 2
     private var holdsThreadReads = false
     private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
@@ -2336,6 +2365,8 @@ private actor CatchUpHTTPTransport: HTTPTransport {
         self.sequence = sequence
         completionResponse = !streaming
     }
+
+    func setPage(_ page: OrchestrationThreadDetailPage) { responsePage = page }
 
     func holdThreadReads(_ hold: Bool) { holdsThreadReads = hold }
 
@@ -2421,7 +2452,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 thread = try JSONValue.object(object).decode(OrchestrationThread.self)
             }
             value = try .encode(OrchestrationThreadDetailSnapshot(
-                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: page ?? snapshot.page
+                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: responsePage ?? page ?? snapshot.page
             ))
         }
         let response = (try JSONEncoder.t3.encode(value), HTTPURLResponse(

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -24,6 +24,171 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
+        for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
+            let fixture = try await CatchUpFixture.make()
+            defer { fixture.cleanUp() }
+            if mode == "streaming" || mode == "no-message-id-streaming" {
+                await fixture.http.setCompletionResponse(text: "Partial", sequence: 2, streaming: true)
+            }
+            var requests = fixture.requests.makeAsyncIterator()
+            let shell = try await nextShellRequest(&requests)
+            var events = fixture.client.events().makeAsyncIterator()
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let detail = try await nextThreadRequest(&requests)
+            if mode == "no-message-id-streaming" {
+                try await detail.completeTurnWithoutMessageID(sequence: 3)
+            }
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+
+            await fixture.http.setCompletionResponse(text: "Final assistant response", sequence: 10)
+            await fixture.http.holdThreadReads(true)
+            let began = expectation(description: "Completion starts a required snapshot: \(mode)")
+            let waiting = Task { @MainActor in
+                var reads = fixture.http.heldRequests.makeAsyncIterator()
+                let read = await reads.next(isolation: #isolation)
+                if read != nil { began.fulfill() }
+                return read
+            }
+            try await shell.completeShell(sequence: 10, assistantMessageID: mode.hasPrefix("no-message-id") ? nil : "answer-0")
+            // Failure watchdog only: successful progress is signaled by the held HTTP read.
+            await fulfillment(of: [began], timeout: 2)
+            waiting.cancel()
+            guard let read = await waiting.value else {
+                await fixture.client.disconnect()
+                continue
+            }
+            read.succeed()
+            let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(repaired, ["Final assistant response"], mode)
+
+            // The same subscription remains usable after HTTP repair.
+            try await detail.sendMessage(text: "Next response", sequence: 11)
+            try await detail.synchronize()
+            let next = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(next, ["Final assistant response", "Next response"], mode)
+            try await shell.completeShell(
+                sequence: 30, assistantMessageID: mode.hasPrefix("no-message-id") ? nil : "answer-0",
+                activeOrderKey: "already-complete"
+            )
+            while let event = await events.next(isolation: #isolation) {
+                if case .threadSync(fixture.firstID, .catchingUp) = event {
+                    XCTFail("Already-complete detail must not start another repair")
+                }
+                if case let .detail(value) = event, value.thread.activeOrderKey == "already-complete" { break }
+                if case let .detailDelta(value, _) = event, value.thread.activeOrderKey == "already-complete" { break }
+            }
+            let count = await fixture.http.threadRequests.count
+            XCTAssertEqual(count, 2, mode)
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testShellCompletionCoalescesWhileRequiredSnapshotTracksNewerDetailEvents() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        let shell = try await nextShellRequest(&requests)
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setCompletionResponse(text: "Final", sequence: 10)
+        await fixture.http.holdThreadReads(true)
+        let began = expectation(description: "Completion starts required read")
+        let waiting = Task { @MainActor in
+            var reads = fixture.http.heldRequests.makeAsyncIterator()
+            let read = await reads.next(isolation: #isolation)
+            if read != nil { began.fulfill() }
+            return read
+        }
+        try await shell.completeShell(sequence: 10, assistantMessageID: "answer-0")
+        await fulfillment(of: [began], timeout: 2)
+        waiting.cancel()
+        guard let first = await waiting.value else {
+            await fixture.client.disconnect()
+            return
+        }
+        await nextCatchUp(&events, threadID: fixture.firstID)
+
+        // An unrelated shell cursor advance must not invalidate the same completion twice.
+        try await shell.completeShell(sequence: 100, assistantMessageID: "answer-0", activeOrderKey: "completion-seen-again")
+        while let event = await events.next(isolation: #isolation) {
+            if case let .detail(value) = event, value.thread.activeOrderKey == "completion-seen-again" { break }
+            if case let .detailDelta(value, _) = event, value.thread.activeOrderKey == "completion-seen-again" { break }
+        }
+        await fixture.http.setCompletionResponse(text: "Final with newer detail", sequence: 20)
+        try await detail.sendMessage(text: "Final with newer detail", sequence: 20)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        first.succeed()
+        let replacement = try await nextHeldRead(&reads)
+        replacement.succeed()
+        let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(repaired, ["Final with newer detail"])
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 3, "Initial read plus one stale repair and one cursor replacement")
+        await fixture.client.disconnect()
+    }
+
+    func testWarmCachedOpenRepairsAlreadyCompletedShellWithoutAnotherShellEvent() async throws {
+        let fixture = try await CatchUpFixture.make()
+        defer { fixture.cleanUp() }
+        var requests = fixture.requests.makeAsyncIterator()
+        let shell = try await nextShellRequest(&requests)
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let first = try await nextThreadRequest(&requests)
+        try await first.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        fixture.client.releaseThread(id: fixture.firstID)
+        try await shell.completeShell(sequence: 10, assistantMessageID: "answer-0", activeOrderKey: "cached-completion")
+        while let event = await events.next(isolation: #isolation) {
+            if case let .thread(value) = event, value.activeOrderKey == "cached-completion" { break }
+            if case let .snapshot(value) = event,
+               value.threads.contains(where: { $0.activeOrderKey == "cached-completion" }) { break }
+        }
+        await fixture.http.setCompletionResponse(text: "Final while closed", sequence: 10)
+        await fixture.http.holdThreadReads(true)
+        let began = expectation(description: "Cached completion starts required read on reopen")
+        let waiting = Task { @MainActor in
+            var reads = fixture.http.heldRequests.makeAsyncIterator()
+            let read = await reads.next(isolation: #isolation)
+            if read != nil { began.fulfill() }
+            return read
+        }
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let resumed = try await nextThreadRequest(&requests)
+        try await resumed.synchronize()
+        await fulfillment(of: [began], timeout: 2)
+        waiting.cancel()
+        guard let read = await waiting.value else {
+            await fixture.client.disconnect()
+            return
+        }
+        // Ignore the warm-cache immediate live receipt preceding the repair.
+        while let event = await events.next(isolation: #isolation) {
+            if case .threadSync(fixture.firstID, .catchingUp) = event { break }
+        }
+        read.succeed()
+        let repaired = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(repaired, ["Final while closed"])
+        let count = await fixture.http.threadRequests.count
+        XCTAssertEqual(count, 2)
+        await fixture.client.disconnect()
+    }
+
+    private func nextShellRequest(
+        _ iterator: inout AsyncStream<CatchUpRequest>.Iterator
+    ) async throws -> CatchUpRequest {
+        while let request = await iterator.next(isolation: #isolation) {
+            if request.tag == RPCMethod.subscribeShell.rawValue { return request }
+        }
+        throw CancellationError()
+    }
+
     func testRequestSnapshotsKeepTerminalRequestsClosedAndOtherFailuresRetryable() async throws {
         var activities: [OrchestrationActivity] = []
         for kind in ["approval", "user-input"] {
@@ -978,14 +1143,17 @@ private struct CatchUpFixture {
                 requests: requests.continuation, completionMarker: completionMarker
             )
         )
+        let readiness = CatchUpBootstrapReadiness()
         let client = NativeFeatureClient(
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
+            aggregateRefreshReceipt: { readiness.record($0) },
             catchUpDelay: { try await delay.wait() },
             threadRetryDelay: threadRetryDelay
         )
         _ = try await client.initialSnapshot()
+        try await readiness.wait()
         return Self(client: client, http: http, requests: requests.stream, delay: delay, directory: directory)
     }
 
@@ -996,6 +1164,7 @@ private actor CatchUpHTTPTransport: HTTPTransport {
     private(set) var threadRequests: [URLRequest] = []
     private var messages: [OrchestrationMessage] = []
     private var activities: [OrchestrationActivity] = []
+    private var completionResponse = false
     private var sequence = 2
     private var holdsThreadReads = false
     private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
@@ -1017,6 +1186,15 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             catchUpMessage(text, index: index, withImage: withImage)
         }
         self.sequence = sequence
+    }
+
+    func setCompletionResponse(text: String, sequence: Int, streaming: Bool = false) {
+        messages = [OrchestrationMessage(
+            id: "answer-0", role: "assistant", text: text, attachments: [], turnId: "turn-1",
+            streaming: streaming, createdAt: "2026-09-02T12:00:00Z", updatedAt: "2026-09-02T12:00:00Z"
+        )]
+        self.sequence = sequence
+        completionResponse = !streaming
     }
 
     func holdThreadReads(_ hold: Bool) { holdsThreadReads = hold }
@@ -1046,6 +1224,11 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             )
             var thread = snapshot.thread
             thread.activities = activities
+            if completionResponse {
+                var object = try JSONValue.encode(thread).decode([String: JSONValue].self)
+                object["latestTurn"] = catchUpCompletedTurn(assistantMessageID: "answer-0")
+                thread = try JSONValue.object(object).decode(OrchestrationThread.self)
+            }
             value = try .encode(OrchestrationThreadDetailSnapshot(
                 snapshotSequence: snapshot.snapshotSequence, thread: thread, page: snapshot.page
             ))
@@ -1107,6 +1290,34 @@ private struct CatchUpRequest: Sendable {
     let id: Int
     let payload: JSONValue
     let socket: CatchUpSocket
+
+    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil) async throws {
+        let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: "First")
+        var thread = try JSONValue.encode(shell.threads[0]).decode([String: JSONValue].self)
+        thread["latestTurn"] = catchUpCompletedTurn(assistantMessageID: assistantMessageID)
+        thread["activeOrderKey"] = activeOrderKey.map(JSONValue.string)
+        let snapshot = OrchestrationShellSnapshot(
+            snapshotSequence: sequence, projects: shell.projects,
+            threads: [try JSONValue.object(thread).decode(OrchestrationThreadShell.self)], updatedAt: shell.updatedAt
+        )
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("snapshot"), "snapshot": try .encode(snapshot),
+        ])])
+    }
+
+    func completeTurnWithoutMessageID(sequence: Int) async throws {
+        try await socket.chunk(id: id, values: [.object([
+            "kind": .string("event"), "event": .object([
+                "type": .string("thread.turn-diff-completed"), "sequence": .number(Double(sequence)),
+                "occurredAt": .string("2026-09-02T12:01:00Z"), "payload": .object([
+                    "threadId": payload["threadId"]!, "turnId": .string("turn-1"),
+                    "checkpointTurnCount": .number(1), "checkpointRef": .string("refs/t3/checkpoints/turn-1"),
+                    "status": .string("ready"), "files": .array([]),
+                    "completedAt": .string("2026-09-02T12:01:00Z"), "assistantMessageId": .null,
+                ]),
+            ]),
+        ])])
+    }
 
     func terminate(_ failure: CatchUpStreamFailure) async throws {
         switch failure {
@@ -1324,5 +1535,50 @@ private actor CatchUpDelay {
     }
     private func cancel(_ id: UUID) {
         waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+    }
+}
+
+private func catchUpCompletedTurn(assistantMessageID: String?) -> JSONValue {
+    .object([
+        "turnId": .string("turn-1"), "state": .string("completed"),
+        "requestedAt": .string("2026-09-02T12:00:00Z"),
+        "startedAt": .string("2026-09-02T12:00:00Z"),
+        "completedAt": .string("2026-09-02T12:01:00Z"),
+        "assistantMessageId": assistantMessageID.map(JSONValue.string) ?? .null,
+    ])
+}
+
+/// The detail tests retain their one FeatureEvent consumer. Readiness comes
+/// from applied shell/config receipts and does not drain that event stream.
+@MainActor
+private final class CatchUpBootstrapReadiness {
+    private var hasShell = false
+    private var hasConfig = false
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    func record(_ receipt: NativePassiveShellReceipt) {
+        switch receipt {
+        case .shellApplied(environmentID: "one", sequence: _): hasShell = true
+        case .configurationApplied(environmentID: "one"): hasConfig = true
+        default: break
+        }
+        if hasShell && hasConfig {
+            let pending = waiters.values
+            waiters.removeAll()
+            pending.forEach { $0.resume() }
+        }
+    }
+
+    func wait() async throws {
+        try Task.checkCancellation()
+        guard !hasShell || !hasConfig else { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { waiters[id] = $0 }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.waiters.removeValue(forKey: id)?.resume(throwing: CancellationError())
+            }
+        }
     }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -5,6 +5,51 @@ import XCTest
 @MainActor
 @available(iOS 18.0, *)
 final class NativeThreadCatchUpTests: XCTestCase {
+    func testFaultInjectedOmittedMessageRepairsAtEqualWatermark() async throws {
+        // Deliberate application-delivery omission, not simulated TCP packet loss.
+        // HTTP is authoritative for both messages; only event 4 reaches the client.
+        for paginated in [false, true] {
+            let clock = SelectedReconciliationClock()
+            let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+            let fixture = try await CatchUpFixture.make(
+                reconciliationClock: clock,
+                reconciliationReceipt: { receipts.continuation.yield($0) }
+            )
+            retainForSelectedReconciliationTest(fixture, clock: clock)
+            var ticks = clock.requests.stream.makeAsyncIterator()
+            var completed = receipts.stream.makeAsyncIterator()
+            var requests = fixture.requests.makeAsyncIterator()
+            var events = fixture.client.events().makeAsyncIterator()
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let detail = try await nextThreadRequest(&requests)
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            // The missing event would have sequence 3; later event 4 is valid.
+            try await detail.sendMessage(text: "Later delivered message", sequence: 4)
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            let before = try rawThreadForHistoryTest(fixture.client)
+            XCTAssertEqual(before.messages.map(\.id), ["message-4"])
+            await fixture.http.setFaultInjectionMessages(paginated: paginated)
+            for attempt in 1...2 {
+                let pendingTick = await ticks.next()
+                let tick = try XCTUnwrap(pendingTick)
+                clock.advance(by: .seconds(30))
+                tick.release()
+                let receipt = await completed.next()
+                XCTAssertEqual(receipt, .finished(threadID: fixture.firstID))
+                let raw = try rawThreadForHistoryTest(fixture.client)
+                let reads = await fixture.http.threadRequests.count
+                XCTAssertEqual(reads, attempt + 1)
+                print("FAULT_INJECTED_EQUAL_WATERMARK paginated=\(paginated) attempt=\(attempt) reads=\(reads) messageIDs=\(raw.messages.map(\.id))")
+                XCTAssertEqual(Set(raw.messages.map(\.id)), Set(["message-3", "message-4"]),
+                    "An authoritative equal-watermark read must repair omitted message 3; attempt \(attempt).")
+            }
+            await fixture.client.disconnect()
+        }
+    }
+
+
     func testSelectedReconciliationPreservesExplicitOlderRawFanoutBelowTenUsers() async throws {
         let clock = SelectedReconciliationClock()
         let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
@@ -115,7 +160,7 @@ final class NativeThreadCatchUpTests: XCTestCase {
             let pendingUnchanged = await ticks.next(); let unchangedTick = try XCTUnwrap(pendingUnchanged)
             clock.advance(by: .seconds(30)); unchangedTick.release(); _ = await completed.next()
             let unchangedURLs = await fixture.http.threadRequests
-            XCTAssertEqual(unchangedURLs.count, collection == "activities" ? 7 : 6, "Unchanged capped recent reads must not repeat full fallback.")
+            XCTAssertEqual(unchangedURLs.count, collection == "activities" ? 8 : 6, "A matching cursor cannot certify omitted rows outside a capped recent window.")
             raw = try rawThreadForHistoryTest(fixture.client)
             XCTAssertEqual(collection == "activities" ? raw.activities.count : raw.checkpoints.count, 299)
         }
@@ -2199,6 +2244,19 @@ private struct CatchUpFixture {
 }
 
 private actor CatchUpHTTPTransport: HTTPTransport {
+    func setFaultInjectionMessages(paginated: Bool) {
+        let authoritative = [3, 4].map { index in
+            OrchestrationMessage(id: "message-\(index)", role: "assistant",
+                text: index == 3 ? "Omitted message" : "Later delivered message",
+                attachments: [], turnId: nil, streaming: false,
+                createdAt: "2026-09-02T12:00:00Z", updatedAt: "2026-09-02T12:00:00Z")
+        }
+        messages = authoritative
+        paginatedMessages = paginated ? authoritative : nil
+        sequence = 4
+    }
+
+
     private(set) var threadRequests: [URLRequest] = []
     private(set) var threadResponseBytes: [Int] = []
     private var messages: [OrchestrationMessage] = []

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -5,6 +5,128 @@ import XCTest
 @MainActor
 @available(iOS 18.0, *)
 final class NativeThreadCatchUpTests: XCTestCase {
+    func testSelectedReconciliationPreservesExplicitOlderRawFanoutBelowTenUsers() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setRawFanoutMessages(sequence: 300)
+        let initial = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertEqual(initial.messages.count, 150)
+        XCTAssertEqual(initial.messages.filter { $0.role == .user }.count, 1)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let loaded = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(loaded?.messages.count, 300)
+        XCTAssertEqual(loaded?.messages.filter { $0.role == .user }.count, 2)
+        XCTAssertEqual(loaded?.messages.first?.text, "Raw 0")
+        XCTAssertEqual(loaded?.page?.hasMore, false)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("Changed raw tail", sequence: 301)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.last?.text, "Changed raw tail")
+        XCTAssertEqual(value?.messages.count, 300, "Quiet repair must preserve explicitly loaded raw-turn history even below ten user rows.")
+        XCTAssertEqual(value?.messages.first?.text, "Raw 0")
+        XCTAssertNotEqual(value?.page?.hasMore, true)
+        print("RAW_CAP_PROOF initial=\(initial.messages.count) loaded=\(loaded?.messages.count ?? -1) loadedUsers=\(loaded?.messages.filter { $0.role == .user }.count ?? -1) repaired=\(value?.messages.count ?? -1)")
+        print("RAW_CAP_REQUESTS \(await fixture.http.threadRequests.map { $0.url!.absoluteString })")
+    }
+
+    func testSelectedReconciliationPreservesExplicitOlderRawFanoutWithZeroUsers() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setRawFanoutMessages(sequence: 300, userSlots: [])
+        let initial = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertEqual(initial.messages.count, 150)
+        XCTAssertEqual(initial.messages.filter { $0.role == .user }.count, 0)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let loaded = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(loaded?.messages.count, 300)
+        XCTAssertEqual(loaded?.messages.filter { $0.role == .user }.count, 0)
+        XCTAssertEqual(loaded?.messages.first?.text, "Raw 0")
+        XCTAssertEqual(loaded?.page?.hasMore, false)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("Changed raw tail", sequence: 301)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.last?.text, "Changed raw tail")
+        XCTAssertEqual(value?.messages.count, 300, "Quiet repair must preserve explicitly loaded raw-turn history even below ten user rows.")
+        XCTAssertEqual(value?.messages.first?.text, "Raw 0")
+        XCTAssertNotEqual(value?.page?.hasMore, true)
+        print("RAW_CAP_PROOF initial=\(initial.messages.count) loaded=\(loaded?.messages.count ?? -1) loadedUsers=\(loaded?.messages.filter { $0.role == .user }.count ?? -1) repaired=\(value?.messages.count ?? -1)")
+        print("RAW_CAP_REQUESTS \(await fixture.http.threadRequests.map { $0.url!.absoluteString })")
+    }
+
+    func testSelectedReconciliationRetainsRawCollectionsAndAcceptsAuthoritativeDeletion() async throws {
+        for collection in ["activities", "checkpoints"] {
+            let clock = SelectedReconciliationClock()
+            let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+            let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+            retainForSelectedReconciliationTest(fixture, clock: clock)
+            var ticks = clock.requests.stream.makeAsyncIterator()
+            var completed = receipts.stream.makeAsyncIterator()
+            var requests = fixture.requests.makeAsyncIterator()
+            var events = fixture.client.events().makeAsyncIterator()
+            await fixture.http.setRawFanoutMessages(sequence: 300, userSlots: [], collection: collection)
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let detail = try await nextThreadRequest(&requests)
+            try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+            var raw = try rawThreadForHistoryTest(fixture.client)
+            XCTAssertEqual(raw.messages.count, 0)
+            XCTAssertEqual(collection == "activities" ? raw.activities.count : raw.checkpoints.count, 300)
+            await fixture.http.editLatestUserText("Changed raw tail", sequence: 301)
+            let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+            clock.advance(by: .seconds(30)); tick.release(); _ = await completed.next()
+            raw = try rawThreadForHistoryTest(fixture.client)
+            XCTAssertEqual(collection == "activities" ? raw.activities.count : raw.checkpoints.count, 300)
+            var urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+            XCTAssertEqual(urls.count, collection == "activities" ? 4 : 3)
+            XCTAssertEqual(urls.last!.contains("turnLimit="), collection == "checkpoints",
+                "Only windowed activities need full fallback for an ordinary changed tail.")
+            await fixture.http.removePaginatedUser(id: "raw-0", sequence: 302)
+            let pendingDelete = await ticks.next(); let deleteTick = try XCTUnwrap(pendingDelete)
+            clock.advance(by: .seconds(30)); deleteTick.release(); _ = await completed.next()
+            raw = try rawThreadForHistoryTest(fixture.client)
+            XCTAssertEqual(collection == "activities" ? raw.activities.count : raw.checkpoints.count, 299)
+            XCTAssertFalse(raw.activities.contains { $0.id == "activity-raw-0" })
+            XCTAssertFalse(raw.checkpoints.contains { $0.turnId == "turn-raw-0" })
+            urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+            XCTAssertEqual(urls.count, collection == "activities" ? 6 : 5)
+            XCTAssertFalse(urls.last!.contains("turnLimit="))
+            let pendingUnchanged = await ticks.next(); let unchangedTick = try XCTUnwrap(pendingUnchanged)
+            clock.advance(by: .seconds(30)); unchangedTick.release(); _ = await completed.next()
+            let unchangedURLs = await fixture.http.threadRequests
+            XCTAssertEqual(unchangedURLs.count, collection == "activities" ? 7 : 6, "Unchanged capped recent reads must not repeat full fallback.")
+            raw = try rawThreadForHistoryTest(fixture.client)
+            XCTAssertEqual(collection == "activities" ? raw.activities.count : raw.checkpoints.count, 299)
+        }
+    }
+
+    private func rawThreadForHistoryTest(_ client: NativeFeatureClient) throws -> OrchestrationThread {
+        // Read-only test inspection: checkpoints are retained raw state and have
+        // no standalone published collection in FeatureThreadDetail.
+        try XCTUnwrap(Mirror(reflecting: client).children.first { $0.label == "activeRawThread" }?.value as? OrchestrationThread)
+    }
+
     func testSelectedReconciliationRepairsSilentDetailWithoutSyncFlicker() async throws {
         let clock = SelectedReconciliationClock()
         let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
@@ -463,6 +585,34 @@ final class NativeThreadCatchUpTests: XCTestCase {
         if urls.count > 3 { XCTAssertTrue(urls[3].contains("turnLimit=31")) }
     }
 
+    func testSelectedReconciliationUserlessPendingAheadPageRecoversWithoutStreamProgress() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setRawFanoutMessages(sequence: 300, userSlots: [])
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("New head", sequence: 301)
+        let pendingPage = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(pendingPage?.page?.isLoading, true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let receipt = await completed.next()
+        XCTAssertEqual(receipt, .finished(threadID: fixture.firstID))
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 300)
+        XCTAssertEqual(value?.messages.first?.text, "Raw 0")
+        XCTAssertEqual(value?.messages.last?.text, "New head")
+        XCTAssertNotEqual(value?.page?.isLoading, true)
+    }
+
     func testSelectedReconciliationPendingAheadPageRecoversWithoutStreamProgress() async throws {
         let clock = SelectedReconciliationClock()
         let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
@@ -489,6 +639,43 @@ final class NativeThreadCatchUpTests: XCTestCase {
         XCTAssertEqual(value?.messages.first?.text, "User 20")
         XCTAssertEqual(value?.messages.last?.text, "New head")
         XCTAssertEqual(value?.page?.isLoading, false)
+    }
+
+    func testSelectedReconciliationUserlessChangedQuietReadYieldsToOlderPageRequest() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.setRawFanoutMessages(sequence: 300, userSlots: [])
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("Changed head", sequence: 301)
+        await fixture.http.holdThreadReads(true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let quiet = try await nextHeldRead(&reads)
+        let olderTask = Task { try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID) }
+        let olderRead = try await nextHeldRead(&reads)
+        quiet.succeed(); _ = await completed.next()
+        olderRead.succeed()
+        let waitingOlder = try await olderTask.value
+        XCTAssertEqual(waitingOlder?.page?.isLoading, true, "Optional quiet read must not invalidate the user's older-page epoch.")
+        await fixture.http.holdThreadReads(false)
+        let nextPending = await ticks.next(); let nextTick = try XCTUnwrap(nextPending)
+        clock.advance(by: .seconds(30)); nextTick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 300)
+        XCTAssertEqual(value?.messages.first?.text, "Raw 0")
+        XCTAssertEqual(value?.messages.last?.text, "Changed head")
+        XCTAssertNotEqual(value?.page?.isLoading, true)
     }
 
     func testSelectedReconciliationChangedQuietReadYieldsToOlderPageRequest() async throws {
@@ -2016,6 +2203,8 @@ private actor CatchUpHTTPTransport: HTTPTransport {
     private(set) var threadResponseBytes: [Int] = []
     private var messages: [OrchestrationMessage] = []
     private var paginatedMessages: [OrchestrationMessage]?
+    private var rawTurnCap: Int?
+    private var rawCollection: String?
     private var pendingHeldReads: [CatchUpHTTPRead] = []
     private var activities: [OrchestrationActivity] = []
     private var completionResponse = false
@@ -2029,6 +2218,18 @@ private actor CatchUpHTTPTransport: HTTPTransport {
         let reads = AsyncStream<CatchUpHTTPRead>.makeStream()
         heldRequests = reads.stream
         heldReadContinuation = reads.continuation
+    }
+
+    func setRawFanoutMessages(sequence: Int, userSlots: Set<Int> = [0, 200], collection: String? = nil) {
+        rawTurnCap = 150
+        rawCollection = collection
+        paginatedMessages = (0..<300).map { index in
+            let stamp = String(format: "2026-09-02T12:%02d:%02dZ", index / 60, index % 60)
+            return OrchestrationMessage(id: "raw-\(index)", role: userSlots.contains(index) ? "user" : "assistant",
+                text: "Raw \(index)", attachments: [], turnId: userSlots.contains(index) ? nil : "turn-\(index)",
+                streaming: false, createdAt: stamp, updatedAt: stamp)
+        }
+        self.sequence = sequence
     }
 
     func setPaginatedUserMessages(_ range: Range<Int>, sequence: Int) {
@@ -2114,7 +2315,17 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 let limit = query.first { $0.name == "turnLimit" }?.value.flatMap(Int.init)
                 let cursor = query.first { $0.name == "beforeCursor" }?.value
                 let end = cursor.flatMap { value in paginatedMessages.firstIndex { $0.id == value } } ?? paginatedMessages.count
-                let start = max(0, end - (limit ?? end))
+                var start = max(0, end - (limit ?? end))
+                if let cap = rawTurnCap, let limit {
+                    // One fixture message per raw turn. Match server candidates LIMIT150,
+                    // then walk descending until the user-anchored turn limit is reached.
+                    start = max(0, end - cap)
+                    var usersSeen = 0
+                    for index in stride(from: end - 1, through: start, by: -1) {
+                        if paginatedMessages[index].role == "user" { usersSeen += 1 }
+                        if usersSeen == limit { start = index; break }
+                    }
+                }
                 responseMessages = Array(paginatedMessages[start..<end])
                 if limit != nil {
                     page = OrchestrationThreadDetailPage(
@@ -2129,6 +2340,22 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             )
             var thread = snapshot.thread
             thread.activities = activities
+            if let rawCollection {
+                thread.messages = []
+                if rawCollection == "activities" {
+                    thread.activities = responseMessages.map { row in
+                        OrchestrationActivity(id: "activity-\(row.id)", tone: "info", kind: "fixture.raw-turn",
+                            summary: row.text, payload: .null, turnId: "turn-\(row.id)", sequence: nil, createdAt: row.createdAt)
+                    }
+                } else {
+                    // Server checkpoints are unwindowed even when messages/activities
+                    // hit the raw-turn cap. Keep this fixture faithful to that contract.
+                    thread.checkpoints = (paginatedMessages ?? responseMessages).enumerated().map { offset, row in
+                        CheckpointSummary(turnId: "turn-\(row.id)", checkpointTurnCount: offset,
+                            checkpointRef: row.text, status: "completed", files: [], assistantMessageId: nil, completedAt: row.createdAt)
+                    }
+                }
+            }
             if runningResponse {
                 var object = try JSONValue.encode(thread).decode([String: JSONValue].self)
                 object["latestTurn"] = .object([

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -24,6 +24,201 @@ final class NativeThreadCatchUpTests: XCTestCase {
         await fixture.client.disconnect()
     }
 
+    func testLegacyBurstCoalescesUntilExplicitMarker() async throws {
+        for capability: Bool? in [nil, false] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: capability, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var events = fixture.client.events().makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 100, includeMarker: true)
+                var publications = 0
+                var sawLive = false
+                var finalText: String?
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        publications += 1
+                        finalText = value.messages.last?.text
+                    case .threadSync(fixture.firstID, .live):
+                        XCTAssertEqual(publications, 1)
+                        XCTAssertEqual(finalText, String(repeating: "x", count: 100))
+                        sawLive = true
+                        break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(sawLive)
+                XCTAssertEqual(finalText, String(repeating: "x", count: 100))
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await clock.release()
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testLegacyMarkerlessFinalPublishesWhenClockReleases() async throws {
+        for capability: Bool? in [nil, false] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: capability, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var events = fixture.client.events().makeAsyncIterator()
+                var entries = clock.entries.makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 1, includeMarker: false)
+                guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
+                await clock.release()
+                var foundFinal = false
+                while let event = await events.next(isolation: #isolation) {
+                    if case .threadSync(fixture.firstID, .live) = event {
+                        XCTFail("An already live legacy event must not emit another live status")
+                    }
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        XCTAssertEqual(value.messages.last?.text, "x")
+                        foundFinal = true
+                    default: continue
+                    }
+                    if foundFinal { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(foundFinal)
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testLegacyBufferedFinalPrecedesShellDone() async throws {
+        for shellSequence in [3, 10] {
+            let clock = CatchUpPublicationClock()
+            let fixture = try await CatchUpFixture.make(
+                completionMarker: nil, detailPublicationSleep: { try await clock.wait() }
+            )
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                let shell = try await nextShellRequest(&requests)
+                var events = fixture.client.events().makeAsyncIterator()
+                var entries = clock.entries.makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.sendBurst(count: 1, includeMarker: false)
+                guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
+                try await shell.completeShell(sequence: shellSequence, assistantMessageID: "burst-message")
+                var reachedDone = false
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        guard value.thread.id == fixture.firstID else { continue }
+                        if value.thread.state == .completed {
+                            XCTAssertEqual(value.messages.last?.text, "x")
+                            reachedDone = true
+                        }
+                    default: continue
+                    }
+                    if reachedDone { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertTrue(reachedDone)
+            } catch {
+                await clock.release()
+                await fixture.client.disconnect()
+                throw error
+            }
+            await clock.release()
+            await fixture.client.disconnect()
+        }
+    }
+
+    func testDelayedCompletedShellPreservesNewerRunningDetailAndBackgroundLiveness() async throws {
+        for background: String? in [nil, "working"] {
+            let receipts = AsyncStream<Int>.makeStream()
+            let fixture = try await CatchUpFixture.make(aggregateRefreshReceipt: { receipt in
+                if case let .shellApplied("one", sequence) = receipt { receipts.continuation.yield(sequence) }
+            })
+            defer { fixture.cleanUp() }
+            do {
+                var requests = fixture.requests.makeAsyncIterator()
+                var applied = receipts.stream.makeAsyncIterator()
+                let shell = try await nextShellRequest(&requests)
+                try await shell.completeShell(sequence: 10, assistantMessageID: nil)
+                while let sequence = await applied.next(isolation: #isolation) {
+                    if sequence == 10 { break }
+                }
+                try Task.checkCancellation()
+                var events = fixture.client.events().makeAsyncIterator()
+                _ = try await fixture.client.loadThread(id: fixture.firstID)
+                let detail = try await nextThreadRequest(&requests)
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.runningTurnSnapshot(sequence: 12)
+                var latest: FeatureThreadDetail?
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _): latest = value
+                    case .threadSync(fixture.firstID, .live): break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                XCTAssertEqual(latest?.thread.state, .working)
+                let startedAt = try XCTUnwrap(latest?.thread.workingStartedAt)
+                try await shell.completeShell(
+                    sequence: 11, assistantMessageID: nil, backgroundLiveness: background
+                )
+                while let sequence = await applied.next(isolation: #isolation) {
+                    if sequence == 11 { break }
+                }
+                try Task.checkCancellation()
+                // The applied shell receipt orders this explicit detail marker
+                // after any detail publication caused by the delayed shell.
+                try await detail.synchronize()
+                while let event = await events.next(isolation: #isolation) {
+                    switch event {
+                    case let .detail(value), let .detailDelta(value, _):
+                        latest = value
+                        XCTAssertEqual(value.thread.state, .working)
+                        XCTAssertEqual(value.thread.workingStartedAt, startedAt)
+                    case .threadSync(fixture.firstID, .live): break
+                    default: continue
+                    }
+                    if case .threadSync(fixture.firstID, .live) = event { break }
+                }
+                try Task.checkCancellation()
+                XCTAssertEqual(latest?.thread.state, .working)
+                XCTAssertEqual(latest?.backgroundWorkIsActive, background == "working")
+            } catch {
+                await fixture.client.disconnect()
+                throw error
+            }
+            await fixture.client.disconnect()
+        }
+    }
+
     func testShellCompletionRepairsMissingOrStreamingFinalWithoutClosingDetailStream() async throws {
         for mode in ["missing", "streaming", "no-message-id", "no-message-id-streaming"] {
             let fixture = try await CatchUpFixture.make()
@@ -1118,8 +1313,12 @@ private struct CatchUpFixture {
     var secondID: String { FeatureScopedID.thread(environmentID: "one", wireID: "second") }
 
     static func make(
-        completionMarker: Bool = true,
+        completionMarker: Bool? = true,
         activities: [OrchestrationActivity] = [],
+        aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
+        detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(80))
+        },
         threadRetryDelay: @escaping @Sendable (Int) async throws -> Void = { _ in
             try await Task.sleep(for: .milliseconds(250))
         }
@@ -1148,7 +1347,8 @@ private struct CatchUpFixture {
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
-            aggregateRefreshReceipt: { readiness.record($0) },
+            aggregateRefreshReceipt: { readiness.record($0); aggregateRefreshReceipt($0) },
+            detailPublicationSleep: detailPublicationSleep,
             catchUpDelay: { try await delay.wait() },
             threadRetryDelay: threadRetryDelay
         )
@@ -1275,7 +1475,7 @@ private func catchUpMessage(
 
 private struct CatchUpConnector: WebSocketConnecting {
     let requests: AsyncStream<CatchUpRequest>.Continuation
-    let completionMarker: Bool
+    let completionMarker: Bool?
     func connect(to url: URL) async throws -> any WebSocketConnection {
         CatchUpSocket(requests: requests, completionMarker: completionMarker)
     }
@@ -1291,11 +1491,12 @@ private struct CatchUpRequest: Sendable {
     let payload: JSONValue
     let socket: CatchUpSocket
 
-    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil) async throws {
+    func completeShell(sequence: Int, assistantMessageID: String?, activeOrderKey: String? = nil, backgroundLiveness: String? = nil) async throws {
         let shell = multiEnvironmentShell(projectID: "project", threadID: "first", title: "First")
         var thread = try JSONValue.encode(shell.threads[0]).decode([String: JSONValue].self)
         thread["latestTurn"] = catchUpCompletedTurn(assistantMessageID: assistantMessageID)
         thread["activeOrderKey"] = activeOrderKey.map(JSONValue.string)
+        thread["backgroundLiveness"] = backgroundLiveness.map(JSONValue.string)
         let snapshot = OrchestrationShellSnapshot(
             snapshotSequence: sequence, projects: shell.projects,
             threads: [try JSONValue.object(thread).decode(OrchestrationThreadShell.self)], updatedAt: shell.updatedAt
@@ -1373,6 +1574,44 @@ private struct CatchUpRequest: Sendable {
         ])])
     }
 
+    func runningTurnSnapshot(sequence: Int) async throws {
+        let snapshot = multiEnvironmentDetail(
+            projectID: "project", threadID: payload["threadId"]!.stringValue!, snapshotSequence: sequence
+        )
+        var thread = try JSONValue.encode(snapshot.thread).decode([String: JSONValue].self)
+        thread["latestTurn"] = .object([
+            "turnId": .string("turn-2"), "state": .string("running"),
+            "requestedAt": .string("2026-09-02T12:02:00Z"),
+            "startedAt": .string("2026-09-02T12:02:00Z"),
+            "completedAt": .null, "assistantMessageId": .null,
+        ])
+        let updated = OrchestrationThreadDetailSnapshot(
+            snapshotSequence: sequence, thread: try JSONValue.object(thread).decode(OrchestrationThread.self)
+        )
+        try await socket.chunk(id: id, values: [
+            .object(["kind": .string("snapshot"), "snapshot": try .encode(updated)]),
+        ])
+    }
+
+    func sendBurst(count: Int, includeMarker: Bool) async throws {
+        var values: [JSONValue] = (1...count).map { index in
+            .object([
+                "kind": .string("event"), "event": .object([
+                    "type": .string("thread.message-sent"), "sequence": .number(Double(index + 2)),
+                    "occurredAt": .string("2026-09-02T12:00:00Z"), "payload": .object([
+                        "threadId": payload["threadId"]!, "messageId": .string("burst-message"),
+                        "role": .string("assistant"), "text": .string(index < count ? "x" : String(repeating: "x", count: count)),
+                        "streaming": .bool(index < count),
+                        "createdAt": .string("2026-09-02T12:00:00Z"),
+                        "updatedAt": .string("2026-09-02T12:00:00Z"),
+                    ]),
+                ]),
+            ])
+        }
+        if includeMarker { values.append(.object(["kind": .string("synchronized")])) }
+        try await socket.chunk(id: id, values: values)
+    }
+
     func sendMessage(text: String, sequence: Int) async throws {
         try await socket.chunk(id: id, values: [.object([
             "kind": .string("event"), "event": .object([
@@ -1390,13 +1629,13 @@ private struct CatchUpRequest: Sendable {
 
 private actor CatchUpSocket: WebSocketConnection {
     let requests: AsyncStream<CatchUpRequest>.Continuation
-    let completionMarker: Bool
+    let completionMarker: Bool?
     private(set) var assetRequestCount = 0
     private var pending: [Data] = []
     private var receiver: CheckedContinuation<Data, any Error>?
     private var closed = false
 
-    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool) {
+    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool?) {
         self.requests = requests
         self.completionMarker = completionMarker
     }
@@ -1410,11 +1649,12 @@ private actor CatchUpSocket: WebSocketConnection {
         guard let tag = request["tag"]?.stringValue, case let .number(id) = request["id"] else { return }
         if tag == RPCMethod.assetsCreateURL.rawValue { assetRequestCount += 1 }
         if tag == RPCMethod.subscribeServerConfig.rawValue {
+            var config: [String: JSONValue] = [
+                "providers": .array([]), "threadSnapshotPagination": .bool(true),
+            ]
+            if let completionMarker { config["threadResumeCompletionMarker"] = .bool(completionMarker) }
             try chunk(id: Int(id), values: [.object([
-                "type": .string("snapshot"), "config": .object([
-                    "providers": .array([]), "threadSnapshotPagination": .bool(true),
-                    "threadResumeCompletionMarker": .bool(completionMarker),
-                ]),
+                "type": .string("snapshot"), "config": .object(config),
             ])])
         }
         requests.yield(.init(tag: tag, id: Int(id), payload: request["payload"]!, socket: self))
@@ -1581,4 +1821,23 @@ private final class CatchUpBootstrapReadiness {
             }
         }
     }
+}
+
+private final class CatchUpPublicationClock: Sendable {
+    private let gate = CatchUpDelay()
+    private let receipt: AsyncStream<Void>.Continuation
+    let entries: AsyncStream<Void>
+
+    init() {
+        let pair = AsyncStream<Void>.makeStream()
+        entries = pair.stream
+        receipt = pair.continuation
+    }
+
+    func wait() async throws {
+        receipt.yield(())
+        try await gate.wait()
+    }
+
+    func release() async { await gate.release() }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -5,6 +5,635 @@ import XCTest
 @MainActor
 @available(iOS 18.0, *)
 final class NativeThreadCatchUpTests: XCTestCase {
+    func testSelectedReconciliationRepairsSilentDetailWithoutSyncFlicker() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(text: "Quiet HTTP repair", sequence: 20)
+        let pendingTick = await ticks.next(); let tick = try XCTUnwrap(pendingTick)
+        clock.advance(by: .seconds(30)); tick.release()
+        let receipt = await completed.next()
+        XCTAssertEqual(receipt, .finished(threadID: fixture.firstID))
+        try await detail.synchronize()
+        var messages: [String] = []
+        while let event = await events.next(isolation: #isolation) {
+            switch event {
+            case let .detail(value), let .detailDelta(value, _): messages = value.messages.map(\.text)
+            case .threadSync(fixture.firstID, .live): break
+            case .threadSync(fixture.firstID, .catchingUp): XCTFail("Quiet repair must not flash catch-up.")
+            default: continue
+            }
+            if case .threadSync(fixture.firstID, .live) = event { break }
+        }
+        XCTAssertEqual(messages, ["Quiet HTTP repair"])
+        let reads = await fixture.http.threadRequests.count
+        XCTAssertEqual(reads, 2)
+        await fixture.client.disconnect()
+    }
+
+    func testSelectedReconciliationUnchangedSnapshotPublishesNothing() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let pendingTick = await ticks.next(); let tick = try XCTUnwrap(pendingTick)
+        clock.advance(by: .seconds(30)); tick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        var publications = 0
+        while let event = await events.next(isolation: #isolation) {
+            if case .detail = event { publications += 1 }
+            if case .detailDelta = event { publications += 1 }
+            if case .threadSync(fixture.firstID, .live) = event { break }
+        }
+        XCTAssertEqual(publications, 0)
+        await fixture.client.disconnect()
+    }
+
+    func testSelectedReconciliationActualProgressPostponesButMarkerDoesNot() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let pendingFirst = await ticks.next(); let first = try XCTUnwrap(pendingFirst)
+        clock.advance(by: .seconds(20))
+        try await detail.sendMessage(text: "Live progress", sequence: 3)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        clock.advance(by: .seconds(10)); first.release()
+        let deferred = await completed.next()
+        XCTAssertEqual(deferred, .deferred(threadID: fixture.firstID))
+        let pendingNext = await ticks.next(); let next = try XCTUnwrap(pendingNext)
+        XCTAssertEqual(next.duration, .seconds(20))
+        clock.advance(by: .seconds(10))
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        clock.advance(by: .seconds(10)); next.release()
+        let finished = await completed.next()
+        XCTAssertEqual(finished, .finished(threadID: fixture.firstID))
+        let reads = await fixture.http.threadRequests.count
+        XCTAssertEqual(reads, 2)
+        await fixture.client.disconnect()
+    }
+
+    func testSelectedReconciliationRejectsOlderHeldHTTPAfterNewerDetail() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(text: "Old HTTP", sequence: 3)
+        await fixture.http.holdThreadReads(true)
+        let pendingTick = await ticks.next(); let tick = try XCTUnwrap(pendingTick)
+        clock.advance(by: .seconds(30)); tick.release()
+        let held = try await nextHeldRead(&reads)
+        try await detail.sendMessage(text: "Newer live response", sequence: 4)
+        try await detail.synchronize()
+        let live = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(live, ["Newer live response"])
+        held.succeed()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let replaced = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertTrue(replaced.isEmpty, "Older HTTP must not republish over newer detail.")
+        await fixture.client.disconnect()
+    }
+
+    func testSelectedReconciliationBackgroundCancelsItsHeldRead() async throws {
+        let clock = SelectedReconciliationClock()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock)
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        let pendingTick = await ticks.next(); let tick = try XCTUnwrap(pendingTick)
+        clock.advance(by: .seconds(30)); tick.release()
+        let held = try await nextHeldRead(&reads)
+        fixture.client.suspendForBackground()
+        held.succeed()
+        let cancelled = await held.finished.first { _ in true }
+        XCTAssertEqual(cancelled, true)
+        await fixture.client.disconnect()
+    }
+
+    func testSelectedReconciliationRequiredReadKeepsItsFailureAfterQuietRead() async throws {
+        let clock = SelectedReconciliationClock()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock)
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        let pendingTick = await ticks.next(); let tick = try XCTUnwrap(pendingTick)
+        clock.advance(by: .seconds(30)); tick.release()
+        let quiet = try await nextHeldRead(&reads)
+        try await detail.invalidate(sequence: 3)
+        await nextCatchUp(&events, threadID: fixture.firstID)
+        quiet.succeed()
+        let required = try await nextHeldRead(&reads)
+        required.fail()
+        var failure: String?
+        while let event = await events.next(isolation: #isolation) {
+            if case let .threadSync(id, .failed(message)) = event, id == fixture.firstID {
+                failure = message; break
+            }
+        }
+        XCTAssertEqual(failure, URLError(.notConnectedToInternet).localizedDescription)
+        await fixture.client.disconnect()
+    }
+
+    private func retainForSelectedReconciliationTest(_ fixture: CatchUpFixture, clock: SelectedReconciliationClock? = nil) {
+        addTeardownBlock {
+            await MainActor.run { clock?.cancelAll() }
+            await fixture.http.cancelHeldReads()
+            await fixture.client.disconnect()
+            await MainActor.run { fixture.cleanUp() }
+        }
+    }
+
+    func testSelectedReconciliationPreservesLoadedHistoryWhenUnchanged() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<50, sequence: 50)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let older = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(older?.messages.count, 30)
+        let retainedPage = older?.page
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let unchanged = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertTrue(unchanged.isEmpty, "An unchanged enlarged window must not publish extra history.")
+        let earlier = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(retainedPage?.beforeCursor, "user-20")
+        XCTAssertEqual(earlier?.messages.count, 50)
+        let urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertTrue(urls[2].contains("turnLimit=30"))
+        XCTAssertTrue(urls[3].contains("beforeCursor=user-20"))
+    }
+
+    func testSelectedReconciliationExpandedGapAndDeletedBoundaryUseAuthoritativeFullRead() async throws {
+        for deletedBoundary in [false, true] {
+            let clock = SelectedReconciliationClock()
+            let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+            let fixture = try await CatchUpFixture.make(
+                reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+            )
+            retainForSelectedReconciliationTest(fixture, clock: clock)
+            var ticks = clock.requests.stream.makeAsyncIterator()
+            var completed = receipts.stream.makeAsyncIterator()
+            var requests = fixture.requests.makeAsyncIterator()
+            var events = fixture.client.events().makeAsyncIterator()
+            await fixture.http.setPaginatedUserMessages(0..<50, sequence: 50)
+            _ = try await fixture.client.loadThread(id: fixture.firstID)
+            let detail = try await nextThreadRequest(&requests)
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+            try await detail.synchronize()
+            _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            let lower = deletedBoundary ? 21 : 0
+            await fixture.http.setPaginatedUserMessages(lower..<110, sequence: 200)
+            let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+            clock.advance(by: .seconds(30)); tick.release()
+            _ = await completed.next()
+            try await detail.synchronize()
+            let messages = await messagesBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(messages.first, "User \(lower)")
+            XCTAssertEqual(messages.last, "User 109")
+            XCTAssertEqual(messages.count, 110 - lower)
+            let urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+            XCTAssertEqual(urls.count, 4)
+            XCTAssertTrue(urls[2].contains("turnLimit=30"))
+            XCTAssertFalse(urls[3].contains("turnLimit="))
+        }
+    }
+
+    func testSelectedReconciliationUnchangedReadDoesNotInvalidatePendingOlderPage() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<50, sequence: 50)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.holdThreadReads(true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let quiet = try await nextHeldRead(&reads)
+        let olderTask = Task { try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID) }
+        let olderRead = try await nextHeldRead(&reads)
+        quiet.succeed()
+        _ = await completed.next()
+        olderRead.succeed()
+        let older = try await olderTask.value
+        XCTAssertEqual(older?.messages.count, 30)
+        XCTAssertEqual(older?.page?.beforeCursor, "user-20")
+        XCTAssertEqual(older?.page?.isLoading, false)
+    }
+
+    func testSelectedReconciliationNavigationRejectsHeldResponse() async throws {
+        let clock = SelectedReconciliationClock()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock)
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setResponse(text: "Must not arrive after navigation", sequence: 20)
+        await fixture.http.holdThreadReads(true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let held = try await nextHeldRead(&reads)
+        fixture.client.releaseThread(id: fixture.firstID)
+        await fixture.http.holdThreadReads(false)
+        _ = try await fixture.client.loadThread(id: fixture.secondID)
+        _ = try await nextThreadRequest(&requests)
+        held.succeed()
+        let cancelled = await held.finished.first { _ in true }
+        XCTAssertEqual(cancelled, true)
+        fixture.client.releaseThread(id: fixture.secondID)
+        let restored = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertFalse(restored.messages.contains { $0.text == "Must not arrive after navigation" })
+    }
+
+    func testSelectedReconciliationUsesSelectedPassivePeerRoute() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(
+            includePeer: true, reconciliationClock: clock,
+            reconciliationReceipt: { receipts.continuation.yield($0) }
+        )
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        let peerID = FeatureScopedID.thread(environmentID: "two", wireID: "first")
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        _ = try await fixture.client.loadThread(id: peerID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: peerID)
+        await fixture.http.setResponse(text: "Peer HTTP repair", sequence: 20)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let receipt = await completed.next()
+        XCTAssertEqual(receipt, .finished(threadID: peerID))
+        try await detail.synchronize()
+        let messages = await messagesBeforeLive(&events, threadID: peerID)
+        XCTAssertEqual(messages, ["Peer HTTP repair"])
+        let reads = await fixture.http.threadRequests
+        XCTAssertEqual(reads.count, 2)
+        XCTAssertTrue(reads.allSatisfy { $0.url?.host == "two.example" })
+    }
+
+    func testSelectedReconciliationDefaultDeadlineRepairsMessageAndWorkingState() async throws {
+        let fixture = try await CatchUpFixture.make()
+        retainForSelectedReconciliationTest(fixture)
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        let initial = try await fixture.client.loadThread(id: fixture.firstID)
+        XCTAssertEqual(initial.thread.state, .idle)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize()
+        _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setRunningResponse(text: "Default deadline repair", sequence: 20)
+        let start = ContinuousClock.now
+        var repaired: FeatureThreadDetail?
+        while let event = await events.next(isolation: #isolation) {
+            switch event {
+            case let .detail(value), let .detailDelta(value, _):
+                if value.thread.id == fixture.firstID,
+                   value.messages.contains(where: { $0.text == "Default deadline repair" }) {
+                    repaired = value
+                }
+            case .threadSync(fixture.firstID, .catchingUp): XCTFail("Quiet recovery must not flash catch-up.")
+            default: break
+            }
+            if repaired != nil { break }
+        }
+        let elapsed = start.duration(to: .now)
+        XCTAssertEqual(repaired?.thread.state, .working)
+        XCTAssertGreaterThanOrEqual(elapsed, .seconds(29))
+        XCTAssertLessThan(elapsed, .seconds(40))
+        let reads = await fixture.http.threadRequests
+        XCTAssertEqual(reads.count, 2)
+        print("DEFAULT_RECONCILIATION elapsed=\(elapsed) state=\(String(describing: repaired?.thread.state)) reads=\(reads.count) bytes=\(await fixture.http.threadResponseBytes)")
+    }
+
+    func testSelectedReconciliationRepeatedTailEditsKeepExplicitHistoryExtent() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<100, sequence: 100)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        for edit in 1...3 {
+            await fixture.http.editLatestUserText("Tail edit \(edit)", sequence: 100 + edit)
+            let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+            clock.advance(by: .seconds(30)); tick.release()
+            _ = await completed.next()
+            try await detail.synchronize()
+            let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+            XCTAssertEqual(value?.messages.count, 30)
+            XCTAssertEqual(value?.messages.first?.text, "User 70")
+            XCTAssertEqual(value?.messages.last?.text, "Tail edit \(edit)")
+            XCTAssertEqual(value?.page?.beforeCursor, "user-70")
+        }
+        let urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertEqual(urls.count, 5)
+        XCTAssertTrue(urls.dropFirst(2).allSatisfy { $0.contains("turnLimit=30") })
+    }
+
+    func testSelectedReconciliationNewUserAddsOnlyRequiredWindowExtent() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<100, sequence: 100)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setPaginatedUserMessages(0..<101, sequence: 101)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 31)
+        XCTAssertEqual(value?.messages.first?.text, "User 70")
+        XCTAssertEqual(value?.messages.last?.text, "User 100")
+        XCTAssertEqual(value?.page?.beforeCursor, "user-70")
+        let urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertEqual(urls.count, 4)
+        XCTAssertTrue(urls[2].contains("turnLimit=30"))
+        if urls.count > 3 { XCTAssertTrue(urls[3].contains("turnLimit=31")) }
+    }
+
+    func testSelectedReconciliationPendingAheadPageRecoversWithoutStreamProgress() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<50, sequence: 50)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("New head", sequence: 51)
+        let pendingPage = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        XCTAssertEqual(pendingPage?.page?.isLoading, true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let receipt = await completed.next()
+        XCTAssertEqual(receipt, .finished(threadID: fixture.firstID))
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 30)
+        XCTAssertEqual(value?.messages.first?.text, "User 20")
+        XCTAssertEqual(value?.messages.last?.text, "New head")
+        XCTAssertEqual(value?.page?.isLoading, false)
+    }
+
+    func testSelectedReconciliationChangedQuietReadYieldsToOlderPageRequest() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<50, sequence: 50)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.editLatestUserText("Changed head", sequence: 51)
+        await fixture.http.holdThreadReads(true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let quiet = try await nextHeldRead(&reads)
+        let olderTask = Task { try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID) }
+        let olderRead = try await nextHeldRead(&reads)
+        quiet.succeed(); _ = await completed.next()
+        olderRead.succeed()
+        let waitingOlder = try await olderTask.value
+        XCTAssertEqual(waitingOlder?.page?.isLoading, true, "Optional quiet read must not invalidate the user's older-page epoch.")
+        await fixture.http.holdThreadReads(false)
+        let nextPending = await ticks.next(); let nextTick = try XCTUnwrap(nextPending)
+        clock.advance(by: .seconds(30)); nextTick.release()
+        _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 30)
+        XCTAssertEqual(value?.messages.first?.text, "User 20")
+        XCTAssertEqual(value?.messages.last?.text, "Changed head")
+        XCTAssertEqual(value?.page?.isLoading, false)
+    }
+
+    private func selectedDetailBeforeLive(_ events: inout AsyncStream<FeatureEvent>.Iterator, threadID: String) async -> FeatureThreadDetail? {
+        var value: FeatureThreadDetail?
+        while let event = await events.next(isolation: #isolation) {
+            switch event {
+            case let .detail(detail), let .detailDelta(detail, _):
+                if detail.thread.id == threadID { value = detail }
+            case .threadSync(threadID, .live): return value
+            default: break
+            }
+        }
+        return value
+    }
+
+    func testSelectedReconciliationMovingAdaptiveHeadDefersWithoutFullRead() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        var reads = fixture.http.heldRequests.makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<100, sequence: 100)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setPaginatedUserMessages(0..<101, sequence: 101)
+        await fixture.http.holdThreadReads(true)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release()
+        let first = try await nextHeldRead(&reads)
+        await fixture.http.setPaginatedUserMessages(0..<102, sequence: 102)
+        first.succeed()
+        let adaptive = try await nextHeldRead(&reads)
+        adaptive.succeed(); _ = await completed.next()
+        var urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertEqual(urls.count, 4)
+        XCTAssertTrue(urls[2].contains("turnLimit=30"))
+        XCTAssertTrue(urls[3].contains("turnLimit=31"))
+        try await detail.synchronize()
+        let unchanged = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertNil(unchanged, "A moving second read must not widen or replace the retained range.")
+        await fixture.http.holdThreadReads(false)
+        let nextPending = await ticks.next(); let next = try XCTUnwrap(nextPending)
+        clock.advance(by: .seconds(30)); next.release(); _ = await completed.next()
+        try await detail.synchronize()
+        let repaired = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(repaired?.messages.count, 32)
+        XCTAssertEqual(repaired?.messages.first?.text, "User 70")
+        XCTAssertEqual(repaired?.messages.last?.text, "User 101")
+        urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertEqual(urls.count, 6)
+        XCTAssertTrue(urls[5].contains("turnLimit=32"))
+    }
+
+    func testSelectedReconciliationDeletedAnchorAfterAdaptiveReadUsesOneFullFallback() async throws {
+        let clock = SelectedReconciliationClock()
+        let receipts = AsyncStream<NativeSelectedThreadReconciliationReceipt>.makeStream()
+        let fixture = try await CatchUpFixture.make(reconciliationClock: clock, reconciliationReceipt: { receipts.continuation.yield($0) })
+        retainForSelectedReconciliationTest(fixture, clock: clock)
+        var ticks = clock.requests.stream.makeAsyncIterator()
+        var completed = receipts.stream.makeAsyncIterator()
+        var requests = fixture.requests.makeAsyncIterator()
+        var events = fixture.client.events().makeAsyncIterator()
+        await fixture.http.setPaginatedUserMessages(0..<100, sequence: 100)
+        _ = try await fixture.client.loadThread(id: fixture.firstID)
+        let detail = try await nextThreadRequest(&requests)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        _ = try await fixture.client.loadEarlierThreadTurns(id: fixture.firstID)
+        try await detail.synchronize(); _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+        await fixture.http.setPaginatedUserMessages(0..<101, sequence: 101)
+        await fixture.http.removePaginatedUser(id: "user-70", sequence: 102)
+        let pending = await ticks.next(); let tick = try XCTUnwrap(pending)
+        clock.advance(by: .seconds(30)); tick.release(); _ = await completed.next()
+        try await detail.synchronize()
+        let value = await selectedDetailBeforeLive(&events, threadID: fixture.firstID)
+        XCTAssertEqual(value?.messages.count, 100)
+        XCTAssertFalse(value?.messages.contains(where: { $0.text == "User 70" }) ?? true)
+        let urls = await fixture.http.threadRequests.map { $0.url!.absoluteString }
+        XCTAssertEqual(urls.count, 5)
+        XCTAssertTrue(urls[2].contains("turnLimit=30"))
+        XCTAssertTrue(urls[3].contains("turnLimit=31"))
+        XCTAssertFalse(urls[4].contains("turnLimit="))
+    }
+
+    func testStaleDetailReplaySkipsReductionOnlyAfterEnvelopeValidation() throws {
+        let thread = multiEnvironmentDetail(
+            projectID: "project", threadID: "first", snapshotSequence: 2, messages: []
+        ).thread
+        let event = replayMessage(sequence: 2, text: "Duplicate")
+        let ordinary = NativeThreadDetailReducer.apply(event, to: thread)
+        guard case .updated = ordinary.result else {
+            return XCTFail("The control must exercise a real message reduction.")
+        }
+        let skipped = NativeThreadDetailReducer.apply(event, to: thread, afterSequence: 2)
+        XCTAssertEqual(skipped.sequence, 2)
+        guard case .unchanged = skipped.result, case .none = skipped.renderMutation else {
+            return XCTFail("A validated stale event must bypass message reduction.")
+        }
+        let newer = NativeThreadDetailReducer.apply(event, to: thread, afterSequence: 1)
+        guard case .updated = newer.result else { return XCTFail("New events must still reduce.") }
+    }
+
     func testOnlyMessageQuestionsCanBeDismissed() async throws {
         let fixture = try await CatchUpFixture.make(activities: [
             requestActivity("user-input.requested", id: "callback"),
@@ -1314,6 +1943,9 @@ private struct CatchUpFixture {
 
     static func make(
         completionMarker: Bool? = true,
+        includePeer: Bool = false,
+        reconciliationClock: SelectedReconciliationClock? = nil,
+        reconciliationReceipt: @escaping @MainActor @Sendable (NativeSelectedThreadReconciliationReceipt) -> Void = { _ in },
         activities: [OrchestrationActivity] = [],
         aggregateRefreshReceipt: @escaping @MainActor @Sendable (NativePassiveShellReceipt) -> Void = { _ in },
         detailPublicationSleep: @escaping @Sendable () async throws -> Void = {
@@ -1328,7 +1960,10 @@ private struct CatchUpFixture {
         try await store.save([Environment(
             id: "one", label: "Computer", httpBaseURL: URL(string: "https://one.example")!,
             webSocketBaseURL: URL(string: "wss://one.example/ws")!
-        )])
+        )] + (includePeer ? [Environment(
+            id: "two", label: "Peer", httpBaseURL: URL(string: "https://two.example")!,
+            webSocketBaseURL: URL(string: "wss://two.example/ws")!
+        )] : []))
         try await store.setActiveEnvironment(id: "one")
         let http = CatchUpHTTPTransport()
         await http.setActivities(activities)
@@ -1336,24 +1971,40 @@ private struct CatchUpFixture {
         let delay = CatchUpDelay()
         let runtime = EnvironmentRuntime(
             environmentStore: store,
-            credentialStore: InMemoryCredentialStore(credentials: ["one": .init(accessToken: "test")]),
+            credentialStore: InMemoryCredentialStore(credentials: ["one": .init(accessToken: "test"), "two": .init(accessToken: "test")]),
             httpTransport: http,
             webSocketConnector: CatchUpConnector(
                 requests: requests.continuation, completionMarker: completionMarker
             )
         )
         let readiness = CatchUpBootstrapReadiness()
+        let peerReadiness = CatchUpBootstrapReadiness()
         let client = NativeFeatureClient(
             runtime: runtime, settingsStore: UserDefaults(suiteName: UUID().uuidString)!,
             fallbackPollingInitialDelay: .seconds(3_600),
             aggregateRefreshInterval: .seconds(3_600),
-            aggregateRefreshReceipt: { readiness.record($0); aggregateRefreshReceipt($0) },
+            aggregateRefreshReceipt: {
+                readiness.record($0)
+                switch $0 {
+                case let .shellApplied("two", sequence): peerReadiness.record(.shellApplied(environmentID: "one", sequence: sequence))
+                case .configurationApplied("two"): peerReadiness.record(.configurationApplied(environmentID: "one"))
+                default: break
+                }
+                aggregateRefreshReceipt($0)
+            },
             detailPublicationSleep: detailPublicationSleep,
             catchUpDelay: { try await delay.wait() },
+            selectedThreadReconciliationSleep: { duration in
+                if let reconciliationClock { try await reconciliationClock.sleep(for: duration) }
+                else { try await Task.sleep(for: duration) }
+            },
+            selectedThreadReconciliationNow: { reconciliationClock?.now ?? .now },
+            selectedThreadReconciliationReceipt: reconciliationReceipt,
             threadRetryDelay: threadRetryDelay
         )
         _ = try await client.initialSnapshot()
         try await readiness.wait()
+        if includePeer { try await peerReadiness.wait() }
         return Self(client: client, http: http, requests: requests.stream, delay: delay, directory: directory)
     }
 
@@ -1362,9 +2013,13 @@ private struct CatchUpFixture {
 
 private actor CatchUpHTTPTransport: HTTPTransport {
     private(set) var threadRequests: [URLRequest] = []
+    private(set) var threadResponseBytes: [Int] = []
     private var messages: [OrchestrationMessage] = []
+    private var paginatedMessages: [OrchestrationMessage]?
+    private var pendingHeldReads: [CatchUpHTTPRead] = []
     private var activities: [OrchestrationActivity] = []
     private var completionResponse = false
+    private var runningResponse = false
     private var sequence = 2
     private var holdsThreadReads = false
     private let heldReadContinuation: AsyncStream<CatchUpHTTPRead>.Continuation
@@ -1374,6 +2029,35 @@ private actor CatchUpHTTPTransport: HTTPTransport {
         let reads = AsyncStream<CatchUpHTTPRead>.makeStream()
         heldRequests = reads.stream
         heldReadContinuation = reads.continuation
+    }
+
+    func setPaginatedUserMessages(_ range: Range<Int>, sequence: Int) {
+        paginatedMessages = range.map { index in
+            OrchestrationMessage(
+                id: "user-\(index)", role: "user", text: "User \(index)", attachments: [],
+                turnId: nil, streaming: false,
+                createdAt: String(format: "2026-09-02T12:%02d:%02dZ", index / 60, index % 60),
+                updatedAt: String(format: "2026-09-02T12:%02d:%02dZ", index / 60, index % 60)
+            )
+        }
+        self.sequence = sequence
+    }
+    func removePaginatedUser(id: String, sequence: Int) {
+        paginatedMessages?.removeAll { $0.id == id }
+        self.sequence = sequence
+    }
+    func editLatestUserText(_ text: String, sequence: Int) {
+        guard let latest = paginatedMessages?.popLast() else { return }
+        paginatedMessages?.append(OrchestrationMessage(
+            id: latest.id, role: latest.role, text: text, attachments: latest.attachments,
+            turnId: latest.turnId, streaming: latest.streaming, createdAt: latest.createdAt,
+            updatedAt: latest.updatedAt
+        ))
+        self.sequence = sequence
+    }
+    func cancelHeldReads() {
+        pendingHeldReads.forEach { $0.fail() }
+        pendingHeldReads.removeAll()
     }
 
     func setResponse(text: String, sequence: Int, attachment: ChatAttachment? = nil) {
@@ -1386,6 +2070,11 @@ private actor CatchUpHTTPTransport: HTTPTransport {
             catchUpMessage(text, index: index, withImage: withImage)
         }
         self.sequence = sequence
+    }
+
+    func setRunningResponse(text: String, sequence: Int) {
+        setResponse(text: text, sequence: sequence)
+        runningResponse = true
     }
 
     func setCompletionResponse(text: String, sequence: Int, streaming: Bool = false) {
@@ -1418,24 +2107,50 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 throw URLError(.unsupportedURL)
             }
             threadRequests.append(request)
+            var responseMessages = messages
+            var page: OrchestrationThreadDetailPage?
+            if let paginatedMessages {
+                let query = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)?.queryItems ?? []
+                let limit = query.first { $0.name == "turnLimit" }?.value.flatMap(Int.init)
+                let cursor = query.first { $0.name == "beforeCursor" }?.value
+                let end = cursor.flatMap { value in paginatedMessages.firstIndex { $0.id == value } } ?? paginatedMessages.count
+                let start = max(0, end - (limit ?? end))
+                responseMessages = Array(paginatedMessages[start..<end])
+                if limit != nil {
+                    page = OrchestrationThreadDetailPage(
+                        beforeCursor: responseMessages.first?.id, hasMore: start > 0,
+                        snapshotSequence: sequence, threadSequence: sequence
+                    )
+                }
+            }
             let snapshot = multiEnvironmentDetail(
                 projectID: "project", threadID: request.url!.lastPathComponent,
-                snapshotSequence: sequence, messages: messages
+                snapshotSequence: sequence, messages: responseMessages
             )
             var thread = snapshot.thread
             thread.activities = activities
+            if runningResponse {
+                var object = try JSONValue.encode(thread).decode([String: JSONValue].self)
+                object["latestTurn"] = .object([
+                    "turnId": .string("synthetic-turn"), "state": .string("running"),
+                    "requestedAt": .string("2026-09-02T12:00:00Z"), "startedAt": .string("2026-09-02T12:00:00Z"),
+                    "completedAt": .null, "assistantMessageId": .null
+                ])
+                thread = try JSONValue.object(object).decode(OrchestrationThread.self)
+            }
             if completionResponse {
                 var object = try JSONValue.encode(thread).decode([String: JSONValue].self)
                 object["latestTurn"] = catchUpCompletedTurn(assistantMessageID: "answer-0")
                 thread = try JSONValue.object(object).decode(OrchestrationThread.self)
             }
             value = try .encode(OrchestrationThreadDetailSnapshot(
-                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: snapshot.page
+                snapshotSequence: snapshot.snapshotSequence, thread: thread, page: page ?? snapshot.page
             ))
         }
         let response = (try JSONEncoder.t3.encode(value), HTTPURLResponse(
             url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
         )!)
+        if request.url!.path.hasPrefix("/api/orchestration/threads/") { threadResponseBytes.append(response.0.count) }
         if holdsThreadReads, request.url!.path.hasPrefix("/api/orchestration/threads/") {
             let finished = AsyncStream<Bool>.makeStream()
             defer {
@@ -1443,21 +2158,30 @@ private actor CatchUpHTTPTransport: HTTPTransport {
                 finished.continuation.finish()
             }
             return try await withCheckedThrowingContinuation { continuation in
-                heldReadContinuation.yield(CatchUpHTTPRead(
-                    response: response, continuation: continuation, finished: finished.stream
-                ))
+                let read = CatchUpHTTPRead(response: response, continuation: continuation, finished: finished.stream)
+                pendingHeldReads.append(read)
+                heldReadContinuation.yield(read)
             }
         }
         return response
     }
 }
 
-private struct CatchUpHTTPRead: Sendable {
+private final class CatchUpHTTPRead: @unchecked Sendable {
     let response: (Data, HTTPURLResponse)
-    let continuation: CheckedContinuation<(Data, HTTPURLResponse), any Error>
+    private var continuation: CheckedContinuation<(Data, HTTPURLResponse), any Error>?
+    private let lock = NSLock()
     let finished: AsyncStream<Bool>
-    func succeed() { continuation.resume(returning: response) }
-    func fail() { continuation.resume(throwing: URLError(.notConnectedToInternet)) }
+    init(response: (Data, HTTPURLResponse), continuation: CheckedContinuation<(Data, HTTPURLResponse), any Error>, finished: AsyncStream<Bool>) {
+        self.response = response; self.continuation = continuation; self.finished = finished
+    }
+    private func take() -> CheckedContinuation<(Data, HTTPURLResponse), any Error>? {
+        lock.lock(); defer { lock.unlock() }
+        defer { continuation = nil }
+        return continuation
+    }
+    func succeed() { take()?.resume(returning: response) }
+    func fail() { take()?.resume(throwing: URLError(.notConnectedToInternet)) }
 }
 
 private func catchUpMessage(
@@ -1477,7 +2201,7 @@ private struct CatchUpConnector: WebSocketConnecting {
     let requests: AsyncStream<CatchUpRequest>.Continuation
     let completionMarker: Bool?
     func connect(to url: URL) async throws -> any WebSocketConnection {
-        CatchUpSocket(requests: requests, completionMarker: completionMarker)
+        CatchUpSocket(requests: requests, completionMarker: completionMarker, publishInitialShell: url.host == "two.example")
     }
 }
 
@@ -1635,9 +2359,12 @@ private actor CatchUpSocket: WebSocketConnection {
     private var receiver: CheckedContinuation<Data, any Error>?
     private var closed = false
 
-    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool?) {
+    private let publishInitialShell: Bool
+
+    init(requests: AsyncStream<CatchUpRequest>.Continuation, completionMarker: Bool?, publishInitialShell: Bool = false) {
         self.requests = requests
         self.completionMarker = completionMarker
+        self.publishInitialShell = publishInitialShell
     }
 
     func send(_ data: Data) throws {
@@ -1647,6 +2374,12 @@ private actor CatchUpSocket: WebSocketConnection {
             try enqueue(.object(["_tag": .string("Pong")]))
         }
         guard let tag = request["tag"]?.stringValue, case let .number(id) = request["id"] else { return }
+        if publishInitialShell, tag == RPCMethod.subscribeShell.rawValue {
+            let snapshot = multiEnvironmentShell(projectID: "project", threadID: "first", title: "Peer")
+            try chunk(id: Int(id), values: [.object([
+                "kind": .string("snapshot"), "snapshot": try .encode(snapshot)
+            ])])
+        }
         if tag == RPCMethod.assetsCreateURL.rawValue { assetRequestCount += 1 }
         if tag == RPCMethod.subscribeServerConfig.rawValue {
             var config: [String: JSONValue] = [
@@ -1840,4 +2573,39 @@ private final class CatchUpPublicationClock: Sendable {
     }
 
     func release() async { await gate.release() }
+}
+
+@MainActor
+private final class SelectedReconciliationClock {
+    var now = ContinuousClock.now
+    let requests = AsyncStream<Wait>.makeStream()
+    private var pending: [UUID: CheckedContinuation<Void, any Error>] = [:]
+    struct Wait: Sendable {
+        let duration: Duration
+        let release: @MainActor @Sendable () -> Void
+    }
+    func advance(by duration: Duration) { now = now.advanced(by: duration) }
+    func cancelAll() {
+        let waits = pending.values
+        pending.removeAll()
+        waits.forEach { $0.resume(throwing: CancellationError()) }
+        requests.continuation.finish()
+    }
+    func sleep(for duration: Duration) async throws {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled { continuation.resume(throwing: CancellationError()) }
+                else {
+                    pending[id] = continuation
+                    requests.continuation.yield(Wait(duration: duration, release: { [weak self] in
+                        self?.pending.removeValue(forKey: id)?.resume()
+                    }))
+                }
+            }
+            pending.removeValue(forKey: id)
+        } onCancel: { Task { @MainActor [weak self] in
+            self?.pending.removeValue(forKey: id)?.resume(throwing: CancellationError())
+        } }
+    }
 }

--- a/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/NativeThreadCatchUpTests.swift
@@ -898,6 +898,11 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                // HTTP readiness can precede installation of the subscription's
+                // connection UUID. Establish this stream's own live boundary
+                // before counting the already-synchronized burst publications.
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 100, includeMarker: true)
                 var publications = 0
                 var sawLive = false
@@ -944,6 +949,8 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.synchronize()
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 1, includeMarker: false)
                 guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }
                 await clock.release()
@@ -986,6 +993,8 @@ final class NativeThreadCatchUpTests: XCTestCase {
                 var entries = clock.entries.makeAsyncIterator()
                 _ = try await fixture.client.loadThread(id: fixture.firstID)
                 let detail = try await nextThreadRequest(&requests)
+                _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
+                try await detail.synchronize()
                 _ = await messagesBeforeLive(&events, threadID: fixture.firstID)
                 try await detail.sendBurst(count: 1, includeMarker: false)
                 guard await entries.next(isolation: #isolation) != nil else { throw CancellationError() }

--- a/apps/swift-ios/Tests/FeatureTests/T3ConnectNativeCapabilityTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/T3ConnectNativeCapabilityTests.swift
@@ -39,7 +39,9 @@ final class T3ConnectNativeCapabilityTests: XCTestCase {
         guard case let .snapshot(snapshot)? = event else {
             return XCTFail("Managed connect did not publish its initial Home snapshot")
         }
-        XCTAssertEqual(snapshot.connection.state, .connected)
+        // HTTP hydration publishes content before the deliberately blocked live stream.
+        XCTAssertEqual(snapshot.connection.state, .reconnecting)
+        XCTAssertEqual(snapshot.environments.first(where: { $0.id == "managed-1" })?.connectionState, .connected)
         XCTAssertEqual(snapshot.connection.environmentName, "Managed Studio")
 
         let saved = try await store.load()

--- a/apps/swift-ios/Tests/FeatureTests/WorkspaceThreadPresentationTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/WorkspaceThreadPresentationTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import T3Code
+
+struct WorkspaceThreadPresentationTests {
+    @Test(arguments: [false, true], [false, true])
+    func presentationTracksCompactColumnWithoutHidingRegularDetail(isCompact: Bool, showsDetail: Bool) {
+        var selection = WorkspaceThreadSelection()
+        selection.open("a")
+        let isHidden = isCompact && !showsDetail
+        #expect(selection.presentedID(isCompact: isCompact, showsDetailColumn: showsDetail) == (isHidden ? nil : "a"))
+        selection.reconcilePresentation(isCompact: isCompact, showsDetailColumn: showsDetail)
+        #expect(selection.selectedID == (isHidden ? nil : "a"))
+        #expect(selection.highlightedID == "a")
+    }
+
+    @Test
+    func compactBackAndRegularToCompactHideCannotResurrectClosedThread() {
+        var selection = WorkspaceThreadSelection()
+        selection.open("a")
+        selection.reconcilePresentation(isCompact: false, showsDetailColumn: false)
+        #expect(selection.selectedID == "a")
+        selection.reconcilePresentation(isCompact: true, showsDetailColumn: false)
+        #expect(selection.selectedID == nil)
+        selection.reconcilePresentation(isCompact: false, showsDetailColumn: false)
+        #expect(selection.presentedID(isCompact: false, showsDetailColumn: false) == nil)
+        #expect(selection.highlightedID == "a")
+        selection.open("a")
+        #expect(selection.presentedID(isCompact: true, showsDetailColumn: true) == "a")
+        selection.close()
+        #expect(selection.presentedID(isCompact: true, showsDetailColumn: true) == nil)
+    }
+}


### PR DESCRIPTION
Child-view churn can release the selected thread transport while the workspace still owns its selection. Move that lifetime to workspace selection, preserve it across navigation transitions, and reconcile foreground shell/detail authority when delivery is silently stale. Equal cursors do not suppress a changed authoritative HTTP body.

Verification: current-head CI passes, including [contract fixtures and native tests](https://github.com/pingdotgg/t3code/actions/runs/34291597024/job/102279122313). The final bootstrap/environment run passed 38 tests, covering environment switching, error visibility and archive hydration; separate focused checks cover passive-worker lifetime. Skipped checks are not claimed as executed proof.

Delivery: chain; prerequisites [#10763](https://github.com/pingdotgg/t3code/pull/10763). The diff includes these prerequisites; rebase after they land.

Base: Theo’s `t3code/rebuild-mobile-app-swift`, `93ca26695eb1c6ac6ef2d44bb76fe371ac0bb385`.

Navigation verification: Baseline `e163f9cee` and candidate `a361b2212` use actual WorkspaceView with a synthetic selected thread and a fixture full-screen cover. Both capture tests passed: no client release during cover/return, one release after the production Back action. This is ordinary navigation regression proof; it does not reproduce the race. Focused native tests cover presentation replacement, held-load cancellation, refresh ownership and compact/regular selection.

[Before video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/navigation-before-clean.mp4) · [Clean candidate video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/navigation-after-clean.mp4) · [Annotated candidate video](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/navigation-after-annotated.mp4) · [Evidence receipt](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/navigation-media-receipt.json)

Static context only: the unchanged selected-thread presentation is shown below. The lifetime race is established by the focused native ownership tests, not by a visible animation difference.

![Selected thread context; not proof of the lifetime race](https://github.com/saphid/t3code/releases/download/pr-evidence-swiftui-repairs-20260909/navigation-after.png)

Capture currency: checked against `5b93f19c8`. WorkspaceView and ThreadDetailView are unchanged since `a361b2212`; later edits affect environment hydration/error handling and tests, which this synthetic navigation fixture does not exercise.

Independent cross-provider review was unavailable: `claude auth status` returned exit 1 with `loggedIn: false`. No Claude review or maintainer approval is claimed.

Model and harness: GPT-6 / Codex.
