### PR TITLE
fix(usage): identify Codex quotas by workspace account

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,85 @@
 import { assert, it } from "@effect/vitest";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  readCodexAccountId,
+  resolveCodexAuthHome,
+} from "./CodexProvider.ts";
+
+it("resolves the selected or shadow home ahead of inherited credentials", () => {
+  const inherited = { CODEX_HOME: "/shared", HOME: "/user" };
+  assert.strictEqual(
+    resolveCodexAuthHome(
+      { homePath: "/shadow", environment: { CODEX_HOME: "/instance" } },
+      inherited,
+    ),
+    "/shadow",
+  );
+  assert.strictEqual(
+    resolveCodexAuthHome({ environment: { CODEX_HOME: "/instance" } }, inherited),
+    "/instance",
+  );
+  assert.strictEqual(resolveCodexAuthHome({}, inherited), "/shared");
+  assert.strictEqual(
+    resolveCodexAuthHome({ environment: { HOME: "/instance-user" } }, { HOME: "/user" }),
+    "/instance-user/.codex",
+  );
+  assert.strictEqual(resolveCodexAuthHome({}, { HOME: "/user" }), "/user/.codex");
+});
+
+it.effect(
+  "reads workspace identity from the selected home without treating API keys as subscriptions",
+  () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "codex-account-identity-")),
+      ),
+      (root) =>
+        Effect.gen(function* () {
+          for (const accountId of ["personal", "work"]) {
+            const home = NodePath.join(root, accountId);
+            yield* Effect.promise(() => NodeFSP.mkdir(home));
+            yield* Effect.promise(() =>
+              NodeFSP.writeFile(
+                NodePath.join(home, "auth.json"),
+                JSON.stringify({ tokens: { account_id: accountId } }),
+              ),
+            );
+            assert.strictEqual(yield* readCodexAccountId(home), accountId);
+          }
+          yield* Effect.promise(() =>
+            NodeFSP.writeFile(
+              NodePath.join(root, "auth.json"),
+              JSON.stringify({ OPENAI_API_KEY: "local-proxy" }),
+            ),
+          );
+          assert.strictEqual(yield* readCodexAccountId(root), undefined);
+          assert.strictEqual(yield* readCodexAccountId(NodePath.join(root, "missing")), undefined);
+          const payload = Buffer.from(
+            JSON.stringify({
+              "https://api.openai.com/auth": { chatgpt_account_id: "token-workspace" },
+            }),
+          ).toString("base64url");
+          for (const [tokens, expected] of [
+            [{ id_token: `header.${payload}.signature` }, "token-workspace"],
+            [{ account_id: null, id_token: `header.${payload}.signature` }, "token-workspace"],
+            [{ account_id: "explicit", id_token: `header.${payload}.signature` }, "explicit"],
+            [{ id_token: "malformed" }, undefined],
+          ] as const) {
+            yield* Effect.promise(() =>
+              NodeFSP.writeFile(NodePath.join(root, "auth.json"), JSON.stringify({ tokens })),
+            );
+            assert.strictEqual(yield* readCodexAccountId(root), expected);
+          }
+        }),
+      (root) => Effect.promise(() => NodeFSP.rm(root, { recursive: true, force: true })),
+    ),
+);
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -1,3 +1,6 @@
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -67,6 +70,7 @@ const CODEX_PRESENTATION = {
 
 export interface CodexAppServerProviderSnapshot {
   readonly account: CodexSchema.V2GetAccountResponse;
+  readonly accountId?: string;
   readonly rateLimits?: CodexRateLimitsProbe;
   readonly version: string | undefined;
   readonly models: ReadonlyArray<ServerProviderModel>;
@@ -404,6 +408,65 @@ export const withCodexAppServerClient = Effect.fn("withCodexAppServerClient")(fu
   return { client, initialize };
 });
 
+const decodeCodexAccountIdentity = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      tokens: Schema.Struct({
+        account_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
+        id_token: Schema.optionalKey(Schema.NullOr(Schema.String)),
+      }),
+    }),
+  ),
+);
+
+const decodeCodexIdTokenIdentity = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      "https://api.openai.com/auth": Schema.Struct({
+        chatgpt_account_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
+      }),
+    }),
+  ),
+);
+
+export function resolveCodexAuthHome(
+  input: {
+    readonly homePath?: string;
+    readonly environment?: NodeJS.ProcessEnv;
+  },
+  inheritedEnvironment: NodeJS.ProcessEnv = process.env,
+) {
+  return expandHomePath(
+    input.homePath?.trim() ||
+      input.environment?.CODEX_HOME ||
+      inheritedEnvironment.CODEX_HOME ||
+      NodePath.join(
+        input.environment?.HOME || inheritedEnvironment.HOME || NodeOS.homedir(),
+        ".codex",
+      ),
+  );
+}
+
+export const readCodexAccountId = Effect.fn("readCodexAccountId")(function* (homePath: string) {
+  return yield* Effect.tryPromise(() =>
+    NodeFSP.readFile(NodePath.join(homePath, "auth.json"), "utf8"),
+  ).pipe(
+    Effect.flatMap(decodeCodexAccountIdentity),
+    Effect.flatMap((auth) => {
+      const accountId = auth.tokens.account_id?.trim();
+      if (accountId) return Effect.succeed(accountId);
+      const payload = auth.tokens.id_token?.split(".")[1];
+      if (!payload) return Effect.succeed(undefined);
+      return decodeCodexIdTokenIdentity(Buffer.from(payload, "base64url").toString("utf8")).pipe(
+        Effect.map(
+          (claims) => claims["https://api.openai.com/auth"].chatgpt_account_id?.trim() || undefined,
+        ),
+      );
+    }),
+    Effect.orElseSucceed(() => undefined),
+  );
+});
+
 const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
