### PR TITLE
Add Harness provider for local Mixr routing

### DIFF
--- a/apps/server/src/provider/Drivers/HarnessDriver.ts
+++ b/apps/server/src/provider/Drivers/HarnessDriver.ts
@@ -1,0 +1,126 @@
+import { HarnessSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeHarnessTextGeneration } from "../../textGeneration/HarnessTextGeneration.ts";
+import * as BackgroundPolicy from "../../background/BackgroundPolicy.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeHarnessAdapter } from "../Layers/HarnessAdapter.ts";
+import {
+  checkHarnessProviderStatus,
+  makePendingHarnessProvider,
+} from "../Layers/HarnessProvider.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+
+const decodeHarnessSettings = Schema.decodeSync(HarnessSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("harness");
+
+export type HarnessDriverEnv =
+  | BackgroundPolicy.BackgroundPolicy
+  | Crypto.Crypto
+  | HttpClient.HttpClient
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const HarnessDriver: ProviderDriver<HarnessSettings, HarnessDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Harness",
+    supportsMultipleInstances: true,
+  },
+  configSchema: HarnessSettings,
+  defaultConfig: (): HarnessSettings => decodeHarnessSettings({}),
+  create: ({ instanceId, displayName, accentColor, enabled, config }) =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies HarnessSettings;
+      const maintenanceCapabilities = makeManualOnlyProviderMaintenanceCapabilities({
+        provider: DRIVER_KIND,
+        packageName: null,
+      });
+
+      const adapter = yield* makeHarnessAdapter(effectiveConfig, { instanceId });
+      const textGeneration = yield* makeHarnessTextGeneration(effectiveConfig);
+
+      const checkProvider = checkHarnessProviderStatus(effectiveConfig).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(HttpClient.HttpClient, httpClient),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<ProviderSnapshotSettings<HarnessSettings>>({
+        resolveMaintenance: () => Effect.succeed(maintenanceCapabilities),
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          makePendingHarnessProvider(settings.provider).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        enrichSnapshot: ({ snapshot, publishSnapshot }) => publishSnapshot(snapshot),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Harness snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/HarnessAdapter.ts
+++ b/apps/server/src/provider/Layers/HarnessAdapter.ts
@@ -1,0 +1,352 @@
+import {
+  EventId,
+  type HarnessSettings,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderSessionStartInput,
+  type ProviderSendTurnInput,
+  type ProviderTurnStartResult,
+  RuntimeItemId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+} from "../Errors.ts";
+import type { HarnessAdapterShape } from "../Services/HarnessAdapter.ts";
+
+const PROVIDER = ProviderDriverKind.make("harness");
+const HARNESS_RESUME_VERSION = 1 as const;
+
+function normalizeBaseUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim().replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : "http://127.0.0.1:8765";
+}
+
+function parseResume(raw: unknown): { readonly nodeId: string } | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const record = raw as Record<string, unknown>;
+  if (record.schemaVersion !== HARNESS_RESUME_VERSION) {
+    return undefined;
+  }
+  if (typeof record.nodeId !== "string" || record.nodeId.trim().length === 0) {
+    return undefined;
+  }
+  return { nodeId: record.nodeId.trim() };
+}
+
+interface HarnessSessionContext {
+  readonly threadId: ThreadId;
+  nodeId: string;
+  session: ProviderSession;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  stopped: boolean;
+}
+
+export interface HarnessAdapterLiveOptions {
+  readonly instanceId?: ProviderInstanceId;
+}
+
+export const makeHarnessAdapter = Effect.fn("makeHarnessAdapter")(function* (
+  settings: HarnessSettings,
+  options?: HarnessAdapterLiveOptions,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const http = yield* HttpClient.HttpClient;
+  const baseUrl = normalizeBaseUrl(settings.serverUrl);
+  const sessionsRef = yield* Ref.make(new Map<ThreadId, HarnessSessionContext>());
+  const eventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+  const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+  const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+    Effect.mapError(
+      (cause) =>
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "crypto/randomUUIDv4",
+          detail: "Failed to generate Harness runtime identifier.",
+          cause,
+        }),
+    ),
+  );
+  const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+  const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+  const publish = (event: ProviderRuntimeEvent) =>
+    PubSub.publish(eventPubSub, event).pipe(Effect.asVoid);
+
+  const requireSession = (threadId: ThreadId) =>
+    Ref.get(sessionsRef).pipe(
+      Effect.flatMap((sessions) => {
+        const ctx = sessions.get(threadId);
+        if (!ctx || ctx.stopped) {
+          return new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId,
+          });
+        }
+        return Effect.succeed(ctx);
+      }),
+    );
+
+  const postJson = <T>(path: string, body: unknown, threadId: ThreadId) =>
+    http
+      .execute(
+        HttpClientRequest.post(`${baseUrl}${path}`).pipe(
+          HttpClientRequest.bodyText(JSON.stringify(body), "application/json"),
+        ),
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: `Harness request failed: ${String(cause)}`,
+              cause,
+            }),
+        ),
+        Effect.flatMap((response) =>
+          response.status >= 200 && response.status < 300
+            ? response.json.pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new ProviderAdapterRequestError({
+                      provider: PROVIDER,
+                      method: path,
+                      detail: `Harness ${path} returned invalid JSON`,
+                      cause,
+                    }),
+                ),
+              )
+            : new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: path,
+                detail: `Harness ${path} returned HTTP ${response.status}`,
+              }),
+        ),
+        Effect.map((json) => json as T),
+      );
+
+  const adapter: HarnessAdapterShape = {
+    provider: PROVIDER,
+    capabilities: { sessionModelSwitch: "unsupported" },
+
+    startSession: (input: ProviderSessionStartInput) =>
+      Effect.gen(function* () {
+        const resume = parseResume(input.resumeCursor);
+        const payload = yield* postJson<{
+          readonly sessionId: string;
+          readonly nodeId: string;
+          readonly title?: string;
+        }>(
+          "/api/provider/session",
+          {
+            threadId: input.threadId,
+            title: input.title ?? "t3-thread",
+            cwd: input.cwd,
+            ...(resume ? { resumeNodeId: resume.nodeId } : {}),
+          },
+          input.threadId,
+        );
+
+        const createdAt = yield* nowIso;
+        const session: ProviderSession = {
+          threadId: input.threadId,
+          provider: PROVIDER,
+          ...(options?.instanceId ? { providerInstanceId: options.instanceId } : {}),
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          createdAt,
+          updatedAt: createdAt,
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          resumeCursor: {
+            schemaVersion: HARNESS_RESUME_VERSION,
+            nodeId: payload.nodeId,
+          },
+        };
+
+        const ctx: HarnessSessionContext = {
+          threadId: input.threadId,
+          nodeId: payload.nodeId,
+          session,
+          turns: [],
+          stopped: false,
+        };
+        yield* Ref.update(sessionsRef, (map) => {
+          const next = new Map(map);
+          next.set(input.threadId, ctx);
+          return next;
+        });
+
+        const stamp = yield* makeEventStamp();
+        yield* publish({
+          type: "session.started",
+          ...stamp,
+          provider: PROVIDER,
+          threadId: input.threadId,
+          payload: { message: "Harness session ready" },
+          raw: { source: "harness.http", method: "session", payload },
+        });
+        return session;
+      }),
+
+    sendTurn: (input: ProviderSendTurnInput) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        const turnId = TurnId.make(yield* randomUUIDv4);
+        const text = input.input?.trim() ?? "";
+        if (!text) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "sendTurn",
+            detail: "Harness turn requires non-empty input.",
+          });
+        }
+
+        ctx.turns = [...ctx.turns, { id: turnId, items: [] }];
+        const startedStamp = yield* makeEventStamp();
+        yield* publish({
+          type: "turn.started",
+          ...startedStamp,
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: {},
+          raw: { source: "harness.http", method: "turn.started", payload: { turnId } },
+        });
+
+        const result = yield* postJson<{
+          readonly assistantText: string;
+          readonly route?: unknown;
+        }>(
+          "/api/provider/turn",
+          {
+            sessionId: ctx.nodeId,
+            input: text,
+          },
+          input.threadId,
+        );
+
+        const itemId = RuntimeItemId.make(yield* randomUUIDv4);
+        const deltaStamp = yield* makeEventStamp();
+        yield* publish({
+          type: "content.delta",
+          ...deltaStamp,
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          itemId,
+          payload: {
+            streamKind: "assistant_text",
+            delta: result.assistantText,
+          },
+          raw: {
+            source: "harness.http",
+            method: "turn",
+            payload: result,
+          },
+        });
+
+        const completedStamp = yield* makeEventStamp();
+        yield* publish({
+          type: "turn.completed",
+          ...completedStamp,
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: { state: "completed" as const },
+          raw: { source: "harness.http", method: "turn.completed", payload: result.route ?? {} },
+        });
+
+        const turnResult: ProviderTurnStartResult = {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: {
+            schemaVersion: HARNESS_RESUME_VERSION,
+            nodeId: ctx.nodeId,
+          },
+        };
+        return turnResult;
+      }),
+
+    interruptTurn: (threadId) =>
+      requireSession(threadId).pipe(
+        Effect.flatMap((ctx) =>
+          Effect.gen(function* () {
+            const stamp = yield* makeEventStamp();
+            yield* publish({
+              type: "turn.aborted",
+              ...stamp,
+              provider: PROVIDER,
+              threadId,
+              payload: { reason: "interrupted" },
+              raw: {
+                source: "harness.http",
+                method: "interrupt",
+                payload: { nodeId: ctx.nodeId },
+              },
+            });
+          }),
+        ),
+      ),
+
+    respondToRequest: () => Effect.void,
+    respondToUserInput: () => Effect.void,
+
+    stopSession: (threadId) =>
+      Ref.update(sessionsRef, (map) => {
+        const next = new Map(map);
+        next.delete(threadId);
+        return next;
+      }),
+
+    listSessions: () =>
+      Ref.get(sessionsRef).pipe(
+        Effect.map((sessions) =>
+          Array.from(sessions.values())
+            .filter((ctx) => !ctx.stopped)
+            .map((ctx) => ctx.session),
+        ),
+      ),
+
+    hasSession: (threadId) =>
+      Ref.get(sessionsRef).pipe(Effect.map((sessions) => sessions.has(threadId))),
+
+    readThread: (threadId) =>
+      requireSession(threadId).pipe(
+        Effect.map((ctx) => ({
+          threadId,
+          turns: ctx.turns,
+        })),
+      ),
+
+    rollbackThread: (threadId, numTurns) =>
+      requireSession(threadId).pipe(
+        Effect.map((ctx) => {
+          ctx.turns = ctx.turns.slice(0, Math.max(0, ctx.turns.length - numTurns));
+          return { threadId, turns: ctx.turns };
+        }),
+      ),
+
+    stopAll: () => Ref.set(sessionsRef, new Map()),
+
+    streamEvents: Stream.fromPubSub(eventPubSub),
+  };
+
+  return adapter;
+});

