### PR TITLE
fix(relay): use current APNs registration routing for queued jobs

### DIFF
--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -1978,17 +1978,18 @@ describe("fast completion delivery", () => {
 
 describe("signed APNs registration metadata", () => {
   for (const kind of ["live_activity_update", "push_notification"] as const) {
-    for (const changed of ["bundle", "environment"] as const) {
-      it.effect(`skips ${kind} when the ${changed} changes without token rotation`, () => {
+    for (const changed of ["bundle", "environment", "legacy"] as const) {
+      it.effect(`routes ${kind} using current registration with ${changed} job metadata`, () => {
         const attempts: DeliveryAttempts.DeliveryAttemptInput[] = [];
-        let sent = 0;
+        const requests: HttpClientRequest.HttpClientRequest[] = [];
         const payload = makeApnsDeliveryJobPayload({
           kind,
           userId: target.user_id,
           deviceId: target.device_id,
           token: "unchanged-token",
-          bundleId: "com.t3tools.t3code.dev",
-          apsEnvironment: "sandbox",
+          ...(changed === "legacy"
+            ? {}
+            : { bundleId: "com.t3tools.t3code.dev", apsEnvironment: "sandbox" as const }),
           aggregate: kind === "live_activity_update" ? aggregate : null,
           ...(kind === "push_notification"
             ? {
@@ -2012,8 +2013,14 @@ describe("signed APNs registration metadata", () => {
         return Effect.gen(function* () {
           const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
           const result = yield* deliveries.processSignedJob(signed);
-          expect(sent).toBe(0);
-          expect(result.apnsReason).toBe("Stale APNs delivery job skipped.");
+          expect(result.ok).toBe(true);
+          expect(requests).toHaveLength(1);
+          expect(requests[0]?.url).toBe(
+            `${changed === "environment" ? "https://api.push.apple.com" : "https://api.sandbox.push.apple.com"}/3/device/unchanged-token`,
+          );
+          expect(requests[0]?.headers["apns-topic"]).toBe(
+            `${changed === "bundle" ? "com.t3tools.t3code.preview" : "com.t3tools.t3code.dev"}${kind === "live_activity_update" ? ".push-type.liveactivity" : ""}`,
+          );
         }).pipe(
           Effect.provide(
             makeLayer({
@@ -2031,7 +2038,7 @@ describe("signed APNs registration metadata", () => {
               ],
               execute: (request) =>
                 Effect.sync(() => {
-                  sent++;
+                  requests.push(request);
                   return HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
                 }),
             }),

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -486,6 +486,9 @@ describe("ApnsDeliveries", () => {
       Effect.provide(
         makeLayer({
           attempts,
+          currentTargets: [
+            { ...target, bundle_id: "com.t3tools.t3code.preview", aps_environment: "sandbox" },
+          ],
           config: signingConfig,
           execute,
         }),
@@ -1971,4 +1974,70 @@ describe("fast completion delivery", () => {
       expect(queuedJobs[0]?.payload.alert).toBeUndefined();
     }).pipe(Effect.provide(makeLayer({ attempts: [], queuedJobs })));
   });
+});
+
+describe("signed APNs registration metadata", () => {
+  for (const kind of ["live_activity_update", "push_notification"] as const) {
+    for (const changed of ["bundle", "environment"] as const) {
+      it.effect(`skips ${kind} when the ${changed} changes without token rotation`, () => {
+        const attempts: DeliveryAttempts.DeliveryAttemptInput[] = [];
+        let sent = 0;
+        const payload = makeApnsDeliveryJobPayload({
+          kind,
+          userId: target.user_id,
+          deviceId: target.device_id,
+          token: "unchanged-token",
+          bundleId: "com.t3tools.t3code.dev",
+          apsEnvironment: "sandbox",
+          aggregate: kind === "live_activity_update" ? aggregate : null,
+          ...(kind === "push_notification"
+            ? {
+                notification: {
+                  title: "Thread",
+                  body: "Input: Project",
+                  environmentId: "env",
+                  threadId: "thread",
+                  deepLink: "/",
+                },
+              }
+            : {}),
+          createdAt: "1970-01-01T00:00:00.000Z",
+          expiresAt: "1970-01-01T00:10:00.000Z",
+          jobId: `metadata-${kind}-${changed}`,
+        });
+        const signed = signApnsDeliveryJob({
+          secret: config.apnsDeliveryJobSigningSecret,
+          payload,
+        });
+        return Effect.gen(function* () {
+          const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+          const result = yield* deliveries.processSignedJob(signed);
+          expect(sent).toBe(0);
+          expect(result.apnsReason).toBe("Stale APNs delivery job skipped.");
+        }).pipe(
+          Effect.provide(
+            makeLayer({
+              attempts,
+              config: signingConfig,
+              currentTargets: [
+                {
+                  ...target,
+                  push_token: "unchanged-token",
+                  activity_push_token: "unchanged-token",
+                  bundle_id:
+                    changed === "bundle" ? "com.t3tools.t3code.preview" : "com.t3tools.t3code.dev",
+                  aps_environment: changed === "environment" ? "production" : "sandbox",
+                },
+              ],
+              execute: (request) =>
+                Effect.sync(() => {
+                  sent++;
+                  return HttpClientResponse.fromWeb(request, new Response("", { status: 200 }));
+                }),
+            }),
+          ),
+        );
+      });
+    }
+  }
 });

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -666,9 +666,7 @@ export const make = Effect.gen(function* () {
       Effect.map((targets) => {
         const currentTarget = targets.find((row) => row.device_id === input.target.device_id);
         return currentTarget &&
-          expectedCurrentToken({ target: currentTarget, kind: input.kind }) === input.token &&
-          currentTarget.bundle_id === input.target.bundle_id &&
-          currentTarget.aps_environment === input.target.aps_environment
+          expectedCurrentToken({ target: currentTarget, kind: input.kind }) === input.token
           ? currentTarget
           : null;
       }),
@@ -683,6 +681,7 @@ export const make = Effect.gen(function* () {
       "relay.delivery.kind": input.kind,
       ...(input.sourceJobId ? { "relay.delivery.job_id": input.sourceJobId } : {}),
     });
+    let deliveryTarget = input.target;
     const now = yield* DateTime.now;
     const aggregate =
       input.aggregate === null ? null : sanitizeAgentActivityAggregateState(input.aggregate);
@@ -724,6 +723,7 @@ export const make = Effect.gen(function* () {
         });
         return staleJobResult({ deviceId: input.target.device_id, kind: input.kind });
       }
+      deliveryTarget = currentTarget;
       if (alert) {
         const preferences = parsePreferences(currentTarget.preferences_json);
         const previousAggregate = parseAggregate(currentTarget.last_aggregate_json);
@@ -781,7 +781,7 @@ export const make = Effect.gen(function* () {
     );
     const result = yield* apns
       .sendLiveActivityRequest({
-        credentials: credentialsForTarget(config.apns, input.target),
+        credentials: credentialsForTarget(config.apns, deliveryTarget),
         request,
         issuedAtUnixSeconds: epochSeconds,
       })
@@ -847,6 +847,7 @@ export const make = Effect.gen(function* () {
       "relay.delivery.kind": "push_notification",
       ...(input.sourceJobId ? { "relay.delivery.job_id": input.sourceJobId } : {}),
     });
+    let deliveryTarget = input.target;
     const now = yield* DateTime.now;
     const epochSeconds = Math.floor(now.epochMilliseconds / 1_000);
     const notification = sanitizeApnsNotificationPayload(input.notification);
@@ -916,6 +917,7 @@ export const make = Effect.gen(function* () {
           kind: "push_notification",
         });
       }
+      deliveryTarget = currentTarget;
       const preferences = parsePreferences(currentTarget.preferences_json);
       const alertAllowed =
         notification.phase !== undefined && notification.updatedAt !== undefined
@@ -937,7 +939,7 @@ export const make = Effect.gen(function* () {
     }
     const result = yield* apns
       .sendPushNotificationRequest({
-        credentials: credentialsForTarget(config.apns, input.target),
+        credentials: credentialsForTarget(config.apns, deliveryTarget),
         request,
         issuedAtUnixSeconds: epochSeconds,
       })

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -666,7 +666,9 @@ export const make = Effect.gen(function* () {
       Effect.map((targets) => {
         const currentTarget = targets.find((row) => row.device_id === input.target.device_id);
         return currentTarget &&
-          expectedCurrentToken({ target: currentTarget, kind: input.kind }) === input.token
+          expectedCurrentToken({ target: currentTarget, kind: input.kind }) === input.token &&
+          currentTarget.bundle_id === input.target.bundle_id &&
+          currentTarget.aps_environment === input.target.aps_environment
           ? currentTarget
           : null;
       }),


### PR DESCRIPTION
A queued APNs job can retain a valid token after registration changes its bundle ID or APNs environment. Sending old routing metadata can produce a permanent APNs rejection and invalidate the current token.

Use the current registration's routing after validating the queued token. This handles both stale routing snapshots and older jobs that omit routing metadata. It follows up the review of merged [#10849](https://github.com/pingdotgg/t3code/pull/10849).

Validation: all 49 APNs delivery tests pass, including both delivery kinds with changed bundles, changed APNs environments, and omitted legacy fields. Tests assert the actual HTTP host and topic. Relay typecheck and targeted lint pass. Queue routing changes have no visual layout changes.

Implemented with GPT-6 in Codex.
