### PR TITLE
fix(usage): keep same-email Codex subscriptions apart when their plans differ

### DIFF
--- a/apps/server/src/usage/cliproxyApi.ts
+++ b/apps/server/src/usage/cliproxyApi.ts
@@ -221,9 +221,11 @@ export const makeCliproxyApi = Effect.gen(function* () {
               ]
             : [],
         );
+        // The OAuth usage read carries no subscription tier, and the pooled
+        // views treat a plan label as part of the account's identity, so the
+        // hub claims none rather than a placeholder a native tier would not match.
         return {
           ...base,
-          plan: "Claude Subscription",
           usageLimits: claudeUsageResponseToLimits({
             checkedAt,
             response: {

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -238,6 +238,18 @@ describe("collectLimitSources", () => {
     ).toEqual(accounts);
   });
 
+  it("does not hide a hub account whose plan differs from the native subscription", () => {
+    const plusNative = {
+      ...native,
+      auth: { ...native.auth, label: "ChatGPT Plus Subscription" },
+    };
+    const businessAccount = { ...account, plan: "ChatGPT Business Subscription" };
+
+    expect(collectLimitSources(presentations([plusNative], [businessAccount]))).toMatchObject([
+      { accounts: [businessAccount], hiddenAccountCount: 0 },
+    ]);
+  });
+
   it.each([
     { enabled: false },
     { installed: false },
@@ -387,6 +399,73 @@ describe("pools", () => {
     });
     // The fresher native snapshot wins; the hub row is pre-filtered by email.
     expect(accounts[0]?.limits.windows[0]?.usedPercent).toBe(55);
+  });
+
+  it("still merges same-email accounts when both sides report the same plan", () => {
+    const native = provider({
+      driver: claude,
+      instanceId: ProviderInstanceId.make("claude"),
+      auth: { status: "authenticated", email: "same@example.com", label: "Claude Subscription" },
+      usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 40 }] },
+    });
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [native],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "claude-same@example.com.json",
+                    driver: claude,
+                    email: "same@example.com",
+                    plan: "Claude Subscription",
+                    usageLimits: {
+                      checkedAt: "2026-09-03T11:30:00.000Z",
+                      windows: [{ ...window, usedPercent: 55 }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    expect(collectLimitAccounts(input)).toHaveLength(1);
+  });
+
+  it("keeps same-email Codex instances apart when their plans differ", () => {
+    const plus = provider({
+      instanceId: ProviderInstanceId.make("codex-plus"),
+      auth: {
+        status: "authenticated",
+        email: "same@example.com",
+        label: "ChatGPT Plus Subscription",
+      },
+      usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 20 }] },
+    });
+    const business = provider({
+      instanceId: ProviderInstanceId.make("codex-business"),
+      auth: {
+        status: "authenticated",
+        email: "same@example.com",
+        label: "ChatGPT Business Subscription",
+      },
+      usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 70 }] },
+    });
+    const input = new Map([
+      [EnvironmentId.make("env-a"), { ...laptop, serverConfig: { providers: [plus, business] } }],
+    ]);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts).toHaveLength(2);
+    const byPlan = new Map(accounts.map((entry) => [entry.plan, entry]));
+    expect(byPlan.get("ChatGPT Plus Subscription")?.limits.windows[0]?.usedPercent).toBe(20);
+    expect(byPlan.get("ChatGPT Business Subscription")?.limits.windows[0]?.usedPercent).toBe(70);
   });
 
   it("takes windows from a fresher hub read but credits and redeem from the native instance", () => {

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -403,9 +403,53 @@ describe("pools", () => {
 
   it("still merges same-email accounts when both sides report the same plan", () => {
     const native = provider({
+      auth: {
+        status: "authenticated",
+        email: "same@example.com",
+        label: "ChatGPT Plus Subscription",
+      },
+      usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 40 }] },
+    });
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: {
+            providers: [native],
+            usageLimitSources: [
+              {
+                ...source,
+                accounts: [
+                  {
+                    id: "codex-same@example.com.json",
+                    driver: ProviderDriverKind.make("codex"),
+                    email: "same@example.com",
+                    plan: "ChatGPT Plus Subscription",
+                    usageLimits: {
+                      checkedAt: "2026-09-03T11:30:00.000Z",
+                      windows: [{ ...window, usedPercent: 55 }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    expect(collectLimitAccounts(input)).toHaveLength(1);
+  });
+
+  it("merges a native Claude tier with the hub's tierless read of the same account", () => {
+    const native = provider({
       driver: claude,
       instanceId: ProviderInstanceId.make("claude"),
-      auth: { status: "authenticated", email: "same@example.com", label: "Claude Subscription" },
+      auth: {
+        status: "authenticated",
+        email: "same@example.com",
+        label: "Claude Max Subscription",
+      },
       usageLimits: { checkedAt, windows: [{ ...window, usedPercent: 40 }] },
     });
     const input = new Map([
@@ -423,7 +467,6 @@ describe("pools", () => {
                     id: "claude-same@example.com.json",
                     driver: claude,
                     email: "same@example.com",
-                    plan: "Claude Subscription",
                     usageLimits: {
                       checkedAt: "2026-09-03T11:30:00.000Z",
                       windows: [{ ...window, usedPercent: 55 }],
@@ -436,7 +479,10 @@ describe("pools", () => {
         },
       ],
     ]);
-    expect(collectLimitAccounts(input)).toHaveLength(1);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.plan).toBe("Claude Max Subscription");
+    expect(accounts[0]?.limits.windows[0]?.usedPercent).toBe(55);
   });
 
   it("keeps same-email Codex instances apart when their plans differ", () => {

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -438,7 +438,10 @@ describe("pools", () => {
         },
       ],
     ]);
-    expect(collectLimitAccounts(input)).toHaveLength(1);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.plan).toBe("ChatGPT Plus Subscription");
+    expect(accounts[0]?.limits.windows[0]?.usedPercent).toBe(55);
   });
 
   it("merges a native Claude tier with the hub's tierless read of the same account", () => {

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -312,31 +312,30 @@ export function collectLimitAccounts(
         : source.label;
       for (const account of source.accounts) {
         if (limitsNotice(account.usageLimits) !== null) continue;
-        merge(
+        const key =
           accountGroupKey(account.driver, account.email, account.plan, knownPlans) ??
-            `${source.id}:${account.id}`,
-          {
-            key: `${source.id}:${account.id}`,
-            driver: account.driver,
-            displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
-            email: account.email,
-            plan: account.plan,
-            accentColor: undefined,
-            environments: [],
-            sourceLabel,
-            redeem: account.usageLimits.resetCredits?.nextCreditId
-              ? {
-                  environmentId,
-                  input: {
-                    sourceId: source.id,
-                    accountId: account.id,
-                    creditId: account.usageLimits.resetCredits.nextCreditId,
-                  },
-                }
-              : null,
-            limits: account.usageLimits,
-          },
-        );
+          `${source.id}:${account.id}`;
+        merge(key, {
+          key: `${source.id}:${account.id}`,
+          driver: account.driver,
+          displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
+          email: account.email,
+          plan: account.plan,
+          accentColor: undefined,
+          environments: [],
+          sourceLabel,
+          redeem: account.usageLimits.resetCredits?.nextCreditId
+            ? {
+                environmentId,
+                input: {
+                  sourceId: source.id,
+                  accountId: account.id,
+                  creditId: account.usageLimits.resetCredits.nextCreditId,
+                },
+              }
+            : null,
+          limits: account.usageLimits,
+        });
       }
     }
   }

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -100,16 +100,17 @@ export function collectLimitSources(
   }
 > {
   const nativeAccounts = new Set<string>();
+  const knownPlans = new Map<string, string>();
   for (const presentation of presentations.values()) {
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
-      const key = accountKey(provider.driver, provider.auth.email);
-      if (
-        key !== null &&
-        provider.usageLimits?.windows.length &&
-        !provider.usageLimits.unavailable
-      ) {
-        nativeAccounts.add(key);
-      }
+      if (!provider.usageLimits?.windows.length || provider.usageLimits.unavailable) continue;
+      const key = accountGroupKey(
+        provider.driver,
+        provider.auth.email,
+        provider.auth.label,
+        knownPlans,
+      );
+      if (key !== null) nativeAccounts.add(key);
     }
   }
   const perEnvironment: Array<{
@@ -130,7 +131,7 @@ export function collectLimitSources(
   return perEnvironment.flatMap(({ environmentId, environmentLabel, sources }) =>
     sources.map((source) => {
       const accounts = source.accounts.filter((account) => {
-        const key = accountKey(account.driver, account.email);
+        const key = accountGroupKey(account.driver, account.email, account.plan, knownPlans);
         return key === null || !nativeAccounts.has(key);
       });
       return {
@@ -151,10 +152,38 @@ function accountKey(driver: ServerProvider["driver"], email: string | undefined)
 }
 
 /**
+ * accountKey, split further when two same-email accounts carry different plan
+ * strings -- a personal ChatGPT Plus subscription and a Business workspace
+ * behind the same address are two independent quotas, not one. An unset plan
+ * on either side does not split the group: callers do not always know a
+ * subscription's plan, and treating unknown as a wildcard keeps the existing
+ * native/hub and multi-environment dedupe intact. `knownPlans` records the
+ * first plan seen per base key; pass one shared map per collection pass so
+ * every account examined agrees on which group is "the" unlabeled one.
+ */
+function accountGroupKey(
+  driver: ServerProvider["driver"],
+  email: string | undefined,
+  plan: string | undefined,
+  knownPlans: Map<string, string>,
+): string | null {
+  const base = accountKey(driver, email);
+  if (base === null || plan === undefined) return base;
+  const knownPlan = knownPlans.get(base);
+  if (knownPlan === undefined) {
+    knownPlans.set(base, plan);
+    return base;
+  }
+  return knownPlan === plan ? base : `${base}::${plan}`;
+}
+
+/**
  * One subscription account as the pooled views see it, whichever way it was
  * reported. The same email signed in natively on two environments, or reported
  * by a hub as well as natively, is one account: its quota is one bucket, so
- * counting it twice would misstate what is left.
+ * counting it twice would misstate what is left. The same email can also hold
+ * two independent subscriptions -- a personal plan and a Business workspace,
+ * say -- which stay two accounts because their plan strings disagree.
  */
 export interface LimitAccount {
   readonly key: string;
@@ -190,6 +219,7 @@ export function collectLimitAccounts(
   const accounts = new Map<string, LimitAccount>();
   const creditSources = new Map<string, LimitAccount>();
   const hubRedeems = new Map<string, LimitAccount>();
+  const knownPlans = new Map<string, string>();
   const merge = (key: string, next: LimitAccount) => {
     // Redeeming through a hub also clears the routing cooldown that hub holds
     // for the account. Redeeming natively against the same subscription resets
@@ -254,7 +284,7 @@ export function collectLimitAccounts(
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
       if (!provider.usageLimits || limitsNotice(provider.usageLimits) !== null) continue;
       merge(
-        accountKey(provider.driver, provider.auth.email) ??
+        accountGroupKey(provider.driver, provider.auth.email, provider.auth.label, knownPlans) ??
           `${environmentId}:${provider.instanceId}`,
         {
           key: `${environmentId}:${provider.instanceId}`,
@@ -282,27 +312,31 @@ export function collectLimitAccounts(
         : source.label;
       for (const account of source.accounts) {
         if (limitsNotice(account.usageLimits) !== null) continue;
-        merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
-          key: `${source.id}:${account.id}`,
-          driver: account.driver,
-          displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
-          email: account.email,
-          plan: account.plan,
-          accentColor: undefined,
-          environments: [],
-          sourceLabel,
-          redeem: account.usageLimits.resetCredits?.nextCreditId
-            ? {
-                environmentId,
-                input: {
-                  sourceId: source.id,
-                  accountId: account.id,
-                  creditId: account.usageLimits.resetCredits.nextCreditId,
-                },
-              }
-            : null,
-          limits: account.usageLimits,
-        });
+        merge(
+          accountGroupKey(account.driver, account.email, account.plan, knownPlans) ??
+            `${source.id}:${account.id}`,
+          {
+            key: `${source.id}:${account.id}`,
+            driver: account.driver,
+            displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
+            email: account.email,
+            plan: account.plan,
+            accentColor: undefined,
+            environments: [],
+            sourceLabel,
+            redeem: account.usageLimits.resetCredits?.nextCreditId
+              ? {
+                  environmentId,
+                  input: {
+                    sourceId: source.id,
+                    accountId: account.id,
+                    creditId: account.usageLimits.resetCredits.nextCreditId,
+                  },
+                }
+              : null,
+            limits: account.usageLimits,
+          },
+        );
       }
     }
   }


### PR DESCRIPTION
## What Changed

`collectLimitSources` and `collectLimitAccounts` in `packages/shared/src/usageLimits.ts` now identify a subscription by driver, email, and the plan string each side already carries (`provider.auth.label` natively, `account.plan` from a hub). Two same-email accounts whose plans differ stay two pooled accounts; an unset plan on either side still merges exactly as before. A small `accountGroupKey` helper next to `accountKey` holds that rule so both collectors agree on identity. `accountKey` itself is unchanged, so `collectProviderUsageLimits` (the `/usage-limits` command) still emits one row per native instance.

The hub adapter (`apps/server/src/usage/cliproxyApi.ts`) no longer labels Claude accounts with a placeholder `"Claude Subscription"` plan. The Anthropic OAuth usage read carries no subscription tier, so that string could never match a native tier such as `"Claude Max Subscription"` and would have split one Claude subscription reported natively and by a hub into two accounts (Macroscope caught this on the first revision). Hub-only Claude accounts therefore show no Plan row in Limits; Codex hub accounts keep their `codexPlanLabel` plan, which is the same table the native provider uses.

## Why

Fixes #10835.

One ChatGPT email can hold a personal Plus subscription and also belong to a Business workspace; those are two independent quotas. `accountKey` was driver + email only, so Usage → Limits collapsed both Codex instances into one account, and because both are probed in the same pass with an identical `checkedAt`, iteration order decided which one survived.

Native and hub Codex plan strings come from the same `codexPlanLabel` table (`apps/server/src/provider/Layers/CodexProvider.ts` and `apps/server/src/usage/cliproxyApi.ts`), so one real subscription produces the same label on both sides and equality is a safe comparison. The existing fixtures show native instances with no label merging with a hub account that does carry a plan, so an unknown plan is treated as compatible rather than as a split, which keeps the native-plus-hub and two-environment dedupe intact.

This follows the fix prescribed in the triage. Because the rule lives in the shared helper, #10700 can adopt it for `/usage-limits` rows when it lands, so both collectors share one identity. Residual, as noted in the triage: two Business workspaces on the same email with an identical plan string still collapse, since nothing on the data distinguishes them today.

## Verification

- `vp test run packages/shared/src/usageLimits.test.ts`: 49 passed. The two new regression tests (same-email Plus + Business stay two accounts; a hub account with a different plan is not hidden behind the native instance) failed before the fix and pass after. Two more pin that same email + same plan still merges into one, and that a native Claude tier still merges with the hub's tierless read of the same account.
- `vp test run apps/server/src/usage/cliproxyApi.test.ts`: 12 passed.
- `vp lint` on both files: clean. `vp run --filter @t3tools/shared typecheck`, `--filter @t3tools/web typecheck`, and `--filter t3 typecheck` (server): pass.

No layout change. The only visible difference is the dropped placeholder Plan row for hub-only Claude accounts, which needs a CLIProxyAPI hub to reproduce, so no screenshot is attached.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (not applicable: no UI change)
- [ ] I included a video for animation/interaction changes (not applicable)

Written by Claude Fable 5.1 in Claude Code, with a Claude Sonnet 5 subagent for the implementation pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Same-email accounts with different subscription plans are now kept separate, preventing incorrect usage-limit merging.
  - Matching plans continue to merge correctly across native and hub accounts.
  - Claude usage now preserves the native plan while using the freshest available usage windows.
  - Codex accounts with different plans remain distinct, ensuring usage limits are attributed to the correct subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->