### PR TITLE
feat(web): show environment label in new-thread project picker

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.logic.test.ts
+++ b/apps/web/src/components/chat/DraftHeroHeadline.logic.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { SidebarProjectPickerEntry } from "~/sidebarProjectGrouping";
+import { resolveProjectPickerEnvironmentHints } from "./DraftHeroHeadline.logic";
+
+function entry(input: {
+  projectKey: string;
+  displayName: string;
+  environmentId: string;
+  environmentLabel: string | null;
+  workspaceRoot: string;
+}): SidebarProjectPickerEntry {
+  return {
+    group: { projectKey: input.projectKey, displayName: input.displayName },
+    targetProject: {
+      environmentId: input.environmentId,
+      environmentLabel: input.environmentLabel,
+      workspaceRoot: input.workspaceRoot,
+    },
+    isPreferred: false,
+  } as unknown as SidebarProjectPickerEntry;
+}
+
+describe("resolveProjectPickerEnvironmentHints", () => {
+  it("hides environment labels when every entry lives in one environment", () => {
+    const hints = resolveProjectPickerEnvironmentHints([
+      entry({
+        projectKey: "a",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: "laptop",
+        workspaceRoot: "/a/quasar",
+      }),
+      entry({
+        projectKey: "b",
+        displayName: "pulsar",
+        environmentId: "local",
+        environmentLabel: "laptop",
+        workspaceRoot: "/a/pulsar",
+      }),
+    ]);
+    expect(hints.get("a")).toEqual({ environmentLabel: null, text: null });
+    expect(hints.get("b")).toEqual({ environmentLabel: null, text: null });
+  });
+
+  it("shows the environment label once entries span two environments", () => {
+    const hints = resolveProjectPickerEnvironmentHints([
+      entry({
+        projectKey: "a",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: "laptop",
+        workspaceRoot: "/a/quasar",
+      }),
+      entry({
+        projectKey: "b",
+        displayName: "quasar",
+        environmentId: "remote",
+        environmentLabel: "build-box",
+        workspaceRoot: "/srv/quasar",
+      }),
+    ]);
+    expect(hints.get("a")).toEqual({ environmentLabel: "laptop", text: "laptop" });
+    expect(hints.get("b")).toEqual({ environmentLabel: "build-box", text: "build-box" });
+  });
+
+  it("falls back to the workspace path when name and label both collide", () => {
+    const hints = resolveProjectPickerEnvironmentHints([
+      entry({
+        projectKey: "a",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: "laptop",
+        workspaceRoot: "/a/quasar",
+      }),
+      entry({
+        projectKey: "b",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: "laptop",
+        workspaceRoot: "/b/quasar",
+      }),
+      entry({
+        projectKey: "c",
+        displayName: "quasar",
+        environmentId: "remote",
+        environmentLabel: "build-box",
+        workspaceRoot: "/srv/quasar",
+      }),
+    ]);
+    expect(hints.get("a")).toEqual({
+      environmentLabel: "laptop",
+      text: "laptop · /a/quasar",
+    });
+    expect(hints.get("b")).toEqual({
+      environmentLabel: "laptop",
+      text: "laptop · /b/quasar",
+    });
+    expect(hints.get("c")).toEqual({ environmentLabel: "build-box", text: "build-box" });
+  });
+
+  it("uses the bare workspace path for same-name checkouts in a single environment", () => {
+    const hints = resolveProjectPickerEnvironmentHints([
+      entry({
+        projectKey: "a",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: null,
+        workspaceRoot: "/a/quasar",
+      }),
+      entry({
+        projectKey: "b",
+        displayName: "quasar",
+        environmentId: "local",
+        environmentLabel: null,
+        workspaceRoot: "/b/quasar",
+      }),
+    ]);
+    expect(hints.get("a")).toEqual({ environmentLabel: null, text: "/a/quasar" });
+    expect(hints.get("b")).toEqual({ environmentLabel: null, text: "/b/quasar" });
+  });
+});

