### PR TITLE
fix(contracts): tolerate an unreadable snap-shot source on persisted image attachments

### DIFF
--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -343,6 +343,36 @@ it.effect("tolerates attachment types from newer builds when decoding messages",
   }),
 );
 
+// A snap-shot source is provenance, not the image. A persisted event written
+// by a build with a different source shape must still decode, with the source
+// dropped, or the whole event store refuses to load on the next start.
+it.effect("drops an unreadable snap-shot source instead of failing the message", () =>
+  Effect.gen(function* () {
+    const message = yield* decodeOrchestrationMessage({
+      id: "message-1",
+      role: "user",
+      text: "look at this",
+      attachments: [
+        {
+          type: "image",
+          id: "thread-1-00000000-0000-4000-8000-000000000003-png",
+          name: "window.png",
+          mimeType: "image/png",
+          sizeBytes: 12,
+          source: { kind: "window-capture", capturedAt: "2026-01-01T00:00:00.000Z" },
+        },
+      ],
+      turnId: null,
+      streaming: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const attachment = message.attachments?.[0];
+    assert.strictEqual(attachment?.type, "image");
+    assert.strictEqual(attachment && "source" in attachment ? attachment.source : null, undefined);
+  }),
+);
+
 // The tolerant member must not catch malformed known attachments: a file over
 // the size cap or an image with a bad mime has to fail its own schema, not
 // slide through the open one with those constraints unchecked.

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 import * as SchemaTransformation from "effect/SchemaTransformation";
@@ -292,13 +293,23 @@ export const SnapShotSource = Schema.Struct({
 });
 export type SnapShotSource = typeof SnapShotSource.Type;
 
+/**
+ * Persisted image attachments carry the source shape their build knew. A
+ * source this build cannot read (an older or newer field set, or a value that
+ * no longer passes today's bounds) must not fail the whole event: the image
+ * is still valid, only its provenance is lost. Uploads keep the strict schema.
+ */
+const PersistedSnapShotSource = Schema.optional(SnapShotSource).pipe(
+  Schema.catchDecoding(() => Effect.succeed(Option.some(undefined))),
+);
+
 export const ChatImageAttachment = Schema.Struct({
   type: Schema.Literal("image"),
   id: ChatAttachmentId,
   name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
   mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100), Schema.isPattern(/^image\//i)),
   sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES)),
-  source: Schema.optional(SnapShotSource),
+  source: PersistedSnapShotSource,
 });
 export type ChatImageAttachment = typeof ChatImageAttachment.Type;
 


### PR DESCRIPTION
## What Changed

`ChatImageAttachment.source` now decodes tolerantly on persisted events. When a stored snap-shot source does not match the current `SnapShotSource` schema, the decoder drops the source and keeps the image attachment instead of failing the whole message. Upload schemas keep the strict source validation.

One regression test added in `packages/contracts/src/orchestration.test.ts`.

## Why

Starting the desktop app (`pnpm dev:desktop`) against an existing database crashed the backend in a restart loop:

```
PersistenceDecodeError: Decode error in OrchestrationEventStore.readFromSequence:rowToEvent
  Expected { readonly "kind": "snap-shot", ... } | undefined
    at ["payload"]["attachments"][0]["source"]
```

An image attachment written by an earlier build carried a `source` that today's `SnapShotSource` rejects. Because `ChatAttachment` is a union and the unknown-attachment member deliberately excludes `type: "image"`, there was no fallback, so one old row made the whole event store unreadable and locked the user out of all their threads.

The source is provenance for the image, not the image. Losing it on an old row is harmless; refusing to start is not.

## Verification

- `vp test run packages/contracts/src/orchestration.test.ts`: 57 passed, including the new case.
- `tsc --noEmit` clean for `packages/contracts`, `apps/web`, and `apps/desktop`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (n/a, no UI change)
- [x] I included a video for animation/interaction changes (n/a)

Written by Claude Fable 5.1 in Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when loading chat messages containing snapshot image sources the current version cannot read.
  - Unreadable snapshot sources are now omitted while the rest of the message remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->