### PR TITLE
fix(server): omit native quota for custom Codex providers

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -648,7 +648,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const snapshot = probeResult.success.value;
   const accountStatus = accountProbeStatus(snapshot.account);
   const usageLimits =
-    snapshot.account.account?.type === "apiKey"
+    snapshot.account.account?.type === "apiKey" || !snapshot.account.requiresOpenaiAuth
       ? makeUnavailableUsageLimits({ checkedAt, reason: "unsupported" })
       : snapshot.rateLimits === undefined || "failure" in snapshot.rateLimits
         ? makeUnavailableUsageLimits({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -299,7 +299,7 @@ function makeCodexProbeSnapshot(
         email: "test@example.com",
         planType: "pro",
       },
-      requiresOpenaiAuth: false,
+      requiresOpenaiAuth: true,
     },
     models: [
       {
@@ -365,6 +365,31 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
   "ProviderRegistry",
   (it) => {
     describe("checkCodexProviderStatus", () => {
+      it.effect("does not count proxy rate limits as a native subscription", () =>
+        Effect.gen(function* () {
+          for (const account of [
+            null,
+            { type: "chatgpt" as const, email: "test@example.com", planType: "pro" as const },
+          ]) {
+            const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+              Effect.succeed(
+                makeCodexProbeSnapshot({
+                  account: { account, requiresOpenaiAuth: false },
+                  rateLimits: {
+                    snapshot: {
+                      primary: { usedPercent: 90, windowDurationMins: 10080, resetsAt: 1789436313 },
+                    },
+                    rateLimitsByLimitId: null,
+                    resetCredits: null,
+                  },
+                }),
+              ),
+            );
+            assert.strictEqual(status.usageLimits?.unavailable?.reason, "unsupported");
+            assert.deepStrictEqual(status.usageLimits?.windows, []);
+          }
+        }),
+      );
       it.effect("uses the app-server account and model list for provider status", () =>
         Effect.gen(function* () {
           const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>


### PR DESCRIPTION
## What changed

A custom Codex provider can expose rate-limit data that does not describe the account serving requests through its proxy. T3 currently presents that data as native subscription quota.

Mark native usage limits unsupported when `requiresOpenaiAuth` is false, using the existing API-key exclusion path. Configured hub usage remains available. In Codex, this flag describes the selected provider's authentication requirements, as shown in [its account-state implementation](https://github.com/openai/codex/blob/5ac0b8768d952280940682da09aed0279603f550/codex-rs/model-provider/src/provider.rs#L401-L440).

## UI

Synthetic browser fixtures generated from baseline and patched provider checks. Before, an unrelated 10% native row appears beside the hub's 80% quota. After, only the hub quota remains.

| Before | After |
| --- | --- |
| ![Before](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-proxy-before.png) | ![After](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-proxy-after.png) |

## Verification

- 51 provider-registry tests passed, including null and ChatGPT account snapshots with `requiresOpenaiAuth: false`; both report unsupported usage with no windows.
- Server package typecheck and changed-file lint passed.
- The server report applies to all clients and connection modes. Other providers are unchanged. Browser evidence uses synthetic fixtures; no live proxy/OAuth or mobile end-to-end test was run.
- Fable approved the one-line condition change and regression coverage.

Implemented with GPT-6 in Codex; reviewed with claude-fable-5-1 through Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex provider status detection for accounts that do not use OpenAI authentication.
  - Proxy-based rate-limit information is no longer incorrectly interpreted as native subscription usage limits.
  - Unsupported usage-limit scenarios now report a clear unsupported status instead of displaying misleading rate-limit data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #11873