### PR TITLE
fix(web): open remote files correctly in VS Code editors

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -77,14 +77,19 @@ describe("ElectronShell", () => {
       openExternalMock.mockResolvedValue(undefined);
 
       const electronShell = yield* ElectronShell.ElectronShell;
-      const result = yield* electronShell.openExternal(
+      const urls = [
         "vscode://vscode-remote/ssh-remote+example.com/home/user/project",
-      );
+        "vscode://vscode-remote/ssh-remote+example.com/home/user/my%20file%20%231.json:1",
+      ];
+      for (const url of urls) {
+        const result = yield* electronShell.openExternal(url);
 
-      assert.equal(result, true);
-      assert.deepEqual(openExternalMock.mock.calls, [
-        ["vscode://vscode-remote/ssh-remote+example.com/home/user/project"],
-      ]);
+        assert.equal(result, true);
+      }
+      assert.deepEqual(
+        openExternalMock.mock.calls,
+        urls.map((url) => [url]),
+      );
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -426,7 +426,8 @@ export const ChatHeader = memo(function ChatHeader({
             environmentId={activeThreadEnvironmentId}
             keybindings={keybindings}
             availableEditors={availableEditors}
-            openInCwd={openInCwd}
+            openInPath={openInCwd}
+            pathKind="folder"
           />
         )}
         {activeProjectName && (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -177,14 +177,16 @@ export const OpenInPicker = memo(function OpenInPicker({
   environmentId,
   keybindings,
   availableEditors,
-  openInCwd,
+  openInPath,
+  pathKind,
   compact = false,
   enableShortcut = true,
 }: {
   environmentId: EnvironmentId;
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
-  openInCwd: string | null;
+  openInPath: string | null;
+  pathKind: "file" | "folder";
   compact?: boolean;
   enableShortcut?: boolean;
 }) {
@@ -205,7 +207,7 @@ export const OpenInPicker = memo(function OpenInPicker({
 
   const openInEditor = useCallback(
     (editorId: EditorId | null) => {
-      if (!openInCwd) return;
+      if (!openInPath) return;
       const editor = editorId ?? preferredEditor;
       if (!editor) return;
       if (remote.mode === "remote-unavailable") return;
@@ -213,7 +215,8 @@ export const OpenInPicker = memo(function OpenInPicker({
         const url = buildRemoteOpenUrl({
           editor,
           host: remote.host.host,
-          absolutePath: openInCwd,
+          absolutePath: openInPath,
+          pathKind,
         });
         if (url === undefined) return;
         // Only record hint-seen/preferred when the shell actually accepted
@@ -228,7 +231,7 @@ export const OpenInPicker = memo(function OpenInPicker({
       const result = openInEditorMutation({
         environmentId,
         input: {
-          cwd: openInCwd,
+          cwd: openInPath,
           editor,
         },
       });
@@ -238,8 +241,9 @@ export const OpenInPicker = memo(function OpenInPicker({
     [
       environmentId,
       markRemoteHintSeen,
-      openInCwd,
+      openInPath,
       openInEditorMutation,
+      pathKind,
       preferredEditor,
       remote,
       setPreferredEditor,
@@ -255,7 +259,7 @@ export const OpenInPicker = memo(function OpenInPicker({
     if (!enableShortcut) return;
     const handler = (e: globalThis.KeyboardEvent) => {
       if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
-      if (!openInCwd) return;
+      if (!openInPath) return;
       if (!preferredEditor) return;
 
       e.preventDefault();
@@ -263,7 +267,7 @@ export const OpenInPicker = memo(function OpenInPicker({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [enableShortcut, keybindings, openInCwd, openInEditor, preferredEditor]);
+  }, [enableShortcut, keybindings, openInPath, openInEditor, preferredEditor]);
 
   return (
     <Group aria-label="Open in editor">
@@ -272,7 +276,7 @@ export const OpenInPicker = memo(function OpenInPicker({
         className="ps-[8.5px]"
         size="xs"
         variant="outline"
-        disabled={!preferredEditor || !openInCwd || remote.mode === "remote-unavailable"}
+        disabled={!preferredEditor || !openInPath || remote.mode === "remote-unavailable"}
         onClick={() => openInEditor(preferredEditor)}
       >
         {primaryOption?.Icon && (

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -1140,7 +1140,8 @@ export default function FilePreviewPanel({
               environmentId={environmentId}
               keybindings={keybindings}
               availableEditors={availableEditors}
-              openInCwd={absolutePath}
+              openInPath={absolutePath}
+              pathKind="file"
               compact
               enableShortcut={false}
             />

--- a/apps/web/src/remoteOpen.test.ts
+++ b/apps/web/src/remoteOpen.test.ts
@@ -119,31 +119,68 @@ describe("resolveRemoteOpenState", () => {
 });
 
 describe("buildRemoteOpenUrl", () => {
+  it.each([
+    ["/home/user/.local/share/app/settings.json", "/home/user/.local/share/app/settings.json"],
+    ["/tmp/README", "/tmp/README"],
+    ["/tmp/my file #1?.json", "/tmp/my%20file%20%231%3F.json"],
+    ["C:\\Users\\user\\settings.json", "/C%3A/Users/user/settings.json"],
+    ["/tmp/project.code-workspace", "/tmp/project.code-workspace"],
+  ])("opens %s as a remote file", (absolutePath, encodedPath) => {
+    expect(
+      buildRemoteOpenUrl({
+        editor: "vscode",
+        host: "sol",
+        absolutePath,
+        pathKind: "file",
+      }),
+    ).toBe(`vscode://vscode-remote/ssh-remote+sol${encodedPath}:1`);
+  });
+
   it("builds a vscode-remote deep link", () => {
     expect(
       buildRemoteOpenUrl({
         editor: "vscode",
         host: "sol.tail1234.ts.net",
         absolutePath: "/home/theo/code/my repo",
+        pathKind: "folder",
       }),
     ).toBe("vscode://vscode-remote/ssh-remote+sol.tail1234.ts.net/home/theo/code/my%20repo");
   });
 
-  it("uses the fork's scheme", () => {
-    expect(buildRemoteOpenUrl({ editor: "cursor", host: "sol", absolutePath: "/tmp/x" })).toBe(
-      "cursor://vscode-remote/ssh-remote+sol/tmp/x",
-    );
+  it.each(["cursor", "vscode-insiders", "vscodium"] as const)("uses %s's scheme", (editor) => {
+    expect(
+      buildRemoteOpenUrl({ editor, host: "sol", absolutePath: "/tmp/x", pathKind: "file" }),
+    ).toBe(`${editor}://vscode-remote/ssh-remote+sol/tmp/x:1`);
+    expect(
+      buildRemoteOpenUrl({ editor, host: "sol", absolutePath: "/tmp/x", pathKind: "folder" }),
+    ).toBe(`${editor}://vscode-remote/ssh-remote+sol/tmp/x`);
+  });
+
+  it("keeps folders with file extensions as folders", () => {
+    expect(
+      buildRemoteOpenUrl({
+        editor: "vscode",
+        host: "sol",
+        absolutePath: "/tmp/project.json",
+        pathKind: "folder",
+      }),
+    ).toBe("vscode://vscode-remote/ssh-remote+sol/tmp/project.json");
   });
 
   it("roots Windows paths", () => {
     expect(
-      buildRemoteOpenUrl({ editor: "vscode", host: "sol", absolutePath: "C:\\Users\\theo" }),
+      buildRemoteOpenUrl({
+        editor: "vscode",
+        host: "sol",
+        absolutePath: "C:\\Users\\theo",
+        pathKind: "folder",
+      }),
     ).toBe("vscode://vscode-remote/ssh-remote+sol/C%3A/Users/theo");
   });
 
   it("returns undefined for editors without remote support", () => {
-    expect(buildRemoteOpenUrl({ editor: "zed", host: "sol", absolutePath: "/tmp/x" })).toBe(
-      undefined,
-    );
+    expect(
+      buildRemoteOpenUrl({ editor: "zed", host: "sol", absolutePath: "/tmp/x", pathKind: "file" }),
+    ).toBe(undefined);
   });
 });

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -103,6 +103,7 @@ export const buildRemoteOpenUrl = (input: {
   readonly editor: EditorId;
   readonly host: string;
   readonly absolutePath: string;
+  readonly pathKind: "file" | "folder";
 }): string | undefined => {
   const scheme = remoteSchemeForEditor(input.editor);
   if (scheme === undefined) {
@@ -112,7 +113,9 @@ export const buildRemoteOpenUrl = (input: {
   const posixPath = input.absolutePath.replaceAll("\\", "/");
   const rootedPath = posixPath.startsWith("/") ? posixPath : `/${posixPath}`;
   const encodedPath = rootedPath.split("/").map(encodeURIComponent).join("/");
-  return `${scheme}://vscode-remote/ssh-remote+${encodeURIComponent(input.host)}${encodedPath}`;
+  // A :line suffix makes VS Code's remote URL handler open a file instead of a folder.
+  const position = input.pathKind === "file" ? ":1" : "";
+  return `${scheme}://vscode-remote/ssh-remote+${encodeURIComponent(input.host)}${encodedPath}${position}`;
 };
 
 /**


### PR DESCRIPTION
## What Changed

Opening a remote file from the file preview could connect over SSH and leave an empty VS Code window with `ENOTDIR`. `FilePreviewPanel` intentionally passed the selected file's absolute path to `OpenInPicker` as `openInCwd`; the URL builder treated every target as a folder.

Rename the picker input to `openInPath` and require an explicit file/folder kind. File links get a `:1` suffix, while project and worktree links keep their folder behavior. The shared fix covers VS Code, Cursor, VS Code Insiders, and VSCodium.

## Why

VS Code's [remote protocol handler](https://github.com/microsoft/vscode/blob/main/src/vs/code/electron-main/app.ts#L960) uses a trailing line number to distinguish a file from a folder. The caller already knows which it is, so this needs no filesystem request, extension guessing, project-root restriction, or server protocol change. Local editor launches keep their existing behavior.

Validation:

- 36 focused tests pass across `remoteOpen.test.ts`, `ChatHeader.test.ts`, and `ElectronShell.test.ts`. Coverage includes all supported remote editor schemes, extensionless files, Windows paths, URL encoding, folders with extensions, and desktop URL forwarding.
- Web and contracts typechecks pass. Targeted lint passes with two existing warnings on untouched lines; formatting passes.
- The new file-URL regression failed before the fix. In the real client, the old preview action produced `ENOTDIR`, and the corrected URL opened the fixture's contents over SSH.

## UI Changes

Captured the file-preview button's output in an isolated T3 web environment and replayed it through VS Code's URL handler because the embedded test browser did not launch the custom scheme. Both runs used the same harmless fixture and SSH host. No layout changes.

| Before: SSH connected, empty editor | After: remote file contents |
| --- | --- |
| ![Before](https://github.com/KyleKincer/t3code/releases/download/pr-evidence-remote-editor-files/remote-editor-before.jpg) | ![After](https://github.com/KyleKincer/t3code/releases/download/pr-evidence-remote-editor-files/remote-editor-after.jpg) |

[Short recording of the remote file opening](https://github.com/KyleKincer/t3code/releases/download/pr-evidence-remote-editor-files/remote-file-open.mp4)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved opening files and folders from chat and file previews in remote editors.
  - File paths containing spaces or special characters now open correctly.
  - Remote editor links now open files at the intended location, while folders remain recognized as folders.
  - Added support for additional editor schemes, including VS Code, VS Code Insiders, and VSCodium.
  - Improved handling of Windows paths and remote SSH editor URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->