### PR TITLE
feat(web): show project favicon in new-thread project picker

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import { ProjectFavicon } from "../ProjectFavicon";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
   Menu,
@@ -114,11 +115,14 @@ export function DraftHeroHeadline({
           render={
             <MenuTrigger
               aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
-              className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-baseline text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+              className="pointer-events-auto inline-flex max-w-64 items-center gap-2 border-foreground/60 border-b border-dotted align-baseline text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             />
           }
         >
-          {activeProjectDisplayName ?? "Choose a project"}
+          {activeProjectGroup ? (
+            <ProjectFavicon project={activeProjectGroup} className="size-6 shrink-0 sm:size-7" />
+          ) : null}
+          <span className="min-w-0 truncate">{activeProjectDisplayName ?? "Choose a project"}</span>
         </TooltipTrigger>
         {activeProjectDisplayName ? (
           <TooltipPopup side="top" className="max-w-80">
@@ -164,7 +168,13 @@ export function DraftHeroHeadline({
         >
           {projectPickerEntries.map(({ group }) => {
             return (
-              <MenuRadioItem key={group.projectKey} value={group.projectKey} closeOnClick>
+              <MenuRadioItem
+                key={group.projectKey}
+                value={group.projectKey}
+                closeOnClick
+                className="[&>span:last-child]:flex [&>span:last-child]:min-w-0 [&>span:last-child]:items-center [&>span:last-child]:gap-2"
+              >
+                <ProjectFavicon project={group} className="size-4 shrink-0" />
                 <Tooltip>
                   <TooltipTrigger render={<span className="block min-w-0 truncate" />}>
                     {group.displayName}


### PR DESCRIPTION
The "What should we build in {project}?" headline on the new-thread screen now shows the project favicon next to the project name, both in the underlined `MenuTrigger` and in each project item of the dropdown. This reuses the existing `ProjectFavicon` component and the same inline layout pattern already used by the sidebar project scope menu, so the folder-icon fallback is handled for projects without a favicon. Related to a sibling PR that adds environment labels to the same dropdown.

Verified with `tsgo --noEmit` for `apps/web` (clean), `vp lint --report-unused-disable-directives apps/web/src` (only a pre-existing unrelated warning in `ThemeEditorPanel.tsx`), and the existing `apps/web/src/components/chat/draftHeroTransition.test.ts` suite (5 passing); there are no `DraftHeroHeadline` tests to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Project selectors now display each project’s favicon alongside its name.
  - Updated menu styling improves alignment and text truncation for project names.
  - The active project selection and project menu items now present clearer visual identification while preserving readable names in limited space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->