### PR TITLE
feat(web): show provider usage limits below chat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1383,6 +1383,10 @@ function releaseChatTimelineAnchor<T extends { readonly messageId: MessageId | n
   return current.messageId === null ? current : { ...current, messageId: null };
 }
 
+/**
+ * Hosts the conversation and composer for a local draft or persisted thread,
+ * using the route's environment for provider data and thread commands.
+ */
 export default function ChatView(props: ChatViewProps) {
   const {
     environmentId,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import {
 } from "@t3tools/shared/usageLimits";
 import { feedbackBannerItem } from "./chat/ComposerFeedback";
 import { usageLimitsBannerItem } from "./chat/ComposerUsageLimits";
+import { UsageLimitsBar } from "./chat/UsageLimitsBar";
 import { derivePendingRequests } from "@t3tools/client-runtime/pending-requests";
 import {
   questionAttachmentDraftId,
@@ -8493,6 +8494,16 @@ export default function ChatView(props: ChatViewProps) {
                         </div>
                       </div>
                     </ComposerSurface.Shell>
+                    {settings.showUsageLimitsBar &&
+                    activeProviderInstanceId !== null &&
+                    !activeEnvironmentUnavailable ? (
+                      <UsageLimitsBar
+                        key={`${environmentId}:${activeProviderInstanceId}`}
+                        instanceId={activeProviderInstanceId}
+                        providers={providerStatuses}
+                        sources={usageLimitSources}
+                      />
+                    ) : null}
                     <div
                       aria-hidden
                       className="h-[calc(env(safe-area-inset-bottom)+1rem)] sm:h-[calc(env(safe-area-inset-bottom)+1.25rem)]"

--- a/apps/web/src/components/chat/UsageLimitsBar.tsx
+++ b/apps/web/src/components/chat/UsageLimitsBar.tsx
@@ -45,7 +45,7 @@ export function UsageLimitsBar({
         {report.accounts.map((account) => {
           const notice = limitsNotice(account.limits);
           return (
-            <div key={account.id} className="flex flex-wrap items-center gap-x-4 gap-y-1 py-0.5">
+            <div key={account.id} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-0.5">
               {report.accounts.length > 1 ? (
                 <RedactedSensitiveText
                   value={account.displayName || account.email || account.id}
@@ -62,9 +62,12 @@ export function UsageLimitsBar({
                   const remaining = remainingPercent(window);
                   const reset = formatResetsIn(window, now);
                   return (
-                    <span key={window.id} className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                    <span
+                      key={window.id}
+                      className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5"
+                    >
                       <span>{window.label}</span>
-                      <span aria-hidden className="h-1 w-10 overflow-hidden rounded-full bg-muted">
+                      <span aria-hidden className="h-1 w-8 overflow-hidden rounded-full bg-muted">
                         <span
                           className="block h-full rounded-full"
                           style={{

--- a/apps/web/src/components/chat/UsageLimitsBar.tsx
+++ b/apps/web/src/components/chat/UsageLimitsBar.tsx
@@ -1,0 +1,93 @@
+import type {
+  ProviderInstanceId,
+  ServerProvider,
+  UsageLimitSourceSnapshots,
+} from "@t3tools/contracts";
+import {
+  collectProviderUsageLimits,
+  formatResetsIn,
+  limitsNotice,
+  remainingPercent,
+} from "@t3tools/shared/usageLimits";
+import { useMemo, useState } from "react";
+
+import { RedactedSensitiveText } from "../settings/RedactedSensitiveText";
+import { barColor } from "../usage/UsageLimits";
+
+/** Reads the same provider snapshots as Limits, without polling from the composer. */
+export function UsageLimitsBar({
+  instanceId,
+  providers,
+  sources,
+}: {
+  readonly instanceId: ProviderInstanceId;
+  readonly providers: readonly ServerProvider[];
+  readonly sources: UsageLimitSourceSnapshots;
+}) {
+  const [openedAt] = useState(() => Date.now());
+  const report = useMemo(
+    () => collectProviderUsageLimits(instanceId, providers, sources, openedAt),
+    [instanceId, providers, sources, openedAt],
+  );
+  if (!report || (report.accounts.length === 0 && report.notices.length === 0)) return null;
+  // Advance countdowns with fresh snapshots instead of running a repaint timer.
+  const now = report.accounts.reduce(
+    (latest, account) => Math.max(latest, Date.parse(account.limits.checkedAt) || openedAt),
+    openedAt,
+  );
+
+  return (
+    <section
+      aria-label="Provider usage limits"
+      className="pointer-events-auto mx-[1.375rem] mt-2 flex max-h-24 items-start gap-3 overflow-y-auto px-4 text-xs text-muted-foreground"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {report.accounts.map((account) => {
+          const notice = limitsNotice(account.limits);
+          return (
+            <div key={account.id} className="flex flex-wrap items-center gap-x-4 gap-y-1 py-0.5">
+              {report.accounts.length > 1 ? (
+                <RedactedSensitiveText
+                  value={account.displayName || account.email || account.id}
+                  ariaLabel="Toggle account label visibility"
+                  revealTooltip="Click to reveal account"
+                  hideTooltip="Click to hide account"
+                  className="max-w-32 truncate text-xs"
+                />
+              ) : null}
+              {notice ? (
+                <span>{notice}</span>
+              ) : (
+                account.limits.windows.map((window) => {
+                  const remaining = remainingPercent(window);
+                  const reset = formatResetsIn(window, now);
+                  return (
+                    <span key={window.id} className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                      <span>{window.label}</span>
+                      <span aria-hidden className="h-1 w-10 overflow-hidden rounded-full bg-muted">
+                        <span
+                          className="block h-full rounded-full"
+                          style={{
+                            width: `${remaining}%`,
+                            backgroundColor: barColor(account.driver),
+                          }}
+                        />
+                      </span>
+                      <span className="font-medium text-foreground tabular-nums">
+                        {remaining}% left
+                      </span>
+                      {reset ? <span className="tabular-nums">{reset}</span> : null}
+                    </span>
+                  );
+                })
+              )}
+            </div>
+          );
+        })}
+        {report.notices.map((notice) => (
+          <span key={notice}>{notice}</span>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2344,6 +2344,32 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          {...searchableSetting("usage-limits-bar")}
+          description="Show remaining provider limits and reset times below the chat composer."
+          resetAction={
+            settings.showUsageLimitsBar !== DEFAULT_UNIFIED_SETTINGS.showUsageLimitsBar ? (
+              <SettingResetButton
+                label="usage limits bar"
+                onClick={() =>
+                  updateSettings({
+                    showUsageLimitsBar: DEFAULT_UNIFIED_SETTINGS.showUsageLimitsBar,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.showUsageLimitsBar}
+              onCheckedChange={(checked) =>
+                updateSettings({ showUsageLimitsBar: Boolean(checked) })
+              }
+              aria-label="Show usage limits below chat"
+            />
+          }
+        />
+
+        <SettingsRow
           {...searchableSetting("composer-collapse")}
           description="Rest the composer of an existing thread into a single line when you scroll the conversation. Focus the composer or start typing to expand it again."
           resetAction={

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2006,6 +2006,10 @@ function LegacyFeaturesSection() {
   );
 }
 
+/**
+ * Edits general preferences through the unified settings hooks, which route
+ * client preferences to local storage and server settings to their environments.
+ */
 export function GeneralSettingsPanel() {
   const settings = usePrimarySettings();
   const updateSettings = useUpdatePrimarySettings();

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -215,6 +215,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["command menu dollar $ slash /"],
   },
   {
+    id: "usage-limits-bar",
+    title: "Show usage limits below chat",
+    to: "/settings/general",
+    searchTerms: ["provider quota remaining reset info bar composer usage limits"],
+  },
+  {
     id: "composer-collapse",
     title: "Collapse composer on scroll",
     to: "/settings/general",

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -407,6 +407,7 @@ export const ClientSettingsSchema = Schema.Struct({
   // settles the composer into its single-line layout. Losing focus never does.
   composerCollapseOnScroll: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   proactivePanelsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  showUsageLimitsBar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   showSkillsInSlashMenu: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   // Legacy sidebar (the original per-project tree). Deliberately a fresh key
   // (was `sidebarV2Enabled` + `sidebarV2ConfiguredByUser`): decoding drops the
@@ -1353,6 +1354,7 @@ export const ClientSettingsPatch = Schema.Struct({
   contextWindowMeterEnabled: Schema.optionalKey(Schema.Boolean),
   composerCollapseOnScroll: Schema.optionalKey(Schema.Boolean),
   proactivePanelsEnabled: Schema.optionalKey(Schema.Boolean),
+  showUsageLimitsBar: Schema.optionalKey(Schema.Boolean),
   showSkillsInSlashMenu: Schema.optionalKey(Schema.Boolean),
   legacySidebarEnabled: Schema.optionalKey(Schema.Boolean),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),


### PR DESCRIPTION
## What Changed

Adds a compact usage limits bar below the chat composer in web and desktop. It follows the selected provider and shows remaining quota and reset times from the same snapshots as Usage → Limits. Multiple accounts have revealable account labels.

The bar is enabled by default and can be disabled in Settings → General → Show usage limits below chat. The preference is stored on the client. Native mobile is unchanged.

## Why

I like the Limits view, but switching away from the conversation just to check remaining quota gets repetitive. This keeps those numbers visible while working, without adding another polling loop or timer. Providers without limit data have no bar.

## UI Changes

Before (bar disabled, matching the previous chat layout):

![Before](https://github.com/muffe/t3code/releases/download/pr-evidence-usage-limits-bar/before-v2.png)

After:

![After](https://github.com/muffe/t3code/releases/download/pr-evidence-usage-limits-bar/after-v2.png)

Codex:

![Codex](https://github.com/muffe/t3code/releases/download/pr-evidence-usage-limits-bar/codex.png)

Settings:

![Settings](https://github.com/muffe/t3code/releases/download/pr-evidence-usage-limits-bar/settings-v2.png)

[Narrow web viewport](https://github.com/muffe/t3code/releases/download/pr-evidence-usage-limits-bar/mobile-v2.png)

## Validation

- Web typecheck passed.
- 162 tests passed across settings contracts, settings persistence hooks, and shared usage-limit logic.
- Targeted lint passed with existing warnings in ChatView.
- Checked Claude/Codex selection, disabling the bar, persistence after reload, restoring the default, and a 390px viewport in an isolated local web instance. No browser errors during these checks.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- No animation or timing changes; static screenshots show the display change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a usage limits bar below the chat composer.
  * Displays provider quota status, remaining usage, progress, and reset times.
  * Supports multiple provider accounts with account labels.
  * Added a setting to show or hide the usage limits bar, including settings search support.
  * The bar is enabled by default and appears when provider usage information is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