--- a/apps/server/src/provider/Layers/HarnessProvider.ts
+++ b/apps/server/src/provider/Layers/HarnessProvider.ts
@@ -1,0 +1,178 @@
+import {
+  type HarnessSettings,
+  type ModelCapabilities,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { createModelCapabilities } from "@t3tools/shared/model";
+
+import {
+  buildServerProvider,
+  providerModelsFromSettings,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+
+const HARNESS_PRESENTATION = {
+  displayName: "Harness",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: false,
+} as const;
+
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const HARNESS_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "z-ai/glm-5.3-flash",
+    name: "GLM 5.3 Flash",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "z-ai/glm-5.3",
+    name: "GLM 5.3",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "minimax/minimax-m3",
+    name: "MiniMax M3",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "moonshotai/kimi-k3",
+    name: "Kimi K3",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "deepseek/deepseek-chat",
+    name: "DeepSeek Chat",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+];
+
+function normalizeBaseUrl(serverUrl: string): string {
+  const trimmed = serverUrl.trim().replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : "http://127.0.0.1:8765";
+}
+
+function harnessModels(settings: HarnessSettings): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    HARNESS_BUILT_IN_MODELS,
+    settings.customModels ?? [],
+    EMPTY_CAPABILITIES,
+  );
+}
+
+export function makePendingHarnessProvider(
+  settings: HarnessSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = harnessModels(settings);
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: HARNESS_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Harness is disabled in T3 Code settings.",
+        },
+      });
+    }
+    return buildServerProvider({
+      presentation: HARNESS_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Harness desk…",
+      },
+    });
+  });
+}
+
+export function checkHarnessProviderStatus(
+  settings: HarnessSettings,
+): Effect.Effect<ServerProviderDraft, never, HttpClient.HttpClient> {
+  return Effect.gen(function* () {
+    const http = yield* HttpClient.HttpClient;
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = harnessModels(settings);
+    const baseUrl = normalizeBaseUrl(settings.serverUrl);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: HARNESS_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Harness is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    const unreachable = buildServerProvider({
+      presentation: HARNESS_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: `Couldn't reach Harness at ${baseUrl}. Run \`harness serve <chat-root>\` on this machine.`,
+      },
+    });
+
+    const body = yield* http.execute(HttpClientRequest.get(`${baseUrl}/api/health`)).pipe(
+      Effect.flatMap((response) => response.json),
+      Effect.timeout("3 seconds"),
+      Effect.orElseSucceed(() => null),
+    );
+
+    if (body === null || typeof body !== "object") {
+      return unreachable;
+    }
+
+    const record = body as { readonly ok?: boolean; readonly version?: string };
+    const version = typeof record.version === "string" ? record.version : null;
+    return buildServerProvider({
+      presentation: HARNESS_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version,
+        status: record.ok === true ? "ready" : "warning",
+        auth: { status: "authenticated", type: "harness" },
+        message:
+          record.ok === true
+            ? `Harness desk reachable at ${baseUrl}.`
+            : `Harness responded unexpectedly from ${baseUrl}.`,
+      },
+    });
+  });
+}

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -2616,6 +2616,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 "codex",
                 "cursor",
                 "grok",
