### PR TITLE
fix(web): follow the thread's model after another client changes it

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1554,6 +1554,9 @@ export default function ChatView(props: ChatViewProps) {
     (store) => store.setInteractionMode,
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
+  const releaseComposerDraftModelSelection = useComposerDraftStore(
+    (store) => store.releaseModelSelection,
+  );
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
   const getDraftSessionByLogicalProjectKey = useComposerDraftStore(
     (store) => store.getDraftSessionByLogicalProjectKey,
@@ -6477,6 +6480,11 @@ export default function ChatView(props: ChatViewProps) {
       interactionMode: sendInteractionMode,
       interactionModeEnabled: sendInteractionModeEnabled,
     } = sendCtx;
+    // Read with the selection that ships in this send, so a pick made while
+    // the send is in flight survives the release after it succeeds.
+    const sentModelSelectionId = useComposerDraftStore
+      .getState()
+      .getComposerDraft(composerDraftTarget)?.modelSelectionId;
     const annotationImageAlreadyAttached =
       directAnnotation?.image !== undefined &&
       sendContextImages.some((image) => image.id === directAnnotation.image?.id);
@@ -7021,6 +7029,12 @@ export default function ChatView(props: ChatViewProps) {
         failure = startResult;
       } else {
         turnStartSucceeded = true;
+        // The thread now runs on the model this turn carried, so the composer
+        // follows the thread again until the next pick.
+        releaseComposerDraftModelSelection(
+          scopeThreadRef(activeThread.environmentId, threadIdForSend),
+          sentModelSelectionId,
+        );
         // The turn is under way and will spend quota, so that thread's limits
         // snapshot is stale. Uploads may have outlasted a navigation, so only
         // the sending thread's panel clears.
@@ -7427,6 +7441,9 @@ export default function ChatView(props: ChatViewProps) {
         selectedPromptEffort: ctxSelectedPromptEffort,
         selectedModelSelection: ctxSelectedModelSelection,
       } = sendCtx;
+      const sentModelSelectionId = useComposerDraftStore
+        .getState()
+        .getComposerDraft(composerDraftTarget)?.modelSelectionId;
 
       const threadIdForSend = activeThread.id;
       const messageIdForSend = newMessageId();
@@ -7508,6 +7525,10 @@ export default function ChatView(props: ChatViewProps) {
       }
 
       if (failure === null) {
+        releaseComposerDraftModelSelection(
+          scopeThreadRef(activeThread.environmentId, threadIdForSend),
+          sentModelSelectionId,
+        );
         clearUsageLimitsFor(routeThreadKey);
         acknowledgeActiveThreadWoke();
         sendInFlightRef.current = false;
@@ -7537,6 +7558,7 @@ export default function ChatView(props: ChatViewProps) {
       isServerThread,
       localCheckoutBranchMismatch,
       persistThreadSettingsForNextTurn,
+      releaseComposerDraftModelSelection,
       resetLocalDispatch,
       runtimeMode,
       scrollToEnd,
@@ -7547,6 +7569,7 @@ export default function ChatView(props: ChatViewProps) {
       composerRef,
       clearUsageLimitsFor,
       routeThreadKey,
+      composerDraftTarget,
     ],
   );
 

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -2263,6 +2263,201 @@ describe("composerDraftStore sticky composer settings", () => {
   });
 });
 
+describe("composerDraftStore releaseModelSelection", () => {
+  const threadId = ThreadId.make("thread-release-model");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+  const projectRef = scopeProjectRef(TEST_ENVIRONMENT_ID, ProjectId.make("project-release-model"));
+  const draftId = DraftId.make("draft-release-model");
+  const pickA = modelSelection(CODEX_DRIVER, "gpt-5.4");
+  const pickB = modelSelection(CODEX_DRIVER, "gpt-5.3-codex");
+  const pickIdFor = (key: string) => draftByKey(key)?.modelSelectionId;
+  const serverDraft = () => draftFor(threadId, TEST_ENVIRONMENT_ID);
+
+  beforeEach(async () => {
+    resetComposerDraftStore();
+    await useComposerDraftStore.persist.clearStorage();
+  });
+
+  afterEach(async () => {
+    await useComposerDraftStore.persist.clearStorage();
+  });
+
+  it("gives every explicit pick its own id, including a same-value re-pick", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(threadRef, pickA);
+    expect(serverDraft()?.modelSelectionId).toBeUndefined();
+
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+    const firstPickId = serverDraft()?.modelSelectionId;
+    expect(firstPickId).toEqual(expect.any(String));
+
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+    const rePickId = serverDraft()?.modelSelectionId;
+    expect(rePickId).toEqual(expect.any(String));
+    expect(rePickId).not.toBe(firstPickId);
+
+    store.setProviderModelOptions(
+      threadRef,
+      CODEX_DRIVER,
+      toSelections({ reasoningEffort: "high" }),
+      { model: pickA.model },
+    );
+    const traitPickId = serverDraft()?.modelSelectionId;
+    expect(traitPickId).toEqual(expect.any(String));
+    expect(traitPickId).not.toBe(rePickId);
+
+    // A seed is not a pick.
+    store.setModelSelection(threadRef, pickA, { replaceOptions: true });
+    expect(serverDraft()?.modelSelectionId).toBeUndefined();
+  });
+
+  it("releases the pick a confirmed send carried and keeps the rest of the draft", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+    store.setRuntimeMode(threadRef, "approval-required");
+    store.setPrompt(threadRef, "typed while sending");
+    const sentPickId = serverDraft()?.modelSelectionId;
+
+    store.releaseModelSelection(threadRef, sentPickId);
+
+    expect(serverDraft()).toMatchObject({
+      prompt: "typed while sending",
+      runtimeMode: "approval-required",
+      modelSelectionByProvider: {},
+      activeProvider: null,
+    });
+    expect(serverDraft()?.modelSelectionExplicit).toBeUndefined();
+    expect(serverDraft()?.modelSelectionId).toBeUndefined();
+  });
+
+  it("removes a draft that held nothing but the released seed", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(threadRef, pickA);
+
+    store.releaseModelSelection(threadRef, undefined);
+
+    expect(serverDraft()).toBeUndefined();
+  });
+
+  it("keeps a pick made after the send captured its id", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+    const sentPickId = serverDraft()?.modelSelectionId;
+    store.setModelSelection(threadRef, pickB, { explicit: true });
+
+    store.releaseModelSelection(threadRef, sentPickId);
+
+    expect(serverDraft()).toMatchObject({
+      modelSelectionByProvider: { [CODEX_INSTANCE]: pickB },
+      activeProvider: CODEX_INSTANCE,
+      modelSelectionExplicit: true,
+    });
+  });
+
+  it("keeps a same-value re-pick made after the send captured its id", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+    const sentPickId = serverDraft()?.modelSelectionId;
+    store.setModelSelection(threadRef, pickA, { explicit: true });
+
+    store.releaseModelSelection(threadRef, sentPickId);
+
+    expect(serverDraft()).toMatchObject({
+      modelSelectionByProvider: { [CODEX_INSTANCE]: pickA },
+      modelSelectionExplicit: true,
+    });
+  });
+
+  it("holds a draft session's confirmed selection until promotion drops it", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setModelSelection(draftId, pickA, { explicit: true });
+    const sentPickId = pickIdFor(draftId);
+
+    // The send addresses the thread it created, which still resolves to the
+    // draft session while that session exists.
+    store.releaseModelSelection(threadRef, sentPickId);
+    store.setPrompt(draftId, "typed after sending");
+
+    expect(draftByKey(draftId)).toMatchObject({
+      modelSelectionByProvider: { [CODEX_INSTANCE]: pickA },
+      modelSelectionSent: true,
+    });
+
+    markPromotedDraftThreadByRef(threadRef);
+    finalizePromotedDraftThreadByRef(threadRef);
+
+    expect(draftByKey(draftId)).toBeUndefined();
+    expect(serverDraft()).toMatchObject({
+      prompt: "typed after sending",
+      modelSelectionByProvider: {},
+      activeProvider: null,
+    });
+    expect(serverDraft()?.modelSelectionSent).toBeUndefined();
+  });
+
+  it("does not move a draft session onto the server thread once only its seed remains", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setModelSelection(draftId, pickA);
+
+    store.releaseModelSelection(threadRef, undefined);
+    markPromotedDraftThreadByRef(threadRef);
+    finalizePromotedDraftThreadByRef(threadRef);
+
+    expect(draftByKey(draftId)).toBeUndefined();
+    expect(serverDraft()).toBeUndefined();
+  });
+
+  it("carries a pick made after the send across promotion", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+    store.setModelSelection(draftId, pickA, { explicit: true });
+    store.releaseModelSelection(threadRef, pickIdFor(draftId));
+    store.setModelSelection(draftId, pickB, { explicit: true });
+
+    markPromotedDraftThreadByRef(threadRef);
+    finalizePromotedDraftThreadByRef(threadRef);
+
+    expect(serverDraft()).toMatchObject({
+      modelSelectionByProvider: { [CODEX_INSTANCE]: pickB },
+      activeProvider: CODEX_INSTANCE,
+      modelSelectionExplicit: true,
+    });
+    expect(serverDraft()?.modelSelectionSent).toBeUndefined();
+  });
+
+  it("keeps the sent marker across a reload so promotion still drops the selection", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = useComposerDraftStore.getState();
+      store.setProjectDraftThreadId(projectRef, draftId, { threadId });
+      store.setModelSelection(draftId, pickA, { explicit: true });
+      store.releaseModelSelection(threadRef, pickIdFor(draftId));
+      // Land the debounced persist write.
+      await vi.advanceTimersByTimeAsync(300);
+
+      resetComposerDraftStore();
+      await useComposerDraftStore.persist.rehydrate();
+
+      expect(draftByKey(draftId)).toMatchObject({
+        modelSelectionByProvider: { [CODEX_INSTANCE]: pickA },
+        modelSelectionExplicit: true,
+        modelSelectionSent: true,
+      });
+      expect(pickIdFor(draftId)).toBeUndefined();
+
+      markPromotedDraftThreadByRef(threadRef);
+      finalizePromotedDraftThreadByRef(threadRef);
+
+      expect(draftByKey(draftId)).toBeUndefined();
+      expect(serverDraft()).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("composerDraftStore model seed migration", () => {
   const staleDraftId = DraftId.make("draft-legacy-stale-model");
   const explicitDraftId = DraftId.make("draft-legacy-explicit-model");
@@ -2272,6 +2467,12 @@ describe("composerDraftStore model seed migration", () => {
   const typedThreadId = ThreadId.make("thread-legacy-typed-model");
   const serverThreadId = ThreadId.make("thread-server-model");
   const serverThreadKey = scopedThreadKey(scopeThreadRef(TEST_ENVIRONMENT_ID, serverThreadId));
+  const typedServerThreadKey = scopedThreadKey(
+    scopeThreadRef(TEST_ENVIRONMENT_ID, ThreadId.make("thread-server-typed-model")),
+  );
+  const explicitServerThreadKey = scopedThreadKey(
+    scopeThreadRef(TEST_ENVIRONMENT_ID, ThreadId.make("thread-server-explicit-model")),
+  );
   const projectId = ProjectId.make("project-model-migration");
   const logicalProjectKey = `${TEST_ENVIRONMENT_ID}:/tmp/project-model-migration`;
 
@@ -2335,7 +2536,7 @@ describe("composerDraftStore model seed migration", () => {
     },
   );
 
-  it("strips seeded models only from empty draft sessions when upgrading storage", async () => {
+  it("strips seeded models from empty draft sessions and server threads when upgrading storage", async () => {
     vi.useFakeTimers();
     try {
       const staleSelection = modelSelection(CODEX_DRIVER, "gpt-5.4");
@@ -2374,6 +2575,19 @@ describe("composerDraftStore model seed migration", () => {
               modelSelectionByProvider: { [CODEX_INSTANCE]: staleSelection },
               activeProvider: CODEX_INSTANCE,
             },
+            [typedServerThreadKey]: {
+              prompt: "keep this server thread prompt",
+              attachments: [],
+              modelSelectionByProvider: { [CODEX_INSTANCE]: staleSelection },
+              activeProvider: CODEX_INSTANCE,
+            },
+            [explicitServerThreadKey]: {
+              prompt: "",
+              attachments: [],
+              modelSelectionByProvider: { [CODEX_INSTANCE]: staleSelection },
+              activeProvider: CODEX_INSTANCE,
+              modelSelectionExplicit: true,
+            },
           },
           draftThreadsByThreadKey: {
             [staleDraftId]: draftThread(staleThreadId),
@@ -2406,9 +2620,18 @@ describe("composerDraftStore model seed migration", () => {
         activeProvider: CODEX_INSTANCE,
         modelSelectionExplicit: true,
       });
-      expect(draftByKey(serverThreadKey)).toMatchObject({
+      // A server thread has a model of its own, so a seed left on it is stale
+      // by definition; an explicit pick is unsent intent and stays.
+      expect(draftByKey(serverThreadKey)).toBeUndefined();
+      expect(draftByKey(typedServerThreadKey)).toMatchObject({
+        prompt: "keep this server thread prompt",
+        modelSelectionByProvider: {},
+        activeProvider: null,
+      });
+      expect(draftByKey(explicitServerThreadKey)).toMatchObject({
         modelSelectionByProvider: { [CODEX_INSTANCE]: staleSelection },
         activeProvider: CODEX_INSTANCE,
+        modelSelectionExplicit: true,
       });
       expect(useComposerDraftStore.getState().draftThreadsByThreadKey[staleDraftId]).toMatchObject({
         environmentId: TEST_ENVIRONMENT_ID,

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -66,7 +66,7 @@ const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
 const isSnapShotSource = Schema.is(SnapShotSource);
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
-const COMPOSER_DRAFT_STORAGE_VERSION = 9;
+const COMPOSER_DRAFT_STORAGE_VERSION = 10;
 const DraftThreadEnvModeSchema = Schema.Literals(["local", "worktree"]);
 export type DraftThreadEnvMode = typeof DraftThreadEnvModeSchema.Type;
 
@@ -254,6 +254,10 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   // selections (project default / sticky) leave it unset so later seeds can
   // replace them; legacy entries predate the flag and read as seeded too.
   modelSelectionExplicit: Schema.optionalKey(Schema.Boolean),
+  // True once the server confirmed a send carrying this selection while the
+  // draft was still a draft session; promotion drops it instead of moving it
+  // onto the server thread.
+  modelSelectionSent: Schema.optionalKey(Schema.Boolean),
   runtimeMode: Schema.optionalKey(RuntimeMode),
   interactionMode: Schema.optionalKey(ProviderInteractionMode),
 });
@@ -391,6 +395,20 @@ export interface ComposerThreadDraftState {
    * may replace it. Legacy entries predate the flag and read as seeded.
    */
   modelSelectionExplicit?: boolean;
+  /**
+   * Identity of the current explicit pick. Fresh on every picker or trait
+   * write, even one that repeats the value, and never persisted: a send
+   * captures it so that confirming the send releases only the pick it
+   * carried. See `releaseModelSelection`.
+   */
+  modelSelectionId?: string;
+  /**
+   * True once the server confirmed a send carrying this selection while the
+   * draft was still a draft session. Promotion then drops the selection
+   * instead of moving it onto the server thread, whose own model is the
+   * source of truth from that point on.
+   */
+  modelSelectionSent?: boolean;
   runtimeMode: RuntimeMode | null;
   interactionMode: ProviderInteractionMode | null;
 }
@@ -583,6 +601,18 @@ interface ComposerDraftStoreState {
       | undefined,
   ) => void;
   applyStickyState: (threadRef: ComposerThreadTarget) => void;
+  /**
+   * Lets the thread's own model show through again after the server
+   * confirmed a send. `modelSelectionId` is the draft's id captured when
+   * that send started; a pick made since then has a different id and stays.
+   * A draft session only marks the selection sent: its local placeholder
+   * thread would show the project default until the server thread arrives,
+   * so promotion drops the selection instead.
+   */
+  releaseModelSelection: (
+    threadRef: ComposerThreadTarget,
+    modelSelectionId: string | undefined,
+  ) => void;
   setProviderModelOptions: (
     threadRef: ComposerThreadTarget,
     provider: ProviderDriverKind,
@@ -892,6 +922,24 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.runtimeMode === null &&
     draft.interactionMode === null
   );
+}
+
+let nextModelSelectionPickSequence = 0;
+/** Identity for one explicit model pick; see `ComposerThreadDraftState.modelSelectionId`. */
+function newModelSelectionId(): string {
+  nextModelSelectionPickSequence += 1;
+  return nextModelSelectionPickSequence.toString(36);
+}
+
+/** The draft with its model override dropped so the thread's own model shows through. */
+function withoutModelSelection(draft: ComposerThreadDraftState): ComposerThreadDraftState {
+  const {
+    modelSelectionExplicit: _explicit,
+    modelSelectionId: _id,
+    modelSelectionSent: _sent,
+    ...retained
+  } = draft;
+  return { ...retained, modelSelectionByProvider: {}, activeProvider: null };
 }
 
 function normalizeProviderDriverKind(value: unknown): ProviderDriverKind | null {
@@ -1664,7 +1712,14 @@ function removeDraftThreadReferences(
     state.draftThreadsByThreadKey;
   const { [threadKey]: removedComposerDraft, ...restDraftsByThreadKey } = state.draftsByThreadKey;
   if (composerDestination && removedComposerDraft) {
-    restDraftsByThreadKey[composerTargetKey(composerDestination)] = removedComposerDraft;
+    // A selection the server already confirmed stops here: the server thread
+    // runs on it now, and only a pick made since the send crosses over.
+    const movedComposerDraft = removedComposerDraft.modelSelectionSent
+      ? withoutModelSelection(removedComposerDraft)
+      : removedComposerDraft;
+    if (!shouldRemoveDraft(movedComposerDraft)) {
+      restDraftsByThreadKey[composerTargetKey(composerDestination)] = movedComposerDraft;
+    }
   } else {
     revokeDraftThreadPreviewUrls(removedComposerDraft);
   }
@@ -1939,6 +1994,7 @@ function normalizePersistedDraftsByThreadId(
     let modelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>> = {};
     let activeProvider: ProviderInstanceId | null = null;
     let modelSelectionExplicit: true | undefined = undefined;
+    let modelSelectionSent: true | undefined = undefined;
 
     if (
       draftCandidate.modelSelectionByProvider &&
@@ -1950,6 +2006,7 @@ function normalizePersistedDraftsByThreadId(
       >;
       activeProvider = normalizeProviderInstanceId(draftCandidate.activeProvider);
       modelSelectionExplicit = draftCandidate.modelSelectionExplicit === true ? true : undefined;
+      modelSelectionSent = draftCandidate.modelSelectionSent === true ? true : undefined;
     } else {
       // v2 or legacy format: migrate
       const normalizedModelOptions =
@@ -2021,6 +2078,7 @@ function normalizePersistedDraftsByThreadId(
             modelSelectionByProvider: compactModelSelectionByProvider(modelSelectionByProvider),
             activeProvider,
             ...(modelSelectionExplicit ? { modelSelectionExplicit: true } : {}),
+            ...(modelSelectionSent ? { modelSelectionSent: true } : {}),
           }
         : {}),
       ...(runtimeMode ? { runtimeMode } : {}),
@@ -2043,16 +2101,22 @@ function persistedComposerDraftHasUserContent(draft: PersistedComposerThreadDraf
   );
 }
 
-function stripLegacyModelSeedsFromEmptyDraftSessions(
+/**
+ * Drops model selections nobody picked: a seed on an empty draft session,
+ * which the next new-thread flow re-seeds anyway, and any seed on a server
+ * thread, which already has a model of its own. Explicit picks and typed
+ * content stay.
+ */
+function stripLegacyModelSeeds(
   draftsByThreadKey: PersistedComposerDraftStoreState["draftsByThreadKey"],
   draftThreadsByThreadKey: PersistedComposerDraftStoreState["draftThreadsByThreadKey"],
 ): PersistedComposerDraftStoreState["draftsByThreadKey"] {
   return Object.fromEntries(
     Object.entries(draftsByThreadKey).flatMap(([threadKey, draft]) => {
+      const isDraftSession = draftThreadsByThreadKey[threadKey] !== undefined;
       if (
-        draftThreadsByThreadKey[threadKey] === undefined ||
         draft.modelSelectionExplicit === true ||
-        persistedComposerDraftHasUserContent(draft)
+        (isDraftSession && persistedComposerDraftHasUserContent(draft))
       ) {
         return [[threadKey, draft]];
       }
@@ -2061,9 +2125,14 @@ function stripLegacyModelSeedsFromEmptyDraftSessions(
         activeProvider: _activeProvider,
         modelSelectionByProvider: _modelSelectionByProvider,
         modelSelectionExplicit: _modelSelectionExplicit,
+        modelSelectionSent: _modelSelectionSent,
         ...retained
       } = draft;
-      return retained.runtimeMode || retained.interactionMode ? [[threadKey, retained]] : [];
+      return retained.runtimeMode ||
+        retained.interactionMode ||
+        persistedComposerDraftHasUserContent(retained)
+        ? [[threadKey, retained]]
+        : [];
     }),
   );
 }
@@ -2074,7 +2143,7 @@ function migratePersistedComposerDraftStoreState(
   const normalized = normalizeCurrentPersistedComposerDraftStoreState(persistedState);
   return {
     ...normalized,
-    draftsByThreadKey: stripLegacyModelSeedsFromEmptyDraftSessions(
+    draftsByThreadKey: stripLegacyModelSeeds(
       normalized.draftsByThreadKey,
       normalized.draftThreadsByThreadKey,
     ),
@@ -2202,6 +2271,7 @@ export function partializeComposerDraftStoreState(
             ),
             activeProvider: draft.activeProvider,
             ...(draft.modelSelectionExplicit ? { modelSelectionExplicit: true } : {}),
+            ...(draft.modelSelectionSent ? { modelSelectionSent: true } : {}),
           }
         : {}),
       ...(draft.runtimeMode ? { runtimeMode: draft.runtimeMode } : {}),
@@ -2467,6 +2537,7 @@ function toHydratedThreadDraft(
     modelSelectionByProvider,
     activeProvider,
     ...(persistedDraft.modelSelectionExplicit ? { modelSelectionExplicit: true } : {}),
+    ...(persistedDraft.modelSelectionSent ? { modelSelectionSent: true } : {}),
     runtimeMode: persistedDraft.runtimeMode ?? null,
     interactionMode: persistedDraft.interactionMode ?? null,
   };
@@ -2956,16 +3027,48 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             if (
               Equal.equals(base.modelSelectionByProvider, nextMap) &&
               base.activeProvider === stickyActiveProvider &&
-              base.modelSelectionExplicit === undefined
+              base.modelSelectionExplicit === undefined &&
+              base.modelSelectionSent === undefined
             ) {
               return state;
             }
-            const { modelSelectionExplicit: _modelSelectionExplicit, ...retained } = base;
+            const {
+              modelSelectionExplicit: _modelSelectionExplicit,
+              modelSelectionId: _modelSelectionId,
+              modelSelectionSent: _modelSelectionSent,
+              ...retained
+            } = base;
             const nextDraft: ComposerThreadDraftState = {
               ...retained,
               modelSelectionByProvider: nextMap,
               activeProvider: stickyActiveProvider,
             };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) {
+              delete nextDraftsByThreadKey[threadKey];
+            } else {
+              nextDraftsByThreadKey[threadKey] = nextDraft;
+            }
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        releaseModelSelection: (threadRef, modelSelectionId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return;
+          }
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            if (!current || current.modelSelectionId !== modelSelectionId) {
+              return state;
+            }
+            const nextDraft: ComposerThreadDraftState =
+              state.draftThreadsByThreadKey[threadKey] !== undefined
+                ? { ...current, modelSelectionSent: true }
+                : withoutModelSelection(current);
+            if (Equal.equals(current, nextDraft)) {
+              return state;
+            }
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {
               delete nextDraftsByThreadKey[threadKey];
@@ -3051,22 +3154,35 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               }
             }
             const nextActiveProvider = normalized?.instanceId ?? base.activeProvider;
+            // A pick always writes, even one repeating the current value: it
+            // needs a fresh id so a send that completes afterwards leaves it
+            // alone.
             if (
+              opts?.explicit !== true &&
+              !base.modelSelectionExplicit &&
+              !base.modelSelectionSent &&
               Equal.equals(base.modelSelectionByProvider, nextMap) &&
-              base.activeProvider === nextActiveProvider &&
-              (base.modelSelectionExplicit ?? false) === (opts?.explicit === true)
+              base.activeProvider === nextActiveProvider
             ) {
               return state;
             }
             // Last writer defines intent: picker writes mark the selection
             // explicit; seeding writes leave it unset so future seeds can
-            // replace it.
-            const { modelSelectionExplicit: _previousExplicit, ...restBase } = base;
+            // replace it. Either way the previous pick's id and sent marker
+            // no longer describe the selection.
+            const {
+              modelSelectionExplicit: _previousExplicit,
+              modelSelectionId: _previousId,
+              modelSelectionSent: _previousSent,
+              ...restBase
+            } = base;
             const nextDraft: ComposerThreadDraftState = {
               ...restBase,
               modelSelectionByProvider: nextMap,
               activeProvider: nextActiveProvider,
-              ...(opts?.explicit === true ? { modelSelectionExplicit: true as const } : {}),
+              ...(opts?.explicit === true
+                ? { modelSelectionExplicit: true as const, modelSelectionId: newModelSelectionId() }
+                : {}),
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {
@@ -3181,22 +3297,22 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 : (base.activeProvider ?? instanceKey);
             }
 
-            if (
-              Equal.equals(base.modelSelectionByProvider, nextMap) &&
-              Equal.equals(state.stickyModelSelectionByProvider, nextStickyMap) &&
-              state.stickyActiveProvider === nextStickyActiveProvider
-            ) {
-              return state;
-            }
-
             // Trait edits are user-driven intent: mark the selection explicit
-            // so later seeds cannot silently replace the chosen options.
-            const { modelSelectionExplicit: _previousExplicit, ...restBase } = base;
+            // so later seeds cannot silently replace the chosen options, and
+            // give it a fresh pick id even when the value repeats (see
+            // `modelSelectionId`).
+            const {
+              modelSelectionExplicit: _previousExplicit,
+              modelSelectionId: _previousId,
+              modelSelectionSent: _previousSent,
+              ...restBase
+            } = base;
             const nextDraft: ComposerThreadDraftState = {
               ...restBase,
               ...(options?.instanceId ? { activeProvider: instanceKey } : {}),
               modelSelectionByProvider: nextMap,
               modelSelectionExplicit: true,
+              modelSelectionId: newModelSelectionId(),
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {


### PR DESCRIPTION
Fixes #10684.

After a send, the web composer kept its stored model selection for that thread. That selection wins over the server thread's model for both the picker and the next send, so when another client switched the thread to a different model, desktop kept showing the old one and silently wrote it back on the next message.

Every explicit model pick on a thread draft now gets its own id. A send captures that id, and once the turn starts the composer releases the selection only while the draft still holds that id. A pick made while the send was in flight, including a same-value re-pick, has a different id and stays. With the override gone, the composer follows `thread.modelSelection`, so a change from another client shows through and the next send no longer reverts it.

A draft session is only marked sent, because its local placeholder thread shows the project default until the server thread arrives. The marker is persisted, and promotion drops the selection instead of moving it onto the server thread. Draft storage moves to version 10; the migration also strips never-picked seeds from server-thread drafts, which fixes threads created before this change without one more silent reversal.

Known limitation: explicit picks persisted before this change carry no marker, so a stale one is released only after the next send from this client. Seeded ones are covered by the migration. Mobile has its own fix in #10205; no wire, server, or mobile changes here.

### Verification

Two paired browser tabs against one isolated dev server, Claude provider, same thread. The thread's `model_selection_json` was read from the projection table after each step.

| Step | Before (main) | After (this branch) |
| --- | --- | --- |
| Tab 1 picks Sonnet 5, sends | thread: sonnet-5 | thread: sonnet-5 |
| Tab 2 picks Opus 5, sends | thread: opus-5, tab 1 still shows Sonnet 5 | thread: opus-5, tab 1 shows Opus 5 |
| Tab 1 sends again | thread reverts to sonnet-5 | thread stays opus-5 |
| Tab 1 picks Fable 5.1 without sending, tab 2 switches to Sonnet 5 and sends | not run | thread: sonnet-5, tab 1 keeps its unsent Fable 5.1 pick |

Recordings of tab 1; the second tab acts off-screen.

Before, on `main`: tab 1 keeps showing Sonnet 5 after the remote switch to Opus 5, and its next send reverts the thread.

<video src="https://github.com/alizenhom/t3code/raw/pr-assets/10684-model-handoff/before-stale-model.mp4" controls muted></video>

After, on this branch: tab 1 switches to Opus 5 when the remote change lands, and its next send leaves the thread on Opus 5.

<video src="https://github.com/alizenhom/t3code/raw/pr-assets/10684-model-handoff/after-follows-remote-model.mp4" controls muted></video>

Reloading both tabs between the runs migrated their v9 storage to v10 in place.

Tests: composer draft store suite (115 tests, 9 new) covering the pick id rules, release on server threads, a newer pick surviving the in-flight window, the draft-session hold and promotion drop, and the persisted marker across a reload. Model selection, thread action, and ChatView logic suites pass (169 tests). Web typecheck, lint on the changed files, and formatting pass.

Prepared with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Model selections now stay aligned with the model used by the conversation after a message is sent.
  * Composer selections are updated after a send is successfully confirmed, including plan follow-ups.
  * New model choices made after sending are preserved until they are used.
  * Draft content and unsent model selections are retained more reliably across conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->