@@ -419,6 +482,12 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const version = versionMatch ? versionMatch[1] : undefined;
 
   const accountResponse = yield* client.request("account/read", {});
+  // account/read omits workspace identity. File-backed logins keep it beside
+  // the credentials in the same home used by this app-server instance.
+  const accountId =
+    accountResponse.account?.type === "chatgpt"
+      ? yield* readCodexAccountId(resolveCodexAuthHome(input))
+      : undefined;
   if (!accountResponse.account && accountResponse.requiresOpenaiAuth) {
     return {
       account: accountResponse,
@@ -460,6 +529,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
 
   return {
     account: accountResponse,
+    ...(accountId ? { accountId } : {}),
     rateLimits,
     version,
     models: applyPreferredCodexDefaultModel(
@@ -524,7 +594,10 @@ const makePendingCodexProvider = (
     });
   });
 
-function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]): {
+function accountProbeStatus(
+  account: CodexAppServerProviderSnapshot["account"],
+  accountId?: string,
+): {
   readonly status: Exclude<ServerProviderState, "disabled">;
   readonly auth: ServerProvider["auth"];
   readonly message?: string;
@@ -536,6 +609,7 @@ function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]):
     ...(account.account?.type ? { type: account.account?.type } : {}),
     ...(authLabel ? { label: authLabel } : {}),
     ...(authEmail ? { email: authEmail } : {}),
+    ...(accountId ? { accountId } : {}),
   } satisfies ServerProvider["auth"];
 
   if (account.account) {
@@ -646,9 +720,9 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   }
 
   const snapshot = probeResult.success.value;
-  const accountStatus = accountProbeStatus(snapshot.account);
+  const accountStatus = accountProbeStatus(snapshot.account, snapshot.accountId);
   const usageLimits =