+                "harness",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/Services/HarnessAdapter.ts
+++ b/apps/server/src/provider/Services/HarnessAdapter.ts
@@ -1,0 +1,9 @@
+/**
+ * HarnessAdapter — shape type for the Harness HTTP provider adapter.
+ *
+ * @module HarnessAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+export interface HarnessAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { HarnessDriver, type HarnessDriverEnv } from "./Drivers/HarnessDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
@@ -38,6 +39,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | HarnessDriverEnv
   | OpenCodeDriverEnv
   | AntigravityDriverEnv;
 
@@ -51,6 +53,7 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  HarnessDriver,
   OpenCodeDriver,
   AntigravityDriver,
 ];

--- a/apps/server/src/textGeneration/HarnessTextGeneration.ts
+++ b/apps/server/src/textGeneration/HarnessTextGeneration.ts
@@ -1,0 +1,56 @@
+import * as Effect from "effect/Effect";
+import type { HarnessSettings } from "@t3tools/contracts";
+import { sanitizeFeatureBranchName } from "@t3tools/shared/git";
+
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+
+/**
+ * Heuristic text generation for Harness until Mixr proxies live completions
+ * for git/title jobs. Keeps the driver usable without a frontier model call.
+ */
+export const makeHarnessTextGeneration = Effect.fn("makeHarnessTextGeneration")(function* (
+  _settings: HarnessSettings,
+) {
+  void _settings;
+
+  const firstLine = (message: string): string => {
+    const line = message
+      .split(/\r?\n/)
+      .map((part) => part.trim())
+      .find((part) => part.length > 0);
+    return line ?? "update";
+  };
+
+  return TextGeneration.TextGeneration.of({
+    generateCommitMessage: (input) =>
+      Effect.sync(() => {
+        const subject = sanitizeCommitSubject(firstLine(input.stagedSummary || input.stagedPatch));
+        return {
+          subject,
+          body: "",
+          ...(input.includeBranch ? { branch: sanitizeFeatureBranchName(subject) } : {}),
+        };
+      }),
+    generatePrContent: (input) =>
+      Effect.sync(() => {
+        const title = sanitizePrTitle(firstLine(input.commitSummary || input.diffSummary));
+        return {
+          title,
+          body: input.diffSummary.slice(0, 4_000),
+        };
+      }),
+    generateBranchName: (input) =>
+      Effect.sync(() => ({
+        branch: sanitizeFeatureBranchName(firstLine(input.message)),
+      })),
+    generateThreadTitle: (input) =>
+      Effect.sync(() => ({
+        title: sanitizeThreadTitle(firstLine(input.message)),
+      })),
+  });
+});

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -8,7 +8,13 @@ import * as ProviderInstanceRegistry from "../provider/Services/ProviderInstance
 import type { ProviderInstance } from "../provider/ProviderDriver.ts";
 import type { TextGenerationPolicy } from "./TextGenerationPolicy.ts";
 
