### PR TITLE
fix(usage): recover missing Codex hub plans from auth metadata

### DIFF
--- a/apps/server/src/usage/cliproxyApi.test.ts
+++ b/apps/server/src/usage/cliproxyApi.test.ts
@@ -47,7 +47,12 @@ const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 function fixture(
   options: {
-    accounts?: Array<(typeof accounts)[number] & { disabled?: boolean }>;
+    accounts?: Array<
+      (typeof accounts)[number] & {
+        disabled?: boolean;
+        id_token: { chatgpt_account_id: string; plan_type?: string; chatgpt_plan_type?: string };
+      }
+    >;
     upstream?: (request: RequestBody) => { status: number; body: unknown };
     cooldownStatus?: number;
   } = {},
@@ -139,6 +144,34 @@ describe("CLIProxyAPI built-in management API", () => {
           ],
         ).toBe("account-b");
       }),
+  );
+
+  it.effect("uses current and legacy token plans for missing Free and Go quota metadata", () =>
+    Effect.gen(function* () {
+      for (const field of ["plan_type", "chatgpt_plan_type"] as const) {
+        const test = fixture({
+          accounts: accounts.map((account, index) => ({
+            ...account,
+            id_token: { ...account.id_token, [field]: index === 0 ? "free" : "go" },
+          })),
+          upstream: () => ({
+            status: 200,
+            body: { rate_limit: { primary_window: { used_percent: 12 } } },
+          }),
+        });
+        const api = yield* test.api;
+        const result = yield* api.readAccounts(config);
+        expect(result.map((account) => account.plan)).toEqual([
+          "ChatGPT Free Subscription",
+          "ChatGPT Go Subscription",
+        ]);
+        for (const account of result) {
+          expect(account.usageLimits.windows).toMatchObject([
+            { kind: "monthly", windowDurationMins: 43_200, usedPercent: 12 },
+          ]);
+        }
+      }
+    }),
   );
 
   it.effect("keeps usage when the credits endpoint fails", () =>

--- a/apps/server/src/usage/cliproxyApi.ts
+++ b/apps/server/src/usage/cliproxyApi.ts
@@ -27,6 +27,7 @@ const AuthFile = Schema.Struct({
     Schema.Struct({
       chatgpt_account_id: Schema.optional(Schema.String),
       chatgpt_plan_type: Schema.optional(Schema.String),
+      plan_type: Schema.optional(Schema.String),
     }),
   ),
 });
@@ -252,14 +253,16 @@ export const makeCliproxyApi = Effect.gen(function* () {
       // A credits outage must not hide successfully fetched quota windows.
       const available = yield* credits(config, account).pipe(Effect.orElseSucceed(() => undefined));
       const next = available?.[0];
+      const planType =
+        usage.plan_type ?? account.id_token?.plan_type ?? account.id_token?.chatgpt_plan_type;
       return {
         ...base,
-        plan: codexPlanLabel(usage.plan_type ?? account.id_token?.chatgpt_plan_type),
+        plan: codexPlanLabel(planType),
         usageLimits: {
           ...codexRateLimitsToLimits({
             checkedAt,
             snapshot: {
-              planType: usage.plan_type ?? null,
+              planType: planType ?? null,
               primary: toWindow(usage.rate_limit?.primary_window),
               secondary: toWindow(usage.rate_limit?.secondary_window),
             },


### PR DESCRIPTION
## What changed

When CLIProxyAPI's usage response omits `plan_type`, T3 can lose the account's plan label and classify a Free or Go quota window as a session window even though the auth-file metadata contains the plan.

Resolve the plan once from the usage response, then `id_token.plan_type`, then the legacy `id_token.chatgpt_plan_type`. Use that value for both the label and quota conversion. The current [CLIProxyAPI management handler emits `plan_type`](https://github.com/router-for-me/CLIProxyAPI/blob/v7.2.155/internal/api/handlers/management/auth_files.go#L556-L583).

## UI

Synthetic browser fixture generated from the baseline and patched adapters. The usage response omits the plan and window duration; auth metadata contains `plan_type: "free"`. The quota is now classified as Monthly.

| Before | After |
| --- | --- |
| ![Before](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-plan-before.png) | ![After](https://github.com/RTVision/t3code/releases/download/quota-workspace-pr-evidence/t3-plan-after.png) |

## Verification

- 32 adapter/converter tests passed. Regression coverage checks Free and Go with both current and legacy token fields, asserting the plan labels and monthly window duration when the usage plan is absent.
- Server package typecheck and changed-file lint passed.
- The adapter produces the shared report for all clients. Browser evidence uses synthetic fixtures; no live hub or mobile end-to-end test was run.
- Fable approved the final diff after checking the management-handler schema evidence.

Implemented with GPT-6 in Codex; reviewed with claude-fable-5-1 through Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex account plan detection when upstream usage data omits subscription metadata.
  - Subscription labels now correctly identify Free and Go plans using available current or legacy account information.
  - Rate-limit snapshots and monthly quota windows now reflect the resolved account plan more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->