--- a/apps/web/src/components/chat/DraftHeroHeadline.logic.ts
+++ b/apps/web/src/components/chat/DraftHeroHeadline.logic.ts
@@ -1,0 +1,42 @@
+import type { SidebarProjectPickerEntry } from "~/sidebarProjectGrouping";
+
+export interface ProjectPickerEnvironmentHint {
+  /** Environment label for the row, or null when the row has no environment to show. */
+  readonly environmentLabel: string | null;
+  /**
+   * Secondary text rendered next to the project name. Falls back to the
+   * workspace path when another row would otherwise read identically.
+   */
+  readonly text: string | null;
+}
+
+/**
+ * The same project name can exist in several environments, so the environment
+ * label is only surfaced when the picker spans two or more environments.
+ * Labels are not unique either: two checkouts of one project on the same
+ * machine collide on both name and label, so those rows fall back to the
+ * workspace path (mirroring ProjectSettingsPanel's checkout labels).
+ */
+export function resolveProjectPickerEnvironmentHints(
+  entries: ReadonlyArray<SidebarProjectPickerEntry>,
+): ReadonlyMap<string, ProjectPickerEnvironmentHint> {
+  const environmentIds = new Set(entries.map((entry) => entry.targetProject.environmentId));
+  const showEnvironmentLabels = environmentIds.size >= 2;
+  const hints = new Map<string, ProjectPickerEnvironmentHint>();
+  for (const entry of entries) {
+    const environmentLabel = showEnvironmentLabels ? entry.targetProject.environmentLabel : null;
+    const collides = entries.some(
+      (other) =>
+        other.group.projectKey !== entry.group.projectKey &&
+        other.group.displayName === entry.group.displayName &&
+        (showEnvironmentLabels ? other.targetProject.environmentLabel : null) === environmentLabel,
+    );
+    const text = collides
+      ? environmentLabel === null
+        ? entry.targetProject.workspaceRoot
+        : `${environmentLabel} · ${entry.targetProject.workspaceRoot}`
+      : environmentLabel;
+    hints.set(entry.group.projectKey, { environmentLabel, text });
+  }
+  return hints;
+}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -1,6 +1,7 @@
 import type { DraftId } from "~/composerDraftStore";
 import { useComposerDraftStore } from "~/composerDraftStore";
 import type { ScopedProjectRef } from "@t3tools/contracts";
+import { resolveEnvironmentMachineKind } from "@t3tools/contracts";
 import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { FolderPlusIcon } from "lucide-react";
 import { useCallback, useMemo } from "react";
@@ -15,6 +16,7 @@ import {
 } from "~/sidebarProjectGrouping";
 import { useProjects, useThreadShells } from "~/state/entities";
 import { useEnvironments, usePrimaryEnvironmentId } from "~/state/environments";