-export type TextGenerationProvider = "codex" | "claudeAgent" | "cursor" | "grok" | "opencode";
+export type TextGenerationProvider =
+  | "codex"
+  | "claudeAgent"
+  | "cursor"
+  | "grok"
+  | "harness"
+  | "opencode";
 
 export interface CommitMessageGenerationInput {
   cwd: string;

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -681,6 +681,19 @@ export const OpenCodeIcon: Icon = (props) => (
   </svg>
 );
 
+/** DevCentr Harness provider mark — framed H for the provider picker. */
+export const HarnessIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M16 2L28 9.5V22.5L16 30L4 22.5V9.5L16 2Z"
+      className="stroke-current"
+      strokeWidth="2"
+      fill="none"
+    />
+    <path d="M16 10V22M11 14H21M11 18H21" className="stroke-current" strokeWidth="2" />
+  </svg>
+);
+
 export const GithubCopilotIcon: Icon = ({ className, ...props }) => (
   <svg
     {...props}

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -4,6 +4,7 @@ import {
   ClaudeAI,
   CursorIcon,
   GrokIcon,
+  HarnessIcon,
   Icon,
   OpenAI,
   OpenCodeIcon,
@@ -15,6 +16,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("harness")]: HarnessIcon,
   [ProviderDriverKind.make("antigravity")]: AntigravityIcon,
 };
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -22,6 +22,10 @@ OpenCode also stores persistent approval grants per directory. Automatic full-ac
 `once` so they cannot widen a supervised thread's permissions on a shared external server.
 See the [adapter](../../apps/server/src/provider/Layers/OpenCodeAdapter.ts).
 