-    snapshot.account.account?.type === "apiKey"
+    snapshot.account.account?.type === "apiKey" || !snapshot.account.requiresOpenaiAuth
       ? makeUnavailableUsageLimits({ checkedAt, reason: "unsupported" })
       : snapshot.rateLimits === undefined || "failure" in snapshot.rateLimits
         ? makeUnavailableUsageLimits({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -299,7 +299,7 @@ function makeCodexProbeSnapshot(
         email: "test@example.com",
         planType: "pro",
       },
-      requiresOpenaiAuth: false,
+      requiresOpenaiAuth: true,
     },
     models: [
       {
@@ -365,11 +365,44 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
   "ProviderRegistry",
   (it) => {
     describe("checkCodexProviderStatus", () => {
+      it.effect("does not count proxy rate limits as a native subscription", () =>
+        Effect.gen(function* () {
+          for (const account of [
+            null,
+            { type: "chatgpt" as const, email: "test@example.com", planType: "pro" as const },
+          ]) {
+            const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+              Effect.succeed(
+                makeCodexProbeSnapshot({
+                  account: { account, requiresOpenaiAuth: false },
+                  rateLimits: {
+                    snapshot: {
+                      primary: { usedPercent: 90, windowDurationMins: 10080, resetsAt: 1789436313 },
+                    },
+                    rateLimitsByLimitId: null,
+                    resetCredits: null,
+                  },
+                }),
+              ),
+            );
+            assert.strictEqual(status.usageLimits?.unavailable?.reason, "unsupported");
+            assert.deepStrictEqual(status.usageLimits?.windows, []);
+          }
+        }),
+      );
       it.effect("uses the app-server account and model list for provider status", () =>
         Effect.gen(function* () {
           const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
             Effect.succeed(
               makeCodexProbeSnapshot({
+                accountId: "workspace-a",
+                rateLimits: {
+                  snapshot: {
+                    primary: { usedPercent: 42, windowDurationMins: 300, resetsAt: 1789436313 },
+                  },
+                  rateLimitsByLimitId: null,
+                  resetCredits: null,
+                },
                 skills: [
                   {
                     name: "github:gh-fix-ci",
@@ -389,6 +422,9 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.auth.type, "chatgpt");
           assert.strictEqual(status.auth.label, "ChatGPT Pro 20x Subscription");
           assert.strictEqual(status.auth.email, "test@example.com");
+          assert.strictEqual(status.auth.accountId, "workspace-a");
+          assert.strictEqual(status.usageLimits?.unavailable, undefined);
+          assert.strictEqual(status.usageLimits?.windows[0]?.usedPercent, 42);
           assert.deepStrictEqual(status.models, [
             {
               slug: "gpt-live-codex",

--- a/apps/server/src/usage/cliproxyApi.test.ts
+++ b/apps/server/src/usage/cliproxyApi.test.ts
@@ -47,7 +47,12 @@ const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 function fixture(
   options: {
-    accounts?: Array<(typeof accounts)[number] & { disabled?: boolean }>;
+    accounts?: Array<
+      Omit<(typeof accounts)[number], "id_token"> & {
+        disabled?: boolean;
+        id_token?: { chatgpt_account_id?: string; plan_type?: string; chatgpt_plan_type?: string };
+      }
+    >;
     upstream?: (request: RequestBody) => { status: number; body: unknown };
     cooldownStatus?: number;
   } = {},
@@ -119,6 +124,7 @@ describe("CLIProxyAPI built-in management API", () => {
         const test = fixture();
         const api = yield* test.api;
         const result = yield* api.readAccounts(config);
+        expect(result.map((account) => account.accountId)).toEqual(["account-a", "account-b"]);
         expect(result.map((account) => account.usageLimits.resetCredits)).toEqual([
           { availableCount: 2, nextCreditId: "first", nextExpiresAt: "2099-01-01T00:00:00.000Z" },
           { availableCount: 2, nextCreditId: "first", nextExpiresAt: "2099-01-01T00:00:00.000Z" },
@@ -139,6 +145,88 @@ describe("CLIProxyAPI built-in management API", () => {
           ],
         ).toBe("account-b");
       }),
+  );
+
+  it.effect("skips blank plan fields when falling back to account metadata", () =>
+    Effect.gen(function* () {
+      const test = fixture({
+        accounts: accounts.map((account, index) => ({
+          ...account,
+          id_token: {
+            ...account.id_token,
+            plan_type: index === 0 ? " pro " : "  ",
+            chatgpt_plan_type: "business",
+          },
+        })),
+        upstream: () => ({
+          status: 200,
+          body: { plan_type: " ", rate_limit: { primary_window: { used_percent: 12 } } },
+        }),
+      });
+      const api = yield* test.api;
+      const result = yield* api.readAccounts(config);
+      expect(result.map((account) => account.plan)).toEqual([
+        "ChatGPT Pro 20x Subscription",
+        "ChatGPT Business Subscription",
+      ]);
+    }),
+  );
+
+  it.effect("uses fallback Free and Go plans for monthly quota windows", () =>
+    Effect.gen(function* () {
+      const test = fixture({
+        accounts: accounts.map((account, index) => ({
+          ...account,
+          id_token: {
+            ...account.id_token,
+            plan_type: index === 0 ? " free " : " ",
+            chatgpt_plan_type: " go ",
+          },
+        })),
+        upstream: () => ({
+          status: 200,
+          body: { plan_type: " ", rate_limit: { primary_window: { used_percent: 12 } } },
+        }),
+      });
+      const api = yield* test.api;
+      const result = yield* api.readAccounts(config);
+      expect(result.map((account) => account.plan)).toEqual([
+        "ChatGPT Free Subscription",
+        "ChatGPT Go Subscription",
+      ]);
+      for (const account of result) {
+        expect(account.usageLimits.windows).toMatchObject([
+          { kind: "monthly", windowDurationMins: 43200, usedPercent: 12 },
+        ]);
+      }
+    }),
+  );
+
+  it.effect("uses trimmed account IDs for quota headers and omits empty IDs", () =>
+    Effect.gen(function* () {
+      const ids = [" account-a ", "", "  ", undefined];
+      const test = fixture({
+        accounts: ids.map((accountId, index) => ({
+          ...accounts[0]!,
+          id: `${index}.json`,
+          auth_index: String(index),
+          id_token: accountId === undefined ? {} : { chatgpt_account_id: accountId },
+        })),
+      });
+      const api = yield* test.api;
+      const result = yield* api.readAccounts(config);
+      expect(result.map((account) => account.accountId)).toEqual([
+        "account-a",
+        undefined,
+        undefined,
+        undefined,
+      ]);
+      for (const request of test.requests.filter((request) => request.body?.url)) {
+        expect(request.body?.header?.["Chatgpt-Account-Id"]).toBe(
+          request.body?.auth_index === "0" ? "account-a" : undefined,
+        );
+      }
+    }),
   );
 
   it.effect("keeps usage when the credits endpoint fails", () =>

--- a/apps/server/src/usage/cliproxyApi.ts
+++ b/apps/server/src/usage/cliproxyApi.ts
@@ -27,6 +27,7 @@ const AuthFile = Schema.Struct({
     Schema.Struct({
       chatgpt_account_id: Schema.optional(Schema.String),
       chatgpt_plan_type: Schema.optional(Schema.String),
+      plan_type: Schema.optional(Schema.String),
     }),
   ),
 });
@@ -151,6 +152,7 @@ export const makeCliproxyApi = Effect.gen(function* () {
     url: string,
     data?: unknown,
   ) {
+    const accountId = account.id_token?.chatgpt_account_id?.trim();
     const header =
       account.provider === "codex"
         ? {
@@ -158,9 +160,7 @@ export const makeCliproxyApi = Effect.gen(function* () {
             "Content-Type": "application/json",
             "OpenAI-Beta": "codex-1",
             Originator: "Codex Desktop",
-            ...(account.id_token?.chatgpt_account_id
-              ? { "Chatgpt-Account-Id": account.id_token.chatgpt_account_id }
-              : {}),
+            ...(accountId ? { "Chatgpt-Account-Id": accountId } : {}),
           }
         : { Authorization: "Bearer $TOKEN$", "anthropic-beta": "oauth-2025-04-20" };
     const raw = yield* management(config, "api-call", {
@@ -205,6 +205,9 @@ export const makeCliproxyApi = Effect.gen(function* () {
       id: account.id,
       driver: ProviderDriverKind.make(account.provider === "codex" ? "codex" : "claudeAgent"),
       ...(account.email ? { email: account.email } : {}),
+      ...(account.provider === "codex" && account.id_token?.chatgpt_account_id?.trim()
+        ? { accountId: account.id_token.chatgpt_account_id.trim() }
+        : {}),
     };
     const read = Effect.gen(function* () {
       if (account.provider === "claude") {
@@ -252,14 +255,18 @@ export const makeCliproxyApi = Effect.gen(function* () {
       // A credits outage must not hide successfully fetched quota windows.
       const available = yield* credits(config, account).pipe(Effect.orElseSucceed(() => undefined));
       const next = available?.[0];
+      const planType =
+        usage.plan_type?.trim() ||
+        account.id_token?.plan_type?.trim() ||
+        account.id_token?.chatgpt_plan_type?.trim();
       return {
         ...base,
-        plan: codexPlanLabel(usage.plan_type ?? account.id_token?.chatgpt_plan_type),
+        plan: codexPlanLabel(planType),
         usageLimits: {
           ...codexRateLimitsToLimits({
             checkedAt,
             snapshot: {
-              planType: usage.plan_type ?? null,
+              planType: planType ?? null,
               primary: toWindow(usage.rate_limit?.primary_window),
               secondary: toWindow(usage.rate_limit?.secondary_window),
             },

--- a/packages/contracts/src/providerUsageLimits.ts
+++ b/packages/contracts/src/providerUsageLimits.ts
@@ -81,6 +81,8 @@ export const UsageLimitSourceAccount = Schema.Struct({
   driver: ProviderDriverKind,
   /** The signed-in address, when the source names one; clients blur it like provider auth. */
   email: Schema.optional(TrimmedNonEmptyString),
+  /** Provider account or workspace ID; an email can belong to several quota buckets. */
+  accountId: Schema.optional(TrimmedNonEmptyString),
   /** Plan as the matching provider would label it (`ChatGPT Pro 20x Subscription`). */
   plan: Schema.optional(TrimmedNonEmptyString),
   usageLimits: ServerProviderUsageLimits,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -63,6 +63,7 @@ export const ServerProviderAuth = Schema.Struct({
   type: Schema.optional(TrimmedNonEmptyString),
   label: Schema.optional(TrimmedNonEmptyString),
   email: Schema.optional(TrimmedNonEmptyString),
+  accountId: Schema.optional(TrimmedNonEmptyString),
 });
 export type ServerProviderAuth = typeof ServerProviderAuth.Type;
 

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -332,6 +332,150 @@ describe("pools", () => {
   };
   const laptop = { entry: { target: { label: "Laptop" } } };
 
+  it.each([true, false])(
+    "merges legacy reports with one known workspace and retains hub redemption, native ID %s",
+    (nativeHasId) => {
+      const driver = ProviderDriverKind.make("codex");
+      const native = provider({
+        driver,
+        auth: {
+          status: "authenticated",
+          email: "Same@example.com",
+          ...(nativeHasId ? { accountId: "workspace" } : {}),
+        },
+        usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 40 }] },
+      });
+      const hub = {
+        ...source,
+        accounts: [
+          {
+            id: "account.json",
+            driver,
+            email: "same@example.com",
+            ...(!nativeHasId ? { accountId: "workspace" } : {}),
+            usageLimits: {
+              checkedAt,
+              windows: [{ ...weekly, usedPercent: 40 }],
+              resetCredits: { availableCount: 1, nextCreditId: "hub-credit" },
+            },
+          },
+        ],
+      };
+      const input = new Map([
+        [
+          EnvironmentId.make("env-a"),
+          { ...laptop, serverConfig: { providers: [native], usageLimitSources: [hub] } },
+        ],
+        [
+          EnvironmentId.make("env-b"),
+          {
+            ...laptop,
+            serverConfig: {
+              providers: [
+                {
+                  ...native,
+                  auth: { status: "authenticated" as const, email: "same@example.com" },
+                },
+              ],
+              usageLimitSources: [],
+            },
+          },
+        ],
+      ]);
+      const accounts = collectLimitAccounts(input);
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]?.environments).toHaveLength(2);
+      expect(accounts[0]?.redeem?.input).toEqual({
+        sourceId: source.id,
+        accountId: "account.json",
+        creditId: "hub-credit",
+      });
+      expect(collectLimitSources(input)[0]?.accounts).toHaveLength(0);
+      const report = collectProviderUsageLimits(
+        native.instanceId,
+        [native],
+        [hub],
+        Date.parse(checkedAt),
+      );
+      expect(report?.accounts).toHaveLength(1);
+      expect(report?.accounts[0]?.resetCreditInput).toEqual({
+        sourceId: source.id,
+        accountId: "account.json",
+        creditId: "hub-credit",
+      });
+    },
+  );
+
+  it("keeps same-email Codex workspaces separate and merges only matching account IDs", () => {
+    const driver = ProviderDriverKind.make("codex");
+    const native = provider({
+      driver,
+      instanceId: ProviderInstanceId.make("codex"),
+      auth: { status: "authenticated", email: "same@example.com", accountId: "pro" },
+      usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 90 }] },
+    });
+    const hub = {
+      ...source,
+      accounts: [
+        {
+          id: "pro.json",
+          accountId: "pro",
+          driver,
+          email: "same@example.com",
+          usageLimits: native.usageLimits!,
+        },
+        {
+          id: "business.json",
+          accountId: "business",
+          driver,
+          email: "same@example.com",
+          usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 0 }] },
+        },
+      ],
+    };
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: { providers: [native], usageLimitSources: [hub] },
+        },
+      ],
+      [
+        EnvironmentId.make("env-b"),
+        {
+          entry: { target: { label: "Desktop" } },
+          serverConfig: {
+            providers: [{ ...native, instanceId: ProviderInstanceId.make("codex-work") }],
+            usageLimitSources: [
+              {
+                ...hub,
+                id: UsageLimitSourceId.make("other-hub"),
+                accounts: hub.accounts.map((account) => ({ ...account, id: `copy-${account.id}` })),
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const pooled = collectLimitAccounts(input);
+    expect(pooled).toHaveLength(2);
+    expect(
+      pooled.find((account) => account.limits.windows[0]?.usedPercent === 90)?.environments,
+    ).toHaveLength(2);
+    expect(pooled.map((account) => account.limits.windows[0]?.usedPercent).sort()).toEqual([0, 90]);
+    expect(collectLimitSources(input)[0]?.accounts.map((account) => account.accountId)).toEqual([
+      "business",
+    ]);
+    const report = collectProviderUsageLimits(
+      native.instanceId,
+      [native],
+      [hub],
+      Date.parse(checkedAt),
+    );
+    expect(report?.accounts).toHaveLength(2);
+  });
+
   it("merges one account reported natively on two environments and by a hub into one entry", () => {
     const native = provider({
       driver: claude,

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -99,10 +99,11 @@ export function collectLimitSources(
     readonly hiddenAccountCount: number;
   }
 > {
+  const accountKey = makeAccountKey(Array.from(presentations.values(), (p) => p.serverConfig));
   const nativeAccounts = new Set<string>();
   for (const presentation of presentations.values()) {
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
-      const key = accountKey(provider.driver, provider.auth.email);
+      const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
       if (
         key !== null &&
         provider.usageLimits?.windows.length &&
@@ -130,7 +131,7 @@ export function collectLimitSources(
   return perEnvironment.flatMap(({ environmentId, environmentLabel, sources }) =>
     sources.map((source) => {
       const accounts = source.accounts.filter((account) => {
-        const key = accountKey(account.driver, account.email);
+        const key = accountKey(account.driver, account.email, account.accountId);
         return key === null || !nativeAccounts.has(key);
       });
       return {
@@ -145,16 +146,48 @@ export function collectLimitSources(
   );
 }
 
-function accountKey(driver: ServerProvider["driver"], email: string | undefined): string | null {
-  const normalizedEmail = email?.trim().toLowerCase();
-  return normalizedEmail ? `${driver}:${normalizedEmail}` : null;
+function makeAccountKey(
+  configs: Iterable<{
+    readonly providers?: readonly ServerProvider[] | undefined;
+    readonly usageLimitSources?: UsageLimitSourceSnapshots | undefined;
+  } | null>,
+) {
+  const idsByEmail = new Map<string, Set<string>>();
+  const emailKey = (driver: ServerProvider["driver"], email: string | undefined) => {
+    const normalized = email?.trim().toLowerCase();
+    return normalized ? `${driver}:${normalized}` : null;
+  };
+  for (const config of configs) {
+    const identities = [
+      ...(config?.providers ?? []).map((provider) => ({
+        driver: provider.driver,
+        ...provider.auth,
+      })),
+      ...(config?.usageLimitSources ?? []).flatMap((source) => source.accounts),
+    ];
+    for (const identity of identities) {
+      const key = emailKey(identity.driver, identity.email);
+      const id = identity.accountId?.trim();
+      if (!key || !id) continue;
+      const ids = idsByEmail.get(key) ?? new Set<string>();
+      ids.add(id);
+      idsByEmail.set(key, ids);
+    }
+  }
+  return (driver: ServerProvider["driver"], email: string | undefined, accountId?: string) => {
+    const id = accountId?.trim();
+    if (id) return `${driver}:account:${id}`;
+    const key = emailKey(driver, email);
+    const ids = key ? idsByEmail.get(key) : undefined;
+    // Legacy reports can join a known workspace only when the email is unambiguous.
+    return ids?.size === 1 ? `${driver}:account:${ids.values().next().value}` : key;
+  };
 }
 
 /**
  * One subscription account as the pooled views see it, whichever way it was
- * reported. The same email signed in natively on two environments, or reported
- * by a hub as well as natively, is one account: its quota is one bucket, so
- * counting it twice would misstate what is left.
+ * reported. Provider account IDs identify quota buckets; email is a fallback
+ * for providers and older servers that do not supply an account ID.
  */
 export interface LimitAccount {
   readonly key: string;
@@ -187,6 +220,7 @@ export interface LimitAccount {
 export function collectLimitAccounts(
   presentations: Parameters<typeof collectLimitSources>[0],
 ): readonly LimitAccount[] {
+  const accountKey = makeAccountKey(Array.from(presentations.values(), (p) => p.serverConfig));
   const accounts = new Map<string, LimitAccount>();
   const creditSources = new Map<string, LimitAccount>();
   const hubRedeems = new Map<string, LimitAccount>();
@@ -254,7 +288,7 @@ export function collectLimitAccounts(
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
       if (!provider.usageLimits || limitsNotice(provider.usageLimits) !== null) continue;
       merge(
-        accountKey(provider.driver, provider.auth.email) ??
+        accountKey(provider.driver, provider.auth.email, provider.auth.accountId) ??
           `${environmentId}:${provider.instanceId}`,
         {
           key: `${environmentId}:${provider.instanceId}`,
@@ -282,27 +316,31 @@ export function collectLimitAccounts(
         : source.label;
       for (const account of source.accounts) {
         if (limitsNotice(account.usageLimits) !== null) continue;
-        merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
-          key: `${source.id}:${account.id}`,
-          driver: account.driver,
-          displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
-          email: account.email,
-          plan: account.plan,
-          accentColor: undefined,
-          environments: [],
-          sourceLabel,
-          redeem: account.usageLimits.resetCredits?.nextCreditId
-            ? {
-                environmentId,
-                input: {
-                  sourceId: source.id,
-                  accountId: account.id,
-                  creditId: account.usageLimits.resetCredits.nextCreditId,
-                },
-              }
-            : null,
-          limits: account.usageLimits,
-        });
+        merge(
+          accountKey(account.driver, account.email, account.accountId) ??
+            `${source.id}:${account.id}`,
+          {
+            key: `${source.id}:${account.id}`,
+            driver: account.driver,
+            displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
+            email: account.email,
+            plan: account.plan,
+            accentColor: undefined,
+            environments: [],
+            sourceLabel,
+            redeem: account.usageLimits.resetCredits?.nextCreditId
+              ? {
+                  environmentId,
+                  input: {
+                    sourceId: source.id,
+                    accountId: account.id,
+                    creditId: account.usageLimits.resetCredits.nextCreditId,
+                  },
+                }
+              : null,
+            limits: account.usageLimits,
+          },
+        );
       }
     }
   }
@@ -642,6 +680,7 @@ export function collectProviderUsageLimits(
   sources: UsageLimitSourceSnapshots,
   now: number,
 ): UsageLimitsReport | null {
+  const accountKey = makeAccountKey([{ providers, usageLimitSources: sources }]);
   const selected = providers.find((provider) => provider.instanceId === instanceId);
   if (!selected || !hasProviderUsageLimits(selected.driver, providers, sources)) return null;
   const native = providersWithLimits(providers).filter(
@@ -649,7 +688,7 @@ export function collectProviderUsageLimits(
   );
   const nativeAccounts = new Set(
     native.flatMap((provider) => {
-      const key = accountKey(provider.driver, provider.auth.email);
+      const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
       return key && provider.usageLimits?.windows.length && !provider.usageLimits.unavailable
         ? [key]
         : [];
@@ -659,13 +698,13 @@ export function collectProviderUsageLimits(
   const notices: string[] = [];
   for (const provider of native) {
     if (!provider.usageLimits) continue;
-    const key = accountKey(provider.driver, provider.auth.email);
+    const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
     const hubCredits = sources
       .flatMap((source) => source.accounts.map((account) => ({ source, account })))
       .filter(
         ({ account }) =>
           key !== null &&
-          accountKey(account.driver, account.email) === key &&
+          accountKey(account.driver, account.email, account.accountId) === key &&
           account.usageLimits.resetCredits &&
           !limitsNotice(account.usageLimits),
       )
@@ -712,7 +751,7 @@ export function collectProviderUsageLimits(
   for (const source of sources) {
     const matching = source.accounts.filter((account) => account.driver === selected.driver);
     for (const account of matching) {
-      const key = accountKey(account.driver, account.email);
+      const key = accountKey(account.driver, account.email, account.accountId);
       if (key && nativeAccounts.has(key)) continue;
       accounts.push({
         id: `${source.id}:${account.id}`,


### PR DESCRIPTION
## What Changed

Carry an optional Codex workspace account ID from the native auth home and CLIProxyAPI account into the shared quota collectors. Match native, hub, and multi-environment reports by that ID. Email-only reports retain the existing fallback and join an identified workspace only when the email maps to one known workspace.

Custom-provider Codex instances no longer present a routed account's quota as their own subscription limits. Missing or unreadable auth identity falls back without failing the provider probe. Blank Codex plan values fall through to the ID-token plan fields for both the label and quota-window classification. Account-ID headers use the same trimmed value as the reported identity.

## Why

Fixes #10835.

One email can belong to multiple independent Codex workspaces, including two Business workspaces with the same plan. Grouping by email loses a quota; grouping by email and plan still loses it when those plans match. Conversely, one workspace reported from multiple environments should contribute only once to the pooled quota.

This overlaps with open #10845. That PR follows the plan-label approach in the issue triage and explicitly leaves same-email, same-plan Business workspaces unresolved. This proposes the workspace-ID approach for that remaining case, with optional contract fields for older servers. It does not incorporate #10845.

Related: #10701 and #10700 address duplicate native rows in the `/usage-limits` composer report. This change carries workspace identity through that report's native/hub matching, but does not deduplicate multiple native rows there. That work remains separate and should use the same identity rule if both changes land.

Ported as one commit from RTVision/t3code#40, based on upstream `3e6f856f2`. No fork release, routing plugin, or Vim-navigation changes are included.

## UI Changes

Cropped browser captures of the real Usage → Limits page in an isolated dev server, with the same synthetic fixture and fixed time for both captures. Both accounts use `developer@example.com` and the Business plan. Alpha has 10% weekly quota remaining; Beta has 80%. Alpha is reported on both Laptop and Desktop. The temporary fixture was removed before committing. Backend identity extraction is covered by the focused tests below; the screenshots demonstrate the shared collector and UI behavior.

Before: original upstream collector merges both workspaces and drops Beta, leaving one 10% quota.

![Before: Beta is missing and the pool shows 10% remaining](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-quota-before.png)

After: Alpha and Beta have separate segments, Alpha is counted once across environments, and the pool shows 45% remaining.

![After: Alpha and Beta are separate and the pool shows 45% remaining](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-quota-after.png)

The shared logic is used by web, desktop, and mobile. The integrated visual pass was on web; mobile was not launched. Only Codex supplies the new identity here; other providers retain their existing fallback.

## Verification

- 120 tests passed across `usageLimits.test.ts`, `cliproxyApi.test.ts`, `CodexProvider.test.ts`, and `ProviderRegistry.test.ts`.
- After review fixes, 34 adapter and Codex quota-conversion tests passed, including new Free/Go fallback and account-ID header cases.
- Shared and server type checks passed.
- Changed-file lint and `git diff --check` passed.
- Isolated browser comparison against original upstream and patched collectors.
- Dependency installation completed, but its prepare hook could not install the packaged Effect/Oxlint integration on Linux musl. The checks listed above ran successfully afterward.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation or timing change requires a video

Prepared by GPT-6 via Codex. The original fork patch was reviewed by Claude Fable 5.1 via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account IDs are now included in provider authentication and usage-limit details.
  - Codex account information and subscription plan details are detected from authentication data.
  - Usage limits more accurately distinguish separate workspaces and accounts.

- **Bug Fixes**
  - Prevented accounts with identical email addresses from being incorrectly combined.
  - Improved plan detection when preferred plan fields are blank.
  - API-key accounts are no longer reported as ChatGPT subscriptions.
  - Unsupported usage limits are reported correctly for accounts without required authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->