### PR TITLE
fix(web): show pull request images and videos from private repositories

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -22,6 +22,7 @@ import * as T3ProjectFileLoader from "../project/T3ProjectFileLoader.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 import { assetFileResponse } from "../http.ts";
 import { ASSET_ROUTE_PREFIX, issueAssetUrl, resolveAsset } from "./AssetAccess.ts";
+import * as GitHubAttachmentResolver from "./GitHubAttachmentResolver.ts";
 import * as NativeAppIconResolver from "./NativeAppIconResolver.ts";
 import { openMediaFile } from "./MediaFile.ts";
 import { symlinksSupported } from "@t3tools/shared/testing/symlinks";
@@ -43,10 +44,44 @@ const testLayer = Layer.mergeAll(
     Layer.provide(T3ProjectFileLoader.layer),
   ),
   NativeAppIconResolver.layer.pipe(Layer.provide(configLayer)),
+  Layer.succeed(GitHubAttachmentResolver.GitHubAttachmentResolver, {
+    resolve: (url) =>
+      Effect.succeed(
+        url.endsWith("missing")
+          ? null
+          : `https://signed.example/download?for=${encodeURIComponent(url)}`,
+      ),
+  }),
   ServerSecretStore.layer.pipe(Layer.provide(configLayer)),
 ).pipe(Layer.provideMerge(NodeServices.layer));
 