+Harness sessions are routed through the configured local desk server. The
+[Harness driver](../../apps/server/src/provider/Drivers/HarnessDriver.ts) keeps each T3 thread's
+remote node identifier in its resume cursor and scopes in-memory session state by thread.
+
 Antigravity separates account profiles per instance while sharing installed executables across the
 environment. It forces file-based credential storage because the native macOS keychain entry would
 otherwise be shared across instances. The launch environment removes ambient Google credentials,

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -148,6 +148,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const HARNESS_DRIVER_KIND = ProviderDriverKind.make("harness");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
 
@@ -173,6 +174,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
   [ProviderDriverKind.make("antigravity")]: ANTIGRAVITY_DEFAULT_MODEL,
+  [HARNESS_DRIVER_KIND]: "z-ai/glm-5.3-flash",
 };
 
 /** Per-provider text generation model defaults. */
@@ -184,6 +186,7 @@ export const DEFAULT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [HARNESS_DRIVER_KIND]: "z-ai/glm-5.3-flash",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -210,6 +213,12 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [HARNESS_DRIVER_KIND]: {
+    glm: "z-ai/glm-5.3",
+    "glm-flash": "z-ai/glm-5.3-flash",
+    minimax: "minimax/minimax-m3",
+    kimi: "moonshotai/kimi-k3",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -221,4 +230,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [HARNESS_DRIVER_KIND]: "Harness",
 };

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -28,6 +28,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("claude.sdk.permission"),
   Schema.Literal("codex.sdk.thread-event"),
   Schema.Literal("opencode.sdk.event"),
