### PR TITLE
fix(server): stop Windows terminal processes when closing

### DIFF
--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -21,15 +21,50 @@ const spawn = vi.fn(() => ({
 
 vi.mock("node-pty", () => ({ spawn }));
 
-const testLayer = NodePtyAdapter.layer.pipe(
-  Layer.provide(
-    Layer.mergeAll(
-      NodeServices.layer,
-      Layer.succeed(HostProcessPlatform, "win32"),
-      Layer.succeed(HostProcessArchitecture, "x64"),
+const makeTestLayer = (platform: NodeJS.Platform = "win32") =>
+  NodePtyAdapter.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(HostProcessPlatform, platform),
+        Layer.succeed(HostProcessArchitecture, "x64"),
+      ),
     ),
-  ),
-);
+  );
+
+const testLayer = makeTestLayer();
+
+for (const platform of ["win32", "linux", "darwin"] as const) {
+  it.effect(`terminates through node-pty using ${platform} semantics`, () =>
+    Effect.gen(function* () {
+      const adapter = yield* PtyAdapter.PtyAdapter;
+      const process = yield* adapter.spawn({
+        shell: "test-shell",
+        cwd: ".",
+        cols: 80,
+        rows: 24,
+        env: {},
+      });
+      const nativeProcess = spawn.mock.results.at(-1)!.value;
+      nativeProcess.kill.mockImplementation((signal?: string) => {
+        if (platform === "win32" && signal) {
+          throw new Error("Signals not supported on windows.");
+        }
+      });
+
+      process.kill("SIGTERM");
+      process.kill("SIGKILL");
+      process.kill();
+
+      assert.deepEqual(
+        nativeProcess.kill.mock.calls,
+        platform === "win32"
+          ? [[undefined], [undefined], [undefined]]
+          : [["SIGTERM"], ["SIGKILL"], [undefined]],
+      );
+    }).pipe(Effect.provide(makeTestLayer(platform))),
+  );
+}
 
 it.effect("spawns through the public adapter with the provided host references", () =>
   Effect.gen(function* () {

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -69,9 +69,11 @@ const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
 
 class NodePtyProcess implements PtyAdapter.PtyProcess {
   private readonly process: import("node-pty").IPty;
+  private readonly platform: NodeJS.Platform;
 
-  constructor(process: import("node-pty").IPty) {
+  constructor(process: import("node-pty").IPty, platform: NodeJS.Platform) {
     this.process = process;
+    this.platform = platform;
   }
 
   get pid(): number {
@@ -87,7 +89,8 @@ class NodePtyProcess implements PtyAdapter.PtyProcess {
   }
 
   kill(signal?: string): void {
-    this.process.kill(signal);
+    // node-pty terminates the Windows process tree without a POSIX signal.
+    this.process.kill(this.platform === "win32" ? undefined : signal);
   }
 
   onData(callback: (data: string) => void): () => void {
@@ -164,7 +167,7 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
             cause,
           }),
       });
-      return new NodePtyProcess(ptyProcess);
+      return new NodePtyProcess(ptyProcess, platform);
     }),
   });
 });


### PR DESCRIPTION
## What Changed

Closing a Windows terminal can hide the terminal while its child processes keep running, including HTTP servers that continue holding their ports. The terminal manager sends SIGTERM/SIGKILL, but node-pty rejects POSIX signals on Windows.

Have NodePtyAdapter omit the signal on Windows so node-pty runs its native process-tree termination. Linux and macOS keep their existing signal behavior. The change stays in the server adapter, covering terminal shutdown from every client.

## Validation

- Added Windows, Linux, and macOS adapter regression coverage. The Windows regression fails with the original implementation.
- All 88 adapter and terminal-manager tests pass; server typecheck, targeted lint, and formatting pass.
- Tested real Windows PTYs both after readiness and immediately after spawn.
- Launched a Node HTTP server through T3's Windows terminal UI: HTTP 200 before closing; after confirming close, both shell and child PIDs were gone, the port had no listener, HTTP connections were refused, and T3 still returned HTTP 200.

Validation caveat: node-pty 1.1.0's console-list helper can print `AttachConsole failed` during shutdown. Under `node --watch`, its IPC handling also crashed the development server; the integrated check above passed with the server running without the watcher. This PR does not change that separate helper behavior.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal process termination on Windows by avoiding unsupported POSIX signals.
  * Preserved signal-based termination behavior on Linux and macOS.
* **Tests**
  * Added platform-specific coverage for Windows, Linux, and macOS termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->