### PR TITLE
fix(swift-ios): allow HTTP connections to NetBird and Tailscale IPs

### DIFF
--- a/apps/swift-ios/Resources/Info.plist
+++ b/apps/swift-ios/Resources/Info.plist
@@ -21,18 +21,8 @@
     </array>
     <key>NSAppTransportSecurity</key>
     <dict>
-        <key>NSAllowsLocalNetworking</key>
+        <key>NSAllowsArbitraryLoads</key>
         <true/>
-        <key>NSExceptionDomains</key>
-        <dict>
-            <key>ts.net</key>
-            <dict>
-                <key>NSExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-                <key>NSIncludesSubdomains</key>
-                <true/>
-            </dict>
-        </dict>
     </dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow T3 Code to use your microphone for voice input.</string>


### PR DESCRIPTION
## What Changed

Aligned the native Swift iOS app with the Expo app by configuring App Transport Security with only `NSAllowsArbitraryLoads = true`. This replaces the narrower `NSAllowsLocalNetworking` and `ts.net` exception configuration.

## Why

T3 Code users can connect to arbitrary self-hosted servers over NetBird or Tailscale, including plain HTTP endpoints at `100.*` and `10.*` addresses or custom hostnames. The app cannot enumerate those destinations ahead of time. Matching the Expo client ensures the Swift client applies one global ATS policy to all user-configured server URLs; keeping `NSAllowsLocalNetworking` would cause modern iOS versions to ignore `NSAllowsArbitraryLoads`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Verified by parsing `apps/swift-ios/Resources/Info.plist` with Python `plistlib`, checking the ATS dictionary, running `git diff --check`, and inspecting the Xcode project settings confirming `Resources/Info.plist` is the app target plist. An Xcode build was not run in this Linux environment.

Created with GPT-6 in the Codex harness.