+  Schema.Literal("harness.http"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
 ]);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -706,6 +706,41 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const HarnessSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("harness").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Harness binary (optional when serverUrl is set).",
+        providerSettingsForm: { placeholder: "harness", clearWhenEmpty: "omit" },
+      }),
+    ),
+    serverUrl: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("http://127.0.0.1:8765")),
+      Schema.annotateKey({
+        title: "Server URL",
+        description: "Harness desk base URL (`harness serve`). Required for the HarnessDriver.",
+        providerSettingsForm: {
+          placeholder: "http://127.0.0.1:8765",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(CustomModelSetting).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["serverUrl", "binaryPath"],
+  },
+);
+export type HarnessSettings = typeof HarnessSettings.Type;
+
 /**
  * Antigravity ACP auth methods. Personal and Enterprise open a Google sign-in
  * in the browser. The API key and Agent Platform methods take credentials from
@@ -1042,6 +1077,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    harness: HarnessSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
@@ -1208,6 +1244,13 @@ const AntigravitySettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(CustomModelSetting)),
 });
 
+const HarnessSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  serverUrl: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(CustomModelSetting)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -1272,6 +1315,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
+      harness: Schema.optionalKey(HarnessSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
       antigravity: Schema.optionalKey(AntigravitySettingsPatch),
     }),


### PR DESCRIPTION
## Summary

Hi! T3 Code already supports several agent backends, but it cannot currently connect to DevCentr’s lightweight local Harness runtime.

This PR adds Harness as a built-in provider:

- adds typed `harness` settings for the local server URL and optional binary path
- maps T3 Code sessions and turns onto Harness’s `/api/provider/*` HTTP surface
- reports Harness health and runtime events through the existing provider registry
- adds Harness to the provider picker with a small neutral provider mark

Harness currently returns its persisted Mixr route confirmation while live routed completion invocation is still being implemented in the runtime. The adapter deliberately preserves that current behavior rather than hiding it.

Happy to adjust naming or integration details to better fit the provider architecture.

## Screenshots

Not included. The visible change is limited to a Harness entry in the existing provider picker.

## How to try it

1. Build and run `harness serve <chat-root> --port=8765`.
2. Configure the Harness provider’s server URL as `http://127.0.0.1:8765`.
3. Select **Harness** in the provider picker and start a thread.

## Validation

- contracts, server, and web typechecks
- repository formatting checks
- 182 targeted provider, settings, and UI tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Harness as a supported provider for AI sessions and text generation.
  * Added Harness configuration for server URL, enabled state, custom models, and related settings.
  * Added session management, streaming responses, interruption, and connection health checks.
  * Added built-in model options and provider aliases.
  * Added Harness branding in the provider interface.

* **Documentation**
  * Documented Harness session routing and thread isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->