+function splitAssetUrl(relativeUrl: string): { token: string; name: string } {
+  const suffix = relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+  const separator = suffix.indexOf("/");
+  return { token: suffix.slice(0, separator), name: suffix.slice(separator + 1) };
+}
+
 describe("AssetAccess", () => {
+  it.effect("redirects a GitHub attachment to the download its resolver found", () =>
+    Effect.gen(function* () {
+      const url = "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+      const issued = yield* issueAssetUrl({ resource: { _tag: "github-attachment", url } });
+      const { token, name } = splitAssetUrl(issued.relativeUrl);
+      expect(name).toBe("0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b");
+      expect(yield* resolveAsset(token, name)).toEqual({
+        kind: "redirect",
+        location: `https://signed.example/download?for=${encodeURIComponent(url)}`,
+      });
+      expect(yield* resolveAsset(`${token}tampered`, name)).toBeNull();
+
+      const missing = yield* issueAssetUrl({
+        resource: { _tag: "github-attachment", url: `${url}-missing` },
+      });
+      const missingUrl = splitAssetUrl(missing.relativeUrl);
+      expect(yield* resolveAsset(missingUrl.token, missingUrl.name)).toBeNull();
+    }).pipe(Effect.provide(testLayer)),
+  );
+
   it.effect("issues exact URLs for media and browser documents outside the workspace", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -228,7 +263,7 @@ describe("AssetAccess", () => {
             suffix.slice(0, separator),
             suffix.slice(separator + 1),
           );
-          if (!asset) throw new Error("Expected a resolved media file");
+          if (asset?.kind !== "file") throw new Error("Expected a resolved media file");
 
           yield* fs.rename(filePath, savedPath);
           yield* fs.symlink(secretPath, filePath);
@@ -391,7 +426,7 @@ describe("AssetAccess", () => {
       const name = suffix.slice(separator + 1);
       yield* fs.writeFileString(filePath, "in-place edit");
       const edited = yield* resolveAsset(token, name);
-      if (!edited) throw new Error("Expected the edited media file");
+      if (edited?.kind !== "file") throw new Error("Expected the edited media file");
       const editedResponse = HttpServerResponse.toWeb(yield* assetFileResponse(edited));
       expect(yield* Effect.promise(() => editedResponse.text())).toBe("in-place edit");
 
@@ -407,7 +442,7 @@ describe("AssetAccess", () => {
         renewedSuffix.slice(0, renewedSeparator),
         renewedSuffix.slice(renewedSeparator + 1),
       );
-      if (!renewedAsset) throw new Error("Expected the replacement media file");
+      if (renewedAsset?.kind !== "file") throw new Error("Expected the replacement media file");
       const renewedResponse = HttpServerResponse.toWeb(yield* assetFileResponse(renewedAsset));
       expect(yield* Effect.promise(() => renewedResponse.text())).toBe("replacement");
       yield* fs.remove(filePath);

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -48,6 +48,7 @@ import { parseAttachmentFileExtension, resolveAttachmentPathById } from "../atta
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
+import * as GitHubAttachmentResolver from "./GitHubAttachmentResolver.ts";
 import * as NativeAppIconResolver from "./NativeAppIconResolver.ts";
 import { openMediaFile, readMediaFileHeader, type OpenMediaFile } from "./MediaFile.ts";
 
@@ -133,6 +134,12 @@ const AssetClaimsSchema = Schema.Union([
     app: ToolActivityNativeAppReference,
     expiresAt: Schema.Number,
   }),
+  Schema.Struct({
+    version: Schema.Literal(1),
+    kind: Schema.Literal("github-attachment"),
+    url: Schema.String,
+    expiresAt: Schema.Number,
+  }),
 ]);
 type AssetClaims = typeof AssetClaimsSchema.Type;
 
@@ -140,14 +147,17 @@ const AssetClaimsJson = Schema.fromJsonString(AssetClaimsSchema);
 const decodeAssetClaims = Schema.decodeUnknownOption(AssetClaimsJson);
 const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
-export type ResolvedAsset = {
-  readonly kind: "file";
-  readonly path: string;
-  readonly download?: boolean;
-  readonly fileName?: string;
-  readonly mimeType?: string;
-  readonly file?: OpenMediaFile;
-};
+export type ResolvedAsset =
+  | {
+      readonly kind: "file";
+      readonly path: string;
+      readonly download?: boolean;
+      readonly fileName?: string;
+      readonly mimeType?: string;
+      readonly file?: OpenMediaFile;
+    }
+  // The bytes live elsewhere; the client is sent to a URL that is valid for a short time.
+  | { readonly kind: "redirect"; readonly location: string };
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -577,6 +587,16 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       fileName = "native-app-icon.png";
       break;
     }
+    case "github-attachment": {
+      claims = {
+        version: 1,
+        kind: "github-attachment",
+        url: input.resource.url,
+        expiresAt,
+      };
+      fileName = input.resource.url.slice(input.resource.url.lastIndexOf("/") + 1);
+      break;
+    }
   }
 
   const secretStore = yield* ServerSecretStore.ServerSecretStore;
@@ -681,6 +701,12 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
     const nativeAppIconResolver = yield* NativeAppIconResolver.NativeAppIconResolver;
     const iconPath = yield* nativeAppIconResolver.resolve(claims.app);
     return iconPath ? ({ kind: "file", path: iconPath } satisfies ResolvedAsset) : null;
+  }
+
+  if (claims.kind === "github-attachment") {
+    const attachmentResolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+    const location = yield* attachmentResolver.resolve(claims.url);
+    return location ? ({ kind: "redirect", location } satisfies ResolvedAsset) : null;
   }
 
   const decodedPath = decodeRelativePath(relativePath);

--- a/apps/server/src/assets/GitHubAttachmentResolver.test.ts
+++ b/apps/server/src/assets/GitHubAttachmentResolver.test.ts
@@ -1,0 +1,137 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { VcsProcessExitError } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as ServerConfig from "../config.ts";
+import * as GitHubCli from "../sourceControl/GitHubCli.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
+import * as GitHubAttachmentResolver from "./GitHubAttachmentResolver.ts";
+
+const ATTACHMENT_URL =
+  "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+const SIGNED_URL =
+  "https://github-production-user-asset-6210df.s3.amazonaws.com/1/2.png?X-Amz-Expires=300&X-Amz-Signature=abc";
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly authorization: string | undefined;
+}
+
+function makeResolverLayer(options: {
+  readonly token: string | null;
+  readonly respond: () => Response;
+}) {
+  const ghCalls: Array<ReadonlyArray<string>> = [];
+  const requests: RecordedRequest[] = [];
+  const vcsProcessLayer = Layer.succeed(VcsProcess.VcsProcess, {
+    run: (input) => {
+      ghCalls.push(input.args);
+      if (options.token === null) {
+        return Effect.fail(
+          new VcsProcessExitError({
+            operation: input.operation,
+            command: input.command,
+            cwd: input.cwd,
+            exitCode: 1,
+            detail: "not logged in",
+            failureKind: "authentication",
+          }),
+        );
+      }
+      return Effect.succeed({
+        exitCode: ChildProcessSpawner.ExitCode(0),
+        stdout: `${options.token}\n`,
+        stderr: "",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      });
+    },
+  });
+  const httpClientLayer = Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.sync(() => {
+        requests.push({ url: request.url, authorization: request.headers.authorization });
+        return HttpClientResponse.fromWeb(request, options.respond());
+      }),
+    ),
+  );
+  const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
+    prefix: "t3-github-attachment-test-",
+  });
+  const layer = GitHubAttachmentResolver.layer.pipe(
+    Layer.provide(GitHubCli.layer),
+    Layer.provide(vcsProcessLayer),
+    Layer.provide(httpClientLayer),
+    Layer.provide(configLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  return { layer, ghCalls, requests };
+}
+
+const redirectTo = (location: string) => () =>
+  new Response(null, { status: 302, headers: { location } });
+
+describe("GitHubAttachmentResolver", () => {
+  it.effect("sends the gh token and returns the signed redirect target", () => {
+    const { layer, ghCalls, requests } = makeResolverLayer({
+      token: "ghp_test",
+      respond: redirectTo(SIGNED_URL),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBe(SIGNED_URL);
+      expect(ghCalls).toEqual([["auth", "token", "--hostname", "github.com"]]);
+      expect(requests).toEqual([{ url: ATTACHMENT_URL, authorization: "token ghp_test" }]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("reads the token once for a body full of attachments", () => {
+    const { layer, ghCalls, requests } = makeResolverLayer({
+      token: "ghp_test",
+      respond: redirectTo(SIGNED_URL),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      yield* resolver.resolve(ATTACHMENT_URL);
+      yield* resolver.resolve(`${ATTACHMENT_URL}2`);
+      expect(ghCalls).toHaveLength(1);
+      expect(requests).toHaveLength(2);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("asks anonymously when gh has no token", () => {
+    const { layer, requests } = makeResolverLayer({ token: null, respond: redirectTo(SIGNED_URL) });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBe(SIGNED_URL);
+      expect(requests).toEqual([{ url: ATTACHMENT_URL, authorization: undefined }]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("yields nothing when GitHub answers with a page instead of a redirect", () => {
+    const { layer } = makeResolverLayer({
+      token: "ghp_test",
+      respond: () => new Response("Not Found", { status: 404 }),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBeNull();
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("yields nothing for a redirect that is not https", () => {
+    const { layer } = makeResolverLayer({
+      token: "ghp_test",
+      respond: redirectTo("http://example.com/asset.png"),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBeNull();
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/apps/server/src/assets/GitHubAttachmentResolver.test.ts
+++ b/apps/server/src/assets/GitHubAttachmentResolver.test.ts
@@ -3,7 +3,7 @@ import { VcsProcessExitError } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as ServerConfig from "../config.ts";
@@ -22,8 +22,9 @@ interface RecordedRequest {
 }
 
 function makeResolverLayer(options: {
-  readonly token: string | null;
+  token: string | null;
   readonly respond: () => Response;
+  readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
 }) {
   const ghCalls: Array<ReadonlyArray<string>> = [];
   const requests: RecordedRequest[] = [];
@@ -51,15 +52,17 @@ function makeResolverLayer(options: {
       });
     },
   });
-  const httpClientLayer = Layer.succeed(
-    HttpClient.HttpClient,
-    HttpClient.make((request) =>
-      Effect.sync(() => {
-        requests.push({ url: request.url, authorization: request.headers.authorization });
-        return HttpClientResponse.fromWeb(request, options.respond());
-      }),
-    ),
-  );
+  const httpClientLayer =
+    options.httpClientLayer ??
+    Layer.succeed(
+      HttpClient.HttpClient,
+      HttpClient.make((request) =>
+        Effect.sync(() => {
+          requests.push({ url: request.url, authorization: request.headers.authorization });
+          return HttpClientResponse.fromWeb(request, options.respond());
+        }),
+      ),
+    );
   const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
     prefix: "t3-github-attachment-test-",
   });
@@ -104,12 +107,18 @@ describe("GitHubAttachmentResolver", () => {
     }).pipe(Effect.provide(layer));
   });
 
-  it.effect("asks anonymously when gh has no token", () => {
-    const { layer, requests } = makeResolverLayer({ token: null, respond: redirectTo(SIGNED_URL) });
+  it.effect("asks anonymously when gh has no token and picks up a later login", () => {
+    const options = { token: null as string | null, respond: redirectTo(SIGNED_URL) };
+    const { layer, ghCalls, requests } = makeResolverLayer(options);
     return Effect.gen(function* () {
       const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
       expect(yield* resolver.resolve(ATTACHMENT_URL)).toBe(SIGNED_URL);
       expect(requests).toEqual([{ url: ATTACHMENT_URL, authorization: undefined }]);
+
+      options.token = "ghp_after_login";
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBe(SIGNED_URL);
+      expect(ghCalls).toHaveLength(2);
+      expect(requests[1]).toEqual({ url: ATTACHMENT_URL, authorization: "token ghp_after_login" });
     }).pipe(Effect.provide(layer));
   });
 
@@ -121,6 +130,48 @@ describe("GitHubAttachmentResolver", () => {
     return Effect.gen(function* () {
       const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
       expect(yield* resolver.resolve(ATTACHMENT_URL)).toBeNull();
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("never puts the token on the wire for a URL outside the allowlist", () => {
+    const { layer, ghCalls, requests } = makeResolverLayer({
+      token: "ghp_test",
+      respond: redirectTo(SIGNED_URL),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve("https://github.com/pingdotgg/t3code/pull/1")).toBeNull();
+      expect(yield* resolver.resolve("https://evil.example/user-attachments/assets/x")).toBeNull();
+      expect(ghCalls).toHaveLength(0);
+      expect(requests).toHaveLength(0);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("reports the signed target without following it", () => {
+    // The real fetch client, with fetch itself replaced: following the redirect
+    // would download the file and hand the handler a 200 instead of the target.
+    const inits: Array<RequestInit | undefined> = [];
+    const fakeFetch = ((_input: unknown, init?: RequestInit) => {
+      inits.push(init);
+      return Promise.resolve(
+        init?.redirect === "manual"
+          ? new Response(null, { status: 302, headers: { location: SIGNED_URL } })
+          : new Response("image bytes", { status: 200 }),
+      );
+    }) as typeof fetch;
+    const { layer } = makeResolverLayer({
+      token: "ghp_test",
+      respond: () => {
+        throw new Error("unused");
+      },
+      httpClientLayer: FetchHttpClient.layer.pipe(
+        Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fakeFetch)),
+      ),
+    });
+    return Effect.gen(function* () {
+      const resolver = yield* GitHubAttachmentResolver.GitHubAttachmentResolver;
+      expect(yield* resolver.resolve(ATTACHMENT_URL)).toBe(SIGNED_URL);
+      expect(inits.map((init) => init?.redirect)).toEqual(["manual"]);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/server/src/assets/GitHubAttachmentResolver.ts
+++ b/apps/server/src/assets/GitHubAttachmentResolver.ts
@@ -1,15 +1,19 @@
+import { isGitHubAttachmentUrl } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import { FetchHttpClient, HttpClient } from "effect/unstable/http";
 
 import * as ServerConfig from "../config.ts";
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
 
 const GITHUB_HOST = "github.com";
-const TOKEN_CACHE_TTL = Duration.minutes(5);
+const TOKEN_CACHE_TTL_MS = Duration.toMillis(Duration.minutes(5));
 const RESOLVE_TIMEOUT = Duration.seconds(15);
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
@@ -41,19 +45,38 @@ export const make = Effect.gen(function* () {
   const httpClient = yield* HttpClient.HttpClient;
 
   // `gh` owns the credential, so login state and GH_TOKEN keep working as they do for
-  // every other GitHub call. Cached so a body full of screenshots does not spawn one
-  // process per image. Without a token the request goes out anonymously, which is
-  // what a public repository needs and what a private one already failed with.
-  const token = yield* github
-    .execute({ cwd: config.stateDir, args: ["auth", "token", "--hostname", GITHUB_HOST] })
-    .pipe(
-      Effect.map((output) => output.stdout.trim() || null),
-      Effect.orElseSucceed(() => null),
-      Effect.cachedWithTTL(TOKEN_CACHE_TTL),
-    );
+  // every other GitHub call. A found token is cached so a body full of screenshots
+  // does not spawn one process per image; a missing one is not, so `gh auth login`
+  // takes effect on the next image. Without a token the request goes out
+  // anonymously, which is what a public repository needs and what a private one
+  // already failed with.
+  const tokenCache = yield* Ref.make<{ token: string; expiresAt: number } | null>(null);
+  const tokenLookup = yield* Semaphore.make(1);
+  const token = tokenLookup.withPermits(1)(
+    Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const cached = yield* Ref.get(tokenCache);
+      if (cached !== null && cached.expiresAt > now) return cached.token;
+      const found = yield* github
+        .execute({ cwd: config.stateDir, args: ["auth", "token", "--hostname", GITHUB_HOST] })
+        .pipe(
+          Effect.map((output) => output.stdout.trim() || null),
+          Effect.orElseSucceed(() => null),
+        );
+      if (found !== null) {
+        yield* Ref.set(tokenCache, { token: found, expiresAt: now + TOKEN_CACHE_TTL_MS });
+      }
+      return found;
+    }),
+  );
 
   const resolve = Effect.fn("GitHubAttachmentResolver.resolve")(function* (url: string) {
+    // The claims were signed from a checked resource, but the credential goes on the
+    // wire here, so this is where the allowlist is enforced.
+    if (!isGitHubAttachmentUrl(url)) return null;
     const authorization = yield* token;
+    // Read outward from `get`: the request runs with `redirect: "manual"`, so the
+    // signed target on another host is reported, not followed, and never downloaded.
     return yield* httpClient
       .get(url, {
         headers: authorization === null ? {} : { authorization: `token ${authorization}` },
@@ -74,7 +97,6 @@ export const make = Effect.gen(function* () {
           Effect.logWarning("Failed to resolve a GitHub attachment.", { url, cause }),
         ),
         Effect.orElseSucceed(() => null),
-        // The signed target is on another host and following it would download the file.
         Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" }),
       );
   });

--- a/apps/server/src/assets/GitHubAttachmentResolver.ts
+++ b/apps/server/src/assets/GitHubAttachmentResolver.ts
@@ -1,0 +1,85 @@
+import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import { FetchHttpClient, HttpClient } from "effect/unstable/http";
+
+import * as ServerConfig from "../config.ts";
+import * as GitHubCli from "../sourceControl/GitHubCli.ts";
+
+const GITHUB_HOST = "github.com";
+const TOKEN_CACHE_TTL = Duration.minutes(5);
+const RESOLVE_TIMEOUT = Duration.seconds(15);
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Turns a GitHub upload link into the time-limited download GitHub answers a
+ * signed-in reader with. Only the redirect target is read; the bytes go from
+ * GitHub's storage straight to the client.
+ */
+export class GitHubAttachmentResolver extends Context.Service<
+  GitHubAttachmentResolver,
+  {
+    /** The signed download URL, or `null` when GitHub refuses or answers with a page. */
+    readonly resolve: (url: string) => Effect.Effect<string | null>;
+  }
+>()("t3/assets/GitHubAttachmentResolver") {}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** @public Service construction is part of the canonical Effect module API. */
+export const make = Effect.gen(function* () {
+  const config = yield* ServerConfig.ServerConfig;
+  const github = yield* GitHubCli.GitHubCli;
+  const httpClient = yield* HttpClient.HttpClient;
+
+  // `gh` owns the credential, so login state and GH_TOKEN keep working as they do for
+  // every other GitHub call. Cached so a body full of screenshots does not spawn one
+  // process per image. Without a token the request goes out anonymously, which is
+  // what a public repository needs and what a private one already failed with.
+  const token = yield* github
+    .execute({ cwd: config.stateDir, args: ["auth", "token", "--hostname", GITHUB_HOST] })
+    .pipe(
+      Effect.map((output) => output.stdout.trim() || null),
+      Effect.orElseSucceed(() => null),
+      Effect.cachedWithTTL(TOKEN_CACHE_TTL),
+    );
+
+  const resolve = Effect.fn("GitHubAttachmentResolver.resolve")(function* (url: string) {
+    const authorization = yield* token;
+    return yield* httpClient
+      .get(url, {
+        headers: authorization === null ? {} : { authorization: `token ${authorization}` },
+      })
+      .pipe(
+        Effect.map((response) => {
+          const location = response.headers.location?.trim();
+          return REDIRECT_STATUSES.has(response.status) &&
+            location !== undefined &&
+            isHttpsUrl(location)
+            ? location
+            : null;
+        }),
+        Effect.scoped,
+        Effect.timeoutOption(RESOLVE_TIMEOUT),
+        Effect.map(Option.getOrNull),
+        Effect.tapError((cause) =>
+          Effect.logWarning("Failed to resolve a GitHub attachment.", { url, cause }),
+        ),
+        Effect.orElseSucceed(() => null),
+        // The signed target is on another host and following it would download the file.
+        Effect.provideService(FetchHttpClient.RequestInit, { redirect: "manual" }),
+      );
+  });
+
+  return GitHubAttachmentResolver.of({ resolve });
+});
+
+export const layer = Layer.effect(GitHubAttachmentResolver, make);

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -297,22 +297,34 @@ describe("http dev routing", () => {
 });
 
 describe("assetRedirectHeaders", () => {
+  const signedAt = Date.UTC(2026, 8, 8, 13, 0, 33);
+  const signed = (query: string) =>
+    `https://bucket.s3.amazonaws.com/a.png?X-Amz-Date=20260908T130033Z&${query}&X-Amz-Signature=s`;
+
   it("lets the browser reuse a signed redirect until shortly before it expires", () => {
-    expect(
-      assetRedirectHeaders(
-        "https://bucket.s3.amazonaws.com/a.png?X-Amz-Expires=300&X-Amz-Signature=s",
-      ),
-    ).toEqual({ "Cache-Control": "private, max-age=240" });
+    expect(assetRedirectHeaders(signed("X-Amz-Expires=300"), signedAt)).toEqual({
+      "Cache-Control": "private, max-age=240",
+    });
+    // The lifetime counts from the signing date, so a reused signature yields less.
+    expect(assetRedirectHeaders(signed("X-Amz-Expires=300"), signedAt + 100_000)).toEqual({
+      "Cache-Control": "private, max-age=140",
+    });
   });
 
-  it("never caches a redirect whose lifetime is unknown or too short", () => {
-    expect(assetRedirectHeaders("https://example.com/a.png")).toEqual({
+  it("never caches a redirect whose lifetime is unknown, spent, or too short", () => {
+    expect(assetRedirectHeaders("https://example.com/a.png", signedAt)).toEqual({
       "Cache-Control": "private, no-store",
     });
-    expect(assetRedirectHeaders("https://example.com/a.png?X-Amz-Expires=30")).toEqual({
+    expect(assetRedirectHeaders("https://example.com/a.png?X-Amz-Expires=300", signedAt)).toEqual({
       "Cache-Control": "private, no-store",
     });
-    expect(assetRedirectHeaders("https://example.com/a.png?X-Amz-Expires=soon")).toEqual({
+    expect(assetRedirectHeaders(signed("X-Amz-Expires=300"), signedAt + 300_000)).toEqual({
+      "Cache-Control": "private, no-store",
+    });
+    expect(assetRedirectHeaders(signed("X-Amz-Expires=30"), signedAt)).toEqual({
+      "Cache-Control": "private, no-store",
+    });
+    expect(assetRedirectHeaders(signed("X-Amz-Expires=soon"), signedAt)).toEqual({
       "Cache-Control": "private, no-store",
     });
   });

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -10,6 +10,7 @@ import { HttpServerResponse } from "effect/unstable/http";
 import { openMediaFile } from "./assets/MediaFile.ts";
 
 import {
+  assetRedirectHeaders,
   assetResponseHeaders,
   assetFileResponse,
   downloadContentDisposition,
@@ -292,6 +293,28 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("assetRedirectHeaders", () => {
+  it("lets the browser reuse a signed redirect until shortly before it expires", () => {
+    expect(
+      assetRedirectHeaders(
+        "https://bucket.s3.amazonaws.com/a.png?X-Amz-Expires=300&X-Amz-Signature=s",
+      ),
+    ).toEqual({ "Cache-Control": "private, max-age=240" });
+  });
+
+  it("never caches a redirect whose lifetime is unknown or too short", () => {
+    expect(assetRedirectHeaders("https://example.com/a.png")).toEqual({
+      "Cache-Control": "private, no-store",
+    });
+    expect(assetRedirectHeaders("https://example.com/a.png?X-Amz-Expires=30")).toEqual({
+      "Cache-Control": "private, no-store",
+    });
+    expect(assetRedirectHeaders("https://example.com/a.png?X-Amz-Expires=soon")).toEqual({
+      "Cache-Control": "private, no-store",
+    });
   });
 });
 

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -86,6 +86,28 @@ export function downloadContentDisposition(fileName?: string): string {
   }`;
 }
 
+/**
+ * A redirect to a signed download can be reused until shortly before the
+ * signature expires, so remounting a document does not refetch every image.
+ * Targets without a readable expiry are never cached.
+ */
+export function assetRedirectHeaders(location: string): Record<string, string> {
+  let expiresSeconds: number | null = null;
+  try {
+    const value = new URL(location).searchParams.get("X-Amz-Expires");
+    expiresSeconds = value === null ? null : Number(value);
+  } catch {
+    expiresSeconds = null;
+  }
+  const maxAge =
+    expiresSeconds !== null && Number.isFinite(expiresSeconds)
+      ? Math.max(0, Math.floor(expiresSeconds) - 60)
+      : 0;
+  return {
+    "Cache-Control": maxAge > 0 ? `private, max-age=${maxAge}` : "private, no-store",
+  };
+}
+
 export function assetResponseHeaders(
   filePath: string,
   options?: {
@@ -387,6 +409,12 @@ export const assetRouteLayer = HttpRouter.add(
     );
     if (!asset) {
       return HttpServerResponse.text("Not Found", { status: 404 });
+    }
+    if (asset.kind === "redirect") {
+      return HttpServerResponse.redirect(asset.location, {
+        status: 302,
+        headers: assetRedirectHeaders(asset.location),
+      });
     }
     return yield* assetFileResponse(
       asset,

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -6,6 +6,7 @@ import {
 } from "@t3tools/contracts";
 import { isDevProxiedPath } from "@t3tools/shared/devProxy";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
+import * as Clock from "effect/Clock";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -86,23 +87,33 @@ export function downloadContentDisposition(fileName?: string): string {
   }`;
 }
 
+const AMZ_DATE_PATTERN = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/;
+
+/** When a SigV4 query-signed URL stops working, in epoch milliseconds, or null if unreadable. */
+function signedUrlExpiry(location: string): number | null {
+  let params: URLSearchParams;
+  try {
+    params = new URL(location).searchParams;
+  } catch {
+    return null;
+  }
+  const date = AMZ_DATE_PATTERN.exec(params.get("X-Amz-Date") ?? "");
+  const expires = Number(params.get("X-Amz-Expires"));
+  if (date === null || !Number.isFinite(expires)) return null;
+  const [, year, month, day, hour, minute, second] = date.map(Number);
+  const signedAt = Date.UTC(year!, month! - 1, day!, hour!, minute!, second!);
+  return Number.isFinite(signedAt) ? signedAt + expires * 1000 : null;
+}
+
 /**
  * A redirect to a signed download can be reused until shortly before the
  * signature expires, so remounting a document does not refetch every image.
- * Targets without a readable expiry are never cached.
+ * The lifetime counts from the signing date, not from now. Targets without a
+ * readable expiry are never cached.
  */
-export function assetRedirectHeaders(location: string): Record<string, string> {
-  let expiresSeconds: number | null = null;
-  try {
-    const value = new URL(location).searchParams.get("X-Amz-Expires");
-    expiresSeconds = value === null ? null : Number(value);
-  } catch {
-    expiresSeconds = null;
-  }
-  const maxAge =
-    expiresSeconds !== null && Number.isFinite(expiresSeconds)
-      ? Math.max(0, Math.floor(expiresSeconds) - 60)
-      : 0;
+export function assetRedirectHeaders(location: string, now: number): Record<string, string> {
+  const expiresAt = signedUrlExpiry(location);
+  const maxAge = expiresAt === null ? 0 : Math.floor((expiresAt - now) / 1000) - 60;
   return {
     "Cache-Control": maxAge > 0 ? `private, max-age=${maxAge}` : "private, no-store",
   };
@@ -413,7 +424,7 @@ export const assetRouteLayer = HttpRouter.add(
     if (asset.kind === "redirect") {
       return HttpServerResponse.redirect(asset.location, {
         status: 302,
-        headers: assetRedirectHeaders(asset.location),
+        headers: assetRedirectHeaders(asset.location, yield* Clock.currentTimeMillis),
       });
     }
     return yield* assetFileResponse(

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -141,6 +141,7 @@ import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
+import * as GitHubAttachmentResolver from "./assets/GitHubAttachmentResolver.ts";
 import * as NativeAppIconResolver from "./assets/NativeAppIconResolver.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
@@ -699,6 +700,9 @@ const buildAppUnderTest = (options?: {
         Layer.provide(T3ProjectFileLoader.layer),
       ),
       NativeAppIconResolver.layer,
+      Layer.succeed(GitHubAttachmentResolver.GitHubAttachmentResolver, {
+        resolve: () => Effect.succeed(null),
+      }),
     );
     const gitWorkflowLayer = GitWorkflowService.layer.pipe(
       Layer.provideMerge(vcsDriverRegistryLayer),

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5540,10 +5540,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             });
             const response = yield* fetchEffect(issued.relativeUrl, { redirect: "manual" });
             assert.equal(response.status, 302);
-            assert.equal(
-              response.headers.location,
-              fakeSignedAttachmentDownload(url, yield* Clock.currentTimeMillis),
-            );
+            // The stub dates its signature when the route asks, so compare the parts
+            // that do not depend on the clock.
+            const location = new URL(response.headers.location ?? "");
+            assert.equal(location.origin + location.pathname, "https://signed.example/download");
+            assert.equal(location.searchParams.get("for"), url);
+            assert.equal(location.searchParams.get("X-Amz-Expires"), "300");
             assert.match(response.headers["cache-control"] ?? "", /^private, max-age=2[0-9]{2}$/);
 
             const missing = yield* client[WS_METHODS.assetsCreateUrl]({

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -701,7 +701,10 @@ const buildAppUnderTest = (options?: {
       ),
       NativeAppIconResolver.layer,
       Layer.succeed(GitHubAttachmentResolver.GitHubAttachmentResolver, {
-        resolve: () => Effect.succeed(null),
+        resolve: (url) =>
+          Effect.map(Clock.currentTimeMillis, (now) =>
+            url.endsWith("-missing") ? null : fakeSignedAttachmentDownload(url, now),
+          ),
       }),
     );
     const gitWorkflowLayer = GitWorkflowService.layer.pipe(
@@ -1491,6 +1494,15 @@ const testRequestUrl = (input: Parameters<typeof fetch>[0]): string => {
   const url = new URL(value);
   return `${url.pathname}${url.search}`;
 };
+
+/** What GitHub answers for an upload: a SigV4 query-signed URL, dated now, good for five minutes. */
+function fakeSignedAttachmentDownload(url: string, now: number): string {
+  const date = DateTime.formatIso(DateTime.makeUnsafe(Math.floor(now / 1000) * 1000)).replace(
+    /[-:]|\.\d{3}/g,
+    "",
+  );
+  return `https://signed.example/download?X-Amz-Date=${date}&X-Amz-Expires=300&for=${encodeURIComponent(url)}`;
+}
 
 const fetchEffect = (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
   const request = HttpClientRequest.make((init?.method ?? "GET") as "GET" | "POST")(
@@ -5508,6 +5520,36 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               }).pipe(Effect.flip);
               assert.equal(error._tag, "AssetWorkspaceContextNotFoundError");
             }
+          }),
+        ),
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("redirects a GitHub attachment to the signed download and never relays it", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const url = "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const issued = yield* client[WS_METHODS.assetsCreateUrl]({
+              resource: { _tag: "github-attachment", url },
+            });
+            const response = yield* fetchEffect(issued.relativeUrl, { redirect: "manual" });
+            assert.equal(response.status, 302);
+            assert.equal(
+              response.headers.location,
+              fakeSignedAttachmentDownload(url, yield* Clock.currentTimeMillis),
+            );
+            assert.match(response.headers["cache-control"] ?? "", /^private, max-age=2[0-9]{2}$/);
+
+            const missing = yield* client[WS_METHODS.assetsCreateUrl]({
+              resource: { _tag: "github-attachment", url: `${url}-missing` },
+            });
+            assert.equal((yield* fetchEffect(missing.relativeUrl)).status, 404);
           }),
         ),
       );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -76,6 +76,7 @@ import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
 import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
 import * as ServerSettings from "./serverSettings.ts";
+import * as GitHubAttachmentResolver from "./assets/GitHubAttachmentResolver.ts";
 import * as NativeAppIconResolver from "./assets/NativeAppIconResolver.ts";
 import * as ProjectFaviconResolver from "./project/ProjectFaviconResolver.ts";
 import * as T3ProjectFileLoader from "./project/T3ProjectFileLoader.ts";
@@ -499,7 +500,13 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // keeps a single Live for all opencode consumers.
   Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
   Layer.provideMerge(WorkspaceLayerLive),
-  Layer.provideMerge(Layer.mergeAll(NativeAppIconResolver.layer, ProjectFaviconResolverLayerLive)),
+  Layer.provideMerge(
+    Layer.mergeAll(
+      NativeAppIconResolver.layer,
+      ProjectFaviconResolverLayerLive,
+      GitHubAttachmentResolver.layer.pipe(Layer.provide(GitHubCli.layer)),
+    ),
+  ),
   Layer.provideMerge(RepositoryIdentityResolver.layer),
   Layer.provideMerge(ServerEnvironmentLayerLive),
   Layer.provideMerge(AuthLayerLive),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2396,6 +2396,7 @@ const makeWsRpcLayer = (
               if (
                 input.resource._tag === "attachment" ||
                 input.resource._tag === "native-app-icon" ||
+                input.resource._tag === "github-attachment" ||
                 (input.resource._tag === "media-file" && path.isAbsolute(input.resource.path))
               ) {
                 return yield* issueAssetUrl({ resource: input.resource });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1561,19 +1561,24 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
       : resource._tag === "workspace-file" && props.workspaceRoot
         ? `${props.workspaceRoot.replace(/[\\/]+$/, "")}/${resource.path}`
         : undefined;
-  const reference = path ? mediaFileReference(path, props.workspaceRoot) : undefined;
-  const relativePath = reference?.relativePath;
   // An environment from before the `github-attachment` resource cannot mint a URL for it.
   // Loading the authored link then is exactly what the client did before: a public
   // repository still renders and a private one fails the way it always has.
   const authoredUrl = resource._tag === "github-attachment" ? resource.url : null;
+  const showsAuthoredUrl = assetUrl._tag === "Failure" && authoredUrl !== null;
   const src =
     assetUrl._tag === "Success"
       ? assetUrl.url + (props.srcFragment ?? "")
-      : assetUrl._tag === "Failure"
+      : showsAuthoredUrl
         ? authoredUrl
         : null;
   const sourceFailed = assetUrl._tag === "Failure" && authoredUrl === null;
+  const reference = path
+    ? mediaFileReference(path, props.workspaceRoot)
+    : authoredUrl !== null
+      ? mediaUrlReference(authoredUrl)
+      : undefined;
+  const relativePath = reference?.kind === "file" ? reference.relativePath : undefined;
   // The server reads the pixel size from the file header, so the slot can be
   // the image's final box instead of a 16:9 guess. An authored size wins; a
   // caller's height cap shrinks the box while keeping the ratio.
@@ -1590,7 +1595,8 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
     kind: props.kind ?? "image",
     name: props.alt || (props.kind ?? "image"),
     src,
-    asset: { environmentId: props.environmentId, resource },
+    // Save and copy re-mint the URL; when the authored link is what is showing, they read that.
+    ...(showsAuthoredUrl ? {} : { asset: { environmentId: props.environmentId, resource } }),
     ...(reference ? { reference } : {}),
     ...(relativePath && (resource._tag === "media-file" || resource._tag === "workspace-file")
       ? {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -28,6 +28,7 @@ import type {
   ServerProviderSkill,
   ThreadLinkedPullRequest,
 } from "@t3tools/contracts";
+import { isGitHubAttachmentUrl } from "@t3tools/contracts";
 import { faviconUrlForOrigin } from "@t3tools/shared/favicon";
 import {
   isAtomCommandInterrupted,
@@ -1521,12 +1522,16 @@ function ChatMarkdownVideo(props: {
   );
 }
 
-/** Environment-hosted media loads through an exact-file signed asset URL. */
+/**
+ * Media the environment must vouch for loads through a signed asset URL: a
+ * host file served in place, or a GitHub upload the environment resolves
+ * with its own credentials.
+ */
 export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props: {
   readonly environmentId: EnvironmentId;
   readonly resource: Extract<
     AssetResource,
-    { readonly _tag: "attachment" | "workspace-file" | "media-file" }
+    { readonly _tag: "attachment" | "workspace-file" | "media-file" | "github-attachment" }
   >;
   readonly kind?: "image" | "video";
   readonly alt: string;
@@ -1538,6 +1543,8 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   readonly maxHeightRem?: number | undefined;
   readonly style?: CSSProperties | undefined;
   readonly workspaceRoot?: string | undefined;
+  /** Authored remote destination to open when embedding fails, never a generated asset URL. */
+  readonly originalUrl?: string | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, props.resource);
@@ -1570,7 +1577,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
     src,
     asset: { environmentId: props.environmentId, resource },
     ...(reference ? { reference } : {}),
-    ...(relativePath && resource._tag !== "attachment"
+    ...(relativePath && (resource._tag === "media-file" || resource._tag === "workspace-file")
       ? {
           onOpenFile: () =>
             useRightPanelStore
@@ -1590,6 +1597,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
         sourceFailed={assetUrl._tag === "Failure"}
         alt={props.alt}
         copyMarkdown={props.copyMarkdown}
+        originalUrl={props.originalUrl}
         style={props.style}
         mediaIdentity={JSON.stringify([props.environmentId, props.resource, props.srcFragment])}
         onRetry={refreshAssetUrl}
@@ -1609,6 +1617,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
       className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
       style={style}
       actionsSource={actionsSource}
+      originalUrl={props.originalUrl}
       onImageExpand={props.onImageExpand}
     />
   );
@@ -2995,7 +3004,9 @@ const CHAT_MARKDOWN_COMPONENTS = {
     );
   },
   img: function MarkdownImage({ node, title, src, alt, ...props }) {
-    const { expandMedia, cwd, imageBaseDir, threadRef } = use(ChatMarkdownRendererContext);
+    const { expandMedia, cwd, environmentId, imageBaseDir, threadRef } = use(
+      ChatMarkdownRendererContext,
+    );
     const imageExpand = use(MarkdownLinkContext) ? undefined : expandMedia;
     const localSrc = node?.properties?.dataLocalSrc;
     const markdownTitle = node?.properties?.dataMarkdownTitle;
@@ -3012,6 +3023,27 @@ const CHAT_MARKDOWN_COMPONENTS = {
     const authoredSizeStyle = authoredImageSizeStyle(width, height);
     const imageSource = classifyMarkdownImageSource(classifiedSrc, imageBaseDir ?? cwd);
     const kind = mediaKindFromPath(classifiedSrc) ?? "image";
+    if (
+      imageSource._tag === "Direct" &&
+      environmentId !== null &&
+      isGitHubAttachmentUrl(imageSource.uri)
+    ) {
+      // A private repository's upload 404s without GitHub credentials, so the
+      // environment resolves it. The original link still opens on GitHub.
+      return (
+        <ChatMarkdownAssetImage
+          environmentId={environmentId}
+          resource={{ _tag: "github-attachment", url: imageSource.uri }}
+          alt={altText}
+          kind={kind}
+          copyMarkdown={copyMarkdown}
+          standalone={standalone}
+          style={authoredSizeStyle}
+          originalUrl={imageSource.uri}
+          onImageExpand={imageExpand}
+        />
+      );
+    }
     if (imageSource._tag === "Direct") {
       const mediaSrc = resolveProtocolRelativeMediaUrl(imageSource.uri);
       const originalUrl =

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1545,6 +1545,11 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
   readonly workspaceRoot?: string | undefined;
   /** Authored remote destination to open when embedding fails, never a generated asset URL. */
   readonly originalUrl?: string | undefined;
+  readonly className?: string | undefined;
+  /** Sanitized authored attributes (`id`, `align`, …) that fragment links and layout rely on. */
+  readonly imageProps?:
+    | Omit<ComponentProps<"img">, "src" | "alt" | "className" | "style">
+    | undefined;
   readonly onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
 }) {
   const assetUrl = useAssetUrlState(props.environmentId, props.resource);
@@ -1558,7 +1563,17 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
         : undefined;
   const reference = path ? mediaFileReference(path, props.workspaceRoot) : undefined;
   const relativePath = reference?.relativePath;
-  const src = assetUrl._tag === "Success" ? assetUrl.url + (props.srcFragment ?? "") : null;
+  // An environment from before the `github-attachment` resource cannot mint a URL for it.
+  // Loading the authored link then is exactly what the client did before: a public
+  // repository still renders and a private one fails the way it always has.
+  const authoredUrl = resource._tag === "github-attachment" ? resource.url : null;
+  const src =
+    assetUrl._tag === "Success"
+      ? assetUrl.url + (props.srcFragment ?? "")
+      : assetUrl._tag === "Failure"
+        ? authoredUrl
+        : null;
+  const sourceFailed = assetUrl._tag === "Failure" && authoredUrl === null;
   // The server reads the pixel size from the file header, so the slot can be
   // the image's final box instead of a 16:9 guess. An authored size wins; a
   // caller's height cap shrinks the box while keeping the ratio.
@@ -1594,7 +1609,7 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
     return (
       <ChatMarkdownVideo
         src={src}
-        sourceFailed={assetUrl._tag === "Failure"}
+        sourceFailed={sourceFailed}
         alt={props.alt}
         copyMarkdown={props.copyMarkdown}
         originalUrl={props.originalUrl}
@@ -1610,12 +1625,13 @@ export const ChatMarkdownAssetImage = memo(function ChatMarkdownAssetImage(props
     <ChatMarkdownImage
       key={JSON.stringify([props.environmentId, props.resource, props.srcFragment])}
       src={src}
-      sourceFailed={assetUrl._tag === "Failure"}
+      sourceFailed={sourceFailed}
       alt={props.alt}
       copyMarkdown={props.copyMarkdown}
       standalone={props.standalone ?? true}
-      className={CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME}
+      className={cn(CHAT_MARKDOWN_WORKSPACE_IMAGE_CLASS_NAME, props.className)}
       style={style}
+      imageProps={props.imageProps}
       actionsSource={actionsSource}
       originalUrl={props.originalUrl}
       onImageExpand={props.onImageExpand}
@@ -3038,7 +3054,9 @@ const CHAT_MARKDOWN_COMPONENTS = {
           kind={kind}
           copyMarkdown={copyMarkdown}
           standalone={standalone}
+          className={className}
           style={authoredSizeStyle}
+          imageProps={imageProps}
           originalUrl={imageSource.uri}
           onImageExpand={imageExpand}
         />

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -244,6 +244,32 @@ describe("ChatMarkdown workspace images", () => {
     expect(render(markdown)).not.toContain("aspect-video");
   });
 
+  it("loads a GitHub upload through the environment and keeps its authored id", () => {
+    const url = "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+    const html = render(`<img id="shot" src="${url}" alt="shot">`);
+
+    expect(testState.resources).toEqual([{ _tag: "github-attachment", url }]);
+    expect(html).toContain('id="user-content-shot"');
+    expect(html).not.toContain("Image unavailable");
+  });
+
+  it("loads the authored GitHub link when the environment cannot mint a URL for it", () => {
+    const url = "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+    testState.assetState = "failure";
+    const html = render(`![shot](${url})`);
+
+    expect(html).toContain(`src="${url}"`);
+    expect(html).not.toContain("Image unavailable");
+  });
+
+  it("loads a GitHub upload directly when no environment is known", () => {
+    const url = "https://github.com/user-attachments/assets/0b1f6f2e-3c4d-4e5f-8a9b-0c1d2e3f4a5b";
+    const html = renderWithoutThread(`![shot](${url})`);
+
+    expect(testState.resources).toEqual([]);
+    expect(html).toContain(`src="${url}"`);
+  });
+
   it("keeps an authored id on a remote image so fragment links resolve", () => {
     const html = render('<img id="diagram" src="https://example.com/diagram.png" alt="diagram">');
 

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -28,8 +28,10 @@ function PullRequestAttachmentVideo({
   const resource = useMemo(() => ({ _tag: "github-attachment", url }) as const, [url]);
   const assetUrl = useAssetUrlState(environmentId, resource);
   const refreshAssetUrl = useAssetUrlRefresh(environmentId, resource);
-  // An older environment cannot mint the URL; the authored link is what played before.
-  const src = assetUrl._tag === "Success" ? assetUrl.url : assetUrl._tag === "Failure" ? url : null;
+  // An older environment cannot mint the URL; the authored link is what played before,
+  // and a retry then reloads that link instead of asking the environment again.
+  const showsAuthoredUrl = assetUrl._tag === "Failure";
+  const src = assetUrl._tag === "Success" ? assetUrl.url : showsAuthoredUrl ? url : null;
   return (
     <MediaVideoPlayer
       src={src}
@@ -37,7 +39,7 @@ function PullRequestAttachmentVideo({
       label="Pull request video"
       className="w-full"
       videoClassName={VIDEO_CLASS_NAME}
-      onRetry={refreshAssetUrl}
+      onRetry={showsAuthoredUrl ? undefined : refreshAssetUrl}
     />
   );
 }

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -1,14 +1,45 @@
 import { ExternalLinkIcon, PaperclipIcon } from "lucide-react";
-import type { EnvironmentId, ScopedThreadRef } from "@t3tools/contracts";
+import {
+  isGitHubAttachmentUrl,
+  type EnvironmentId,
+  type ScopedThreadRef,
+} from "@t3tools/contracts";
 import { createContext, useContext, useMemo } from "react";
 import type { Options as ReactMarkdownOptions } from "react-markdown";
 
+import { useAssetUrlRefresh, useAssetUrlState } from "~/assets/assetUrls";
 import { cn } from "~/lib/utils";
 import { PULL_REQUESTS_PANEL_REF } from "~/rightPanelStore";
 
 import ChatMarkdown from "../ChatMarkdown";
 import { MediaVideoPlayer } from "../media/MediaVideoPlayer";
 import { remarkPullRequestAutolinks, splitPullRequestBody } from "./pullRequestMarkdown.logic";
+
+const VIDEO_CLASS_NAME = "rounded-lg border border-border/60";
+
+/** A private repository's upload 404s without GitHub credentials, so the environment resolves it. */
+function PullRequestAttachmentVideo({
+  environmentId,
+  url,
+}: {
+  environmentId: EnvironmentId;
+  url: string;
+}) {
+  const resource = useMemo(() => ({ _tag: "github-attachment", url }) as const, [url]);
+  const assetUrl = useAssetUrlState(environmentId, resource);
+  const refreshAssetUrl = useAssetUrlRefresh(environmentId, resource);
+  return (
+    <MediaVideoPlayer
+      src={assetUrl._tag === "Success" ? assetUrl.url : null}
+      sourceFailed={assetUrl._tag === "Failure"}
+      originalUrl={url}
+      label="Pull request video"
+      className="w-full"
+      videoClassName={VIDEO_CLASS_NAME}
+      onRetry={refreshAssetUrl}
+    />
+  );
+}
 
 export const PullRequestMarkdownContext = createContext<{
   repositoryUrl: string | null;
@@ -55,14 +86,20 @@ export function PullRequestMarkdown({
           );
         }
         if (segment.media === "video") {
-          return (
+          return isGitHubAttachmentUrl(segment.url) ? (
+            <PullRequestAttachmentVideo
+              key={`${segment.id}:${segment.url}`}
+              environmentId={environmentId}
+              url={segment.url}
+            />
+          ) : (
             <MediaVideoPlayer
               key={`${segment.id}:${segment.url}`}
               src={segment.url}
               originalUrl={segment.url}
               label="Pull request video"
               className="w-full"
-              videoClassName="rounded-lg border border-border/60"
+              videoClassName={VIDEO_CLASS_NAME}
             />
           );
         }

--- a/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestMarkdown.tsx
@@ -28,10 +28,11 @@ function PullRequestAttachmentVideo({
   const resource = useMemo(() => ({ _tag: "github-attachment", url }) as const, [url]);
   const assetUrl = useAssetUrlState(environmentId, resource);
   const refreshAssetUrl = useAssetUrlRefresh(environmentId, resource);
+  // An older environment cannot mint the URL; the authored link is what played before.
+  const src = assetUrl._tag === "Success" ? assetUrl.url : assetUrl._tag === "Failure" ? url : null;
   return (
     <MediaVideoPlayer
-      src={assetUrl._tag === "Success" ? assetUrl.url : null}
-      sourceFailed={assetUrl._tag === "Failure"}
+      src={src}
       originalUrl={url}
       label="Pull request video"
       className="w-full"

--- a/apps/web/src/components/pullRequest/pullRequestMarkdown.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestMarkdown.logic.ts
@@ -1,3 +1,5 @@
+import { isGitHubAttachmentUrl } from "@t3tools/contracts";
+
 import {
   findAndReplaceText,
   type MarkdownNode,
@@ -30,8 +32,6 @@ const VIDEO_TAG_MAX_LINES = 8;
 const INDENTED_CODE_PATTERN = /^(?: {4}|\t)/u;
 const BARE_URL_PATTERN = /^<?(https?:\/\/\S+?)>?$/u;
 const VIDEO_EXTENSION_PATTERN = /\.(?:mp4|webm|mov|m4v|ogv)(?:$|[?#])/iu;
-/** A dropped video becomes a bare asset link; a dropped image becomes an `<img>` tag. */
-const GITHUB_ASSET_PATTERN = /^https:\/\/github\.com\/user-attachments\/assets\/[\w-]+$/iu;
 const VIDEO_TAG_SRC_PATTERN = /<(?:video|source)\b[^>]*\bsrc\s*=\s*["']([^"']+)["']/iu;
 /** Only a tag that owns its line is an embed; inline, it is prose the renderer should keep. */
 const STANDALONE_VIDEO_TAG_PATTERN = /^\s*<video\b/iu;
@@ -50,7 +50,8 @@ function isWebUrl(url: string): boolean {
 function attachmentFromLine(line: string): { url: string; media: "video" | "unknown" } | null {
   const url = BARE_URL_PATTERN.exec(line.trim())?.[1];
   if (url === undefined || !isWebUrl(url)) return null;
-  if (VIDEO_EXTENSION_PATTERN.test(url) || GITHUB_ASSET_PATTERN.test(url)) {
+  // A dropped video becomes a bare asset link; a dropped image becomes an `<img>` tag.
+  if (VIDEO_EXTENSION_PATTERN.test(url) || isGitHubAttachmentUrl(url)) {
     return { url, media: "video" };
   }
   return null;

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -52,9 +52,10 @@ file's identity when serving it, so atomic replacement requires a new URL while
 editing the same file in place does not. An HTML file authorized this way cannot
 load sibling assets; directory-scoped workspace previews are a separate grant.
 Clients should share the authored file reference so they do not disclose the
-temporary URL's credential. A URL for a GitHub upload grants one resolution
-through the environment's `gh` credential and answers with a redirect to
-GitHub's own short-lived download, so the server never relays the bytes.
+temporary URL's credential. A URL for a GitHub upload lets its holder resolve
+that one upload through the environment's `gh` credential for as long as the
+URL is valid; each request answers with a redirect to GitHub's own short-lived
+download, so the server never relays the bytes.
 
 Host videos can change in place. Their [HTTP
 responses](../../apps/server/src/http.ts) omit cache validators because file

--- a/docs/internals/environment-auth.md
+++ b/docs/internals/environment-auth.md
@@ -52,7 +52,9 @@ file's identity when serving it, so atomic replacement requires a new URL while
 editing the same file in place does not. An HTML file authorized this way cannot
 load sibling assets; directory-scoped workspace previews are a separate grant.
 Clients should share the authored file reference so they do not disclose the
-temporary URL's credential.
+temporary URL's credential. A URL for a GitHub upload grants one resolution
+through the environment's `gh` credential and answers with a redirect to
+GitHub's own short-lived download, so the server never relays the bytes.
 
 Host videos can change in place. Their [HTTP
 responses](../../apps/server/src/http.ts) omit cache validators because file

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -11,6 +11,17 @@ import { ToolActivityNativeAppReference } from "./providerRuntime.ts";
 
 const ASSET_PATH_MAX_LENGTH = 1024;
 
+/**
+ * An upload dropped into a GitHub pull request or issue. GitHub serves it only
+ * to a signed-in reader when the repository is private, so a browser cannot
+ * load it from the bare link the markdown carries.
+ */
+const GITHUB_ATTACHMENT_URL_PATTERN = /^https:\/\/github\.com\/user-attachments\/assets\/[\w-]+$/iu;
+
+export function isGitHubAttachmentUrl(url: string): boolean {
+  return GITHUB_ATTACHMENT_URL_PATTERN.test(url);
+}
+
 export const AssetResource = Schema.Union([
   Schema.TaggedStruct("workspace-file", {
     threadId: ThreadId,
@@ -43,6 +54,14 @@ export const AssetResource = Schema.Union([
   }),
   Schema.TaggedStruct("native-app-icon", {
     app: ToolActivityNativeAppReference,
+  }),
+  // Resolved with the environment's GitHub credentials; the signed URL redirects
+  // to GitHub's own time-limited download instead of proxying the bytes.
+  Schema.TaggedStruct("github-attachment", {
+    url: TrimmedNonEmptyString.check(
+      Schema.isMaxLength(ASSET_PATH_MAX_LENGTH),
+      Schema.isPattern(GITHUB_ATTACHMENT_URL_PATTERN),
+    ),
   }),
 ]);
 export type AssetResource = typeof AssetResource.Type;


### PR DESCRIPTION
## What Changed

Images and videos dropped into a pull request on a **private** repository now render in the PR panel. Before, they showed an "Image unavailable" chip, and a dropped video showed "Video unavailable".

- `packages/contracts`: a new `github-attachment` asset resource for `https://github.com/user-attachments/assets/<id>` links, plus an `isGitHubAttachmentUrl` helper that the PR body splitter now reuses instead of its own copy of the pattern.
- `apps/server`: a small `GitHubAttachmentResolver` reads the token through `gh auth token`, asks GitHub for the upload with it, and returns the `Location` GitHub answers with. The existing signed asset route answers such a resource with a `302` to that URL, with `Cache-Control` derived from the signature's remaining lifetime (`X-Amz-Date` plus `X-Amz-Expires`, minus a margin) so remounting the panel does not refetch every image. No bytes go through the server. A found token is reused for five minutes; a missing one is not cached, so a `gh auth login` while T3 Code runs takes effect on the next image.
- `apps/web`: `ChatMarkdown` sends a GitHub attachment image through `ChatMarkdownAssetImage` when an environment is known, and `PullRequestMarkdown` does the same for a bare attachment link that is a video. If the environment cannot mint the URL (a server from before this change), both load the authored link, which is exactly what the client did before. Everything else is unchanged.

## Why

GitHub serves `user-attachments` uploads from a private repository only to a signed-in reader. The PR body carries a bare `<img src="https://github.com/user-attachments/assets/…">`, so the browser got the same `404` an anonymous request gets. Public repositories redirect without credentials, which is why they always worked.

Redirecting instead of proxying keeps the fix cheap and remote-ready: a relay or tunnel client fetches the image straight from GitHub's storage, and the server only forwards a redirect. Reading the token through `gh` keeps credentials where every other GitHub call already gets them; without a token the request goes out anonymously, so a public repository behaves exactly as before and an unauthenticated `gh` does not change anything.

Surfaces: web and desktop render PR bodies and are covered. Mobile has no PR body view, so it is untouched; a chat message on mobile that embeds such a link still loads it directly, as today. Routing mobile chat through the same resource is a separate, small follow-up. Chat messages on web and desktop go through the same `ChatMarkdown` path and benefit as well.

Verified against a real private repository with the OAuth token `gh auth login` issues: the resolver returns GitHub's signed S3 URL, the route answers `302` with `Cache-Control: private, max-age=240`, and the PR panel renders both images. Focused tests cover the resolver (token header, token reuse, anonymous fallback that picks up a later login, allowlist before the token goes on the wire, manual redirect handling against the real fetch client, non-redirect answers), the signed claims round trip, the redirect cache header, the route's `302` and `404`, and the web fallbacks.

## UI Changes

<!-- before-and-after:start -->
| Before (PR panel, private repository) | After (PR panel, private repository) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/443d4833-c872-4b66-8e43-c50866c91bda) | ![After](https://github.com/user-attachments/assets/b5961909-5e24-4c3e-852e-482d143d4a30) |

<!-- before-and-after:end -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable)

Model: Claude Fable 5.1. Harness: Claude Code, driven from T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitHub-hosted pull request and issue attachments are now supported as assets.
  - Attachments resolve through authenticated, time-limited redirects without proxying file contents.
  - Markdown images and videos can display GitHub attachments, with fallback to the original GitHub URL when resolution fails.
  - Redirect responses now include cache controls based on signed URL expiry.

- **Documentation**
  - Added guidance explaining GitHub attachment resolution and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
