### PR TITLE
fix(desktop): ignore metadata-only changes in dev watcher

### DIFF
--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -1,5 +1,4 @@
 import * as NodeChildProcess from "node:child_process";
-import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
@@ -9,6 +8,7 @@ import {
   resolveElectronLaunchCommand,
 } from "./electron-launcher.mjs";
 import { waitForResources } from "./wait-for-resources.mjs";
+import { watchBuildFiles } from "./watch-build-files.mjs";
 
 const devServerUrl = process.env.VITE_DEV_SERVER_URL?.trim();
 if (!devServerUrl) {
@@ -204,17 +204,7 @@ function scheduleRestart() {
 
 function startWatchers() {
   for (const { directory, files } of watchedDirectories) {
-    const watcher = NodeFS.watch(
-      NodePath.join(desktopDir, directory),
-      { persistent: true },
-      (_eventType, filename) => {
-        if (typeof filename !== "string" || !files.has(filename)) {
-          return;
-        }
-
-        scheduleRestart();
-      },
-    );
+    const watcher = watchBuildFiles(NodePath.join(desktopDir, directory), files, scheduleRestart);
 
     watchers.push(watcher);
   }

--- a/apps/desktop/scripts/watch-build-files.mjs
+++ b/apps/desktop/scripts/watch-build-files.mjs
@@ -1,0 +1,23 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+
+export function watchBuildFiles(directory, files, onChange) {
+  const readHash = (filename) => {
+    try {
+      return NodeCrypto.hash("sha256", NodeFS.readFileSync(NodePath.join(directory, filename)));
+    } catch (error) {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    }
+  };
+  const hashes = new Map([...files].map((filename) => [filename, readHash(filename)]));
+
+  return NodeFS.watch(directory, { persistent: true }, (_eventType, filename) => {
+    if (typeof filename !== "string" || !files.has(filename)) return;
+    const hash = readHash(filename);
+    if (hash === hashes.get(filename)) return;
+    hashes.set(filename, hash);
+    onChange();
+  });
+}

--- a/apps/desktop/scripts/watch-build-files.test.mjs
+++ b/apps/desktop/scripts/watch-build-files.test.mjs
@@ -1,0 +1,47 @@
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { assert, it, vi } from "vite-plus/test";
+
+import { watchBuildFiles } from "./watch-build-files.mjs";
+
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal()),
+  watch: vi.fn(),
+}));
+
+it("ignores metadata changes while preserving rebuild and replacement notifications", () => {
+  const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-build-watch-"));
+  const file = NodePath.join(directory, "main.cjs");
+  const onChange = vi.fn();
+  try {
+    NodeFS.writeFileSync(file, "first build");
+    watchBuildFiles(directory, new Set(["main.cjs"]), onChange);
+    const notify = NodeFS.watch.mock.calls.at(-1)[2];
+
+    NodeFS.chmodSync(file, 0o600);
+    notify("change", "main.cjs");
+    notify("rename", "main.cjs");
+    assert.equal(onChange.mock.calls.length, 0);
+
+    const timestamp = NodeFS.statSync(file).mtime;
+    NodeFS.writeFileSync(file, "other build");
+    NodeFS.utimesSync(file, timestamp, timestamp);
+    notify("change", "main.cjs");
+    assert.equal(onChange.mock.calls.length, 1);
+
+    notify("change", "main.cjs");
+    notify("change", "main.cjs.map");
+    notify("rename", null);
+    assert.equal(onChange.mock.calls.length, 1);
+
+    NodeFS.unlinkSync(file);
+    notify("rename", "main.cjs");
+    NodeFS.writeFileSync(file, "third build");
+    notify("rename", "main.cjs");
+    assert.equal(onChange.mock.calls.length, 3);
+  } finally {
+    NodeFS.rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Metadata-only file events could restart `pnpm dev:desktop` without a code change. Compare build-file contents before restarting, while preserving restarts for rebuilt, removed, and recreated files.

Verified: 9 focused tests, scoped lint, and a macOS desktop smoke test. Metadata changes caused no restart; changed bundle contents restarted the app and the backend returned HTTP 200.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development file watching now responds only to actual content changes, avoiding unnecessary rebuild notifications from metadata-only updates.
  - Changes to untracked files and invalid file events are ignored.
  - File deletion and recreation events are handled more reliably.

- **Tests**
  - Added coverage for content changes, metadata updates, rename events, ignored files, and file recreation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->