### PR TITLE
feat(desktop): import cookies from Dia

### DIFF
--- a/apps/desktop/src/preview/BrowserImport/Sources.test.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.test.ts
@@ -36,6 +36,7 @@ import {
 import { symlinksSupported } from "@t3tools/shared/testing/symlinks";
 
 const helium = BROWSER_IMPORT_SOURCES.find((source) => source.id === "helium")!;
+const dia = BROWSER_IMPORT_SOURCES.find((source) => String(source.id) === "dia");
 
 describe("Linux Chromium secret applications", () => {
   it("pins the libsecret application attribute for each supported fork", () => {
@@ -111,6 +112,79 @@ const writeCookieDatabase = (file: string, count: number) =>
     for (let index = 0; index < count; index += 1) insert.run("example.test", `c${index}`);
     database.close();
   });
+
+describe("Dia on macOS", () => {
+  it.effect("pins Dia's Chromium path and Keychain coordinates to macOS", () =>
+    run(
+      Effect.gen(function* () {
+        assert.isDefined(dia);
+        if (dia === undefined) return;
+
+        const darwinContext = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, { HOME: "/Users/dia-user" }),
+          Effect.provideService(HostProcessPlatform, "darwin"),
+        );
+        const linuxContext = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, { HOME: "/home/dia-user" }),
+          Effect.provideService(HostProcessPlatform, "linux"),
+        );
+
+        assert.equal(dia.name, "Dia");
+        assert.equal(dia.engine, "chromium");
+        assert.deepEqual([...dia.platforms], ["darwin"]);
+        assert.equal(dia.keychainService, "Dia Safe Storage");
+        assert.equal(dia.keychainAccount, "Dia");
+        assert.equal(
+          dia.userDataDirectory(darwinContext),
+          darwinContext.path.join(
+            "/Users/dia-user",
+            "Library",
+            "Application Support",
+            "Dia",
+            "User Data",
+          ),
+        );
+        assert.isUndefined(dia.userDataDirectory(linuxContext));
+      }),
+    ),
+  );
+
+  it.effect("discovers and counts Dia profiles through Chromium metadata", () =>
+    run(
+      Effect.gen(function* () {
+        assert.isDefined(dia);
+        if (dia === undefined) return;
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const home = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3code-dia-" });
+        const context = yield* sourcePathContext.pipe(
+          Effect.provideService(HostProcessEnvironment, { HOME: home }),
+          Effect.provideService(HostProcessPlatform, "darwin"),
+        );
+        const root = dia.userDataDirectory(context)!;
+        const defaultCookies = context.path.join(root, "Default", "Network", "Cookies");
+        const workCookies = context.path.join(root, "Profile 2", "Network", "Cookies");
+
+        yield* fileSystem.makeDirectory(context.path.dirname(defaultCookies), { recursive: true });
+        yield* fileSystem.makeDirectory(context.path.dirname(workCookies), { recursive: true });
+        yield* writeCookieDatabase(defaultCookies, 3);
+        yield* writeCookieDatabase(workCookies, 2);
+        yield* fileSystem.writeFileString(
+          context.path.join(root, "Local State"),
+          '{"profile":{"info_cache":{"Default":{"name":"Personal"},"Profile 2":{"name":"Work"}}}}',
+        );
+
+        assert.deepEqual(yield* listSourceProfiles(dia, context), [
+          { directory: "Default", name: "Personal", cookieCount: 3 },
+          { directory: "Profile 2", name: "Work", cookieCount: 2 },
+        ]);
+        assert.equal(yield* resolveCookieDatabase(dia, context, "Default"), defaultCookies);
+        assert.isTrue(yield* isSourceInstalled(dia, context));
+        assert.isFalse(yield* isSourceRunning(dia, context));
+      }),
+    ),
+  );
+});
 
 const writeFirefoxCookieDatabase = (
   file: string,

--- a/apps/desktop/src/preview/BrowserImport/Sources.ts
+++ b/apps/desktop/src/preview/BrowserImport/Sources.ts
@@ -159,13 +159,20 @@ export const BROWSER_IMPORT_SOURCES: ReadonlyArray<BrowserImportSourceDefinition
     linuxSegments: ["opera"],
     linuxSecretApplication: "opera",
   }),
-  // Arc has no Linux build.
+  // Arc and Dia have no Linux builds.
   chromiumSource({
     id: "arc",
     name: "Arc",
     keychainService: "Arc Safe Storage",
     keychainAccount: "Arc",
     macSegments: ["Arc", "User Data"],
+  }),
+  chromiumSource({
+    id: "dia",
+    name: "Dia",
+    keychainService: "Dia Safe Storage",
+    keychainAccount: "Dia",
+    macSegments: ["Dia", "User Data"],
   }),
   chromiumSource({
     id: "helium",

--- a/packages/contracts/src/browserImport.ts
+++ b/packages/contracts/src/browserImport.ts
@@ -23,6 +23,7 @@ const BROWSER_IMPORT_SOURCE_IDS = [
   "vivaldi",
   "opera",
   "arc",
+  "dia",
   "helium",
   "firefox",
   "safari",


### PR DESCRIPTION
Adds Dia as a macOS-only browser source using the existing Chromium cookie importer.

Automated verification:
- Focused browser-import tests: 80/80 passed
- Contracts and desktop typechecks passed
- Targeted lint and format checks passed
- git diff --check passed

Live macOS verification confirmed Dia detection, the running-browser guard, clean quit and lock release, and a user-completed import.

Environment isolation and clear/delete behavior were not separately exercised live; this change does not alter those existing paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dia as a supported browser source for cookie imports on macOS.
  - Dia now appears as an available import option when detected, including its browser profiles and cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->