### PR TITLE
feat(web): zoom and pan expanded images

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -577,6 +577,7 @@ const TYPE_TO_FOCUS_INTERACTIVE_SELECTOR = [
   '[role="tab"]',
 ].join(",");
 const TYPE_TO_FOCUS_FLOATING_LAYER_SELECTOR = [
+  '[role="dialog"][aria-modal="true"]',
   '[data-slot="alert-dialog-popup"]:is([data-open],[data-ending-style])',
   '[data-slot="command-dialog-popup"]:is([data-open],[data-ending-style])',
   '[data-slot="dialog-popup"]:is([data-open],[data-ending-style])',

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -16,7 +16,7 @@ import {
 } from "./SnapShotAttachmentDetails";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
-import { ZoomableImage } from "./ZoomableImage";
+import { ZoomableImage, type ZoomableImageHandle } from "./ZoomableImage";
 
 interface ExpandedImageDialogProps {
   preview: ExpandedImagePreview;
@@ -64,6 +64,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
   onClose,
 }: ExpandedImageDialogProps) {
   const [imageOffset, setImageOffset] = useState(0);
+  const zoomableImageRef = useRef<ZoomableImageHandle>(null);
   const [failedImageSrc, setFailedImageSrc] = useState<string | null>(null);
   const [accessibilityDetailsSrc, setAccessibilityDetailsSrc] = useState<string | null>(null);
   const index = (preview.index + imageOffset + preview.images.length) % preview.images.length;
@@ -116,6 +117,11 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
         event.preventDefault();
         event.stopPropagation();
         onClose();
+        return;
+      }
+      if (zoomableImageRef.current?.pan(event.key)) {
+        event.preventDefault();
+        event.stopPropagation();
         return;
       }
       if (preview.images.length <= 1) return;
