### PR TITLE
fix(web): clone destination picker no longer clips folders behind its footer

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -2572,12 +2572,12 @@ function OpenCommandPaletteDialog(props: {
         setHighlightedItemValue(typeof value === "string" ? value : null);
       }}
       onValueChange={handleQueryChange}
-      panelClassName="max-h-[min(28rem,70vh)]"
+      panelClassName="flex max-h-[min(28rem,70vh)] min-h-0 flex-col"
       showBackHint={isSubmenu}
       value={query}
     >
       {remoteProjectContext ? (
-        <div className="p-2 pb-0">
+        <div className="shrink-0 p-2 pb-0">
           <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Repository</div>
           <div className="flex min-h-8 items-center gap-2 rounded-sm px-2 py-1.5">
             {remoteProjectContext.icon}


### PR DESCRIPTION
## What Changed

The clone confirm step of the command palette (Add project → Git URL / GitHub repository → choose destination) now scrolls every directory row fully above the Navigate / Select / Back / Close footer.

Two class changes in `apps/web/src/components/CommandPalette.tsx`: the palette panel becomes a constrained flex column (`flex min-h-0 flex-col`, keeping its existing max-height), and the fixed **Repository** block above the list is `shrink-0`.

## Why

Fixes #10829.

`CommandPanel` is `overflow-hidden` but not a flex column, and the directory list's `ScrollArea` root is `size-full`. On the clone confirm step the non-scrolling Repository block sits above that list, so the list still measured the full panel height but started 84px lower. Its bottom 84px were clipped by the panel, directly behind the footer, and the last directory could never be scrolled into view. Measured at 1280×820: with the list scrolled to the end, the last row sat at y=505–537 while the panel ended at 461.

With the panel as a flex column the list shrinks to the remaining space: the scroll viewport now ends exactly at the footer's top edge and the last row lands at 421–453, fully visible. This is the pattern the content search palette already uses (`panelClassName="flex min-h-0 flex-1 flex-col"`) and matches the fix suggested in the issue triage.

Checked for regressions in the plain palette and in Add project → Local folder browse mode: with no Repository block the list still fills the panel and scrolls as before.

Verification: `vp lint` (only pre-existing warnings on untouched lines), `vp fmt --check`, and `vp run --filter @t3tools/web typecheck` pass.

## UI Changes

Destination picker with the list scrolled to the end, 1280×820. In the before image the bottom rows are cut off under the footer; after, the last folder (`wp-wt-60281`) is fully visible above it.

| Before | After |
| --- | --- |
| ![Before: last rows clipped behind the footer](https://github.com/tan7vir/t3code/releases/download/pr-evidence-10829/clone-picker-before.png) | ![After: last row scrolls fully above the footer](https://github.com/tan7vir/t3code/releases/download/pr-evidence-10829/clone-picker-after.png) |

Full-window captures: [before](https://github.com/tan7vir/t3code/releases/download/pr-evidence-10829/clone-picker-before-full.png) · [after](https://github.com/tan7vir/t3code/releases/download/pr-evidence-10829/clone-picker-after-full.png).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable: no motion or interaction change)

Written by Claude Fable 5.1 in Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command palette layout behavior to better constrain panel height and preserve the remote repository context header’s visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->