### PR TITLE
fix(web): restore text-only draft project title

### DIFF
--- a/apps/web/src/components/chat/DraftHeroHeadline.tsx
+++ b/apps/web/src/components/chat/DraftHeroHeadline.tsx
@@ -115,14 +115,11 @@ export function DraftHeroHeadline({
           render={
             <MenuTrigger
               aria-label={hasResolvedProject ? "Change project" : "Choose a project"}
-              className="pointer-events-auto inline-flex max-w-64 items-center gap-2 border-foreground/60 border-b border-dotted align-baseline text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+              className="pointer-events-auto inline-block max-w-64 truncate border-foreground/60 border-b border-dotted align-baseline text-foreground transition-colors hover:border-foreground/80 focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             />
           }
         >
-          {activeProjectGroup ? (
-            <ProjectFavicon project={activeProjectGroup} className="size-6 shrink-0 sm:size-7" />
-          ) : null}
-          <span className="min-w-0 truncate">{activeProjectDisplayName ?? "Choose a project"}</span>
+          {activeProjectDisplayName ?? "Choose a project"}
         </TooltipTrigger>
         {activeProjectDisplayName ? (
           <TooltipPopup side="top" className="max-w-80">


### PR DESCRIPTION
The project icon added in [#10790](https://github.com/pingdotgg/t3code/pull/10790) crowds the draft headline and truncates names such as `pingdotgg/t3code`.

Restore the previous text-only trigger and its layout. Keep project icons in the dropdown list.

Verified in the isolated web app at 1280×800, including opening the project picker. Targeted lint, formatting, and web typecheck passed. The shared web component also covers desktop; no mobile or protocol changes.

| Before | After |
| --- | --- |
| ![Before: icon crowds and truncates the project name](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9bf56223d02c5da1/before.png) | ![After: text-only project title](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/53713634221a0e55/after.png) |

![Project icons remain in the dropdown list](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e8182f1a27d764cd/list.png)

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the project selector trigger to display the project name as a single truncated inline element.
  - Removed the project favicon from the trigger; picker menu items continue to display their icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->