@@ -208,6 +214,7 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
             </ExpandedMediaFailure>
           ) : (
             <ZoomableImage
+              ref={zoomableImageRef}
               key={`${index}:${item.src}`}
               src={item.src}
               name={item.name}

--- a/apps/web/src/components/chat/ExpandedImageDialog.tsx
+++ b/apps/web/src/components/chat/ExpandedImageDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "./SnapShotAttachmentDetails";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { composerFloatingLayerProps } from "./composerEventScope";
+import { ZoomableImage } from "./ZoomableImage";
 
 interface ExpandedImageDialogProps {
   preview: ExpandedImagePreview;
@@ -206,11 +207,10 @@ export const ExpandedImageDialog = memo(function ExpandedImageDialog({
               {openOriginalLink}
             </ExpandedMediaFailure>
           ) : (
-            <img
+            <ZoomableImage
+              key={`${index}:${item.src}`}
               src={item.src}
-              alt={item.name}
-              className="max-h-[86vh] max-w-[92vw] animate-[snap-shot-contents-enter_140ms_ease-out] select-none rounded-lg border border-border/70 bg-background object-contain shadow-2xl motion-reduce:animate-none"
-              draggable={false}
+              name={item.name}
               onError={() => setFailedImageSrc(item.src)}
             />
           )}

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 
 const MAX_ZOOM = 8;
 
-/** Keeps zoomed pixels in a native scroll area so wheels and touch can explore the whole image. */
+/** Zooms around the pointer and keeps the whole image accessible by dragging or scrolling. */
 export function ZoomableImage({
   src,
   name,
@@ -21,7 +21,13 @@ export function ZoomableImage({
   const [zoom, setZoom] = useState(1);
   const zoomRef = useRef(1);
   const anchorRef = useRef<{ x: number; y: number; clientX: number; clientY: number } | null>(null);
-  const dragRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
+  const dragRef = useRef<{
+    pointerId: number;
+    x: number;
+    y: number;
+    left: number;
+    top: number;
+  } | null>(null);
   const suppressClickRef = useRef(false);
   const [dragging, setDragging] = useState(false);
   const maxHeight = Math.max(1, Math.min(windowSize.height * 0.86, windowSize.height - 80));
@@ -128,6 +134,7 @@ export function ZoomableImage({
           }
         }}
         onPointerDown={(event) => {
+          if (dragRef.current) return;
           suppressClickRef.current = false;
           if (event.pointerType !== "mouse" || event.button !== 0 || zoomRef.current <= 1) return;
           const viewport = event.currentTarget;
@@ -138,6 +145,7 @@ export function ZoomableImage({
           )
             return;
           dragRef.current = {
+            pointerId: event.pointerId,
             x: event.clientX,
             y: event.clientY,
             left: viewport.scrollLeft,
@@ -148,7 +156,7 @@ export function ZoomableImage({
         }}
         onPointerMove={(event) => {
           const drag = dragRef.current;
-          if (!drag) return;
+          if (!drag || drag.pointerId !== event.pointerId) return;
           if (Math.hypot(event.clientX - drag.x, event.clientY - drag.y) > 4) {
             suppressClickRef.current = true;
           }
@@ -156,13 +164,15 @@ export function ZoomableImage({
           event.currentTarget.scrollTop = drag.top - (event.clientY - drag.y);
         }}
         onPointerUp={(event) => {
+          if (dragRef.current?.pointerId !== event.pointerId) return;
           if (event.currentTarget.hasPointerCapture(event.pointerId)) {
             event.currentTarget.releasePointerCapture(event.pointerId);
           }
           dragRef.current = null;
           setDragging(false);
         }}
-        onLostPointerCapture={() => {
+        onLostPointerCapture={(event) => {
+          if (dragRef.current?.pointerId !== event.pointerId) return;
           dragRef.current = null;
           setDragging(false);
         }}

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -1,6 +1,4 @@
-import { MinusIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Button } from "../ui/button";
 
 const MAX_ZOOM = 8;
 
@@ -26,8 +24,9 @@ export function ZoomableImage({
     null,
   );
   const dragRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
+  const suppressClickRef = useRef(false);
   const [dragging, setDragging] = useState(false);
-  const maxHeight = Math.max(1, Math.min(windowSize.height * 0.8, windowSize.height - 120));
+  const maxHeight = Math.max(1, Math.min(windowSize.height * 0.86, windowSize.height - 80));
   const fit = Math.min(
     1,
     (windowSize.width * 0.92) / (naturalSize.width || 1),
@@ -76,12 +75,12 @@ export function ZoomableImage({
     const viewport = viewportRef.current;
     if (!viewport) return;
     const wheel = (event: WheelEvent) => {
-      if (!event.ctrlKey && !event.metaKey) return;
+      if (event.deltaY === 0) return;
       event.preventDefault();
       const delta =
         event.deltaY *
         (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? viewport.clientHeight : 1);
-      changeZoom(zoomRef.current * Math.exp(-delta * 0.01), {
+      changeZoom(zoomRef.current * Math.exp(-delta * (event.ctrlKey ? 0.01 : 0.002)), {
         x: event.clientX,
         y: event.clientY,
       });
@@ -91,25 +90,31 @@ export function ZoomableImage({
   }, [changeZoom]);
 
   return (
-    <div className="flex min-w-0 flex-col items-center gap-2">
+    <div className="min-w-0">
       <div
         ref={viewportRef}
         role="region"
         aria-label={`${name}, zoomable image`}
+        aria-description="Click to zoom in or return to fit. Scroll to zoom, drag to pan. Use Enter to toggle zoom, plus or minus to zoom, and 0 to fit."
         tabIndex={0}
         className="max-w-[92vw] overflow-auto overscroll-contain rounded-lg bg-background shadow-2xl ring-1 ring-border/70 outline-none focus-visible:ring-2 focus-visible:ring-ring"
         style={{
           width: width || undefined,
           height: height || undefined,
           maxHeight,
-          cursor: zoom > 1 ? (dragging ? "grabbing" : "grab") : "default",
+          cursor: zoom > 1 ? (dragging ? "grabbing" : "grab") : "zoom-in",
         }}
-        onDoubleClick={(event) => {
+        onClick={(event) => {
+          // Pointer capture also produces a click after dragging; leave the image zoomed.
+          if (suppressClickRef.current || event.detail > 1) return;
           changeZoom(zoomRef.current > 1 ? 1 : 2, { x: event.clientX, y: event.clientY });
         }}
         onKeyDown={(event) => {
           if (event.ctrlKey || event.metaKey || event.altKey) return;
-          if (event.key === "+" || event.key === "=") {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            if (!event.repeat) changeZoom(zoomRef.current > 1 ? 1 : 2);
+          } else if (event.key === "+" || event.key === "=") {
             event.preventDefault();
             changeZoom(zoomRef.current * 1.5);
           } else if (event.key === "-") {
@@ -124,6 +129,7 @@ export function ZoomableImage({
           }
         }}
         onPointerDown={(event) => {
+          suppressClickRef.current = false;
           if (event.pointerType !== "mouse" || event.button !== 0 || zoomRef.current <= 1) return;
           const viewport = event.currentTarget;
           const bounds = viewport.getBoundingClientRect();
@@ -144,6 +150,9 @@ export function ZoomableImage({
         onPointerMove={(event) => {
           const drag = dragRef.current;
           if (!drag) return;
+          if (Math.hypot(event.clientX - drag.x, event.clientY - drag.y) > 4) {
+            suppressClickRef.current = true;
+          }
           event.currentTarget.scrollLeft = drag.left - (event.clientX - drag.x);
           event.currentTarget.scrollTop = drag.top - (event.clientY - drag.y);
         }}
@@ -174,42 +183,9 @@ export function ZoomableImage({
           onError={onError}
         />
       </div>
-      <div
-        role="group"
-        aria-label="Image zoom"
-        className="flex items-center gap-1 rounded-full bg-black/70 p-1 text-white"
-      >
-        <Button
-          size="icon-xs"
-          variant="overlay"
-          aria-label="Zoom out"
-          disabled={zoom <= 1 || !naturalSize.width}
-          onClick={() => changeZoom(zoomRef.current / 1.5)}
-        >
-          <MinusIcon />
-        </Button>
-        <span className="min-w-12 text-center text-xs tabular-nums" aria-live="polite">
-          {Math.round(zoom * 100)}%
-        </span>
-        <Button
-          size="icon-xs"
-          variant="overlay"
-          aria-label="Zoom in"
-          disabled={zoom >= MAX_ZOOM || !naturalSize.width}
-          onClick={() => changeZoom(zoomRef.current * 1.5)}
-        >
-          <PlusIcon />
-        </Button>
-        <Button
-          size="icon-xs"
-          variant="overlay"
-          aria-label="Reset zoom to fit"
-          disabled={zoom <= 1}
-          onClick={() => changeZoom(1)}
-        >
-          <RotateCcwIcon />
-        </Button>
-      </div>
+      <span className="sr-only" aria-live="polite">
+        {Math.round(zoom * 100)}% zoom
+      </span>
     </div>
   );
 }

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -1,16 +1,30 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type Ref,
+} from "react";
 
 const MAX_ZOOM = 8;
+
+export interface ZoomableImageHandle {
+  pan: (key: string) => boolean;
+}
 
 /** Zooms around the pointer and keeps the whole image accessible by dragging or scrolling. */
 export function ZoomableImage({
   src,
   name,
   onError,
+  ref,
 }: {
   src: string;
   name: string;
   onError: () => void;
+  ref?: Ref<ZoomableImageHandle>;
 }) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
@@ -38,6 +52,34 @@ export function ZoomableImage({
   );
   const width = naturalSize.width * fit * zoom;
   const height = naturalSize.height * fit * zoom;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      pan(key) {
+        const viewport = viewportRef.current;
+        if (!viewport || zoomRef.current <= 1) return false;
+        switch (key) {
+          case "ArrowLeft":
+            viewport.scrollLeft -= 40;
+            break;
+          case "ArrowRight":
+            viewport.scrollLeft += 40;
+            break;
+          case "ArrowUp":
+            viewport.scrollTop -= 40;
+            break;
+          case "ArrowDown":
+            viewport.scrollTop += 40;
+            break;
+          default:
+            return false;
+        }
+        return true;
+      },
+    }),
+    [],
+  );
 
   const changeZoom = useCallback((next: number, point?: { x: number; y: number }) => {
     const viewport = viewportRef.current;
@@ -128,9 +170,6 @@ export function ZoomableImage({
           } else if (event.key === "0") {
             event.preventDefault();
             changeZoom(1);
-          } else if (zoomRef.current > 1 && event.key.startsWith("Arrow")) {
-            // Leave native keyboard scrolling enabled without navigating the gallery.
-            event.stopPropagation();
           }
         }}
         onPointerDown={(event) => {

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -108,6 +108,7 @@ export function ZoomableImage({
           changeZoom(zoomRef.current > 1 ? 1 : 2, { x: event.clientX, y: event.clientY });
         }}
         onKeyDown={(event) => {
+          if (event.ctrlKey || event.metaKey || event.altKey) return;
           if (event.key === "+" || event.key === "=") {
             event.preventDefault();
             changeZoom(zoomRef.current * 1.5);

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -20,9 +20,7 @@ export function ZoomableImage({
   }));
   const [zoom, setZoom] = useState(1);
   const zoomRef = useRef(1);
-  const anchorRef = useRef<{ x: number; y: number; viewportX: number; viewportY: number } | null>(
-    null,
-  );
+  const anchorRef = useRef<{ x: number; y: number; clientX: number; clientY: number } | null>(null);
   const dragRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
   const suppressClickRef = useRef(false);
   const [dragging, setDragging] = useState(false);
@@ -46,8 +44,8 @@ export function ZoomableImage({
     anchorRef.current = {
       x: (viewport.scrollLeft + x) / previous,
       y: (viewport.scrollTop + y) / previous,
-      viewportX: x / viewport.clientWidth,
-      viewportY: y / viewport.clientHeight,
+      clientX: bounds.left + x,
+      clientY: bounds.top + y,
     };
     zoomRef.current = clamped;
     setZoom(clamped);
@@ -57,8 +55,9 @@ export function ZoomableImage({
     const viewport = viewportRef.current;
     const anchor = anchorRef.current;
     if (!viewport || !anchor) return;
-    viewport.scrollLeft = anchor.x * zoom - anchor.viewportX * viewport.clientWidth;
-    viewport.scrollTop = anchor.y * zoom - anchor.viewportY * viewport.clientHeight;
+    const bounds = viewport.getBoundingClientRect();
+    viewport.scrollLeft = anchor.x * zoom - (anchor.clientX - bounds.left);
+    viewport.scrollTop = anchor.y * zoom - (anchor.clientY - bounds.top);
     anchorRef.current = null;
   }, [zoom]);
 

--- a/apps/web/src/components/chat/ZoomableImage.tsx
+++ b/apps/web/src/components/chat/ZoomableImage.tsx
@@ -1,0 +1,214 @@
+import { MinusIcon, PlusIcon, RotateCcwIcon } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Button } from "../ui/button";
+
+const MAX_ZOOM = 8;
+
+/** Keeps zoomed pixels in a native scroll area so wheels and touch can explore the whole image. */
+export function ZoomableImage({
+  src,
+  name,
+  onError,
+}: {
+  src: string;
+  name: string;
+  onError: () => void;
+}) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [naturalSize, setNaturalSize] = useState({ width: 0, height: 0 });
+  const [windowSize, setWindowSize] = useState(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
+  const [zoom, setZoom] = useState(1);
+  const zoomRef = useRef(1);
+  const anchorRef = useRef<{ x: number; y: number; viewportX: number; viewportY: number } | null>(
+    null,
+  );
+  const dragRef = useRef<{ x: number; y: number; left: number; top: number } | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const maxHeight = Math.max(1, Math.min(windowSize.height * 0.8, windowSize.height - 120));
+  const fit = Math.min(
+    1,
+    (windowSize.width * 0.92) / (naturalSize.width || 1),
+    maxHeight / (naturalSize.height || 1),
+  );
+  const width = naturalSize.width * fit * zoom;
+  const height = naturalSize.height * fit * zoom;
+
+  const changeZoom = useCallback((next: number, point?: { x: number; y: number }) => {
+    const viewport = viewportRef.current;
+    const previous = zoomRef.current;
+    const clamped = Math.min(MAX_ZOOM, Math.max(1, next));
+    if (!viewport || previous === clamped) return;
+    const bounds = viewport.getBoundingClientRect();
+    const x = point ? point.x - bounds.left : viewport.clientWidth / 2;
+    const y = point ? point.y - bounds.top : viewport.clientHeight / 2;
+    anchorRef.current = {
+      x: (viewport.scrollLeft + x) / previous,
+      y: (viewport.scrollTop + y) / previous,
+      viewportX: x / viewport.clientWidth,
+      viewportY: y / viewport.clientHeight,
+    };
+    zoomRef.current = clamped;
+    setZoom(clamped);
+  }, []);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    const anchor = anchorRef.current;
+    if (!viewport || !anchor) return;
+    viewport.scrollLeft = anchor.x * zoom - anchor.viewportX * viewport.clientWidth;
+    viewport.scrollTop = anchor.y * zoom - anchor.viewportY * viewport.clientHeight;
+    anchorRef.current = null;
+  }, [zoom]);
+
+  useEffect(() => {
+    const resize = () => {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
+      changeZoom(1);
+    };
+    window.addEventListener("resize", resize);
+    return () => window.removeEventListener("resize", resize);
+  }, [changeZoom]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const wheel = (event: WheelEvent) => {
+      if (!event.ctrlKey && !event.metaKey) return;
+      event.preventDefault();
+      const delta =
+        event.deltaY *
+        (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? viewport.clientHeight : 1);
+      changeZoom(zoomRef.current * Math.exp(-delta * 0.01), {
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
+    viewport.addEventListener("wheel", wheel, { passive: false });
+    return () => viewport.removeEventListener("wheel", wheel);
+  }, [changeZoom]);
+
+  return (
+    <div className="flex min-w-0 flex-col items-center gap-2">
+      <div
+        ref={viewportRef}
+        role="region"
+        aria-label={`${name}, zoomable image`}
+        tabIndex={0}
+        className="max-w-[92vw] overflow-auto overscroll-contain rounded-lg bg-background shadow-2xl ring-1 ring-border/70 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        style={{
+          width: width || undefined,
+          height: height || undefined,
+          maxHeight,
+          cursor: zoom > 1 ? (dragging ? "grabbing" : "grab") : "default",
+        }}
+        onDoubleClick={(event) => {
+          changeZoom(zoomRef.current > 1 ? 1 : 2, { x: event.clientX, y: event.clientY });
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "+" || event.key === "=") {
+            event.preventDefault();
+            changeZoom(zoomRef.current * 1.5);
+          } else if (event.key === "-") {
+            event.preventDefault();
+            changeZoom(zoomRef.current / 1.5);
+          } else if (event.key === "0") {
+            event.preventDefault();
+            changeZoom(1);
+          } else if (zoomRef.current > 1 && event.key.startsWith("Arrow")) {
+            // Leave native keyboard scrolling enabled without navigating the gallery.
+            event.stopPropagation();
+          }
+        }}
+        onPointerDown={(event) => {
+          if (event.pointerType !== "mouse" || event.button !== 0 || zoomRef.current <= 1) return;
+          const viewport = event.currentTarget;
+          const bounds = viewport.getBoundingClientRect();
+          if (
+            event.clientX - bounds.left >= viewport.clientWidth ||
+            event.clientY - bounds.top >= viewport.clientHeight
+          )
+            return;
+          dragRef.current = {
+            x: event.clientX,
+            y: event.clientY,
+            left: viewport.scrollLeft,
+            top: viewport.scrollTop,
+          };
+          viewport.setPointerCapture(event.pointerId);
+          setDragging(true);
+        }}
+        onPointerMove={(event) => {
+          const drag = dragRef.current;
+          if (!drag) return;
+          event.currentTarget.scrollLeft = drag.left - (event.clientX - drag.x);
+          event.currentTarget.scrollTop = drag.top - (event.clientY - drag.y);
+        }}
+        onPointerUp={(event) => {
+          if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+            event.currentTarget.releasePointerCapture(event.pointerId);
+          }
+          dragRef.current = null;
+          setDragging(false);
+        }}
+        onLostPointerCapture={() => {
+          dragRef.current = null;
+          setDragging(false);
+        }}
+      >
+        <img
+          src={src}
+          alt={name}
+          draggable={false}
+          className="block max-w-none select-none"
+          style={naturalSize.width ? { width, height } : { maxWidth: "92vw", maxHeight }}
+          onLoad={(event) => {
+            setNaturalSize({
+              width: event.currentTarget.naturalWidth,
+              height: event.currentTarget.naturalHeight,
+            });
+          }}
+          onError={onError}
+        />
+      </div>
+      <div
+        role="group"
+        aria-label="Image zoom"
+        className="flex items-center gap-1 rounded-full bg-black/70 p-1 text-white"
+      >
+        <Button
+          size="icon-xs"
+          variant="overlay"
+          aria-label="Zoom out"
+          disabled={zoom <= 1 || !naturalSize.width}
+          onClick={() => changeZoom(zoomRef.current / 1.5)}
+        >
+          <MinusIcon />
+        </Button>
+        <span className="min-w-12 text-center text-xs tabular-nums" aria-live="polite">
+          {Math.round(zoom * 100)}%
+        </span>
+        <Button
+          size="icon-xs"
+          variant="overlay"
+          aria-label="Zoom in"
+          disabled={zoom >= MAX_ZOOM || !naturalSize.width}
+          onClick={() => changeZoom(zoomRef.current * 1.5)}
+        >
+          <PlusIcon />
+        </Button>
+        <Button
+          size="icon-xs"
+          variant="overlay"
+          aria-label="Reset zoom to fit"
+          disabled={zoom <= 1}
+          onClick={() => changeZoom(1)}
+        >
+          <RotateCcwIcon />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
expanded images now zoom directly with the mouse: click to zoom in or return to fit, scroll to zoom further, and drag to explore the image. arrows pan while zoomed in regardless of focus, and left/right switches images at fit. gallery changes reset the zoom, and browser zoom shortcuts keep their normal behavior.

verified in the real web app at desktop, phone, and landscape sizes in light and dark themes, including click, wheel, drag release, gallery navigation, and keyboard reset. web typecheck, scoped lint, and 40 existing image tests pass.

![arrow keys pan with focus on the close button, then navigate images at fit](https://uploads-production-47e4.up.railway.app/files/ed33c4eb-d4c1-443a-9728-51081e16d813/keyboard-pan.gif)

![mouse-driven image zoom, scrolling, dragging, and reset](https://uploads-production-47e4.up.railway.app/files/f3810e63-2620-4ee4-a7a8-5538ad3a90eb/mouse-zoom.gif)

![expanded image with mouse-driven zoom](https://uploads-production-47e4.up.railway.app/files/3ea8bbbe-f832-4ec8-a99d-20ca05d488cb/browser-screenshot-perfect-superintendent-imagine-organisms-mttho2ft-840a7ccf.png)

implemented with gpt-6 in the codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved image viewing with single-click zoom, keyboard controls, and smoother wheel-based zooming.
  * Images can now display larger within the viewer while preserving the zoom position during interactions.
  * Added screen-reader announcements for the current zoom level.

* **Bug Fixes**
  * Prevented clicks following image drags from unintentionally toggling zoom.
  * Modal dialogs now correctly prevent keyboard input from being redirected to the message composer.
  * Improved handling of simultaneous pointer interactions during image dragging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->