+import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { sortLogicalProjectsForSidebar } from "../Sidebar.logic";
 import {
@@ -57,6 +59,19 @@ export function DraftHeroHeadline({
     () =>
       new Map(
         environments.map((environment) => [environment.environmentId, environment.label] as const),
+      ),
+    [environments],
+  );
+  const environmentMachineById = useMemo(
+    () =>
+      new Map(
+        environments.map(
+          (environment) =>
+            [
+              environment.environmentId,
+              resolveEnvironmentMachineKind(environment.serverConfig),
+            ] as const,
+        ),
       ),
     [environments],
   );
@@ -192,8 +207,13 @@ export function DraftHeroHeadline({
                   </TooltipPopup>
                 </Tooltip>
                 {environmentLabel === null ? null : (
-                  <span className="ml-auto min-w-0 max-w-32 truncate pl-3 text-muted-foreground text-xs">
-                    {environmentLabel}
+                  <span className="ml-auto inline-flex min-w-0 max-w-32 items-center gap-1 pl-3 text-muted-foreground text-xs">
+                    <EnvironmentMachineIcon
+                      aria-hidden
+                      kind={environmentMachineById.get(targetProject.environmentId) ?? "server"}
+                      className="size-3 shrink-0"
+                    />
+                    <span className="min-w-0 truncate">{environmentLabel}</span>
                   </span>
                 )}
               </MenuRadioItem>

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -192,7 +192,7 @@ export function DraftHeroHeadline({
                   </TooltipPopup>
                 </Tooltip>
                 {environmentLabel === null ? null : (
-                  <span className="ml-auto shrink-0 pl-3 text-muted-foreground text-xs">
+                  <span className="ml-auto min-w-0 max-w-[45%] truncate pl-3 text-muted-foreground text-xs">
                     {environmentLabel}
                   </span>
                 )}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -94,6 +94,12 @@ export function DraftHeroHeadline({
     () => new Map(projectPickerEntries.map((entry) => [entry.group.projectKey, entry] as const)),
     [projectPickerEntries],
   );
+  // The same project name can exist in several environments, so only surface the
+  // environment label when it actually disambiguates the list.
+  const shouldShowEnvironmentLabels = useMemo(
+    () => new Set(projectPickerEntries.map((entry) => entry.targetProject.environmentId)).size >= 2,
+    [projectPickerEntries],
+  );
   const activeProjectGroup =
     activeProjectRef === null
       ? null
@@ -163,7 +169,10 @@ export function DraftHeroHeadline({
             }
           }}
         >
-          {projectPickerEntries.map(({ group }) => {
+          {projectPickerEntries.map(({ group, targetProject }) => {
+            const environmentLabel = shouldShowEnvironmentLabels
+              ? targetProject.environmentLabel
+              : null;
             return (
               <MenuRadioItem
                 key={group.projectKey}
@@ -177,9 +186,16 @@ export function DraftHeroHeadline({
                     {group.displayName}
                   </TooltipTrigger>
                   <TooltipPopup side="top" className="max-w-80">
-                    {group.displayName}
+                    {environmentLabel === null
+                      ? group.displayName
+                      : `${group.displayName} (${environmentLabel})`}
                   </TooltipPopup>
                 </Tooltip>
+                {environmentLabel === null ? null : (
+                  <span className="ml-auto shrink-0 pl-3 text-muted-foreground text-xs">
+                    {environmentLabel}
+                  </span>
+                )}
               </MenuRadioItem>
             );
           })}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -192,7 +192,7 @@ export function DraftHeroHeadline({
                   </TooltipPopup>
                 </Tooltip>
                 {environmentLabel === null ? null : (
-                  <span className="ml-auto min-w-0 max-w-[45%] truncate pl-3 text-muted-foreground text-xs">
+                  <span className="ml-auto min-w-0 max-w-32 truncate pl-3 text-muted-foreground text-xs">
                     {environmentLabel}
                   </span>
                 )}

--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -29,6 +29,7 @@ import {
   MenuTrigger,
 } from "../ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { resolveProjectPickerEnvironmentHints } from "./DraftHeroHeadline.logic";
 
 interface DraftHeroHeadlineProps {
   readonly draftId: DraftId | null;
@@ -109,10 +110,8 @@ export function DraftHeroHeadline({
     () => new Map(projectPickerEntries.map((entry) => [entry.group.projectKey, entry] as const)),
     [projectPickerEntries],
   );
-  // The same project name can exist in several environments, so only surface the
-  // environment label when it actually disambiguates the list.
-  const shouldShowEnvironmentLabels = useMemo(
-    () => new Set(projectPickerEntries.map((entry) => entry.targetProject.environmentId)).size >= 2,
+  const environmentHintByKey = useMemo(
+    () => resolveProjectPickerEnvironmentHints(projectPickerEntries),
     [projectPickerEntries],
   );
   const activeProjectGroup =
@@ -185,9 +184,10 @@ export function DraftHeroHeadline({
           }}
         >
           {projectPickerEntries.map(({ group, targetProject }) => {
-            const environmentLabel = shouldShowEnvironmentLabels
-              ? targetProject.environmentLabel
-              : null;
+            const hint = environmentHintByKey.get(group.projectKey) ?? {
+              environmentLabel: null,
+              text: null,
+            };
             return (
               <MenuRadioItem
                 key={group.projectKey}
@@ -201,19 +201,19 @@ export function DraftHeroHeadline({
                     {group.displayName}
                   </TooltipTrigger>
                   <TooltipPopup side="top" className="max-w-80">
-                    {environmentLabel === null
-                      ? group.displayName
-                      : `${group.displayName} (${environmentLabel})`}
+                    {hint.text === null ? group.displayName : `${group.displayName} (${hint.text})`}
                   </TooltipPopup>
                 </Tooltip>
-                {environmentLabel === null ? null : (
+                {hint.text === null ? null : (
                   <span className="ml-auto inline-flex min-w-0 max-w-32 items-center gap-1 pl-3 text-muted-foreground text-xs">
-                    <EnvironmentMachineIcon
-                      aria-hidden
-                      kind={environmentMachineById.get(targetProject.environmentId) ?? "server"}
-                      className="size-3 shrink-0"
-                    />
-                    <span className="min-w-0 truncate">{environmentLabel}</span>
+                    {hint.environmentLabel === null ? null : (
+                      <EnvironmentMachineIcon
+                        aria-hidden
+                        kind={environmentMachineById.get(targetProject.environmentId) ?? "server"}
+                        className="size-3 shrink-0"
+                      />
+                    )}
+                    <span className="min-w-0 truncate">{hint.text}</span>
                   </span>
                 )}
               </MenuRadioItem>


### PR DESCRIPTION
The project dropdown in the "What should we build in {project}?" headline listed projects by display name only, so the same project name appearing in two environments (e.g. a local and a remote "Headroom") produced indistinguishable entries. Each `MenuRadioItem` now renders the target project's environment as muted secondary text on the right, preceded by the same `EnvironmentMachineIcon` used by the sidebar, branch toolbar, and command palette, and includes the label in the item's tooltip.

The label only appears when it disambiguates: a `useMemo` checks for 2+ distinct `targetProject.environmentId` values across the picker entries, so single-environment users see no change at all. Related to sibling PR #10790, which adds project favicons to the same picker.

Verified with `vp run typecheck` in `apps/web` (pass), `vp lint --report-unused-disable-directives` on the changed file (pass), `vp fmt --check` (pass after formatting), and `vp test run --project unit src/components/chat/draftHeroTransition.test.ts` (5 passed). No existing tests assert on this component's markup.

| Before (`main`) | After (this PR) |
| --- | --- |
| ![Project picker on main: two rows both reading "quasar", indistinguishable](https://raw.githubusercontent.com/gsimone/t3code/assets/draft-hero-project-picker/pr2-env-label-before.png) | ![Project picker with this PR: each row carries a machine icon and its environment label](https://raw.githubusercontent.com/gsimone/t3code/assets/draft-hero-project-picker/pr2-env-label-after.png) |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Project picker entries display environment labels when projects span multiple environments.
  - Environment labels appear in item tooltips for additional context.
  - Labels remain hidden when all projects belong to the same environment.
  - Long environment labels are constrained and truncated to preserve the picker layout.
  - Projects with similar names are easier to distinguish across different environments using workspace path details when needed.
  - Same-name projects in a single environment can use their workspace path for clearer identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
