### PR TITLE
fix(mobile): respect code word break in file viewer

### DIFF
--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -281,8 +281,9 @@ function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
 }
 
 export function SourceFileSurface(props: SourceFileSurfaceProps) {
+  const { appearance } = useAppearancePreferences();
   const NativeView = resolveNativeReviewDiffView();
-  return NativeView ? (
+  return NativeView && !appearance.codeWordBreak ? (
     <NativeSourceFileSurface {...props} NativeView={NativeView} />
   ) : (
     <JavaScriptSourceFileSurface {...props} />

--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -36,6 +36,9 @@ interface SourceFileSurfaceProps {
 
 type SourceHighlightStatus = "highlighting" | "ready" | "error";
 
+const SOURCE_SCROLL_RETRY_DELAY_MS = 100;
+const SOURCE_SCROLL_MAX_RETRIES = 3;
+
 function useSourcePullToRefresh(onRefresh: SourceFileSurfaceProps["onRefresh"]) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const handleRefresh = useCallback(async () => {
@@ -222,16 +225,50 @@ function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
   const { lines, status, targetIndex, tokens } = useSourceFileModel(props);
   const { handleRefresh, isRefreshing } = useSourcePullToRefresh(props.onRefresh);
   const listRef = useRef<FlatList<string>>(null);
+  const scrollRetryCountRef = useRef(0);
+  const scrollRetryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scrollToTargetIndex = useCallback((index: number) => {
+    listRef.current?.scrollToIndex({ index, animated: false, viewPosition: 0.3 });
+  }, []);
 
   useEffect(() => {
     if (targetIndex === null) {
       return;
     }
+    scrollRetryCountRef.current = 0;
     const frame = requestAnimationFrame(() => {
-      listRef.current?.scrollToIndex({ index: targetIndex, animated: false, viewPosition: 0.3 });
+      scrollToTargetIndex(targetIndex);
     });
-    return () => cancelAnimationFrame(frame);
-  }, [props.path, targetIndex]);
+    return () => {
+      cancelAnimationFrame(frame);
+      if (scrollRetryTimeoutRef.current !== null) {
+        clearTimeout(scrollRetryTimeoutRef.current);
+        scrollRetryTimeoutRef.current = null;
+      }
+    };
+  }, [props.path, scrollToTargetIndex, targetIndex]);
+
+  const handleScrollToIndexFailed = useCallback(
+    (failure: { readonly averageItemLength: number; readonly index: number }) => {
+      listRef.current?.scrollToOffset({
+        animated: false,
+        offset: failure.averageItemLength * failure.index,
+      });
+      if (scrollRetryCountRef.current >= SOURCE_SCROLL_MAX_RETRIES) {
+        return;
+      }
+      scrollRetryCountRef.current += 1;
+      if (scrollRetryTimeoutRef.current !== null) {
+        clearTimeout(scrollRetryTimeoutRef.current);
+      }
+      scrollRetryTimeoutRef.current = setTimeout(() => {
+        scrollRetryTimeoutRef.current = null;
+        scrollToTargetIndex(failure.index);
+      }, SOURCE_SCROLL_RETRY_DELAY_MS);
+    },
+    [scrollToTargetIndex],
+  );
 
   const renderLine = useCallback(
     ({ item, index }: { item: string; index: number }) => (
@@ -255,6 +292,7 @@ function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
       initialNumToRender={80}
       maxToRenderPerBatch={80}
       windowSize={12}
+      onScrollToIndexFailed={handleScrollToIndexFailed}
       {...(props.onRefresh
         ? {
             refreshing: isRefreshing,

--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -36,6 +36,23 @@ interface SourceFileSurfaceProps {
 
 type SourceHighlightStatus = "highlighting" | "ready" | "error";
 
+function useSourcePullToRefresh(onRefresh: SourceFileSurfaceProps["onRefresh"]) {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const handleRefresh = useCallback(async () => {
+    if (!onRefresh) {
+      return;
+    }
+    setIsRefreshing(true);
+    try {
+      await onRefresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [onRefresh]);
+
+  return { handleRefresh, isRefreshing };
+}
+
 const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
   readonly codeSurface: ResolvedMobileCodeSurface;
   readonly index: number;
@@ -157,18 +174,7 @@ function NativeSourceFileSurface(
   const appTheme = useUniwindTheme();
   const { width: viewportWidth } = useWindowDimensions();
   const { rowsJson, status, targetIndex, tokens } = useSourceFileModel(props);
-  const [isPullRefreshing, setIsPullRefreshing] = useState(false);
-  const handlePullToRefresh = useCallback(async () => {
-    if (!onRefresh) {
-      return;
-    }
-    setIsPullRefreshing(true);
-    try {
-      await onRefresh();
-    } finally {
-      setIsPullRefreshing(false);
-    }
-  }, [onRefresh]);
+  const { handleRefresh, isRefreshing } = useSourcePullToRefresh(onRefresh);
   const tokensJson = useMemo(() => JSON.stringify(buildNativeSourceTokens(tokens)), [tokens]);
   const selectedRowIdsJson = useMemo(
     () => JSON.stringify(targetIndex === null ? [] : [nativeSourceRowId(targetIndex)]),
@@ -202,8 +208,8 @@ function NativeSourceFileSurface(
         tokensJson={tokensJson}
         {...(onRefresh
           ? {
-              refreshing: isPullRefreshing,
-              onPullToRefresh: () => void handlePullToRefresh(),
+              refreshing: isRefreshing,
+              onPullToRefresh: () => void handleRefresh(),
             }
           : {})}
       />
@@ -214,6 +220,7 @@ function NativeSourceFileSurface(
 function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
   const { codeSurface, codeWordBreak } = useAppearanceCodeSurface();
   const { lines, status, targetIndex, tokens } = useSourceFileModel(props);
+  const { handleRefresh, isRefreshing } = useSourcePullToRefresh(props.onRefresh);
   const listRef = useRef<FlatList<string>>(null);
 
   useEffect(() => {
@@ -248,6 +255,12 @@ function JavaScriptSourceFileSurface(props: SourceFileSurfaceProps) {
       initialNumToRender={80}
       maxToRenderPerBatch={80}
       windowSize={12}
+      {...(props.onRefresh
+        ? {
+            refreshing: isRefreshing,
+            onRefresh: () => void handleRefresh(),
+          }
+        : {})}
       {...(codeWordBreak
         ? {}
         : {


### PR DESCRIPTION
The mobile file viewer always selected the fixed-row native renderer, even when code word break was enabled. Reducing that renderer's content width clipped long lines and removed horizontal scrolling without actually wrapping them.

Use the existing JavaScript source surface when word break is enabled. This gives wrapped lines variable height and matches the Appearance preview, while retaining the performant native renderer and horizontal scrolling when word break is disabled.

Verification:
- `pnpm --filter @t3tools/mobile typecheck`
- `vp fmt --check apps/mobile/src/features/files/SourceFileSurface.tsx`

Implemented with gpt-5.6-sol via the Codex harness in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pull-to-refresh support to the JavaScript source file display surface.
  - Improved scrolling to selected source locations, including retry handling when content is not yet ready.

- **Bug Fixes**
  - Source files now correctly use the JavaScript display surface when word-break mode is enabled.
  - The native display surface is used only when supported and compatible with the selected appearance settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->