### PR TITLE
fix(usage): distinguish Codex workspaces by account ID

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,85 @@
 import { assert, it } from "@effect/vitest";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  mapCodexModelCapabilities,
+  readCodexAccountId,
+  resolveCodexAuthHome,
+} from "./CodexProvider.ts";
+
+it("resolves the selected or shadow home ahead of inherited credentials", () => {
+  const inherited = { CODEX_HOME: "/shared", HOME: "/user" };
+  assert.strictEqual(
+    resolveCodexAuthHome(
+      { homePath: "/shadow", environment: { CODEX_HOME: "/instance" } },
+      inherited,
+    ),
+    "/shadow",
+  );
+  assert.strictEqual(
+    resolveCodexAuthHome({ environment: { CODEX_HOME: "/instance" } }, inherited),
+    "/instance",
+  );
+  assert.strictEqual(resolveCodexAuthHome({}, inherited), "/shared");
+  assert.strictEqual(
+    resolveCodexAuthHome({ environment: { HOME: "/instance-user" } }, { HOME: "/user" }),
+    "/instance-user/.codex",
+  );
+  assert.strictEqual(resolveCodexAuthHome({}, { HOME: "/user" }), "/user/.codex");
+});
+
+it.effect(
+  "reads workspace identity from the selected home without treating API keys as subscriptions",
+  () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "codex-account-identity-")),
+      ),
+      (root) =>
+        Effect.gen(function* () {
+          for (const accountId of ["personal", "work"]) {
+            const home = NodePath.join(root, accountId);
+            yield* Effect.promise(() => NodeFSP.mkdir(home));
+            yield* Effect.promise(() =>
+              NodeFSP.writeFile(
+                NodePath.join(home, "auth.json"),
+                JSON.stringify({ tokens: { account_id: accountId } }),
+              ),
+            );
+            assert.strictEqual(yield* readCodexAccountId(home), accountId);
+          }
+          yield* Effect.promise(() =>
+            NodeFSP.writeFile(
+              NodePath.join(root, "auth.json"),
+              JSON.stringify({ OPENAI_API_KEY: "local-proxy" }),
+            ),
+          );
+          assert.strictEqual(yield* readCodexAccountId(root), undefined);
+          assert.strictEqual(yield* readCodexAccountId(NodePath.join(root, "missing")), undefined);
+          const payload = Buffer.from(
+            JSON.stringify({
+              "https://api.openai.com/auth": { chatgpt_account_id: "token-workspace" },
+            }),
+          ).toString("base64url");
+          for (const [tokens, expected] of [
+            [{ id_token: `header.${payload}.signature` }, "token-workspace"],
+            [{ account_id: null, id_token: `header.${payload}.signature` }, "token-workspace"],
+            [{ account_id: "explicit", id_token: `header.${payload}.signature` }, "explicit"],
+            [{ id_token: "malformed" }, undefined],
+          ] as const) {
+            yield* Effect.promise(() =>
+              NodeFSP.writeFile(NodePath.join(root, "auth.json"), JSON.stringify({ tokens })),
+            );
+            assert.strictEqual(yield* readCodexAccountId(root), expected);
+          }
+        }),
+      (root) => Effect.promise(() => NodeFSP.rm(root, { recursive: true, force: true })),
+    ),
+);
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -1,3 +1,6 @@
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -67,6 +70,7 @@ const CODEX_PRESENTATION = {
 
 export interface CodexAppServerProviderSnapshot {
   readonly account: CodexSchema.V2GetAccountResponse;
+  readonly accountId?: string;
   readonly rateLimits?: CodexRateLimitsProbe;
   readonly version: string | undefined;
   readonly models: ReadonlyArray<ServerProviderModel>;
@@ -404,6 +408,65 @@ export const withCodexAppServerClient = Effect.fn("withCodexAppServerClient")(fu
   return { client, initialize };
 });
 
+const decodeCodexAccountIdentity = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      tokens: Schema.Struct({
+        account_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
+        id_token: Schema.optionalKey(Schema.NullOr(Schema.String)),
+      }),
+    }),
+  ),
+);
+
+const decodeCodexIdTokenIdentity = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(
+    Schema.Struct({
+      "https://api.openai.com/auth": Schema.Struct({
+        chatgpt_account_id: Schema.optionalKey(Schema.NullOr(Schema.String)),
+      }),
+    }),
+  ),
+);
+
+export function resolveCodexAuthHome(
+  input: {
+    readonly homePath?: string;
+    readonly environment?: NodeJS.ProcessEnv;
+  },
+  inheritedEnvironment: NodeJS.ProcessEnv = process.env,
+) {
+  return expandHomePath(
+    input.homePath?.trim() ||
+      input.environment?.CODEX_HOME ||
+      inheritedEnvironment.CODEX_HOME ||
+      NodePath.join(
+        input.environment?.HOME || inheritedEnvironment.HOME || NodeOS.homedir(),
+        ".codex",
+      ),
+  );
+}
+
+export const readCodexAccountId = Effect.fn("readCodexAccountId")(function* (homePath: string) {
+  return yield* Effect.tryPromise(() =>
+    NodeFSP.readFile(NodePath.join(homePath, "auth.json"), "utf8"),
+  ).pipe(
+    Effect.flatMap(decodeCodexAccountIdentity),
+    Effect.flatMap((auth) => {
+      const accountId = auth.tokens.account_id?.trim();
+      if (accountId) return Effect.succeed(accountId);
+      const payload = auth.tokens.id_token?.split(".")[1];
+      if (!payload) return Effect.succeed(undefined);
+      return decodeCodexIdTokenIdentity(Buffer.from(payload, "base64url").toString("utf8")).pipe(
+        Effect.map(
+          (claims) => claims["https://api.openai.com/auth"].chatgpt_account_id?.trim() || undefined,
+        ),
+      );
+    }),
+    Effect.orElseSucceed(() => undefined),
+  );
+});
+
 const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
