### PR TITLE
fix(server): attribute async question replies

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -269,7 +269,7 @@ describe("OrchestrationEngine", () => {
         expect(userMessages).toHaveLength(1);
         expect(userMessages?.[0]?.attachments).toEqual(response.attachmentsByQuestionId["1"]);
         expect(userMessages?.[0]?.text).toBe(
-          "Which package manager?\npnpm\n\nWhat should it be named?\nExample\nAttached file: spec.txt (thread-1-00000000-0000-4000-8000-0000000000aa-txt)",
+          "Agent question: Which package manager?\nUser answer: pnpm\n\nAgent question: What should it be named?\nUser answer: Example\nAttached file: spec.txt (thread-1-00000000-0000-4000-8000-0000000000aa-txt)",
         );
         expect(
           after.threads[0]?.activities.find((activity) => activity.kind === "user-input.resolved")

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1280,7 +1280,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             .map((attachment) => `Attached file: ${attachment.name} (${attachment.id})`)
             .join("\n");
           replies.push(
-            [`${question.question}\n${answer.trim()}`, attachmentLabels].filter(Boolean).join("\n"),
+            [
+              `Agent question: ${question.question}\nUser answer: ${answer.trim()}`,
+              attachmentLabels,
+            ]
+              .filter(Boolean)
+              .join("\n"),
           );
         }
         // Commit the answer and its message together. The normal turn path


### PR DESCRIPTION
Async question replies put the agent’s question and the user’s answer in one user bubble without attribution. Label them `Agent question:` and `User answer:` in the shared server formatter, preserving question context and attachments for the provider.

Closes #10786.

Reproduced with the existing engine test: both running and stopped sessions failed the new attribution assertion before the fix. All 29 engine tests now pass, including multiple questions, attachments, restarts, and duplicate replies. Server typecheck, targeted lint, and formatting pass.

Verified the real web transcript with isolated fixtures. Before uses the reproduced original message text; after is generated by the fixed engine. The shared payload serves web, desktop, and mobile; native clients were not separately exercised. Existing stored messages are unchanged.

Before:

![Before: question and answer without attribution](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10786/t3-10786-before.png)

After:

![After: agent question and user answer labeled](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10786/t3-10786-after.png)

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - User-provided answers now clearly label each associated question and answer, including relevant attached-file details.
  - Empty response sections continue to be omitted for cleaner message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->