### PR TITLE
fix(markdown): preserve descriptive file-link labels

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
+++ b/apps/mobile/modules/t3-markdown-text/src/nativeMarkdownText.ts
@@ -1,3 +1,4 @@
+import { isMarkdownFileLinkLabel } from "@t3tools/client-runtime/markdown-links";
 import type { MarkdownNode } from "react-native-nitro-markdown/headless";
 
 import type { SelectableMarkdownSkill } from "./SelectableMarkdownText.types";
@@ -270,7 +271,7 @@ function appendChildren(
   return runs;
 }
 
-function nodeTextContent(node: MarkdownNode): string {
+export function nodeTextContent(node: MarkdownNode): string {
   if (node.content !== undefined) {
     return node.content;
   }
@@ -312,7 +313,11 @@ function appendNode(
     case "link": {
       const presentation = resolveMarkdownLinkPresentation(node.href ?? "");
       if (presentation.kind === "file") {
-        return appendRun(runs, presentation.label, {
+        const descriptive = !isMarkdownFileLinkLabel(nodeTextContent(node), presentation.href);
+        if (descriptive) {
+          appendChildren(runs, node, { ...context, href: presentation.href });
+        }
+        return appendRun(runs, descriptive ? ` (${presentation.label})` : presentation.label, {
           ...context,
           href: presentation.href,
           fileIcon: presentation.icon,

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1,3 +1,5 @@
+import { isMarkdownFileLinkLabel } from "@t3tools/client-runtime/markdown-links";
+import { nodeTextContent } from "@t3tools/mobile-markdown-text/markdown";
 import * as Haptics from "expo-haptics";
 import { KeyboardAwareLegendList } from "@legendapp/list/keyboard";
 import { useViewabilityAmount, type LegendListRef } from "@legendapp/list/react-native";
@@ -1055,21 +1057,26 @@ function useMarkdownStyles(
       preserveSoftBreaks: boolean,
       highlightCode: boolean,
     ): CustomRenderers => ({
-      link: ({ children, href = "" }) => {
+      link: ({ node, children, href = "" }) => {
         const presentation = resolveMarkdownLinkPresentation(href);
         if (presentation.kind === "file") {
+          const descriptive = !isMarkdownFileLinkLabel(nodeTextContent(node), href);
           return (
-            <NativeText
-              className="font-t3-bold"
-              onPress={() => onLinkPress(href)}
-              style={{ color: inlineTextColor }}
-            >
-              <Image
-                source={markdownFileIconSource(presentation.icon)}
-                style={markdownLinkStyles.inlineIcon}
-              />
-              {presentation.label}
-            </NativeText>
+            <MarkdownLinkLabelContext.Provider value>
+              <NativeText
+                className="font-t3-bold"
+                onPress={() => onLinkPress(href)}
+                style={{ color: inlineTextColor }}
+              >
+                {descriptive ? <>{children} (</> : null}
+                <Image
+                  source={markdownFileIconSource(presentation.icon)}
+                  style={markdownLinkStyles.inlineIcon}
+                />
+                {presentation.label}
+                {descriptive ? ")" : null}
+              </NativeText>
+            </MarkdownLinkLabelContext.Provider>
           );
         }
         if (presentation.kind === "external") {

--- a/apps/mobile/src/lib/nativeMarkdownText.test.ts
+++ b/apps/mobile/src/lib/nativeMarkdownText.test.ts
@@ -92,11 +92,36 @@ describe("nativeMarkdownTextRuns", () => {
         externalHost: "example.com",
       },
       { text: " " },
+      { text: "ignored label", href: "file:///repo/README.md#L12" },
       {
-        text: "README.md:12",
+        text: " (README.md:12)",
         href: "file:///repo/README.md#L12",
         fileIcon: "readme",
       },
+    ]);
+  });
+
+  it("preserves descriptive file-link formatting and keeps filename links compact", () => {
+    const href = "/repo/src/example.ts:12";
+    expect(
+      nativeMarkdownTextRuns({
+        type: "paragraph",
+        children: [
+          {
+            type: "link",
+            href,
+            children: [
+              { type: "bold", children: [{ type: "text", content: "validates" }] },
+              { type: "text", content: " the input" },
+            ],
+          },
+          { type: "link", href, children: [{ type: "code_inline", content: "src/example.ts:12" }] },
+        ],
+      }),
+    ).toEqual([
+      { text: "validates", bold: true, href },
+      { text: " the input", href },
+      { text: " (example.ts:12)example.ts:12", href, fileIcon: "typescript" },
     ]);
   });
 

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -73,6 +73,34 @@ function codeButton(renderer: ReactTestRenderer, label: string) {
 }
 
 describe("ChatMarkdown file-link labels", () => {
+  it.each([
+    [String.raw`read \] here`, "read ] here"],
+    [String.raw`read \[ here`, "read [ here"],
+    [String.raw`read \\\] here`, String.raw`read \] here`],
+  ])("round-trips copied file-link label %s", async (sourceLabel, label) => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ChatMarkdown cwd="/repo" text={`[${sourceLabel}](/repo/example.ts:12)`} />,
+        );
+      });
+      const authoredLabel = () =>
+        renderer!.root.findAllByType("span").find((node) => node.children.includes(label));
+      expect(authoredLabel()).toBeDefined();
+      const copied = authoredLabel()!.props["data-markdown-copy"];
+      await act(async () => {
+        renderer!.update(<ChatMarkdown cwd="/repo" text={copied} />);
+      });
+      expect(authoredLabel()).toBeDefined();
+      expect(authoredLabel()!.props["data-markdown-copy"]).toBe(copied);
+    } finally {
+      await act(async () => renderer?.unmount());
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("retains descriptive prose, emphasis, destinations, and copy text", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
     let renderer: ReactTestRenderer | undefined;

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -72,6 +72,39 @@ function codeButton(renderer: ReactTestRenderer, label: string) {
   return button.props as ComponentProps<typeof Button>;
 }
 
+describe("ChatMarkdown file-link labels", () => {
+  it("retains descriptive prose, emphasis, destinations, and copy text", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ChatMarkdown
+            cwd="/repo"
+            text="This function [**validates** the input](/repo/src/example.ts:12)."
+          />,
+        );
+      });
+      expect(renderer!.root.findByType("strong").children).toEqual(["validates"]);
+      const label = renderer!.root
+        .findAllByType("span")
+        .find((node) => node.children.includes(" the input"));
+      expect(label).toBeDefined();
+      expect(label!.props["data-markdown-copy"]).toBe(
+        "[validates the input](/repo/src/example.ts:12)",
+      );
+      expect(
+        renderer!.root
+          .findAllByType("span")
+          .some((node) => node.children.includes("example.ts · L12")),
+      ).toBe(true);
+    } finally {
+      await act(async () => renderer?.unmount());
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
 describe("ChatMarkdown favicon privacy", () => {
   it("suppresses private link images while preserving public links across updates", async () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -87,7 +87,9 @@ describe("ChatMarkdown file-link labels", () => {
         );
       });
       const authoredLabel = () =>
-        renderer!.root.findAllByType("span").find((node) => node.children.includes(label));
+        renderer!.root
+          .findAll((node) => typeof node.type === "string" && node.children.includes(label))
+          .at(0);
       expect(authoredLabel()).toBeDefined();
       const copied = authoredLabel()!.props["data-markdown-copy"];
       await act(async () => {
@@ -95,6 +97,22 @@ describe("ChatMarkdown file-link labels", () => {
       });
       expect(authoredLabel()).toBeDefined();
       expect(authoredLabel()!.props["data-markdown-copy"]).toBe(copied);
+    } finally {
+      await act(async () => renderer?.unmount());
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("copies the filename for a whitespace-only link label", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(<ChatMarkdown cwd="/repo" text="[   ](/repo/example.ts:12)" />);
+      });
+      expect(renderer!.root.findByType("button").props["data-markdown-copy"]).toBe(
+        "[example.ts](/repo/example.ts:12)",
+      );
     } finally {
       await act(async () => renderer?.unmount());
       vi.unstubAllGlobals();
@@ -114,9 +132,14 @@ describe("ChatMarkdown file-link labels", () => {
         );
       });
       expect(renderer!.root.findByType("strong").children).toEqual(["validates"]);
+      expect(
+        renderer!.root
+          .findAllByType("button")
+          .some((button) => button.findAllByType("strong").length > 0),
+      ).toBe(true);
       const label = renderer!.root
-        .findAllByType("span")
-        .find((node) => node.children.includes(" the input"));
+        .findAll((node) => typeof node.type === "string" && node.children.includes(" the input"))
+        .at(0);
       expect(label).toBeDefined();
       expect(label!.props["data-markdown-copy"]).toBe(
         "[validates the input](/repo/src/example.ts:12)",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -2967,7 +2967,11 @@ const CHAT_MARKDOWN_COMPONENTS = {
     }
 
     const label = nodeToPlainText(children);
-    const copyMarkdown = `[${label || fileLinkMeta.basename}](${normalizedHref})`;
+    const escapedLabel = (label || fileLinkMeta.basename)
+      .replaceAll("\\", "\\\\")
+      .replaceAll("[", "\\[")
+      .replaceAll("]", "\\]");
+    const copyMarkdown = `[${escapedLabel}](${normalizedHref})`;
     const chip = fileLinkChip(fileLinkMeta, copyMarkdown, props.className, normalizedHref);
     return isMarkdownFileLinkLabel(label, normalizedHref) ? (
       chip

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1083,6 +1083,7 @@ function UncachedShikiCodeBlock({
 }
 
 interface MarkdownFileLinkProps {
+  children?: ReactNode;
   href: string;
   targetPath: string;
   iconPath: string;
@@ -1782,6 +1783,7 @@ function MarkdownExternalLinkContent({
 }
 
 const MarkdownFileLink = memo(function MarkdownFileLink({
+  children,
   href,
   targetPath,
   iconPath,
@@ -2064,6 +2066,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
     canOpenInPanel,
   });
 
+  const chip = <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />;
+  const content = children ? (
+    <>
+      {children} (<span className={CHAT_FILE_TAG_CHIP_CLASS_NAME}>{chip}</span>)
+    </>
+  ) : (
+    chip
+  );
+
   return (
     <Tooltip>
       <TooltipTrigger
@@ -2072,7 +2083,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
             <a
               href={href}
               className={cn(
-                CHAT_FILE_TAG_CHIP_CLASS_NAME,
+                children ? "text-left" : CHAT_FILE_TAG_CHIP_CLASS_NAME,
                 MARKDOWN_FILE_LINK_CLASS_NAME,
                 className,
               )}
@@ -2092,15 +2103,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
               }}
               onContextMenu={handleContextMenu}
             >
-              <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+              {content}
             </a>
           ) : (
             <button
               type="button"
-              aria-label={`File options for ${label}`}
+              aria-label={children ? undefined : `File options for ${label}`}
               aria-haspopup="menu"
               className={cn(
-                CHAT_FILE_TAG_CHIP_CLASS_NAME,
+                children ? "text-left" : CHAT_FILE_TAG_CHIP_CLASS_NAME,
                 MARKDOWN_FILE_LINK_CLASS_NAME,
                 "select-text",
                 className,
@@ -2109,7 +2120,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
               onClick={handleContextMenu}
               onContextMenu={handleContextMenu}
             >
-              <FileTagChipContent path={iconPath} label={label} theme={theme} selectable />
+              {content}
             </button>
           )
         }
@@ -2133,6 +2144,7 @@ function areMarkdownFileLinkPropsEqual(
   next: Readonly<MarkdownFileLinkProps>,
 ): boolean {
   return (
+    previous.children === next.children &&
     previous.href === next.href &&
     previous.targetPath === next.targetPath &&
     previous.iconPath === next.iconPath &&
@@ -2496,6 +2508,7 @@ function useChatMarkdownState({
       copyMarkdown: string,
       className?: string,
       mediaSource?: string,
+      children?: ReactNode,
     ) => {
       const parentSuffix = fileLinkParentSuffixByPath.get(
         fileLinkMeta.filePath.replaceAll("\\", "/"),
@@ -2554,7 +2567,9 @@ function useChatMarkdownState({
               : undefined
           }
           className={className}
-        />
+        >
+          {children}
+        </MarkdownFileLink>
       );
     },
     [
@@ -2967,18 +2982,17 @@ const CHAT_MARKDOWN_COMPONENTS = {
     }
 
     const label = nodeToPlainText(children);
-    const escapedLabel = (label || fileLinkMeta.basename)
+    const escapedLabel = (label.trim() ? label : fileLinkMeta.basename)
       .replaceAll("\\", "\\\\")
       .replaceAll("[", "\\[")
       .replaceAll("]", "\\]");
     const copyMarkdown = `[${escapedLabel}](${normalizedHref})`;
-    const chip = fileLinkChip(fileLinkMeta, copyMarkdown, props.className, normalizedHref);
-    return isMarkdownFileLinkLabel(label, normalizedHref) ? (
-      chip
-    ) : (
-      <span data-markdown-copy={copyMarkdown}>
-        {children} ({chip})
-      </span>
+    return fileLinkChip(
+      fileLinkMeta,
+      copyMarkdown,
+      props.className,
+      normalizedHref,
+      isMarkdownFileLinkLabel(label, normalizedHref) ? undefined : children,
     );
   },
   code: function MarkdownCode({ node, children, className, ...props }) {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -43,7 +43,10 @@ import {
   classifyMarkdownImageSource,
   markdownImageSourceFragment,
 } from "@t3tools/client-runtime/markdown-images";
-import { inlineCodeFilePathCandidate } from "@t3tools/client-runtime/markdown-links";
+import {
+  inlineCodeFilePathCandidate,
+  isMarkdownFileLinkLabel,
+} from "@t3tools/client-runtime/markdown-links";
 import { mediaFileReference, mediaUrlReference } from "@t3tools/client-runtime/media-reference";
 import { mediaKindFromPath, mediaMimeTypeFromExtension } from "@t3tools/shared/filePreview";
 import * as Cause from "effect/Cause";
@@ -2963,11 +2966,15 @@ const CHAT_MARKDOWN_COMPONENTS = {
       );
     }
 
-    return fileLinkChip(
-      fileLinkMeta,
-      `[${fileLinkMeta.basename}](${normalizedHref})`,
-      props.className,
-      normalizedHref,
+    const label = nodeToPlainText(children);
+    const copyMarkdown = `[${label || fileLinkMeta.basename}](${normalizedHref})`;
+    const chip = fileLinkChip(fileLinkMeta, copyMarkdown, props.className, normalizedHref);
+    return isMarkdownFileLinkLabel(label, normalizedHref) ? (
+      chip
+    ) : (
+      <span data-markdown-copy={copyMarkdown}>
+        {children} ({chip})
+      </span>
     );
   },
   code: function MarkdownCode({ node, children, className, ...props }) {

--- a/packages/client-runtime/src/markdownLinks.test.ts
+++ b/packages/client-runtime/src/markdownLinks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   fileBasename,
+  isMarkdownFileLinkLabel,
   inlineCodeFilePathCandidate,
   parseFileUrlHref,
   parseMarkdownFileLink,
@@ -166,5 +167,29 @@ describe("workspaceRelativeFilePath", () => {
     ["/repo/project/a.ts", undefined, null],
   ])("relates %s to %s", (path, workspaceRoot, relativePath) => {
     expect(workspaceRelativeFilePath(path, workspaceRoot)).toBe(relativePath);
+  });
+});
+
+describe("isMarkdownFileLinkLabel", () => {
+  it.each([
+    "example.ts",
+    "example.ts:12",
+    "src/example.ts",
+    "./src/example.ts:12",
+    "/repo/src/example.ts",
+    "file:///repo/src/example.ts#L12",
+    "",
+  ])("keeps destination label %s compact", (label) =>
+    expect(isMarkdownFileLinkLabel(label, "/repo/src/example.ts:12")).toBe(true),
+  );
+  it.each(["validates the input", "the example.ts", "other.ts", "src/other.ts"])(
+    "preserves authored label %s",
+    (label) => expect(isMarkdownFileLinkLabel(label, "/repo/src/example.ts:12")).toBe(false),
+  );
+  it("recognizes Windows paths and encoded destinations", () => {
+    expect(isMarkdownFileLinkLabel("src\\example.ts:12", "C:\\repo\\src\\example.ts:12")).toBe(
+      true,
+    );
+    expect(isMarkdownFileLinkLabel("my file.ts", "/repo/my%20file.ts#L12")).toBe(true);
   });
 });

--- a/packages/client-runtime/src/markdownLinks.test.ts
+++ b/packages/client-runtime/src/markdownLinks.test.ts
@@ -186,6 +186,12 @@ describe("isMarkdownFileLinkLabel", () => {
     "preserves authored label %s",
     (label) => expect(isMarkdownFileLinkLabel(label, "/repo/src/example.ts:12")).toBe(false),
   );
+  it.each(["favicons", "favicons/", "/tmp/favicons/"])(
+    "keeps directory label %s compact",
+    (label) => {
+      expect(isMarkdownFileLinkLabel(label, "/tmp/favicons/")).toBe(true);
+    },
+  );
   it("recognizes Windows paths and encoded destinations", () => {
     expect(isMarkdownFileLinkLabel("src\\example.ts:12", "C:\\repo\\src\\example.ts:12")).toBe(
       true,

--- a/packages/client-runtime/src/markdownLinks.ts
+++ b/packages/client-runtime/src/markdownLinks.ts
@@ -339,3 +339,14 @@ export function workspaceRelativeFilePath(
   if (!pathForCompare.startsWith(`${rootForCompare}/`)) return null;
   return normalizedPath.slice(normalizedRoot.length + 1);
 }
+
+export function isMarkdownFileLinkLabel(label: string, href: string): boolean {
+  if (!label.trim()) return true;
+  const target = parseMarkdownFileLink(href);
+  if (!target) return false;
+  const path = (parseMarkdownFileLink(label)?.path ?? splitFilePathPosition(label.trim()).path)
+    .replaceAll("\\", "/")
+    .replace(/^\.\//, "");
+  const targetPath = target.path.replaceAll("\\", "/");
+  return path === targetPath || targetPath.endsWith(`/${path}`);
+}

--- a/packages/client-runtime/src/markdownLinks.ts
+++ b/packages/client-runtime/src/markdownLinks.ts
@@ -346,7 +346,8 @@ export function isMarkdownFileLinkLabel(label: string, href: string): boolean {
   if (!target) return false;
   const path = (parseMarkdownFileLink(label)?.path ?? splitFilePathPosition(label.trim()).path)
     .replaceAll("\\", "/")
-    .replace(/^\.\//, "");
-  const targetPath = target.path.replaceAll("\\", "/");
+    .replace(/^\.\//, "")
+    .replace(/([^/:])\/+$/, "$1");
+  const targetPath = target.path.replaceAll("\\", "/").replace(/([^/:])\/+$/, "$1");
   return path === targetPath || targetPath.endsWith(`/${path}`);
 }


### PR DESCRIPTION
File links discarded descriptive labels, turning “This function [validates the input](/repo/src/example.ts:12)” into “This function example.ts · L12”.

Keep authored prose and emphasis beside the existing destination chip on web/desktop and both mobile renderers. Labels matching the destination filename or path stay compact, and inline-code chips keep their current behavior. Descriptive web text shares the chip’s file action and keyboard focus. Copying retains the label with escaped delimiters and a filename fallback for blank labels. Directory labels stay compact with trailing separators.

Closes #10787.

Validation: reproduced with a failing native renderer test and the actual ChatMarkdown component in an isolated browser. All 182 focused tests, web/mobile/client-runtime typechecks, and targeted lint passed (existing lint warnings). Browser checked prose, emphasis, destination disambiguation, narrow layout, and clipboard serialization. Native mobile was tested at the text-run level and typechecked, not run on a device.

Before:

![Before: file chips remove descriptive sentence text](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10787/issue-10787-before.png)

After:

![After: descriptive text and emphasis remain beside file destinations](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-10787/issue-10787-interactive.png)

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-link rendering across web and mobile so descriptive link text remains visible alongside formatted filenames and locations.
  * Kept descriptive labels and file chips within one clickable, keyboard-accessible element.
  * Ensured filename-only links remain compact while preserving destinations, formatting, and copyable text.
  * Improved matching for directory-style paths, including trailing separators, encoded destinations, and Windows paths.

* **Tests**
  * Expanded coverage for descriptive labels, markdown styling, formatted paths, and stable rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->