### PR TITLE
fix(usage): keep cached usage-limits commands local

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -46,7 +46,7 @@ import { VideoPreviewModal, type VideoPreviewSource } from "../../components/Vid
 import { ProviderIcon } from "../../components/ProviderIcon";
 import { SymbolView } from "../../components/AppSymbol";
 import { AppText as Text } from "../../components/AppText";
-import { hasProviderUsageLimits, isUsageLimitsCommand } from "@t3tools/shared/usageLimits";
+import { hasLocalUsageLimitsCommand, isUsageLimitsCommand } from "@t3tools/shared/usageLimits";
 import { COMPOSER_LAYOUT_TRANSITION, ComposerSurface } from "./ThreadComposer";
 import { ComposerCommandPopover } from "./ComposerCommandPopover";
 import { useComposerCommandMenu } from "./use-composer-command-menu";
@@ -319,11 +319,11 @@ export function NewTaskDraftScreen(props: {
   const isComposerInteractionLocked = isIncomingShareTransferPending || flow.submitting;
   // Also guard while a submit is in flight: an Android back press or iOS
   // Cancel would otherwise abandon the screen while the task still starts.
-  // T3 owns /usage-limits only where Limits has data for the selected provider.
+  // A cached local command stays local while its limits data reconnects.
   const offersUsageLimits =
     flow.selectedProviderStatus !== null &&
-    hasProviderUsageLimits(
-      flow.selectedProviderStatus.driver,
+    hasLocalUsageLimitsCommand(
+      flow.selectedProviderStatus,
       selectedEnvironmentServerConfig?.providers ?? [],
       selectedEnvironmentServerConfig?.usageLimitSources ?? [],
     );

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -11,7 +11,7 @@ import type {
 } from "@t3tools/contracts";
 import {
   collectProviderUsageLimits,
-  hasProviderUsageLimits,
+  hasLocalUsageLimitsCommand,
   isUsageLimitsCommand,
 } from "@t3tools/shared/usageLimits";
 import { StackActions, useFocusEffect, useNavigation } from "@react-navigation/native";
@@ -281,12 +281,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   }, [props.serverConfig, props.selectedThread.modelSelection.instanceId]);
   const composerOwnerKey = scopedThreadKey(props.environmentId, props.selectedThread.id);
   const { onSendMessage, onChangeDraftMessage, onShowUsageLimits } = props;
-  // T3 owns /usage-limits only where Limits has data for the selected provider;
-  // elsewhere the name stays the provider's own and is sent through untouched.
+  // A cached local command stays local while its limits data reconnects.
   const usageLimitsOffered =
     selectedProviderStatus !== null &&
-    hasProviderUsageLimits(
-      selectedProviderStatus.driver,
+    hasLocalUsageLimitsCommand(
+      selectedProviderStatus,
       props.serverConfig?.providers ?? [],
       props.serverConfig?.usageLimitSources ?? [],
     );

--- a/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { ProviderDriverKind } from "@t3tools/contracts";
+import { hasLocalUsageLimitsCommand, USAGE_LIMITS_COMMAND } from "@t3tools/shared/usageLimits";
 
 vi.mock("../../state/queries", () => ({
   useComposerPathSearch: () => ({ entries: [], isPending: false }),
@@ -17,6 +18,30 @@ import {
 } from "./use-composer-command-menu";
 
 describe("mobile slash commands", () => {
+  it.each([true, false])(
+    "keeps cached local=%s usage commands out of New Task without hiding provider commands",
+    (local) => {
+      const selected = {
+        driver: ProviderDriverKind.make("codex"),
+        slashCommands: [
+          local
+            ? USAGE_LIMITS_COMMAND
+            : { name: USAGE_LIMITS_COMMAND.name, description: USAGE_LIMITS_COMMAND.description },
+        ],
+      };
+      const items = buildComposerSlashCommandItems({
+        query: "usage-limits",
+        atMessageStart: true,
+        hasThread: false,
+        allowInteractionMode: true,
+        offersUsageLimits: hasLocalUsageLimitsCommand(selected, [], []),
+        selectedProviderStatus: selected,
+      });
+
+      expect(items.map((item) => item.label)).toEqual(local ? [] : ["/usage-limits"]);
+    },
+  );
+
   const antigravity = {
     driver: ProviderDriverKind.make("antigravity"),
     showInteractionModeToggle: false,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6449,6 +6449,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
                       {
                         name: "usage-limits",
                         description: "Show this provider's usage limits",
+                        source: "t3",
                       },
                     ],
                   },
@@ -6591,7 +6592,11 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
               {
                 ...codex,
                 slashCommands: [
-                  { name: "usage-limits", description: "Show this provider's usage limits" },
+                  {
+                    name: "usage-limits",
+                    description: "Show this provider's usage limits",
+                    source: "t3",
+                  },
                 ],
               },
             ],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,7 +2,7 @@ import { useLoadBalancedEnvironment } from "../hooks/useLoadBalancedEnvironment"
 import type { UsageLimitSourceSnapshots } from "@t3tools/contracts";
 import {
   collectProviderUsageLimits,
-  hasProviderUsageLimits,
+  hasLocalUsageLimitsCommand,
   isUsageLimitsCommand,
 } from "@t3tools/shared/usageLimits";
 import { feedbackBannerItem } from "./chat/ComposerFeedback";
@@ -2864,11 +2864,10 @@ export default function ChatView(props: ChatViewProps) {
         : null,
     [environmentId, usageLimitsPanel, usageLimitsReport],
   );
-  // T3 owns /usage-limits only where Limits has data for the selected provider;
-  // elsewhere the name stays the provider's own and is sent through untouched.
+  // A cached local command stays local while its limits data reconnects.
   const usageLimitsOffered =
     activeProviderStatus !== null &&
-    hasProviderUsageLimits(activeProviderStatus.driver, providerStatuses, usageLimitSources);
+    hasLocalUsageLimitsCommand(activeProviderStatus, providerStatuses, usageLimitSources);
   // Answered locally from the last Limits snapshot; the agent never sees it.
   const openUsageLimits = useCallback(() => {
     const now = Date.now();

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -29,6 +29,28 @@ const baseProviderSnapshot = {
 };
 
 describe("ServerProvider", () => {
+  it("preserves local command ownership when decoding a saved provider catalog", () => {
+    const slashCommands = [
+      { name: "usage-limits", description: "Show limits", source: "t3" },
+      { name: "usage", description: "Provider command" },
+    ];
+    const parsed = decodeServerProvider({
+      ...baseProviderSnapshot,
+      slashCommands,
+      workspaceSnapshots: [
+        {
+          cwd: "/tmp/project",
+          checkedAt: baseProviderSnapshot.checkedAt,
+          slashCommands,
+          skills: [],
+        },
+      ],
+    });
+
+    expect(parsed.slashCommands).toEqual(slashCommands);
+    expect(parsed.workspaceSnapshots?.[0]?.slashCommands).toEqual(slashCommands);
+  });
+
   it("defaults capability arrays when decoding provider snapshots", () => {
     const parsed = decodeServerProvider({
       instanceId: "codex",

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -89,6 +89,8 @@ export const ServerProviderSlashCommand = Schema.Struct({
   name: TrimmedNonEmptyString,
   description: Schema.optional(TrimmedNonEmptyString),
   input: Schema.optional(ServerProviderSlashCommandInput),
+  /** T3 handles this command locally, even before its data is available. */
+  source: Schema.optional(Schema.Literal("t3")),
 });
 export type ServerProviderSlashCommand = typeof ServerProviderSlashCommand.Type;
 

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -2,14 +2,17 @@ import {
   EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
-  type ServerProvider,
+  ServerProvider,
   type UsageLimitSourceAccount,
   UsageLimitSourceId,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
   type LimitAccount,
+  hasLocalUsageLimitsCommand,
+  hasProviderUsageLimits,
   isUsageLimitsCommand,
   collectProviderUsageLimits,
   sameUsageLimitCommandCoverage,
@@ -27,6 +30,7 @@ import {
   remainingPercent,
 } from "./usageLimits.ts";
 
+const decodeServerProvider = Schema.decodeUnknownSync(ServerProvider);
 const now = Date.parse("2026-09-03T12:00:00.000Z");
 
 const window = {
@@ -1194,5 +1198,48 @@ describe("isUsageLimitsCommand", () => {
     expect(isUsageLimitsCommand("/usage-limits explain")).toBe(false);
     expect(isUsageLimitsCommand("Explain /usage-limits")).toBe(false);
     expect(isUsageLimitsCommand("/usage")).toBe(false);
+  });
+});
+
+describe("hasLocalUsageLimitsCommand", () => {
+  const limits = { checkedAt: "2026-09-03T11:00:00.000Z", windows: [] };
+  const sources = [
+    {
+      id: UsageLimitSourceId.make("hub"),
+      kind: "cliproxy" as const,
+      label: "Accounts",
+      checkedAt: "2026-09-03T11:00:00.000Z",
+      accounts: [
+        {
+          id: "account",
+          driver: ProviderDriverKind.make("codex"),
+          usageLimits: limits,
+        },
+      ],
+    },
+  ];
+
+  it("keeps a saved source-only command local without inventing a limits report", () => {
+    const [advertised] = withUsageLimitsCommands([provider({})], sources);
+    const cached = decodeServerProvider(JSON.parse(JSON.stringify(advertised)));
+
+    expect(hasProviderUsageLimits(cached.driver, [cached], [])).toBe(false);
+    expect(hasLocalUsageLimitsCommand(cached, [cached], [])).toBe(true);
+    expect(collectProviderUsageLimits(cached.instanceId, [cached], [], now)).toBeNull();
+  });
+
+  it("does not claim a provider command with the same name and description", () => {
+    const native = provider({
+      slashCommands: [{ name: "usage-limits", description: "Show this provider's usage limits" }],
+    });
+    expect(hasLocalUsageLimitsCommand(native, [native], [])).toBe(false);
+  });
+
+  it("keeps data-based ownership for older servers without command origins", () => {
+    const legacy = provider({ slashCommands: [{ name: "usage-limits" }] });
+    expect(hasLocalUsageLimitsCommand(legacy, [legacy], sources)).toBe(true);
+    expect(hasLocalUsageLimitsCommand(legacy, [legacy], [])).toBe(false);
+    const native = provider({ usageLimits: limits });
+    expect(hasLocalUsageLimitsCommand(native, [native], [])).toBe(true);
   });
 });

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -560,11 +560,25 @@ export function formatResetsIn(window: ServerProviderUsageWindow, now: number): 
 export const USAGE_LIMITS_COMMAND = {
   name: "usage-limits",
   description: "Show this provider's usage limits",
+  source: "t3",
 } satisfies ServerProviderSlashCommand;
 
 /** Handled by the client without sending a turn; anything with arguments stays an ordinary prompt. */
 export function isUsageLimitsCommand(prompt: string): boolean {
   return prompt.trim().toLowerCase() === "/usage-limits";
+}
+
+/** Cached catalogs retain ownership while source data replays. Older servers omit the source. */
+export function hasLocalUsageLimitsCommand(
+  provider: Pick<ServerProvider, "driver" | "slashCommands">,
+  providers: readonly ServerProvider[],
+  sources: UsageLimitSourceSnapshots,
+): boolean {
+  return (
+    provider.slashCommands.some(
+      (command) => command.name === USAGE_LIMITS_COMMAND.name && command.source === "t3",
+    ) || hasProviderUsageLimits(provider.driver, providers, sources)
+  );
 }
 
 /**


### PR DESCRIPTION
## What changed

T3's `/usage-limits` command can become an ordinary provider prompt when its catalog survives a reconnect but its external quota data does not.

Mark T3's command with optional `source: "t3"` metadata and use it in the web, desktop, and mobile composers. Existing threads keep the command local even when limits are unavailable. Mobile New Task keeps it out of the send queue.

## Why

The cache intentionally omits external quota snapshots while retaining the provider catalog. Command ownership must survive that gap without inventing quota data or claiming a provider's own command with the same name.

The existing data-based check remains as a fallback for older servers. Old caches without the marker need one connection to an updated server; this change cannot distinguish them from native commands while offline.

```mermaid
flowchart LR
    catalog["Cached command: source=t3"] --> web["Web and desktop"]
    catalog --> thread["Mobile thread"]
    catalog --> draft["Mobile New Task"]
    web --> local["Handle locally"]
    thread --> local
    draft --> guard["Do not queue a turn"]
```

## UI changes

Real web client in Chromium, with an isolated project and controlled quota responses. PNGs are 2560 × 1600. The before capture uses the original ownership check with the same fixture. Turn-start requests are recorded and stopped at the browser boundary, so no agent runs.

| Before | After |
| --- | --- |
| ![Before: the command becomes a user message and starts the sending UI](https://github.com/Lucenx9/t3code/releases/download/evidence-usage-command-3e675e61a4/before-final-2x.png) | ![After: the command stays in the composer and shows the local unavailable notice](https://github.com/Lucenx9/t3code/releases/download/evidence-usage-command-3e675e61a4/after-final-2x.png) |
| [Before video](https://github.com/Lucenx9/t3code/releases/download/evidence-usage-command-3e675e61a4/before.mp4) | [After video](https://github.com/Lucenx9/t3code/releases/download/evidence-usage-command-3e675e61a4/after.mp4) |

## Verification

- 75 focused tests pass across contracts, shared usage helpers, the mobile command menu, and server config subscriptions.
- The new catalog-decoding regression failed before the schema fix.
- Browser checks cover typed and menu-selected commands without quota data, available external limits, and an unmarked native command with the identical label. Local commands dispatch zero turns; the native command still reaches the send boundary.
- Typechecks pass for contracts, shared, web, and mobile. Targeted lint has no errors or warnings on changed lines. Formatting and `git diff --check` pass.
- Fallow's single-thread audit passes with no newly introduced findings. No repository-wide checks ran.

Desktop shares the web composer. Mobile is covered by focused tests and typechecking, not a device run. No product defaults or diagnostic suppressions change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included videos for the interaction change

Model: GPT-5. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The `/usage-limits` command now remains available while usage-limit information reconnects.
  - Improved handling distinguishes locally available usage-limit commands from provider-provided commands.
  - Cached commands are preserved across provider status updates and older server data formats.

- **Reliability**
  - Usage-limit command availability and provider command data are now handled more consistently across mobile and web experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->