@@ -419,6 +482,12 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const version = versionMatch ? versionMatch[1] : undefined;
 
   const accountResponse = yield* client.request("account/read", {});
+  // account/read omits workspace identity. File-backed logins keep it beside
+  // the credentials in the same home used by this app-server instance.
+  const accountId =
+    accountResponse.account?.type === "chatgpt"
+      ? yield* readCodexAccountId(resolveCodexAuthHome(input))
+      : undefined;
   if (!accountResponse.account && accountResponse.requiresOpenaiAuth) {
     return {
       account: accountResponse,
@@ -460,6 +529,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
 
   return {
     account: accountResponse,
+    ...(accountId ? { accountId } : {}),
     rateLimits,
     version,
     models: applyPreferredCodexDefaultModel(
@@ -524,7 +594,10 @@ const makePendingCodexProvider = (
     });
   });
 
-function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]): {
+function accountProbeStatus(
+  account: CodexAppServerProviderSnapshot["account"],
+  accountId?: string,
+): {
   readonly status: Exclude<ServerProviderState, "disabled">;
   readonly auth: ServerProvider["auth"];
   readonly message?: string;
@@ -536,6 +609,7 @@ function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]):
     ...(account.account?.type ? { type: account.account?.type } : {}),
     ...(authLabel ? { label: authLabel } : {}),
     ...(authEmail ? { email: authEmail } : {}),
+    ...(accountId ? { accountId } : {}),
   } satisfies ServerProvider["auth"];
 
   if (account.account) {
@@ -646,7 +720,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   }
 
   const snapshot = probeResult.success.value;
