### PR TITLE
feat(web): open the preview page in the system browser from the menu

### DIFF
--- a/apps/web/src/components/preview/PreviewMoreMenu.tsx
+++ b/apps/web/src/components/preview/PreviewMoreMenu.tsx
@@ -52,6 +52,8 @@ interface Props {
   nativePictureInPicture: boolean;
   /** Toggles the optional native always-on-top preview window. */
   onNativePictureInPicture: () => void;
+  /** Opens the current page in the OS default browser. */
+  onOpenInBrowser: () => void;
   /** Environment the tab belongs to; scopes storage clearing to its partitions. */
   environmentId: EnvironmentId;
   /** Profile the tab was opened under, if the server recorded one. */
@@ -79,6 +81,7 @@ export function PreviewMoreMenu({
   onToggleDeviceToolbar,
   nativePictureInPicture,
   onNativePictureInPicture,
+  onOpenInBrowser,
   environmentId,
   profileId,
   profileName,
@@ -119,6 +122,9 @@ export function PreviewMoreMenu({
           {nativePictureInPicture
             ? "Close separate preview window"
             : "Open separate preview window"}
+        </MenuItem>
+        <MenuItem onClick={onOpenInBrowser} disabled={tabDisabled}>
+          Open in system browser
         </MenuItem>
         <MenuItem onClick={onToggleDeviceToolbar} disabled={tabDisabled}>
           {deviceToolbarVisible ? "Hide device toolbar" : "Show device toolbar"}

--- a/apps/web/src/components/preview/PreviewView.test.tsx
+++ b/apps/web/src/components/preview/PreviewView.test.tsx
@@ -11,6 +11,16 @@ import { act, Profiler } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+// PreviewView resolves the local API once at module scope behind a `typeof
+// window` guard. The guard has to see a window before the import further down
+// runs, or every shell call in this suite is a silent no-op.
+vi.hoisted(() => {
+  globalThis.window ??= {
+    addEventListener() {},
+    removeEventListener() {},
+  } as unknown as Window & typeof globalThis;
+});
+
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(async (_tabId: string, _url: string): Promise<void> => undefined),
   rememberPreviewUrl: vi.fn(),
@@ -19,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   emptyStateUrl: null as ((url: string) => void) | null,
   togglePictureInPicture: null as (() => void) | null,
   toggleNativePictureInPicture: null as (() => void) | null,
+  openInBrowser: null as (() => void) | null,
+  openExternal: vi.fn(async (_url: string): Promise<void> => undefined),
   pictureInPicturePressed: false,
   miniPlayerTabId: null as string | null,
   openMiniPlayer: vi.fn(),
@@ -95,7 +107,7 @@ vi.mock("~/lib/previewAnnotation", () => ({
 }));
 
 vi.mock("~/localApi", () => ({
-  ensureLocalApi: vi.fn(),
+  ensureLocalApi: vi.fn(() => ({ shell: { openExternal: mocks.openExternal } })),
 }));
 
 vi.mock("~/previewStateStore", () => ({
@@ -221,7 +233,7 @@ vi.mock("./PreviewChromeRow", () => ({
     onPictureInPicture?: () => void;
     pictureInPicture?: boolean;
     trailingActions?: {
-      props: { onNativePictureInPicture?: () => void };
+      props: { onNativePictureInPicture?: () => void; onOpenInBrowser?: () => void };
     };
   }) => {
     mocks.submittedUrl = props.onSubmit;
@@ -229,6 +241,7 @@ vi.mock("./PreviewChromeRow", () => ({
     mocks.togglePictureInPicture = props.onPictureInPicture ?? null;
     mocks.toggleNativePictureInPicture =
       props.trailingActions?.props.onNativePictureInPicture ?? null;
+    mocks.openInBrowser = props.trailingActions?.props.onOpenInBrowser ?? null;
     mocks.pictureInPicturePressed = props.pictureInPicture ?? false;
     return null;
   },
@@ -333,6 +346,8 @@ describe("PreviewView navigation", () => {
     mocks.emptyStateUrl = null;
     mocks.togglePictureInPicture = null;
     mocks.toggleNativePictureInPicture = null;
+    mocks.openInBrowser = null;
+    mocks.openExternal.mockClear();
     mocks.pictureInPicturePressed = false;
     mocks.miniPlayerTabId = null;
     mocks.openMiniPlayer.mockClear();
@@ -517,6 +532,27 @@ describe("PreviewView navigation", () => {
     await vi.waitFor(() =>
       expect(mocks.closePictureInPicture).toHaveBeenCalledWith(TEST_RUNTIME_TAB_ID),
     );
+  });
+
+  it("hands the page the tab is showing to the system browser", async () => {
+    const props = {
+      threadRef: TEST_THREAD_REF,
+      tabId: "tab-1",
+      visible: true,
+    } as const;
+
+    renderToStaticMarkup(<PreviewView {...props} />);
+    mocks.openInBrowser?.();
+    await vi.waitFor(() => expect(mocks.openExternal).toHaveBeenCalledWith("http://example.com/"));
+
+    // An empty tab has no address to hand over; the menu item stays clickable,
+    // so the handler is the only thing keeping it from opening about:blank.
+    mocks.showEmptyState = true;
+    mocks.openExternal.mockClear();
+    renderToStaticMarkup(<PreviewView {...props} />);
+    expect(mocks.openInBrowser).not.toBeNull();
+    mocks.openInBrowser?.();
+    expect(mocks.openExternal).not.toHaveBeenCalled();
   });
 
   it("forwards Cmd/Ctrl+Enter annotations to the composer send path", async () => {

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -767,6 +767,7 @@ export function PreviewView({
               onToggleDeviceToolbar={handleToggleDeviceToolbar}
               nativePictureInPicture={desktopOverlay?.pictureInPicture ?? false}
               onNativePictureInPicture={handleNativePictureInPicture}
+              onOpenInBrowser={handleOpenInBrowser}
             />
           ) : null
         }


### PR DESCRIPTION
## What Changed

The integrated browser's ⋮ menu gets an "Open in system browser" item that hands the page the tab is showing to the OS default browser.

- `PreviewMoreMenu` gains an `onOpenInBrowser` prop and the menu item, placed directly after "Open separate preview window" and disabled under the same condition as its neighbours.
- `PreviewView` passes the existing `handleOpenInBrowser` handler through. That is the same path the chat's right-click "Open in system browser" already takes: `localApi.shell.openExternal` → `desktopBridge.openExternal` → IPC → `Electron.shell.openExternal`. Same label, same destination, one more way in.
- `PreviewView.test.tsx` covers the new path: the menu hands over the address the tab is actually showing, and a tab with no page opens nothing. Removing the `onOpenInBrowser` line from `PreviewView` turns the test red. Reaching the shell from that suite needed a window before the module import, because `PreviewView` resolves the local API once at module scope behind a `typeof window` guard.

Two single-line insertions in the components plus the test.

## Why

The menu offered Hard reload, DevTools, a separate preview window and the device toolbar, but no way to hand the current page to the system browser. The only entry point was the hover-reveal button inside the URL input, which is easy to miss. Reusing the existing handler keeps the menu and the URL-input button on one code path.

## Surfaces

- **Desktop:** fixed here; the menu is only mounted with the desktop bridge.
- **Web:** unaffected, the menu does not render there and the URL-input button already covers the case.
- **Mobile:** has no integrated browser.
- **Contracts:** unchanged, this is client-side wiring.

## UI Changes

Clicked in a real desktop client built from this branch (AppImage on Fedora Kinoite). The item opens the page the tab is showing in the system browser.

| Before | After |
| --- | --- |
| ![Preview menu without the item](https://raw.githubusercontent.com/sti0/t3code/pr-assets/preview-menu-open-in-browser/before.png) | ![Preview menu with "Open in system browser"](https://raw.githubusercontent.com/sti0/t3code/pr-assets/preview-menu-open-in-browser/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes — no motion involved

---

Claude Fable 5.1 via Claude Code inside T3 Code (test and desktop verification: Claude Opus 5).

_Created with AI assistance (Klaus/Claude), reviewed by Timo._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Open in system browser” option to the preview menu.
  - The current preview page opens in the system browser when selected.
  - The option is unavailable when the preview tab has no web content.

- **Tests**
  - Added coverage for opening valid preview URLs and handling empty tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->