### PR TITLE
test(web): cancel queued animation frames during worker cleanup

### DIFF
--- a/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
+++ b/apps/server/src/orchestration-v2/FoundationPersistence.test.ts
@@ -422,7 +422,7 @@ it.layer(TestLayer)("orchestration V2 foundation persistence", (it) => {
           if (stored.event.type !== "turn-item.updated") return;
           assert.equal(stored.event.payload.type, "dynamic_tool");
           if (stored.event.payload.type !== "dynamic_tool") return;
-          assert.deepInclude(stored.event.payload.output, { truncated: true });
+          assert.notProperty(stored.event.payload, "output");
         }
         const persisted = yield* store.read({ threadId: thread.id }).pipe(Stream.runCollect);
         const fullEvent = persisted.find(

--- a/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
+++ b/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
@@ -40,6 +40,7 @@ const source = "export const View = () => <div>Ready</div>;";
 let pool: WorkerPoolManager;
 let renderer: FileRenderer;
 let terminationPromises: Promise<number>[];
+const pendingAnimationFrames = new Set<ReturnType<typeof setImmediate>>();
 
 class WorkerTransport {
   private readonly worker = new NodeWorkerThreads.Worker(
@@ -96,10 +97,18 @@ function firstEnter(highlighter: DiffsHighlighter, file: FileContents, language:
 
 beforeEach(async () => {
   terminationPromises = [];
-  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
-    setImmediate(() => callback(0)),
-  );
-  vi.stubGlobal("cancelAnimationFrame", clearImmediate);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    const handle = setImmediate(() => {
+      pendingAnimationFrames.delete(handle);
+      callback(0);
+    });
+    pendingAnimationFrames.add(handle);
+    return handle;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (handle: ReturnType<typeof setImmediate>) => {
+    pendingAnimationFrames.delete(handle);
+    clearImmediate(handle);
+  });
   vi.stubGlobal("window", { matchMedia: () => ({ matches: true }) });
   await disposeHighlighter();
   pool = new WorkerPoolManager(
@@ -116,6 +125,8 @@ afterEach(async () => {
   pool?.terminate();
   await Promise.all(terminationPromises);
   await disposeHighlighter();
+  for (const handle of pendingAnimationFrames) clearImmediate(handle);
+  pendingAnimationFrames.clear();
   vi.unstubAllGlobals();
 });
 


### PR DESCRIPTION
The editable-file language test can leave a worker statistics animation frame queued after teardown removes the browser globals. CI then reports an uncaught `cancelAnimationFrame is not defined` error even when every assertion passes.

Track the test-owned animation frame handles and cancel the remaining callbacks after worker termination and highlighter disposal, before restoring globals. Production behavior is unchanged. This is a prerequisite for #10051. It includes the existing test-only retention correction from #10865 because the current V2 base otherwise fails that server assertion; merge #10865 first. The incremental cleanup remains one web test file.

Verification: all 7 tests in `fileEditorLanguageReadiness.test.ts` passed with the fix; focused lint and formatting passed. The identical patch was tested in the #10051 composition. A recent direct `claude -p --model claude-opus-5 --effort high --tools '' --output-format json` review attempt exited 1 because OAuth had expired, before inference; independent review was unavailable.

Model: GPT-6 Astra. Harness: Codex (T3 Code).
