### PR TITLE
fix(web): previous worktree means the thread you came from

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -26,6 +26,63 @@ const localEnvironmentId = EnvironmentId.make("environment-local");
 const remoteEnvironmentId = EnvironmentId.make("environment-remote");
 
 describe("resolvePreviousWorktreeSeed", () => {
+  it("prefers the worktree of the thread the user came from", () => {
+    expect(
+      resolvePreviousWorktreeSeed({
+        originThread: { branch: "t3/origin", worktreePath: "/repo/.t3/worktrees/origin" },
+        threads: [
+          {
+            branch: "t3/origin",
+            worktreePath: "/repo/.t3/worktrees/origin",
+            updatedAt: "2026-07-20T00:00:00.000Z",
+          },
+          {
+            branch: "t3/agent-finished-later",
+            worktreePath: "/repo/.t3/worktrees/later",
+            updatedAt: "2026-07-22T00:00:00.000Z",
+          },
+        ],
+        currentWorktreePath: null,
+      }),
+    ).toEqual({ branch: "t3/origin", worktreePath: "/repo/.t3/worktrees/origin" });
+  });
+
+  it("falls back to recency when the origin has no worktree, is current, or is archived", () => {
+    const threads = [
+      {
+        branch: "t3/newer",
+        worktreePath: "/repo/.t3/worktrees/newer",
+        updatedAt: "2026-07-22T00:00:00.000Z",
+      },
+    ];
+    const expected = { branch: "t3/newer", worktreePath: "/repo/.t3/worktrees/newer" };
+    expect(
+      resolvePreviousWorktreeSeed({
+        originThread: { branch: "main", worktreePath: null },
+        threads,
+        currentWorktreePath: null,
+      }),
+    ).toEqual(expected);
+    expect(
+      resolvePreviousWorktreeSeed({
+        originThread: { branch: "t3/current", worktreePath: "/repo/.t3/worktrees/current" },
+        threads,
+        currentWorktreePath: "/repo/.t3/worktrees/current",
+      }),
+    ).toEqual(expected);
+    expect(
+      resolvePreviousWorktreeSeed({
+        originThread: {
+          branch: "t3/archived",
+          worktreePath: "/repo/.t3/worktrees/archived",
+          archivedAt: "2026-07-23T00:00:00.000Z",
+        },
+        threads,
+        currentWorktreePath: null,
+      }),
+    ).toEqual(expected);
+  });
+
   it("picks the most recently updated worktree thread", () => {
     expect(
       resolvePreviousWorktreeSeed({

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -99,27 +99,44 @@ export interface PreviousWorktreeSeed {
   worktreePath: string;
 }
 
-// The most recently touched worktree in the project that the composer isn't
-// already pointing at. Backs the "Previous worktree" entry in the workspace
-// selector so a follow-up thread can hop back into the worktree you just
-// worked in without hunting for its branch. Archived threads don't compete —
-// the rest of the UI hides them, so their worktrees shouldn't resurface here.
+interface PreviousWorktreeCandidate {
+  branch: string | null;
+  worktreePath: string | null;
+  archivedAt?: string | null;
+}
+
+function isPreviousWorktreeCandidate(
+  thread: PreviousWorktreeCandidate,
+  currentWorktreePath: string | null,
+): thread is PreviousWorktreeCandidate & { worktreePath: string } {
+  return (
+    thread.worktreePath !== null &&
+    thread.worktreePath !== currentWorktreePath &&
+    (thread.archivedAt ?? null) === null
+  );
+}
+
+// The worktree the user just left, for the "Previous worktree" entry in the
+// workspace selector: a follow-up thread can hop back into it without
+// hunting for its branch. "Previous" means the thread the user was looking
+// at before this draft (originThread) whenever it has a worktree. Only when
+// there is no such thread — fresh session, or the origin lives on the local
+// checkout — does the project's most recently touched worktree stand in;
+// that one is usually whichever agent finished last, not where the user was.
+// Archived threads don't compete — the rest of the UI hides them, so their
+// worktrees shouldn't resurface here.
 export function resolvePreviousWorktreeSeed(input: {
-  threads: ReadonlyArray<{
-    branch: string | null;
-    worktreePath: string | null;
-    updatedAt: string;
-    archivedAt?: string | null;
-  }>;
+  originThread?: PreviousWorktreeCandidate | null;
+  threads: ReadonlyArray<PreviousWorktreeCandidate & { updatedAt: string }>;
   currentWorktreePath: string | null;
 }): PreviousWorktreeSeed | null {
+  const origin = input.originThread ?? null;
+  if (origin && isPreviousWorktreeCandidate(origin, input.currentWorktreePath)) {
+    return { branch: origin.branch, worktreePath: origin.worktreePath };
+  }
   let latest: { branch: string | null; worktreePath: string; updatedAt: number } | null = null;
   for (const thread of input.threads) {
-    if (
-      !thread.worktreePath ||
-      thread.worktreePath === input.currentWorktreePath ||
-      (thread.archivedAt ?? null) !== null
-    ) {
+    if (!isPreviousWorktreeCandidate(thread, input.currentWorktreePath)) {
       continue;
     }
     const updatedAt = toSortableTimestamp(thread.updatedAt);

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -13,6 +13,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { useProject, useThreadShell, useThreadShellsForProjectRefs } from "../state/entities";
+import { useUiStateStore } from "../uiStateStore";
 import {
   type EnvMode,
   type EnvironmentOption,
@@ -493,15 +494,27 @@ export const BranchToolbar = memo(function BranchToolbar({
     [canUsePreviousWorktree, activeProjectRef],
   );
   const projectThreads = useThreadShellsForProjectRefs(projectRefsForWorktreeLookup);
+  // The thread the user was reading before opening this draft. It only
+  // counts as an origin when it belongs to the draft's project.
+  const lastViewedThreadRef = useUiStateStore((store) => store.lastViewedThreadRef);
+  const lastViewedThread = useThreadShell(canUsePreviousWorktree ? lastViewedThreadRef : null);
+  const originThread =
+    lastViewedThread &&
+    activeProjectRef &&
+    lastViewedThread.environmentId === activeProjectRef.environmentId &&
+    lastViewedThread.projectId === activeProjectRef.projectId
+      ? lastViewedThread
+      : null;
   const previousWorktreeSeed = useMemo(
     () =>
       canUsePreviousWorktree
         ? resolvePreviousWorktreeSeed({
+            originThread,
             threads: projectThreads,
             currentWorktreePath: activeWorktreePath,
           })
         : null,
-    [activeWorktreePath, canUsePreviousWorktree, projectThreads],
+    [activeWorktreePath, canUsePreviousWorktree, originThread, projectThreads],
   );
   const previousWorktreeLabel = previousWorktreeSeed
     ? resolvePreviousWorktreeLabel(previousWorktreeSeed)

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2011,6 +2011,11 @@ export default function ChatView(props: ChatViewProps) {
   const activeRunningTurnId =
     (activeThread?.session?.status === "running" ? activeThread.session.activeTurnId : null) ??
     (activeLatestTurn?.state === "running" ? activeLatestTurn.turnId : null);
+  const setLastViewedThreadRef = useUiStateStore((store) => store.setLastViewedThreadRef);
+  useEffect(() => {
+    if (!serverThread?.id) return;
+    setLastViewedThreadRef(scopeThreadRef(serverThread.environmentId, serverThread.id));
+  }, [serverThread?.environmentId, serverThread?.id, setLastViewedThreadRef]);
   // Reading a finished thread clears the sidebar's Done badge. The visit is
   // stamped at the turn's completion time — not now/updatedAt — so it clears
   // exactly the completion the user is looking at: a wake or completion that

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,5 +1,5 @@
 import { Debouncer } from "@tanstack/react-pacer";
-import type { PullRequestMergeMethod } from "@t3tools/contracts";
+import type { PullRequestMergeMethod, ScopedThreadRef } from "@t3tools/contracts";
 import { create } from "zustand";
 import { normalizeProjectPathForComparison } from "./lib/projectPaths";
 
@@ -424,6 +424,11 @@ export function reorderProjects(
 }
 
 interface UiStateStore extends UiState {
+  // The server thread the user most recently had open. Session-only: after a
+  // reload there is no "thread you came from", and a days-old thread would
+  // be a misleading one. Backs the composer's "Previous worktree" entry.
+  lastViewedThreadRef: ScopedThreadRef | null;
+  setLastViewedThreadRef: (threadRef: ScopedThreadRef) => void;
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
@@ -440,6 +445,14 @@ interface UiStateStore extends UiState {
 
 export const useUiStateStore = create<UiStateStore>((set) => ({
   ...readPersistedState(),
+  lastViewedThreadRef: null,
+  setLastViewedThreadRef: (threadRef) =>
+    set((state) =>
+      state.lastViewedThreadRef?.environmentId === threadRef.environmentId &&
+      state.lastViewedThreadRef.threadId === threadRef.threadId
+        ? state
+        : { lastViewedThreadRef: threadRef },
+    ),
   markThreadVisited: (threadId, visitedAt) =>
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>


### PR DESCRIPTION
## Problem

"Previous worktree" in the composer's workspace selector picked the project's most recently updated worktree thread. That is usually whichever agent finished last in the background, not the thread you were just reading. So when you open a new thread to continue in the workspace you were in (for example to try a different model on the same branch), the entry often pointed somewhere else and you ended up searching the branch picker instead.

## Fix

The client remembers the last server thread the user had open (session-only, in the UI state store). "Previous worktree" now resolves to that thread's worktree when it belongs to the draft's project. The most-recently-updated pick only remains as a fallback when there is no origin thread, for example right after a reload or when the origin thread lives on the local checkout.

No visual change: the entry looks the same, it just names the right worktree.

## Verification

- Unit tests for the seed resolution: origin wins over recency; falls back when the origin has no worktree, is the current worktree, or is archived.
- Manually in the web app: opened a thread on worktree A, created a new thread from the header, and the workspace menu offered "Previous worktree (A)" even though a thread on worktree B had been updated more recently.

Built with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Previous worktree navigation now prioritizes the thread you were viewing before opening a draft in the same project.
  * When that thread is unavailable or invalid, navigation falls back to the most recently updated eligible worktree.
  * The app now remembers the most recently viewed thread during the current session for more consistent navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->