-  const accountStatus = accountProbeStatus(snapshot.account);
+  const accountStatus = accountProbeStatus(snapshot.account, snapshot.accountId);
   const usageLimits =
     snapshot.account.account?.type === "apiKey"
       ? makeUnavailableUsageLimits({ checkedAt, reason: "unsupported" })

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -370,6 +370,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
             Effect.succeed(
               makeCodexProbeSnapshot({
+                accountId: "workspace-a",
                 skills: [
                   {
                     name: "github:gh-fix-ci",
@@ -389,6 +390,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
           assert.strictEqual(status.auth.type, "chatgpt");
           assert.strictEqual(status.auth.label, "ChatGPT Pro 20x Subscription");
           assert.strictEqual(status.auth.email, "test@example.com");
+          assert.strictEqual(status.auth.accountId, "workspace-a");
           assert.deepStrictEqual(status.models, [
             {
               slug: "gpt-live-codex",

--- a/apps/server/src/usage/cliproxyApi.test.ts
+++ b/apps/server/src/usage/cliproxyApi.test.ts
@@ -47,7 +47,12 @@ const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 function fixture(
   options: {
-    accounts?: Array<(typeof accounts)[number] & { disabled?: boolean }>;
+    accounts?: Array<
+      Omit<(typeof accounts)[number], "id_token"> & {
+        disabled?: boolean;
+        id_token?: { chatgpt_account_id?: string };
+      }
+    >;
     upstream?: (request: RequestBody) => { status: number; body: unknown };
     cooldownStatus?: number;
   } = {},
@@ -119,6 +124,7 @@ describe("CLIProxyAPI built-in management API", () => {
         const test = fixture();
         const api = yield* test.api;
         const result = yield* api.readAccounts(config);
+        expect(result.map((account) => account.accountId)).toEqual(["account-a", "account-b"]);
         expect(result.map((account) => account.usageLimits.resetCredits)).toEqual([
           { availableCount: 2, nextCreditId: "first", nextExpiresAt: "2099-01-01T00:00:00.000Z" },
           { availableCount: 2, nextCreditId: "first", nextExpiresAt: "2099-01-01T00:00:00.000Z" },
@@ -139,6 +145,33 @@ describe("CLIProxyAPI built-in management API", () => {
           ],
         ).toBe("account-b");
       }),
+  );
+
+  it.effect("uses trimmed account IDs for quota headers and omits empty IDs", () =>
+    Effect.gen(function* () {
+      const ids = [" account-a ", "", "  ", undefined];
+      const test = fixture({
+        accounts: ids.map((accountId, index) => ({
+          ...accounts[0]!,
+          id: `${index}.json`,
+          auth_index: String(index),
+          id_token: accountId === undefined ? {} : { chatgpt_account_id: accountId },
+        })),
+      });
+      const api = yield* test.api;
+      const result = yield* api.readAccounts(config);
+      expect(result.map((account) => account.accountId)).toEqual([
+        "account-a",
+        undefined,
+        undefined,
+        undefined,
+      ]);
+      for (const request of test.requests.filter((request) => request.body?.url)) {
+        expect(request.body?.header?.["Chatgpt-Account-Id"]).toBe(
+          request.body?.auth_index === "0" ? "account-a" : undefined,
+        );
+      }
+    }),
   );
 
   it.effect("keeps usage when the credits endpoint fails", () =>

--- a/apps/server/src/usage/cliproxyApi.ts
+++ b/apps/server/src/usage/cliproxyApi.ts
@@ -151,6 +151,7 @@ export const makeCliproxyApi = Effect.gen(function* () {
     url: string,
     data?: unknown,
   ) {
+    const accountId = account.id_token?.chatgpt_account_id?.trim();
     const header =
       account.provider === "codex"
         ? {
@@ -158,9 +159,7 @@ export const makeCliproxyApi = Effect.gen(function* () {
             "Content-Type": "application/json",
             "OpenAI-Beta": "codex-1",
             Originator: "Codex Desktop",
-            ...(account.id_token?.chatgpt_account_id
-              ? { "Chatgpt-Account-Id": account.id_token.chatgpt_account_id }
-              : {}),
+            ...(accountId ? { "Chatgpt-Account-Id": accountId } : {}),
           }
         : { Authorization: "Bearer $TOKEN$", "anthropic-beta": "oauth-2025-04-20" };
     const raw = yield* management(config, "api-call", {
@@ -205,6 +204,9 @@ export const makeCliproxyApi = Effect.gen(function* () {
       id: account.id,
       driver: ProviderDriverKind.make(account.provider === "codex" ? "codex" : "claudeAgent"),
       ...(account.email ? { email: account.email } : {}),
+      ...(account.provider === "codex" && account.id_token?.chatgpt_account_id?.trim()
+        ? { accountId: account.id_token.chatgpt_account_id.trim() }
+        : {}),
     };
     const read = Effect.gen(function* () {
       if (account.provider === "claude") {

--- a/packages/contracts/src/providerUsageLimits.ts
+++ b/packages/contracts/src/providerUsageLimits.ts
@@ -81,6 +81,8 @@ export const UsageLimitSourceAccount = Schema.Struct({
   driver: ProviderDriverKind,
   /** The signed-in address, when the source names one; clients blur it like provider auth. */
   email: Schema.optional(TrimmedNonEmptyString),
+  /** Provider account or workspace ID; an email can belong to several quota buckets. */
+  accountId: Schema.optional(TrimmedNonEmptyString),
   /** Plan as the matching provider would label it (`ChatGPT Pro 20x Subscription`). */
   plan: Schema.optional(TrimmedNonEmptyString),
   usageLimits: ServerProviderUsageLimits,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -63,6 +63,7 @@ export const ServerProviderAuth = Schema.Struct({
   type: Schema.optional(TrimmedNonEmptyString),
   label: Schema.optional(TrimmedNonEmptyString),
   email: Schema.optional(TrimmedNonEmptyString),
+  accountId: Schema.optional(TrimmedNonEmptyString),
 });
 export type ServerProviderAuth = typeof ServerProviderAuth.Type;
 

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -332,6 +332,292 @@ describe("pools", () => {
   };
   const laptop = { entry: { target: { label: "Laptop" } } };
 
+  it.each([true, false])(
+    "merges legacy reports with one known workspace and retains hub redemption, native ID %s",
+    (nativeHasId) => {
+      const driver = ProviderDriverKind.make("codex");
+      const native = provider({
+        driver,
+        auth: {
+          status: "authenticated",
+          email: "Same@example.com",
+          ...(nativeHasId ? { accountId: "workspace" } : {}),
+        },
+        usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 40 }] },
+      });
+      const hub = {
+        ...source,
+        accounts: [
+          {
+            id: "account.json",
+            driver,
+            email: "same@example.com",
+            ...(!nativeHasId ? { accountId: "workspace" } : {}),
+            usageLimits: {
+              checkedAt,
+              windows: [{ ...weekly, usedPercent: 40 }],
+              resetCredits: { availableCount: 1, nextCreditId: "hub-credit" },
+            },
+          },
+        ],
+      };
+      const input = new Map([
+        [
+          EnvironmentId.make("env-a"),
+          { ...laptop, serverConfig: { providers: [native], usageLimitSources: [hub] } },
+        ],
+        [
+          EnvironmentId.make("env-b"),
+          {
+            ...laptop,
+            serverConfig: {
+              providers: [
+                {
+                  ...native,
+                  auth: { status: "authenticated" as const, email: "same@example.com" },
+                },
+              ],
+              usageLimitSources: [],
+            },
+          },
+        ],
+      ]);
+      const accounts = collectLimitAccounts(input);
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]?.environments).toHaveLength(2);
+      expect(accounts[0]?.redeem?.input).toEqual({
+        sourceId: source.id,
+        accountId: "account.json",
+        creditId: "hub-credit",
+      });
+      expect(collectLimitSources(input)[0]?.accounts).toHaveLength(0);
+      const report = collectProviderUsageLimits(
+        native.instanceId,
+        [native],
+        [hub],
+        Date.parse(checkedAt),
+      );
+      expect(report?.accounts).toHaveLength(1);
+      expect(report?.accounts[0]?.resetCreditInput).toEqual({
+        sourceId: source.id,
+        accountId: "account.json",
+        creditId: "hub-credit",
+      });
+    },
+  );
+
+  it("keeps ambiguous legacy reports separate from identified workspaces in either order", () => {
+    const driver = ProviderDriverKind.make("codex");
+    const providers = ["workspace-a", "workspace-b", undefined].map((accountId, index) =>
+      provider({
+        driver,
+        instanceId: ProviderInstanceId.make(`codex-${index}`),
+        auth: {
+          status: "authenticated",
+          email: "same@example.com",
+          ...(accountId ? { accountId } : {}),
+        },
+        usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: index * 20 }] },
+      }),
+    );
+    for (const ordered of [providers, providers.toReversed()]) {
+      const accounts = collectLimitAccounts(
+        new Map([
+          [EnvironmentId.make("env-a"), { ...laptop, serverConfig: { providers: ordered } }],
+        ]),
+      );
+      expect(accounts).toHaveLength(3);
+      expect(accounts.map((account) => account.limits.windows[0]?.usedPercent).sort()).toEqual([
+        0, 20, 40,
+      ]);
+    }
+  });
+
+  it("keeps members of one Business workspace separate across native and hub reports", () => {
+    const driver = ProviderDriverKind.make("codex");
+    const native = provider({
+      driver,
+      auth: { status: "authenticated", email: "Primary@example.com", accountId: "business" },
+      usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 71 }] },
+    });
+    const hub = {
+      ...source,
+      accounts: [
+        {
+          id: "primary.json",
+          accountId: "business",
+          driver,
+          email: "primary@example.com",
+          usageLimits: {
+            ...native.usageLimits!,
+            resetCredits: { availableCount: 1, nextCreditId: "primary-credit" },
+          },
+        },
+        {
+          id: "review.json",
+          accountId: "business",
+          driver,
+          email: "review@example.com",
+          usageLimits: {
+            checkedAt,
+            windows: [{ ...weekly, usedPercent: 23 }],
+            resetCredits: { availableCount: 3, nextCreditId: "review-credit" },
+          },
+        },
+      ],
+    };
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        { ...laptop, serverConfig: { providers: [native], usageLimitSources: [hub] } },
+      ],
+      [
+        EnvironmentId.make("env-b"),
+        { ...laptop, serverConfig: { providers: [native], usageLimitSources: [] } },
+      ],
+    ]);
+    const accounts = collectLimitAccounts(input);
+    expect(accounts).toHaveLength(2);
+    expect(
+      accounts.map((account) => [
+        account.email?.toLowerCase(),
+        account.limits.windows[0]?.usedPercent,
+        account.limits.resetCredits?.availableCount,
+        account.redeem?.input,
+      ]),
+    ).toEqual([
+      [
+        "primary@example.com",
+        71,
+        1,
+        { sourceId: source.id, accountId: "primary.json", creditId: "primary-credit" },
+      ],
+      [
+        "review@example.com",
+        23,
+        3,
+        { sourceId: source.id, accountId: "review.json", creditId: "review-credit" },
+      ],
+    ]);
+    expect(accounts[0]?.environments).toHaveLength(2);
+    expect(collectLimitSources(input)[0]?.accounts.map((account) => account.id)).toEqual([
+      "review.json",
+    ]);
+    const report = collectProviderUsageLimits(
+      native.instanceId,
+      [native],
+      [hub],
+      Date.parse(checkedAt),
+    );
+    expect(report?.accounts).toHaveLength(2);
+    expect(report?.accounts.map((account) => account.resetCreditInput)).toEqual([
+      { sourceId: source.id, accountId: "primary.json", creditId: "primary-credit" },
+      { sourceId: source.id, accountId: "review.json", creditId: "review-credit" },
+    ]);
+  });
+
+  it("keeps a workspace report without an email separate from identified members", () => {
+    const driver = ProviderDriverKind.make("codex");
+    const hub = {
+      ...source,
+      accounts: [
+        {
+          id: "known.json",
+          driver,
+          accountId: "business",
+          email: "known@example.com",
+          usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 20 }] },
+        },
+        {
+          id: "unknown.json",
+          driver,
+          accountId: "business",
+          usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 20 }] },
+        },
+      ],
+    };
+    const accounts = collectLimitAccounts(
+      new Map([
+        [
+          EnvironmentId.make("env-a"),
+          { ...laptop, serverConfig: { providers: [], usageLimitSources: [hub] } },
+        ],
+      ]),
+    );
+    expect(accounts).toHaveLength(2);
+    expect(accounts.map((account) => account.email)).toEqual(["known@example.com", undefined]);
+  });
+
+  it("keeps same-email Codex workspaces separate and merges only matching account IDs", () => {
+    const driver = ProviderDriverKind.make("codex");
+    const native = provider({
+      driver,
+      instanceId: ProviderInstanceId.make("codex"),
+      auth: { status: "authenticated", email: "same@example.com", accountId: "pro" },
+      usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 90 }] },
+    });
+    const hub = {
+      ...source,
+      accounts: [
+        {
+          id: "pro.json",
+          accountId: "pro",
+          driver,
+          email: "same@example.com",
+          usageLimits: native.usageLimits!,
+        },
+        {
+          id: "business.json",
+          accountId: "business",
+          driver,
+          email: "same@example.com",
+          usageLimits: { checkedAt, windows: [{ ...weekly, usedPercent: 0 }] },
+        },
+      ],
+    };
+    const input = new Map([
+      [
+        EnvironmentId.make("env-a"),
+        {
+          ...laptop,
+          serverConfig: { providers: [native], usageLimitSources: [hub] },
+        },
+      ],
+      [
+        EnvironmentId.make("env-b"),
+        {
+          entry: { target: { label: "Desktop" } },
+          serverConfig: {
+            providers: [{ ...native, instanceId: ProviderInstanceId.make("codex-work") }],
+            usageLimitSources: [
+              {
+                ...hub,
+                id: UsageLimitSourceId.make("other-hub"),
+                accounts: hub.accounts.map((account) => ({ ...account, id: `copy-${account.id}` })),
+              },
+            ],
+          },
+        },
+      ],
+    ]);
+    const pooled = collectLimitAccounts(input);
+    expect(pooled).toHaveLength(2);
+    expect(
+      pooled.find((account) => account.limits.windows[0]?.usedPercent === 90)?.environments,
+    ).toHaveLength(2);
+    expect(pooled.map((account) => account.limits.windows[0]?.usedPercent).sort()).toEqual([0, 90]);
+    expect(collectLimitSources(input)[0]?.accounts.map((account) => account.accountId)).toEqual([
+      "business",
+    ]);
+    const report = collectProviderUsageLimits(
+      native.instanceId,
+      [native],
+      [hub],
+      Date.parse(checkedAt),
+    );
+    expect(report?.accounts).toHaveLength(2);
+  });
+
   it("merges one account reported natively on two environments and by a hub into one entry", () => {
     const native = provider({
       driver: claude,

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -99,10 +99,11 @@ export function collectLimitSources(
     readonly hiddenAccountCount: number;
   }
 > {
+  const accountKey = makeAccountKey(Array.from(presentations.values(), (p) => p.serverConfig));
   const nativeAccounts = new Set<string>();
   for (const presentation of presentations.values()) {
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
-      const key = accountKey(provider.driver, provider.auth.email);
+      const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
       if (
         key !== null &&
         provider.usageLimits?.windows.length &&
@@ -130,7 +131,7 @@ export function collectLimitSources(
   return perEnvironment.flatMap(({ environmentId, environmentLabel, sources }) =>
     sources.map((source) => {
       const accounts = source.accounts.filter((account) => {
-        const key = accountKey(account.driver, account.email);
+        const key = accountKey(account.driver, account.email, account.accountId);
         return key === null || !nativeAccounts.has(key);
       });
       return {
@@ -145,16 +146,47 @@ export function collectLimitSources(
   );
 }
 
-function accountKey(driver: ServerProvider["driver"], email: string | undefined): string | null {
-  const normalizedEmail = email?.trim().toLowerCase();
-  return normalizedEmail ? `${driver}:${normalizedEmail}` : null;
+function makeAccountKey(
+  configs: Iterable<{
+    readonly providers?: readonly ServerProvider[] | undefined;
+    readonly usageLimitSources?: UsageLimitSourceSnapshots | undefined;
+  } | null>,
+) {
+  const idsByEmail = new Map<string, Set<string>>();
+  const emailKey = (driver: ServerProvider["driver"], email: string | undefined) => {
+    const normalized = email?.trim().toLowerCase();
+    return normalized ? `${driver}:${normalized}` : null;
+  };
+  for (const config of configs) {
+    const identities = [
+      ...(config?.providers ?? []).map((provider) => ({
+        driver: provider.driver,
+        ...provider.auth,
+      })),
+      ...(config?.usageLimitSources ?? []).flatMap((source) => source.accounts),
+    ];
+    for (const identity of identities) {
+      const key = emailKey(identity.driver, identity.email);
+      const id = identity.accountId?.trim();
+      if (!key || !id) continue;
+      const ids = idsByEmail.get(key) ?? new Set<string>();
+      ids.add(id);
+      idsByEmail.set(key, ids);
+    }
+  }
+  return (driver: ServerProvider["driver"], email: string | undefined, accountId?: string) => {
+    const key = emailKey(driver, email);
+    const ids = key ? idsByEmail.get(key) : undefined;
+    // Legacy reports can join a known workspace only when the email is unambiguous.
+    const id = accountId?.trim() || (ids?.size === 1 ? ids.values().next().value : undefined);
+    return id ? `${driver}:account:${id}:${email?.trim().toLowerCase() ?? ""}` : key;
+  };
 }
 
 /**
  * One subscription account as the pooled views see it, whichever way it was
- * reported. The same email signed in natively on two environments, or reported
- * by a hub as well as natively, is one account: its quota is one bucket, so
- * counting it twice would misstate what is left.
+ * reported. Workspace ID and email identify a Codex member's quota bucket.
+ * Email alone is a fallback for providers and older servers without an ID.
  */
 export interface LimitAccount {
   readonly key: string;
@@ -187,6 +219,7 @@ export interface LimitAccount {
 export function collectLimitAccounts(
   presentations: Parameters<typeof collectLimitSources>[0],
 ): readonly LimitAccount[] {
+  const accountKey = makeAccountKey(Array.from(presentations.values(), (p) => p.serverConfig));
   const accounts = new Map<string, LimitAccount>();
   const creditSources = new Map<string, LimitAccount>();
   const hubRedeems = new Map<string, LimitAccount>();
@@ -254,7 +287,7 @@ export function collectLimitAccounts(
     for (const provider of providersWithLimits(presentation.serverConfig?.providers ?? [])) {
       if (!provider.usageLimits || limitsNotice(provider.usageLimits) !== null) continue;
       merge(
-        accountKey(provider.driver, provider.auth.email) ??
+        accountKey(provider.driver, provider.auth.email, provider.auth.accountId) ??
           `${environmentId}:${provider.instanceId}`,
         {
           key: `${environmentId}:${provider.instanceId}`,
@@ -282,7 +315,8 @@ export function collectLimitAccounts(
         : source.label;
       for (const account of source.accounts) {
         if (limitsNotice(account.usageLimits) !== null) continue;
-        merge(accountKey(account.driver, account.email) ?? `${source.id}:${account.id}`, {
+        const key = accountKey(account.driver, account.email, account.accountId);
+        merge(key ?? `${source.id}:${account.id}`, {
           key: `${source.id}:${account.id}`,
           driver: account.driver,
           displayName: account.email ? null : account.id.replace(/\.json$/i, ""),
@@ -642,6 +676,7 @@ export function collectProviderUsageLimits(
   sources: UsageLimitSourceSnapshots,
   now: number,
 ): UsageLimitsReport | null {
+  const accountKey = makeAccountKey([{ providers, usageLimitSources: sources }]);
   const selected = providers.find((provider) => provider.instanceId === instanceId);
   if (!selected || !hasProviderUsageLimits(selected.driver, providers, sources)) return null;
   const native = providersWithLimits(providers).filter(
@@ -649,7 +684,7 @@ export function collectProviderUsageLimits(
   );
   const nativeAccounts = new Set(
     native.flatMap((provider) => {
-      const key = accountKey(provider.driver, provider.auth.email);
+      const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
       return key && provider.usageLimits?.windows.length && !provider.usageLimits.unavailable
         ? [key]
         : [];
@@ -659,13 +694,13 @@ export function collectProviderUsageLimits(
   const notices: string[] = [];
   for (const provider of native) {
     if (!provider.usageLimits) continue;
-    const key = accountKey(provider.driver, provider.auth.email);
+    const key = accountKey(provider.driver, provider.auth.email, provider.auth.accountId);
     const hubCredits = sources
       .flatMap((source) => source.accounts.map((account) => ({ source, account })))
       .filter(
         ({ account }) =>
           key !== null &&
-          accountKey(account.driver, account.email) === key &&
+          accountKey(account.driver, account.email, account.accountId) === key &&
           account.usageLimits.resetCredits &&
           !limitsNotice(account.usageLimits),
       )
@@ -712,7 +747,7 @@ export function collectProviderUsageLimits(
   for (const source of sources) {
     const matching = source.accounts.filter((account) => account.driver === selected.driver);
     for (const account of matching) {
-      const key = accountKey(account.driver, account.email);
+      const key = accountKey(account.driver, account.email, account.accountId);
       if (key && nativeAccounts.has(key)) continue;
       accounts.push({
         id: `${source.id}:${account.id}`,


### PR DESCRIPTION
## What changed

Codex workspaces sharing an email address are currently merged into one quota bucket, even when they have separate subscriptions. Carry the workspace account ID from native file-backed authentication and CLIProxyAPI into the shared quota collectors, and group by workspace ID plus normalized email. Different Business members can share a workspace ID while owning different quotas and reset credits. The same workspace still merges across environments and native/hub reports, and reset credits stay attached to the matching workspace.

Email remains the fallback for older servers and providers without an ID. An email-only report joins an identified workspace only when the match is unambiguous; otherwise it stays separate rather than guessing.

Fixes #10835.

Related: #10845 distinguishes accounts by email and plan. That leaves two Business workspaces with the same email and plan merged. Workspace ID plus email distinguishes that case without treating a plan change as a new subscription.

## UI

Synthetic fixture captures in the web client: two Business workspaces share an email, with 10% and 80% remaining. One workspace is reported on both Laptop and Desktop. Before, both workspaces collapse into 10%; after, they remain separate and pool to 45%.

| Before | After |
| --- | --- |
| ![Before](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-quota-before.png) | ![After](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-quota-after.png) |

A second synthetic fixture uses two members of the same Business workspace. Before, only the primary member's 29% quota appears. After, the review member's 77% quota and three reset credits remain separate from the primary member's one credit.

| Before | After |
| --- | --- |
| ![Business members before](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-member-before.png) | ![Business members after](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-member-after.png) |

## Verification

- 120 focused tests passed across the shared collectors, CLIProxyAPI adapter, Codex provider, and provider registry. The shared suite was rerun after the member-identity correction: 51 passed, including separate users in one workspace and reports with no email.
- Coverage includes workspace separation, cross-environment merging, ambiguous legacy reports in both orders, native/hub matching, reset-credit routing, auth-home resolution, and missing or malformed auth files.
- Server/shared package typechecks and changed-file lint passed. Shared package typecheck and targeted lint were rerun after the member-identity correction.
- Shared collectors serve web/desktop and mobile; contracts remain backward compatible. No client-specific UI code changed. Browser evidence uses synthetic fixtures, not an OAuth end-to-end test; mobile was not run.
- Fable approved the original diff and the member-identity correction. A report with no email stays separate because its workspace ID cannot identify which member owns it. Grouping keys are internal maps; persisted UI keys are unchanged.

Implemented with GPT-6 in Codex; reviewed with claude-fable-5-1 through Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex workspace accounts are now identified separately from sign-in email addresses.
  * Provider authentication and usage-limit details can display an account or workspace ID.
  * Codex account information is detected from supported local authentication data.

* **Bug Fixes**
  * Usage limits remain correctly separated for multiple workspaces sharing an email.
  * Codex account IDs are trimmed before quota requests.
  * Unavailable or ambiguous account IDs no longer merge unrelated usage records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->