### PR TITLE
fix(agents): show recent tools and saved child history

### DIFF
--- a/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
+++ b/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
@@ -123,6 +123,7 @@ const startupDependencies = Layer.mergeAll(
     assertConversationRollbackSupported: () => Effect.die("unused"),
     getInstanceInfo: () => Effect.die("unused"),
     rollbackConversation: () => Effect.die("unused"),
+    getAgentHistory: () => Effect.die("unused"),
     uploadFeedback: () => Effect.die("unused"),
     streamEvents: Stream.empty,
   }),

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -23,6 +23,7 @@ type WsRpcMethod = RpcGroup.Rpcs<typeof WsRpcGroup>["_tag"];
 export const RPC_REQUIRED_SCOPES = {
   [ORCHESTRATION_WS_METHODS.dispatchCommand]: AuthOrchestrationOperateScope,
   [ORCHESTRATION_WS_METHODS.getWorkflowScript]: AuthOrchestrationReadScope,
+  [ORCHESTRATION_WS_METHODS.getAgentHistory]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getTurnDiff]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getFullThreadDiff]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.searchThreads]: AuthOrchestrationReadScope,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -137,6 +137,7 @@ function createProviderServiceHarness(
         },
       }),
     rollbackConversation,
+    getAgentHistory: () => unsupported(),
     uploadFeedback: () => unsupported(),
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -390,6 +390,7 @@ describe("ProviderCommandReactor", () => {
         });
       },
       rollbackConversation: () => unsupported(),
+      getAgentHistory: () => unsupported(),
       uploadFeedback: () => unsupported(),
       get streamEvents() {
         return Stream.fromPubSub(runtimeEventPubSub);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -141,6 +141,7 @@ function createProviderServiceHarness() {
       });
     },
     rollbackConversation: () => unsupported(),
+    getAgentHistory: () => unsupported(),
     uploadFeedback: () => unsupported(),
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -7279,3 +7279,48 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 });
+
+for (const source of ["configured", "inherited"] as const) {
+  it.effect(`reads child history from the ${source} Claude home without starting a session`, () => {
+    const home = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-history-adapter-"));
+    const sessionId = "0945fcd9-8a8d-450a-b8cf-4ebd0ef17468";
+    const directory = NodePath.join(home, "projects", "-workspace", sessionId, "subagents");
+    NodeFS.mkdirSync(directory, { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(directory, "agent-child.jsonl"),
+      JSON.stringify({
+        type: "user",
+        uuid: "9eb84969-819b-4d5b-854f-327474810b34",
+        parentUuid: null,
+        isSidechain: true,
+        sessionId,
+        agentId: "child",
+        message: { role: "user", content: "Saved task" },
+      }) + "\n",
+    );
+    const harness = makeHarness({
+      claudeConfig: { homePath: source === "configured" ? home : "" },
+      environment: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: source === "configured" ? "/unused-claude-home" : home,
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      assert.isDefined(adapter.getAgentHistory);
+      const result = yield* adapter.getAgentHistory!({
+        threadId: ThreadId.make("stopped-history-thread"),
+        agentId: "child",
+        offset: 0,
+        resumeCursor: { resume: sessionId },
+      });
+      assert.equal(result.status, "ready");
+      assert.equal(result.entries[0]?.detail, "Saved task");
+      assert.isUndefined(harness.getLastCreateQueryInput());
+      assert.deepStrictEqual(yield* adapter.listSessions(), []);
+    }).pipe(
+      Effect.provide(harness.layer),
+      Effect.ensuring(Effect.sync(() => NodeFS.rmSync(home, { recursive: true, force: true }))),
+    );
+  });
+}

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -5031,6 +5031,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
+  /** Read the configured instance’s saved child transcript without creating a live SDK query. */
   const getAgentHistory: ClaudeAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
     function* (input) {
       const sessionId = readClaudeResumeState(input.resumeCursor)?.resume;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -6,6 +6,9 @@
  *
  * @module ClaudeAdapterLive
  */
+import * as NodeOS from "node:os";
+import { readClaudeAgentHistory } from "./claudeAgentHistory.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
 import {
   type CanUseTool,
   query,
@@ -5028,6 +5031,38 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
+  const getAgentHistory: ClaudeAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
+    function* (input) {
+      const sessionId = readClaudeResumeState(input.resumeCursor)?.resume;
+      if (!sessionId)
+        return {
+          status: "unavailable",
+          entries: [],
+          nextOffset: null,
+          message: "No saved Claude session is available for this thread.",
+        };
+      return yield* Effect.tryPromise({
+        try: () =>
+          readClaudeAgentHistory({
+            sessionId,
+            agentId: input.agentId,
+            offset: input.offset,
+            view: input.view,
+            configDir: claudeEnvironment.CLAUDE_CONFIG_DIR
+              ? expandHomePath(claudeEnvironment.CLAUDE_CONFIG_DIR)
+              : path.join(NodeOS.homedir(), ".claude"),
+          }),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "getSubagentMessages",
+            detail: "Could not read saved Claude agent history.",
+            cause,
+          }),
+      });
+    },
+  );
+
   const readThread: ClaudeAdapterShape["readThread"] = Effect.fn("readThread")(
     function* (threadId) {
       const context = yield* requireSession(threadId);
@@ -5135,6 +5170,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     sendTurn,
     interruptTurn,
     readThread,
+    getAgentHistory,
     rollbackThread,
     respondToRequest,
     respondToUserInput,

--- a/apps/server/src/provider/Layers/CodexAdapter.history.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.history.test.ts
@@ -1,0 +1,74 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it, expect } from "@effect/vitest";
+import { CodexSettings, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { ServerConfig } from "../../config.ts";
+import { writeFakeCli } from "../../testUtils/fakeCli.ts";
+import { makeCodexAdapter } from "./CodexAdapter.ts";
+
+const decodeCodexSettings = Schema.decodeEffect(CodexSettings);
+
+it.effect(
+  "reuses one initialize-only Codex transport across concurrent and repeated history reads",
+  () =>
+    Effect.gen(function* () {
+      const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "codex-history-client-"));
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(dir, { recursive: true, force: true })),
+      );
+      const log = NodePath.join(dir, "methods.txt");
+      const binaryPath = writeFakeCli({
+        directory: dir,
+        name: "codex-history",
+        env: { HISTORY_TEST_LOG: log },
+        source: `
+      import { appendFileSync } from "node:fs";
+      import { createInterface } from "node:readline";
+      createInterface({ input: process.stdin }).on("line", (line) => {
+        const request = JSON.parse(line);
+        appendFileSync(process.env.HISTORY_TEST_LOG, request.method + "\\n");
+        if (request.id === undefined) return;
+        const result = request.method === "initialize" ? { userAgent: "codex/1.0", codexHome: process.cwd(), platformFamily: "unix", platformOs: "linux" }
+          : { thread: { id: request.params.threadId, cliVersion: "test", createdAt: 0, updatedAt: 0,
+              cwd: process.cwd(), ephemeral: false, modelProvider: "openai", preview: "", sessionId: "session",
+              status: { type: "idle" }, source: { subAgent: { thread_spawn: { parent_thread_id: "parent", depth: 1 } } },
+              turns: [{ id: "turn", status: "completed", error: null, items: [{ id: "message", type: "agentMessage", text: "Saved answer" }] }] } };
+        process.stdout.write(JSON.stringify({ id: request.id, result }) + "\\n");
+      });
+    `,
+      });
+      const adapter = yield* makeCodexAdapter(yield* decodeCodexSettings({ binaryPath }));
+      const input = {
+        threadId: ThreadId.make("stopped"),
+        agentId: "child",
+        cwd: dir,
+        offset: 0,
+        resumeCursor: { threadId: "parent" },
+      };
+      const results = yield* Effect.all(
+        [adapter.getAgentHistory!(input), adapter.getAgentHistory!(input)],
+        { concurrency: "unbounded" },
+      );
+      expect(results.every((result) => result.entries[0]?.detail === "Saved answer")).toBe(true);
+      yield* adapter.getAgentHistory!(input);
+      const methods = NodeFS.readFileSync(log, "utf8").trim().split("\n");
+      expect(methods.filter((method) => method === "initialize")).toHaveLength(1);
+      expect(methods.filter((method) => method === "thread/read")).toHaveLength(6);
+      expect(
+        methods.every((method) => ["initialize", "initialized", "thread/read"].includes(method)),
+      ).toBe(true);
+      expect(yield* adapter.listSessions()).toEqual([]);
+    }).pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), process.cwd()).pipe(
+          Layer.provideMerge(NodeServices.layer),
+        ),
+      ),
+    ),
+);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1,3 +1,4 @@
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
 import { withCodexAppServerClient } from "./CodexProvider.ts";
 import { readCodexAgentHistory } from "./codexAgentHistory.ts";
 /**
@@ -2236,6 +2237,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
 
+  const withHistoryClient = yield* makeAgentHistoryClient((cwd) =>
+    withCodexAppServerClient({
+      binaryPath: codexConfig.binaryPath,
+      homePath: codexConfig.homePath,
+      launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+      environment: options?.environment,
+      cwd,
+    }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner)),
+  );
+
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -2571,6 +2582,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
   });
 
+  /** Read saved descendants through the shared read-only transport without resuming a coding session. */
   const getAgentHistory: CodexAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
     function* (input) {
       if (!isCodexResumeCursorSchema(input.resumeCursor)) {
@@ -2582,27 +2594,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         };
       }
       const parentThreadId = input.resumeCursor.threadId;
-      return yield* Effect.scoped(
-        Effect.gen(function* () {
-          const { client } = yield* withCodexAppServerClient({
-            binaryPath: codexConfig.binaryPath,
-            homePath: codexConfig.homePath,
-            launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
-            environment: options?.environment,
-            cwd: input.cwd ?? process.cwd(),
-          });
-          return yield* readCodexAgentHistory({
-            parentThreadId,
-            agentId: input.agentId,
-            offset: input.offset,
-            view: input.view,
-            readThread: (threadId, includeTurns) =>
-              client.request("thread/read", { threadId, includeTurns }),
-          });
+      return yield* withHistoryClient(input.cwd ?? process.cwd(), ({ client }) =>
+        readCodexAgentHistory({
+          parentThreadId,
+          agentId: input.agentId,
+          offset: input.offset,
+          view: input.view,
+          readThread: (threadId, includeTurns) =>
+            client.request("thread/read", { threadId, includeTurns }),
         }),
       ).pipe(
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
-        Effect.timeout("20 seconds"),
         Effect.mapError(
           (cause) =>
             new ProviderAdapterRequestError({

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1,3 +1,5 @@
+import { withCodexAppServerClient } from "./CodexProvider.ts";
+import { readCodexAgentHistory } from "./codexAgentHistory.ts";
 /**
  * CodexAdapterLive - Scoped live implementation for the Codex provider adapter.
  *
@@ -2569,6 +2571,51 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
   });
 
+  const getAgentHistory: CodexAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
+    function* (input) {
+      if (!isCodexResumeCursorSchema(input.resumeCursor)) {
+        return {
+          status: "unavailable",
+          entries: [],
+          nextOffset: null,
+          message: "No saved Codex session is available for this thread.",
+        };
+      }
+      const parentThreadId = input.resumeCursor.threadId;
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          const { client } = yield* withCodexAppServerClient({
+            binaryPath: codexConfig.binaryPath,
+            homePath: codexConfig.homePath,
+            launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+            environment: options?.environment,
+            cwd: input.cwd ?? process.cwd(),
+          });
+          return yield* readCodexAgentHistory({
+            parentThreadId,
+            agentId: input.agentId,
+            offset: input.offset,
+            view: input.view,
+            readThread: (threadId, includeTurns) =>
+              client.request("thread/read", { threadId, includeTurns }),
+          });
+        }),
+      ).pipe(
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+        Effect.timeout("20 seconds"),
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "thread/read",
+              detail: "Could not read saved agent history.",
+              cause,
+            }),
+        ),
+      );
+    },
+  );
+
   const readThread: CodexAdapterShape["readThread"] = (threadId) =>
     requireSession(threadId).pipe(
       Effect.flatMap((session) => session.runtime.readThread),
@@ -2717,6 +2764,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     compaction: { type: "native", start: compactThread },
     interruptTurn,
     readThread,
+    getAgentHistory,
     rollbackThread,
     uploadFeedback,
     respondToRequest,

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -212,6 +212,115 @@ it("requires a settlement to match the live Grok turn", () => {
 });
 
 it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
+  it.effect("receives underscore-prefixed Grok child lifecycle notifications", () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-lifecycle-")),
+      );
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => NodeFSP.rm(dir, { recursive: true, force: true })),
+      );
+      const wrapper = writeFakeCli({
+        directory: dir,
+        name: "lifecycle-grok",
+        source: `
+        import { createInterface } from "node:readline";
+        createInterface({ input: process.stdin }).on("line", (line) => {
+          const request = JSON.parse(line);
+          const respond = (result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\\n");
+          if (request.method === "initialize") { respond({ protocolVersion: 1, agentCapabilities: {}, authMethods: [] }); return; }
+          if (request.method === "session/new") { respond({ sessionId: "mock-session-1" }); return; }
+          if (request.method !== "session/prompt") { if (request.id !== undefined) respond({}); return; }
+          for (const update of [
+            { sessionUpdate: "subagent_spawned", parent_session_id: "mock-session-1", child_session_id: "child", description: "Review" },
+            { sessionUpdate: "subagent_finished", child_session_id: "child", status: "completed" },
+          ]) process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "_x.ai/session/update", params: { sessionId: "mock-session-1", update } }) + "\\n");
+          respond({ stopReason: "end_turn" });
+        });
+      `,
+      });
+      const adapter = yield* makeTestAdapter(wrapper);
+      const threadId = ThreadId.make("grok-native-child-lifecycle");
+      const events = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.type === "task.started" || event.type === "task.completed"),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId,
+        cwd: dir,
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      });
+      yield* adapter.sendTurn({ threadId, input: "Review" });
+      const tasks = yield* Fiber.join(events);
+      assert.deepEqual(
+        tasks.map((event) => [event.type, event.payload.taskId]),
+        [
+          ["task.started", "child"],
+          ["task.completed", "child"],
+        ],
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+  it.effect("reads stopped child history with an isolated initialize-only transport", () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() =>
+        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-history-")),
+      );
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => NodeFSP.rm(dir, { recursive: true, force: true })),
+      );
+      const log = NodePath.join(dir, "requests.ndjson");
+      const wrapper = writeFakeCli({
+        directory: dir,
+        name: "history-grok",
+        source: `
+        import { appendFileSync } from "node:fs";
+        import { createInterface } from "node:readline";
+        const log = process.env.GROK_HISTORY_TEST_LOG;
+        process.on("SIGTERM", () => { appendFileSync(log, JSON.stringify({ method: "closed" }) + "\\n"); process.exit(0); });
+        createInterface({ input: process.stdin }).on("line", (line) => {
+          const request = JSON.parse(line);
+          appendFileSync(log, JSON.stringify({ method: request.method, params: request.params, home: process.env.GROK_HOME }) + "\\n");
+          if (request.id === undefined) return;
+          const result = request.method === "initialize" ? { protocolVersion: 1, agentCapabilities: {}, authMethods: [] }
+            : request.method === "_x.ai/session/state" ? { summary: { parent_session_id: "parent", session_kind: "subagent" } }
+            : request.method === "_x.ai/session/updates" ? { updates: [{ method: "session/update", params: { sessionId: "child", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Saved child output" } } } }] }
+            : undefined;
+          process.stdout.write(JSON.stringify(result === undefined ? { jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "unexpected method" } } : { jsonrpc: "2.0", id: request.id, result }) + "\\n");
+        });
+      `,
+      });
+      const adapter = yield* makeTestAdapter(wrapper, {
+        environment: { GROK_HISTORY_TEST_LOG: log, GROK_HOME: dir },
+      });
+      const threadId = ThreadId.make("stopped-grok-history");
+      assert.isFalse(yield* adapter.hasSession(threadId));
+      assert.isDefined(adapter.getAgentHistory);
+      const result = yield* adapter.getAgentHistory!({
+        threadId,
+        agentId: "child",
+        offset: 0,
+        cwd: dir,
+        resumeCursor: { schemaVersion: 1, sessionId: "parent" },
+      });
+      assert.equal(result.status, "ready");
+      assert.equal(result.entries[0]?.detail, "Saved child output");
+      assert.isFalse(yield* adapter.hasSession(threadId));
+      const calls = yield* Effect.promise(() => readJsonLines(log));
+      assert.deepEqual(
+        calls.filter((call) => call.method !== "closed").map((call) => call.method),
+        ["initialize", "_x.ai/session/state", "_x.ai/session/updates"],
+      );
+      assert.isTrue(
+        calls.filter((call) => call.method !== "closed").every((call) => call.home === dir),
+      );
+      if (!windowsHost) assert.isTrue(calls.some((call) => call.method === "closed"));
+    }),
+  );
   it.effect("sends runtime context with the current model without changing saved prompts", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-runtime-context");

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -300,25 +300,33 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
       const threadId = ThreadId.make("stopped-grok-history");
       assert.isFalse(yield* adapter.hasSession(threadId));
       assert.isDefined(adapter.getAgentHistory);
-      const result = yield* adapter.getAgentHistory!({
+      const input = {
         threadId,
         agentId: "child",
         offset: 0,
         cwd: dir,
         resumeCursor: { schemaVersion: 1, sessionId: "parent" },
-      });
+      };
+      const result = yield* adapter.getAgentHistory!(input);
+      yield* adapter.getAgentHistory!(input);
       assert.equal(result.status, "ready");
       assert.equal(result.entries[0]?.detail, "Saved child output");
       assert.isFalse(yield* adapter.hasSession(threadId));
       const calls = yield* Effect.promise(() => readJsonLines(log));
       assert.deepEqual(
         calls.filter((call) => call.method !== "closed").map((call) => call.method),
-        ["initialize", "_x.ai/session/state", "_x.ai/session/updates"],
+        [
+          "initialize",
+          "_x.ai/session/state",
+          "_x.ai/session/updates",
+          "_x.ai/session/state",
+          "_x.ai/session/updates",
+        ],
       );
       assert.isTrue(
         calls.filter((call) => call.method !== "closed").every((call) => call.home === dir),
       );
-      if (!windowsHost) assert.isTrue(calls.some((call) => call.method === "closed"));
+      assert.isFalse(calls.some((call) => call.method === "closed"));
     }),
   );
   it.effect("sends runtime context with the current model without changing saved prompts", () =>

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1,3 +1,4 @@
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
 import {
   ApprovalRequestId,
   type GrokSettings,
@@ -367,6 +368,20 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
     };
 
     const sessions = new Map<ThreadId, GrokSessionContext>();
+    const withHistoryClient = yield* makeAgentHistoryClient(
+      Effect.fn("Grok.historyClient")(function* (cwd: string) {
+        const acp = yield* makeGrokAcpRuntime({
+          grokSettings,
+          ...(options?.environment ? { environment: options.environment } : {}),
+          childProcessSpawner,
+          cwd,
+          clientInfo: { name: "t3-code", version: "0.0.0" },
+        });
+        // History needs transport negotiation, never a loaded or resumed coding session.
+        yield* acp.initialize();
+        return acp;
+      }),
+    );
     const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
     const requestedTurnInactivityTimeoutMs = options?.turnInactivityTimeoutMs;
@@ -2100,6 +2115,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         yield* Deferred.succeed(pending.resolution, { _tag: "answered", answers });
       });
 
+    /** Read verified child history over a shared initialized transport without loading a session. */
     const getAgentHistory: GrokAdapterShape["getAgentHistory"] = Effect.fn(
       "GrokAdapter.getAgentHistory",
     )(function* (input) {
@@ -2112,36 +2128,25 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           message: "No saved Grok session is available for this thread.",
         };
       const cwd = input.cwd;
-      return yield* Effect.scoped(
-        Effect.gen(function* () {
-          const acp = yield* makeGrokAcpRuntime({
-            grokSettings,
-            ...(options?.environment ? { environment: options.environment } : {}),
-            childProcessSpawner,
-            cwd,
-            clientInfo: { name: "t3-code", version: "0.0.0" },
-          });
-          // Only negotiate the transport. Never create, load, or resume a session for history.
-          yield* acp.initialize();
-          return yield* readGrokAgentHistory({
-            parentSessionId,
-            agentId: input.agentId,
-            cwd,
-            offset: input.offset,
-            view: input.view,
-            request: acp.request,
-          });
+      return yield* withHistoryClient(cwd, (acp) =>
+        readGrokAgentHistory({
+          parentSessionId,
+          agentId: input.agentId,
+          cwd,
+          offset: input.offset,
+          view: input.view,
+          request: acp.request,
         }),
       ).pipe(
-        Effect.provideService(Crypto.Crypto, crypto),
-        Effect.timeout("20 seconds"),
         Effect.mapError(
           (cause) =>
             new ProviderAdapterRequestError({
               provider: PROVIDER,
               method: "_x.ai/session/updates",
               detail:
-                "Could not read saved Grok agent history. This requires a Grok CLI with session history extensions.",
+                cause._tag === "TimeoutError"
+                  ? "Reading saved Grok agent history timed out after 20 seconds."
+                  : "Could not read saved Grok agent history. This requires a Grok CLI with session history extensions.",
               cause,
             }),
         ),

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -82,6 +82,12 @@ import {
 import { type GrokAdapterShape } from "../Services/GrokAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
+import {
+  GrokSubagentNotification,
+  grokSubagentTask,
+  readGrokAgentHistory,
+} from "./grokAgentHistory.ts";
+
 const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
 
 const PROVIDER = ProviderDriverKind.make("grok");
@@ -1129,6 +1135,28 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 ),
               { discard: true },
             );
+            yield* Effect.forEach(
+              ["x.ai/session/update", "_x.ai/session/update"],
+              (method) =>
+                acp.handleExtNotification(method, GrokSubagentNotification, (notification) =>
+                  mapAcpCallbackFailure(
+                    Effect.gen(function* () {
+                      const ctx = sessions.get(input.threadId);
+                      if (!ctx || ctx.stopped) return;
+                      const task = grokSubagentTask(notification, ctx.acpSessionId);
+                      if (!task) return;
+                      yield* offerRuntimeEvent({
+                        ...task,
+                        ...(yield* makeEventStamp()),
+                        provider: PROVIDER,
+                        threadId: input.threadId,
+                        turnId: resolveSessionCallbackTurnId(sessions, input.threadId),
+                      });
+                    }),
+                  ),
+                ),
+              { discard: true },
+            );
             yield* acp.handleRequestPermission((params) =>
               mapAcpCallbackFailure(
                 Effect.gen(function* () {
@@ -2072,6 +2100,54 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
         yield* Deferred.succeed(pending.resolution, { _tag: "answered", answers });
       });
 
+    const getAgentHistory: GrokAdapterShape["getAgentHistory"] = Effect.fn(
+      "GrokAdapter.getAgentHistory",
+    )(function* (input) {
+      const parentSessionId = parseGrokResume(input.resumeCursor)?.sessionId;
+      if (!parentSessionId || !input.cwd)
+        return {
+          status: "unavailable",
+          entries: [],
+          nextOffset: null,
+          message: "No saved Grok session is available for this thread.",
+        };
+      const cwd = input.cwd;
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          const acp = yield* makeGrokAcpRuntime({
+            grokSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+          });
+          // Only negotiate the transport. Never create, load, or resume a session for history.
+          yield* acp.initialize();
+          return yield* readGrokAgentHistory({
+            parentSessionId,
+            agentId: input.agentId,
+            cwd,
+            offset: input.offset,
+            view: input.view,
+            request: acp.request,
+          });
+        }),
+      ).pipe(
+        Effect.provideService(Crypto.Crypto, crypto),
+        Effect.timeout("20 seconds"),
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "_x.ai/session/updates",
+              detail:
+                "Could not read saved Grok agent history. This requires a Grok CLI with session history extensions.",
+              cause,
+            }),
+        ),
+      );
+    });
+
     const readThread: GrokAdapterShape["readThread"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
@@ -2133,6 +2209,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
       sendTurn,
       interruptTurn,
       readThread,
+      getAgentHistory,
       rollbackThread,
       respondToRequest,
       respondToUserInput,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -68,6 +68,7 @@ type MessageEntry = {
 const runtimeMock = {
   state: {
     startCalls: [] as string[],
+    historyConnectCalls: [] as string[],
     sessionCreateUrls: [] as string[],
     sessionCreateInputs: [] as Array<Record<string, unknown>>,
     createdSessionIds: [] as string[],
@@ -132,6 +133,7 @@ const runtimeMock = {
   },
   reset() {
     this.state.startCalls.length = 0;
+    this.state.historyConnectCalls.length = 0;
     this.state.sessionCreateUrls.length = 0;
     this.state.sessionCreateInputs.length = 0;
     this.state.createdSessionIds.length = 0;
@@ -211,6 +213,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
   connectToOpenCodeServer: ({ serverUrl, serverPassword }) =>
     Effect.gen(function* () {
       const url = serverUrl ?? "http://127.0.0.1:4301";
+      runtimeMock.state.historyConnectCalls.push(url);
       // Always register a finalizer so the closeCalls/closeError probes fire;
       // production attaches none for external servers.
       yield* Effect.addFinalizer(() =>
@@ -785,21 +788,26 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
           ],
         },
       ];
-      const result = yield* adapter.getAgentHistory!({
+      const input = {
         threadId: asThreadId("stopped"),
         agentId: "ses_child",
         offset: 0,
         resumeCursor: { schemaVersion: 1, sessionId: "ses_parent" },
         cwd: "/saved/workspace",
-      });
+      };
+      const result = yield* adapter.getAgentHistory!(input);
+      yield* adapter.getAgentHistory!(input);
       NodeAssert.equal(result.status, "ready");
       NodeAssert.equal(result.entries[0]?.detail, "Saved answer");
-      NodeAssert.deepEqual(runtimeMock.state.sessionGetIds, ["ses_child"]);
+      NodeAssert.deepEqual(runtimeMock.state.sessionGetIds, ["ses_child", "ses_child"]);
       NodeAssert.deepEqual(runtimeMock.state.sessionCreateInputs, []);
       NodeAssert.deepEqual(runtimeMock.state.sessionUpdateCalls, []);
       NodeAssert.deepEqual(runtimeMock.state.abortCalls, []);
       NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
       NodeAssert.deepEqual(yield* adapter.listSessions(), []);
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, []);
+      NodeAssert.deepEqual(runtimeMock.state.historyConnectCalls, ["http://127.0.0.1:9999"]);
+      yield* TestClock.adjust("31 seconds");
       NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -612,6 +612,198 @@ const questionRequest = (id: string, sessionID: string): QuestionRequest => ({
 });
 
 it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
+  it.effect("links native Task tools to child history and keeps child text out of the parent", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const push = makeOpenCodeEventQueue();
+      const threadId = asThreadId("task-history");
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const events = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.type === "task.started" ||
+            event.type === "task.completed" ||
+            event.type === "content.delta",
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const part = {
+        id: "task-part",
+        messageID: "parent-message",
+        sessionID: "http://127.0.0.1:9999/session",
+        type: "tool",
+        callID: "task-call",
+        tool: "task",
+        state: {
+          status: "running",
+          input: { description: "Review changes" },
+          title: "Review changes",
+          metadata: { sessionId: "ses_child" },
+          time: { start: 1 },
+        },
+      };
+      push({ type: "message.part.updated", properties: { sessionID: part.sessionID, part } });
+      push({
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_child",
+          part: {
+            id: "child-text",
+            messageID: "child-message",
+            sessionID: "ses_child",
+            type: "text",
+            text: "Private child answer",
+          },
+        },
+      });
+      push({
+        type: "message.part.updated",
+        properties: {
+          sessionID: part.sessionID,
+          part: {
+            ...part,
+            state: {
+              ...part.state,
+              status: "completed",
+              output: "Review finished",
+              time: { start: 1, end: 2 },
+            },
+          },
+        },
+      });
+      const collected = yield* Fiber.join(events);
+      NodeAssert.deepEqual(
+        collected.map((event) => event.type),
+        ["task.started", "task.completed"],
+      );
+      NodeAssert.deepEqual(
+        collected.map((event) =>
+          event.type === "task.started"
+            ? [event.payload.taskId, "running"]
+            : event.type === "task.completed"
+              ? [event.payload.taskId, event.payload.status]
+              : null,
+        ),
+        [
+          ["ses_child", "running"],
+          ["ses_child", "completed"],
+        ],
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  for (const terminal of ["session.idle", "session.error", "session.deleted"] as const) {
+    it.effect(`settles background agents on ${terminal}, not the launch tool return`, () =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const push = makeOpenCodeEventQueue();
+        const threadId = asThreadId("background-history");
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("opencode"),
+          threadId,
+          runtimeMode: "full-access",
+        });
+        const events = yield* adapter.streamEvents.pipe(
+          Stream.filter(
+            (event) => event.type === "task.started" || event.type === "task.completed",
+          ),
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        push({
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part: {
+              id: "launch",
+              messageID: "message",
+              sessionID: "http://127.0.0.1:9999/session",
+              type: "tool",
+              tool: "task",
+              callID: "launch",
+              state: {
+                status: "completed",
+                input: { description: "Watch changes" },
+                title: "Watch changes",
+                output: "Background launched",
+                metadata: { sessionId: "ses_background", background: true },
+                time: { start: 1, end: 2 },
+              },
+            },
+          },
+        });
+        const nativeTerminal = {
+          type: terminal,
+          properties: {
+            sessionID: "ses_background",
+            info: { id: "ses_background" },
+            error: { name: "UnknownError", data: { message: "Failed" } },
+          },
+        };
+        push(nativeTerminal);
+        const collected = yield* Fiber.join(events);
+        NodeAssert.equal(collected[0]?.type, "task.started");
+        NodeAssert.equal(collected[1]?.type, "task.completed");
+        NodeAssert.deepEqual(collected[1]?.raw?.payload, nativeTerminal);
+        const completion = collected[1];
+        NodeAssert.equal(
+          completion?.type === "task.completed" ? completion.payload.status : null,
+          terminal === "session.error"
+            ? "failed"
+            : terminal === "session.deleted"
+              ? "stopped"
+              : "completed",
+        );
+        yield* adapter.stopSession(threadId);
+      }),
+    );
+  }
+
+  it.effect("reads saved child history without starting or mutating a session", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      runtimeMock.state.sessionParentById.set("ses_child", "ses_parent");
+      runtimeMock.state.messages = [
+        {
+          info: { id: "message", role: "assistant" },
+          parts: [
+            {
+              id: "part",
+              type: "text",
+              sessionID: "ses_child",
+              messageID: "message",
+              text: "Saved answer",
+            },
+          ],
+        },
+      ];
+      const result = yield* adapter.getAgentHistory!({
+        threadId: asThreadId("stopped"),
+        agentId: "ses_child",
+        offset: 0,
+        resumeCursor: { schemaVersion: 1, sessionId: "ses_parent" },
+        cwd: "/saved/workspace",
+      });
+      NodeAssert.equal(result.status, "ready");
+      NodeAssert.equal(result.entries[0]?.detail, "Saved answer");
+      NodeAssert.deepEqual(runtimeMock.state.sessionGetIds, ["ses_child"]);
+      NodeAssert.deepEqual(runtimeMock.state.sessionCreateInputs, []);
+      NodeAssert.deepEqual(runtimeMock.state.sessionUpdateCalls, []);
+      NodeAssert.deepEqual(runtimeMock.state.abortCalls, []);
+      NodeAssert.deepEqual(runtimeMock.state.promptCalls, []);
+      NodeAssert.deepEqual(yield* adapter.listSessions(), []);
+      NodeAssert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
+    }),
+  );
+
   it.effect("reuses a configured OpenCode server URL instead of spawning a local server", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1,3 +1,4 @@
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
 import {
   EventId,
   type OpenCodeSettings,
@@ -972,6 +973,24 @@ export function makeOpenCodeAdapter(
       options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
     const runtimeEvents = yield* Queue.unbounded<ProviderRuntimeEvent>();
     const sessions = new Map<ThreadId, OpenCodeSessionContext>();
+    const withHistoryClient = yield* makeAgentHistoryClient(
+      Effect.fn("OpenCode.historyClient")(function* (directory: string) {
+        const server = yield* openCodeRuntime.connectToOpenCodeServer({
+          binaryPath: openCodeSettings.binaryPath,
+          directory,
+          serverUrl: openCodeSettings.serverUrl,
+          ...(openCodeSettings.serverPassword
+            ? { serverPassword: openCodeSettings.serverPassword }
+            : {}),
+          ...(options?.environment ? { environment: options.environment } : {}),
+        });
+        return openCodeRuntime.createOpenCodeSdkClient({
+          baseUrl: server.url,
+          directory,
+          ...(server.serverPassword ? { serverPassword: server.serverPassword } : {}),
+        });
+      }),
+    );
     const deleteContextIfCurrent = (context: OpenCodeSessionContext) => {
       if (sessions.get(context.session.threadId) === context) {
         sessions.delete(context.session.threadId);
@@ -3885,6 +3904,7 @@ export function makeOpenCodeAdapter(
     const hasSession: OpenCodeAdapterShape["hasSession"] = (threadId) =>
       Effect.sync(() => sessions.has(threadId));
 
+    /** Use the live parent client when available, otherwise share a directory-scoped history connection. */
     const getAgentHistory: OpenCodeAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
       function* (input) {
         const parentSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
@@ -3911,29 +3931,11 @@ export function makeOpenCodeAdapter(
               ).pipe(Effect.map((response) => response.data ?? [])),
           });
         const context = sessions.get(input.threadId);
-        return yield* Effect.scoped(
-          Effect.gen(function* () {
-            if (context?.openCodeSessionId === parentSessionId) return yield* read(context.client);
-            const directory = input.cwd ?? serverConfig.cwd;
-            const server = yield* openCodeRuntime.connectToOpenCodeServer({
-              binaryPath: openCodeSettings.binaryPath,
-              directory,
-              serverUrl: openCodeSettings.serverUrl,
-              ...(openCodeSettings.serverPassword
-                ? { serverPassword: openCodeSettings.serverPassword }
-                : {}),
-              ...(options?.environment ? { environment: options.environment } : {}),
-            });
-            return yield* read(
-              openCodeRuntime.createOpenCodeSdkClient({
-                baseUrl: server.url,
-                directory,
-                ...(server.serverPassword ? { serverPassword: server.serverPassword } : {}),
-              }),
-            );
-          }),
+        return yield* (
+          context?.openCodeSessionId === parentSessionId
+            ? read(context.client).pipe(Effect.timeout("20 seconds"))
+            : withHistoryClient(input.cwd ?? serverConfig.cwd, read)
         ).pipe(
-          Effect.timeout("20 seconds"),
           Effect.mapError(
             (cause) =>
               new ProviderAdapterRequestError({

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -7,6 +7,7 @@ import {
   type ProviderSendTurnInput,
   type ProviderSession,
   RuntimeItemId,
+  RuntimeTaskId,
   RuntimeRequestId,
   ThreadId,
   type ToolLifecycleItemType,
@@ -59,6 +60,8 @@ import {
   type OpenCodeServerConnection,
 } from "../opencodeRuntime.ts";
 import * as Option from "effect/Option";
+
+import { readOpenCodeAgentHistory } from "./openCodeAgentHistory.ts";
 
 const PROVIDER = ProviderDriverKind.make("opencode");
 
@@ -340,6 +343,15 @@ interface OpenCodeSessionContext {
   readonly directory: string;
   readonly openCodeSessionId: string;
   readonly relatedSessionIds: Set<string>;
+  readonly agentTasks: Map<
+    string,
+    {
+      toolUseId: string;
+      description: string;
+      turnId: TurnId | undefined;
+      status: "running" | "completed" | "failed" | "stopped";
+    }
+  >;
   readonly resolvedRequestIds: Set<string>;
   readonly autoRepliedRequestIds: Set<string>;
   readonly emittedTerminalRequestIds: Set<string>;
@@ -2210,6 +2222,45 @@ export function makeOpenCodeAdapter(
 
       const payloadSessionId = openCodeEventSessionId(event);
       const isParentEvent = payloadSessionId === context.openCodeSessionId;
+      const childTask = payloadSessionId ? context.agentTasks.get(payloadSessionId) : undefined;
+      if (
+        !isParentEvent &&
+        payloadSessionId &&
+        childTask &&
+        (event.type === "session.idle" ||
+          event.type === "session.error" ||
+          event.type === "session.deleted" ||
+          (event.type === "session.status" && event.properties.status.type === "idle"))
+      ) {
+        const status =
+          event.type === "session.error"
+            ? "failed"
+            : event.type === "session.deleted"
+              ? "stopped"
+              : "completed";
+        if (childTask.status === "running") {
+          childTask.status = status;
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: childTask.turnId,
+              raw: event,
+            })),
+            type: "task.completed",
+            payload: {
+              taskId: RuntimeTaskId.make(payloadSessionId),
+              status,
+              taskType: "subagent",
+              agentKind: "agent",
+              timelineBypass: true,
+              toolUseId: childTask.toolUseId,
+              title: childTask.description,
+            },
+          });
+        }
+        return;
+      }
+
       let isKnownPendingTerminalEvent = false;
       if (
         payloadSessionId !== undefined &&
@@ -2505,6 +2556,67 @@ export function makeOpenCodeAdapter(
               payload,
             };
             yield* emit(runtimeEvent);
+            // Native Task metadata carries the child session ID used by the history API.
+            const metadata = part.state.status === "pending" ? undefined : part.state.metadata;
+            const childSessionId = metadata?.sessionId;
+            if (
+              part.tool === "task" &&
+              typeof childSessionId === "string" &&
+              childSessionId.trim()
+            ) {
+              const previous = context.agentTasks.get(childSessionId);
+              const description =
+                typeof part.state.input.description === "string" &&
+                part.state.input.description.trim()
+                  ? part.state.input.description
+                  : "Subagent";
+              const status =
+                part.state.status === "error"
+                  ? "failed"
+                  : part.state.status === "completed" && metadata?.background !== true
+                    ? "completed"
+                    : "running";
+              // A background launch returning is not child completion. Its native idle/error event settles it.
+              if (
+                previous?.status !== status &&
+                !(
+                  previous &&
+                  previous.toolUseId === part.callID &&
+                  previous.status !== "running" &&
+                  status === "running"
+                )
+              ) {
+                context.agentTasks.set(childSessionId, {
+                  toolUseId: part.callID,
+                  description,
+                  turnId,
+                  status,
+                });
+                const base = yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  itemId: part.callID,
+                  createdAt: toolStateCreatedAt(part),
+                  raw: event,
+                });
+                const linkage = {
+                  taskId: RuntimeTaskId.make(childSessionId),
+                  taskType: "subagent",
+                  agentKind: "agent" as const,
+                  timelineBypass: true,
+                  toolUseId: part.callID,
+                  title: description,
+                };
+                if (status === "running")
+                  yield* emit({
+                    ...base,
+                    type: "task.started",
+                    payload: { ...linkage, description },
+                  });
+                else
+                  yield* emit({ ...base, type: "task.completed", payload: { ...linkage, status } });
+              }
+            }
           }
           break;
         }
@@ -2983,6 +3095,7 @@ export function makeOpenCodeAdapter(
           directory,
           openCodeSessionId: started.openCodeSession.id,
           relatedSessionIds: new Set([started.openCodeSession.id]),
+          agentTasks: new Map(),
           resolvedRequestIds: new Set(),
           autoRepliedRequestIds: new Set(),
           emittedTerminalRequestIds: new Set(),
@@ -3772,6 +3885,68 @@ export function makeOpenCodeAdapter(
     const hasSession: OpenCodeAdapterShape["hasSession"] = (threadId) =>
       Effect.sync(() => sessions.has(threadId));
 
+    const getAgentHistory: OpenCodeAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
+      function* (input) {
+        const parentSessionId = parseOpenCodeResume(input.resumeCursor)?.sessionId;
+        if (!parentSessionId)
+          return {
+            status: "unavailable",
+            entries: [],
+            nextOffset: null,
+            message: "No saved OpenCode session is available for this thread.",
+          };
+        const read = (client: OpencodeClient) =>
+          readOpenCodeAgentHistory({
+            parentSessionId,
+            agentId: input.agentId,
+            offset: input.offset,
+            view: input.view,
+            readSession: (sessionID) =>
+              runOpenCodeSdk("session.get", (signal) =>
+                client.session.get({ sessionID }, { signal }),
+              ).pipe(Effect.map((response) => response.data)),
+            readMessages: (sessionID) =>
+              runOpenCodeSdk("session.messages", (signal) =>
+                client.session.messages({ sessionID }, { signal }),
+              ).pipe(Effect.map((response) => response.data ?? [])),
+          });
+        const context = sessions.get(input.threadId);
+        return yield* Effect.scoped(
+          Effect.gen(function* () {
+            if (context?.openCodeSessionId === parentSessionId) return yield* read(context.client);
+            const directory = input.cwd ?? serverConfig.cwd;
+            const server = yield* openCodeRuntime.connectToOpenCodeServer({
+              binaryPath: openCodeSettings.binaryPath,
+              directory,
+              serverUrl: openCodeSettings.serverUrl,
+              ...(openCodeSettings.serverPassword
+                ? { serverPassword: openCodeSettings.serverPassword }
+                : {}),
+              ...(options?.environment ? { environment: options.environment } : {}),
+            });
+            return yield* read(
+              openCodeRuntime.createOpenCodeSdkClient({
+                baseUrl: server.url,
+                directory,
+                ...(server.serverPassword ? { serverPassword: server.serverPassword } : {}),
+              }),
+            );
+          }),
+        ).pipe(
+          Effect.timeout("20 seconds"),
+          Effect.mapError(
+            (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session.messages",
+                detail: "Could not read saved agent history.",
+                cause,
+              }),
+          ),
+        );
+      },
+    );
+
     const readThread: OpenCodeAdapterShape["readThread"] = Effect.fn("readThread")(
       function* (threadId) {
         const context = yield* ensureSessionContext(sessions, threadId);
@@ -3853,6 +4028,7 @@ export function makeOpenCodeAdapter(
       listSessions,
       hasSession,
       readThread,
+      getAgentHistory,
       rollbackThread,
       stopAll,
       get streamEvents() {

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -257,6 +257,14 @@ function makeFakeCodexAdapter(
       Effect.succeed({ threadId, turns: [] }),
   );
 
+  const getAgentHistory = vi.fn(
+    (
+      _input: Parameters<
+        NonNullable<ProviderAdapterShape<ProviderAdapterError>["getAgentHistory"]>
+      >[0],
+    ) => Effect.succeed({ status: "ready" as const, entries: [], nextOffset: null, message: null }),
+  );
+
   const uploadFeedback = vi.fn(
     (
       input: ProviderUploadFeedbackInput,
@@ -295,6 +303,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     ...(provider === CODEX_DRIVER ? { uploadFeedback } : {}),
+    ...(provider === CODEX_DRIVER || provider === CLAUDE_AGENT_DRIVER ? { getAgentHistory } : {}),
     stopAll,
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);
@@ -332,6 +341,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     uploadFeedback,
+    getAgentHistory,
     stopAll,
   };
 }
@@ -1971,6 +1981,63 @@ routing.layer("ProviderServiceLive routing", (it) => {
       });
       yield* Fiber.join(retryFiber);
       yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("reads saved agent history without recovering a stopped session", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-agent-history-stopped");
+      const cwd = fixtureCwd("agent-history");
+      yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd,
+        resumeCursor: { threadId: "native-parent" },
+        runtimeMode: "full-access",
+      });
+      yield* routing.codex.stopSession(threadId);
+      routing.codex.startSession.mockClear();
+      routing.codex.sendTurn.mockClear();
+      routing.codex.getAgentHistory.mockClear();
+      const result = yield* provider.getAgentHistory({
+        threadId,
+        agentId: "native-child",
+        offset: 50,
+      });
+      assert.equal(result.status, "ready");
+      assert.equal(routing.codex.startSession.mock.calls.length, 0);
+      assert.equal(routing.codex.sendTurn.mock.calls.length, 0);
+      assert.deepStrictEqual(routing.codex.getAgentHistory.mock.calls, [
+        [
+          {
+            threadId,
+            agentId: "native-child",
+            offset: 50,
+            cwd,
+            resumeCursor: { threadId: "native-parent" },
+          },
+        ],
+      ]);
+    }),
+  );
+
+  it.effect("reports unsupported history without restarting the provider", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-agent-history-unsupported");
+      yield* provider.startSession(threadId, {
+        provider: CURSOR_DRIVER,
+        providerInstanceId: ProviderInstanceId.make("cursor"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* routing.cursor.stopSession(threadId);
+      routing.cursor.startSession.mockClear();
+      const result = yield* provider.getAgentHistory({ threadId, agentId: "child", offset: 0 });
+      assert.equal(result.status, "unsupported");
+      assert.equal(routing.cursor.startSession.mock.calls.length, 0);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -2142,6 +2142,36 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     );
   });
 
+  const getAgentHistory: ProviderServiceMethod<"getAgentHistory"> = Effect.fn("getAgentHistory")(
+    function* (input) {
+      const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
+      if (!binding) {
+        return yield* toValidationError(
+          "ProviderService.getAgentHistory",
+          "No saved provider session exists for this thread.",
+        );
+      }
+      const instanceId = yield* requireBindingInstanceId(
+        "ProviderService.getAgentHistory",
+        binding,
+      );
+      const adapter = yield* registry.getByInstance(instanceId);
+      if (!adapter.getAgentHistory) {
+        return {
+          status: "unsupported",
+          entries: [],
+          nextOffset: null,
+          message: "Agent history is not supported by this provider yet.",
+        };
+      }
+      return yield* adapter.getAgentHistory({
+        ...input,
+        resumeCursor: binding.resumeCursor,
+        cwd: readPersistedCwd(binding.runtimePayload),
+      });
+    },
+  );
+
   const uploadFeedback: ProviderServiceMethod<"uploadFeedback"> = Effect.fn("uploadFeedback")(
     function* (rawInput) {
       const input = yield* decodeInputOrValidationError({
@@ -2276,6 +2306,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     assertConversationRollbackSupported,
     rollbackConversation,
     uploadFeedback,
+    getAgentHistory,
     // Each access creates a fresh PubSub subscription so that multiple
     // consumers (ProviderRuntimeIngestion, CheckpointReactor, etc.) each
     // independently receive all runtime events.

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -2142,6 +2142,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     );
   });
 
+  /** Route history to the persisted provider instance without recovering or starting its session. */
   const getAgentHistory: ProviderServiceMethod<"getAgentHistory"> = Effect.fn("getAgentHistory")(
     function* (input) {
       const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -213,6 +213,7 @@ describe("ProviderSessionReaper", () => {
         });
       },
       rollbackConversation: () => unsupported(),
+      getAgentHistory: () => unsupported(),
       uploadFeedback: () => unsupported(),
       streamEvents: Stream.empty,
     };

--- a/apps/server/src/provider/Layers/agentHistory.test.ts
+++ b/apps/server/src/provider/Layers/agentHistory.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect } from "@effect/vitest";
 import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
 
 describe("agent history selection", () => {
+  it("keeps file edits in recent tools", () => {
+    const page = collectAgentHistory({ offset: 0, view: "recent-tools" });
+    page.add(agentHistoryEntry("edit", "file-edit", "Edit X.jsx", "patch"));
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(["edit"]);
+  });
   const entries = Array.from({ length: 130 }, (_, index) =>
     agentHistoryEntry(
       String(index),

--- a/apps/server/src/provider/Layers/agentHistory.test.ts
+++ b/apps/server/src/provider/Layers/agentHistory.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "@effect/vitest";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+describe("agent history selection", () => {
+  const entries = Array.from({ length: 130 }, (_, index) =>
+    agentHistoryEntry(
+      String(index),
+      index % 2 ? "assistant" : "tool",
+      `Entry ${index}`,
+      "x".repeat(1000),
+    ),
+  );
+  it("returns the newest five tools beyond the first page with compact details", () => {
+    const page = collectAgentHistory({ offset: 0, view: "recent-tools" });
+    for (const entry of entries) page.add(entry);
+    expect(page.result().entries.map((entry) => entry.id)).toEqual([
+      "120",
+      "122",
+      "124",
+      "126",
+      "128",
+    ]);
+    expect(
+      page.result().entries.every((entry) => entry.detail.length === 240 && entry.truncated),
+    ).toBe(true);
+    expect(page.result().nextOffset).toBeNull();
+  });
+  it("opens on the latest page and supplies its position for previous navigation", () => {
+    const page = collectAgentHistory({ offset: 0, view: "latest" });
+    for (const entry of entries) page.add(entry);
+    expect(page.result().startOffset).toBe(80);
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(
+      entries.slice(-50).map((entry) => entry.id),
+    );
+    expect(page.result().nextOffset).toBeNull();
+  });
+  it("keeps forward pagination unchanged", () => {
+    const page = collectAgentHistory({ offset: 50 });
+    for (const entry of entries) if (page.add(entry)) break;
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(
+      entries.slice(50, 100).map((entry) => entry.id),
+    );
+    expect(page.result().nextOffset).toBe(100);
+  });
+});

--- a/apps/server/src/provider/Layers/agentHistory.ts
+++ b/apps/server/src/provider/Layers/agentHistory.ts
@@ -1,0 +1,66 @@
+import type {
+  AgentHistoryEntry,
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
+} from "@t3tools/contracts";
+
+/** Keep history payloads bounded; omitted detail is explicitly marked in the UI. */
+export function agentHistoryEntry(
+  id: string,
+  kind: AgentHistoryEntry["kind"],
+  title: string,
+  detail = "",
+): AgentHistoryEntry {
+  return {
+    id,
+    kind,
+    title: title.slice(0, 500),
+    detail: detail.slice(0, 8000),
+    truncated: title.length > 500 || detail.length > 8000,
+  };
+}
+
+/** Full history pages forward; previews retain only the latest five tools, oldest first. */
+export function collectAgentHistory(
+  input: Pick<OrchestrationGetAgentHistoryInput, "offset" | "view">,
+) {
+  const entries: AgentHistoryEntry[] = [];
+  let index = 0;
+  let nextOffset: number | null = null;
+  return {
+    add(entry: AgentHistoryEntry): boolean {
+      if (input.view === "latest") {
+        index++;
+        entries.push(entry);
+        if (entries.length > 50) entries.shift();
+        return false;
+      }
+      if (input.view === "recent-tools") {
+        if (entry.kind !== "tool") return false;
+        entries.push({
+          ...entry,
+          detail: entry.detail.slice(0, 240),
+          truncated: entry.truncated || entry.detail.length > 240,
+        });
+        if (entries.length > 5) entries.shift();
+        return false;
+      }
+      if (index++ < input.offset) return false;
+      if (entries.length === 50) {
+        nextOffset = input.offset + entries.length;
+        return true;
+      }
+      entries.push(entry);
+      return false;
+    },
+    result(): OrchestrationGetAgentHistoryResult {
+      return {
+        status: "ready",
+        entries,
+        nextOffset,
+        message: null,
+        ...(input.view === "latest" ? { startOffset: Math.max(0, index - entries.length) } : {}),
+      };
+    },
+  };
+}

--- a/apps/server/src/provider/Layers/agentHistory.ts
+++ b/apps/server/src/provider/Layers/agentHistory.ts
@@ -36,7 +36,7 @@ export function collectAgentHistory(
         return false;
       }
       if (input.view === "recent-tools") {
-        if (entry.kind !== "tool") return false;
+        if (entry.kind !== "tool" && entry.kind !== "file-edit") return false;
         entries.push({
           ...entry,
           detail: entry.detail.slice(0, 240),

--- a/apps/server/src/provider/Layers/agentHistoryClient.test.ts
+++ b/apps/server/src/provider/Layers/agentHistoryClient.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
+
+describe("saved history transport lifetime", () => {
+  it.effect(
+    "shares concurrent and repeated reads, isolates directories, and releases idle clients",
+    () =>
+      Effect.gen(function* () {
+        const opened: string[] = [];
+        const closed: string[] = [];
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const use = yield* makeAgentHistoryClient((cwd) =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  opened.push(cwd);
+                  return cwd;
+                }),
+                (cwd) =>
+                  Effect.sync(() => {
+                    closed.push(cwd);
+                  }),
+              ),
+            );
+            yield* Effect.all([use("a", Effect.succeed), use("a", Effect.succeed)], {
+              concurrency: "unbounded",
+            });
+            yield* use("a", Effect.succeed);
+            yield* use("b", Effect.succeed);
+            expect(opened).toEqual(["a", "b"]);
+            expect(closed).toEqual([]);
+            yield* TestClock.adjust("31 seconds");
+            expect(closed.sort()).toEqual(["a", "b"]);
+            yield* use("a", Effect.succeed);
+            expect(opened).toEqual(["a", "b", "a"]);
+          }),
+        );
+        expect(closed).toEqual(["a", "b", "a"]);
+      }),
+  );
+
+  it.effect("invalidates failed reads and retries on a fresh client", () =>
+    Effect.gen(function* () {
+      let opened = 0;
+      let closed = 0;
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.acquireRelease(
+          Effect.sync(() => ++opened),
+          () =>
+            Effect.sync(() => {
+              closed++;
+            }),
+        ),
+      );
+      yield* use("a", () => Effect.fail("disconnected")).pipe(Effect.flip);
+      expect(closed).toBe(1);
+      expect(yield* use("a", Effect.succeed)).toBe(2);
+    }),
+  );
+
+  it.effect("cleans up a transport whose initialization never completes", () =>
+    Effect.gen(function* () {
+      let closed = 0;
+      const started = yield* Deferred.make<void>();
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              closed++;
+            }),
+          );
+          yield* Deferred.succeed(started, undefined);
+          return yield* Effect.never;
+        }),
+      );
+      const pending = yield* use("a", Effect.succeed).pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("21 seconds");
+      expect((yield* Fiber.await(pending))._tag).toBe("Failure");
+      expect(closed).toBe(1);
+    }),
+  );
+  it.effect("releases a timed-out read before returning and permits a fresh lookup", () =>
+    Effect.gen(function* () {
+      let closed = 0;
+      const started = yield* Deferred.make<void>();
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.acquireRelease(Effect.succeed("client"), () =>
+          Effect.sync(() => {
+            closed++;
+          }),
+        ),
+      );
+      const pending = yield* use("a", () =>
+        Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+      ).pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("21 seconds");
+      const result = yield* Fiber.await(pending);
+      expect(result._tag).toBe("Failure");
+      expect(closed).toBe(1);
+      expect(yield* use("a", Effect.succeed)).toBe("client");
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/agentHistoryClient.ts
+++ b/apps/server/src/provider/Layers/agentHistoryClient.ts
@@ -1,0 +1,19 @@
+import * as Effect from "effect/Effect";
+import * as RcMap from "effect/RcMap";
+import type * as Scope from "effect/Scope";
+
+/** Share read-only transports across cards without retaining idle processes or session state. */
+export const makeAgentHistoryClient = Effect.fn("makeAgentHistoryClient")(function* <A, E, R>(
+  lookup: (cwd: string) => Effect.Effect<A, E, R | Scope.Scope>,
+) {
+  const clients = yield* RcMap.make({
+    lookup: (cwd: string) => lookup(cwd).pipe(Effect.timeout("20 seconds")),
+    idleTimeToLive: "30 seconds",
+    capacity: 8,
+  });
+  return <B, E2>(cwd: string, read: (client: A) => Effect.Effect<B, E2>) =>
+    Effect.scoped(RcMap.get(clients, cwd).pipe(Effect.flatMap(read))).pipe(
+      Effect.timeout("20 seconds"),
+      Effect.onError(() => RcMap.invalidate(clients, cwd)),
+    );
+});

--- a/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
@@ -1,0 +1,142 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeCrypto from "node:crypto";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import * as DateTime from "effect/DateTime";
+import { readClaudeAgentHistory } from "./claudeAgentHistory.ts";
+
+const sessionId = "0945fcd9-8a8d-450a-b8cf-4ebd0ef17468";
+let configDir: string;
+beforeEach(async () => {
+  configDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "claude-agent-history-"));
+});
+afterEach(async () => {
+  await NodeFSP.rm(configDir, { recursive: true, force: true });
+});
+
+async function save(agentId: string, contents: ReadonlyArray<unknown>, nested = false) {
+  const directory = NodePath.join(
+    configDir,
+    "projects",
+    "-workspace",
+    sessionId,
+    "subagents",
+    ...(nested ? ["workflow", "review"] : []),
+  );
+  await NodeFSP.mkdir(directory, { recursive: true });
+  let parentUuid: string | null = null;
+  const lines = contents.map((content, index) => {
+    const uuid = NodeCrypto.randomUUID();
+    const type =
+      index === 0 ||
+      (Array.isArray(content) && content.some((block) => block.type === "tool_result"))
+        ? "user"
+        : "assistant";
+    const row = {
+      type,
+      uuid,
+      parentUuid,
+      isSidechain: true,
+      sessionId,
+      agentId,
+      timestamp: DateTime.formatIso(DateTime.makeUnsafe(index * 1000)),
+      message: { role: type, content },
+    };
+    parentUuid = uuid;
+    return JSON.stringify(row);
+  });
+  const file = NodePath.join(directory, `agent-${agentId}.jsonl`);
+  await NodeFSP.writeFile(file, lines.join("\n") + "\n");
+  return file;
+}
+
+const read = (agentId = "child", offset = 0) =>
+  readClaudeAgentHistory({ configDir, sessionId, agentId, offset });
+
+describe("Claude saved agent history", () => {
+  it("reads nested transcripts, preserves calls and results, and bounds entry detail", async () => {
+    await save(
+      "child",
+      [
+        "Review the changes",
+        [
+          { type: "text", text: "Checking the file" },
+          { type: "tool_use", id: "tool1", name: "Read", input: { file_path: "index.ts" } },
+        ],
+        [
+          {
+            type: "tool_result",
+            tool_use_id: "tool1",
+            content: [{ type: "text", text: "x".repeat(9000) }],
+          },
+        ],
+      ],
+      true,
+    );
+    const result = await read();
+    expect(result.status).toBe("ready");
+    expect(result.entries.map((entry) => entry.title)).toEqual([
+      "Prompt",
+      "Agent",
+      "Read",
+      "Tool result",
+    ]);
+    expect(result.entries[2]?.detail).toContain("index.ts");
+    expect(result.entries[3]?.detail).toHaveLength(8000);
+    expect(result.entries[3]?.truncated).toBe(true);
+  });
+
+  it("paginates by visible entries without losing or repeating blocks", async () => {
+    await save("child", [
+      "Prompt",
+      Array.from({ length: 55 }, (_, index) => ({ type: "text", text: `entry ${index}` })),
+    ]);
+    const first = await read();
+    const second = await read("child", first.nextOffset!);
+    expect(first.entries).toHaveLength(50);
+    expect(second.entries).toHaveLength(6);
+    expect(second.nextOffset).toBeNull();
+    expect(new Set([...first.entries, ...second.entries].map((entry) => entry.id)).size).toBe(56);
+    expect(second.entries.at(-1)?.detail).toBe("entry 54");
+  });
+
+  it("does not cross parent sessions, provider homes, or follow child symlinks", async () => {
+    const file = await save("child", ["private"]);
+    expect(
+      (
+        await readClaudeAgentHistory({
+          configDir,
+          sessionId: NodeCrypto.randomUUID(),
+          agentId: "child",
+          offset: 0,
+        })
+      ).status,
+    ).toBe("unavailable");
+    expect(
+      (
+        await readClaudeAgentHistory({
+          configDir: NodePath.join(configDir, "other-home"),
+          sessionId,
+          agentId: "child",
+          offset: 0,
+        })
+      ).status,
+    ).toBe("unavailable");
+    expect((await read("../../child")).status).toBe("unavailable");
+    if (HostProcessPlatform.defaultValue() !== "win32") {
+      await NodeFSP.symlink(file, NodePath.join(NodePath.dirname(file), "agent-alias.jsonl"));
+      expect((await read("alias")).status).toBe("unavailable");
+    }
+  });
+
+  it("tolerates a record still being written but reports corruption in completed records", async () => {
+    const file = await save("child", ["Prompt", [{ type: "text", text: "Done" }]]);
+    await NodeFSP.appendFile(file, '{"type":');
+    expect((await read()).entries).toHaveLength(2);
+    await NodeFSP.appendFile(file, "\n");
+    await expect(read()).rejects.toThrow();
+  });
+});

--- a/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
@@ -57,6 +57,22 @@ const read = (agentId = "child", offset = 0) =>
   readClaudeAgentHistory({ configDir, sessionId, agentId, offset });
 
 describe("Claude saved agent history", () => {
+  it("identifies file edits without putting patch content in the title", async () => {
+    await save("child", [
+      "prompt",
+      [
+        {
+          type: "tool_use",
+          id: "edit",
+          name: "Edit",
+          input: { file_path: "src/X.jsx", old_string: "old", new_string: "new" },
+        },
+      ],
+    ]);
+    const result = await read();
+    expect(result.entries[1]).toMatchObject({ kind: "file-edit", title: "Edit src/X.jsx" });
+    expect(result.entries[1]?.detail).toContain("new_string");
+  });
   it("reads nested transcripts, preserves calls and results, and bounds entry detail", async () => {
     await save(
       "child",

--- a/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
@@ -17,6 +17,7 @@ afterEach(async () => {
   await NodeFSP.rm(configDir, { recursive: true, force: true });
 });
 
+/** Write a linked SDK transcript so reader tests exercise real chain reconstruction. */
 async function save(agentId: string, contents: ReadonlyArray<unknown>, nested = false) {
   const directory = NodePath.join(
     configDir,
@@ -57,6 +58,16 @@ const read = (agentId = "child", offset = 0) =>
   readClaudeAgentHistory({ configDir, sessionId, agentId, offset });
 
 describe("Claude saved agent history", () => {
+  it("skips malformed messages without losing subsequent valid history", async () => {
+    await save("child", [
+      "prompt",
+      null,
+      [{ type: "text", text: 42 }],
+      [{ type: "text", text: "Valid answer" }],
+    ]);
+    const result = await read();
+    expect(result.entries.map((entry) => entry.detail)).toEqual(["prompt", "Valid answer"]);
+  });
   it("identifies file edits without putting patch content in the title", async () => {
     await save("child", [
       "prompt",

--- a/apps/server/src/provider/Layers/claudeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.ts
@@ -123,15 +123,25 @@ export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry
         return block.thinking
           ? [agentHistoryEntry(id, "reasoning", "Reasoning", block.thinking)]
           : [];
-      case "tool_use":
+      case "tool_use": {
+        const fileEdit =
+          block.name === "Edit" || block.name === "Write" || block.name === "MultiEdit";
+        const path =
+          block.input &&
+          typeof block.input === "object" &&
+          "file_path" in block.input &&
+          typeof block.input.file_path === "string"
+            ? block.input.file_path
+            : null;
         return [
           agentHistoryEntry(
             id,
-            "tool",
-            block.name ?? "Tool",
+            fileEdit ? "file-edit" : "tool",
+            fileEdit && path ? `Edit ${path}` : (block.name ?? "Tool"),
             JSON.stringify(block.input ?? {}, null, 2),
           ),
         ];
+      }
       case "tool_result":
         return [
           agentHistoryEntry(

--- a/apps/server/src/provider/Layers/claudeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.ts
@@ -1,0 +1,222 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+import {
+  getSubagentMessages,
+  type SessionMessage,
+  type SessionStoreEntry,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+const isAgentId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9_-]+$/)));
+const isSessionId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9-]+$/)));
+
+const decodeTranscriptEntry = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Struct({ type: Schema.String })),
+  { onExcessProperty: "preserve" },
+);
+const ContentBlock = Schema.Struct({
+  type: Schema.String,
+  text: Schema.optionalKey(Schema.String),
+  thinking: Schema.optionalKey(Schema.String),
+  name: Schema.optionalKey(Schema.String),
+  input: Schema.optionalKey(Schema.Unknown),
+  content: Schema.optionalKey(Schema.Unknown),
+  is_error: Schema.optionalKey(Schema.Boolean),
+});
+const decodeMessage = Schema.decodeUnknownSync(
+  Schema.Struct({
+    content: Schema.Union([Schema.String, Schema.Array(ContentBlock)]),
+  }),
+);
+const decodeTextContent = Schema.decodeUnknownOption(
+  Schema.Array(
+    Schema.Struct({
+      type: Schema.String,
+      text: Schema.optionalKey(Schema.String),
+    }),
+  ),
+);
+
+const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
+  status: "unavailable",
+  entries: [],
+  nextOffset: null,
+  message,
+});
+
+async function directoryEntries(path: string) {
+  try {
+    return await NodeFSP.readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function isDirectory(path: string) {
+  try {
+    return (await NodeFSP.lstat(path)).isDirectory();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/** Find only regular child transcripts inside the persisted parent's directory. */
+async function findTranscript(
+  directory: string,
+  filename: string,
+  depth = 0,
+): Promise<string | null> {
+  if (depth > 16) return null;
+  const entries = await directoryEntries(directory);
+  if (entries.some((entry) => entry.name === filename && entry.isFile()))
+    return NodePath.join(directory, filename);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const found = await findTranscript(NodePath.join(directory, entry.name), filename, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+function resultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  const blocks = decodeTextContent(content);
+  return blocks._tag === "Some"
+    ? blocks.value.flatMap((block) => (block.text ? [block.text] : [])).join("\n")
+    : "";
+}
+
+export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry[] {
+  const { content } = decodeMessage(message.message);
+  if (typeof content === "string")
+    return content
+      ? [
+          agentHistoryEntry(
+            message.uuid,
+            message.type === "user" ? "user" : "assistant",
+            message.type === "user" ? "Prompt" : "Agent",
+            content,
+          ),
+        ]
+      : [];
+  return content.flatMap((block, index): AgentHistoryEntry[] => {
+    const id = `${message.uuid}:${index}`;
+    switch (block.type) {
+      case "text":
+        return block.text
+          ? [
+              agentHistoryEntry(
+                id,
+                message.type === "user" ? "user" : "assistant",
+                message.type === "user" ? "Prompt" : "Agent",
+                block.text,
+              ),
+            ]
+          : [];
+      case "thinking":
+        return block.thinking
+          ? [agentHistoryEntry(id, "reasoning", "Reasoning", block.thinking)]
+          : [];
+      case "tool_use":
+        return [
+          agentHistoryEntry(
+            id,
+            "tool",
+            block.name ?? "Tool",
+            JSON.stringify(block.input ?? {}, null, 2),
+          ),
+        ];
+      case "tool_result":
+        return [
+          agentHistoryEntry(
+            id,
+            "tool",
+            block.is_error ? "Tool error" : "Tool result",
+            resultText(block.content),
+          ),
+        ];
+      default:
+        return [];
+    }
+  });
+}
+
+/** The SDK rebuilds the conversation chain. A read-only store keeps its reads instance-local. */
+export async function readClaudeAgentHistory(input: {
+  configDir: string;
+  sessionId: string;
+  agentId: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+}): Promise<OrchestrationGetAgentHistoryResult> {
+  if (!isAgentId(input.agentId) || !isSessionId(input.sessionId)) {
+    return unavailable("No saved transcript is available for this agent.");
+  }
+  const projectsDir = NodePath.join(input.configDir, "projects");
+  let transcript: string | null = null;
+  for (const project of await directoryEntries(projectsDir)) {
+    if (!project.isDirectory()) continue;
+    const projectDir = NodePath.join(projectsDir, project.name);
+    const sessionDir = NodePath.join(projectDir, input.sessionId);
+    if (
+      !(await isDirectory(sessionDir)) ||
+      !(await isDirectory(NodePath.join(sessionDir, "subagents")))
+    )
+      continue;
+    transcript = await findTranscript(
+      NodePath.join(sessionDir, "subagents"),
+      `agent-${input.agentId}.jsonl`,
+    );
+    if (transcript) break;
+  }
+  if (!transcript)
+    return unavailable("Claude has no saved transcript for this agent in this session.");
+  const handle = await NodeFSP.open(
+    transcript,
+    NodeFS.constants.O_RDONLY | NodeFS.constants.O_NOFOLLOW,
+  );
+  let contents: string;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) return unavailable("The agent transcript is not a regular file.");
+    if (stat.size > 64 * 1024 * 1024)
+      return unavailable("This agent transcript is too large to load.");
+    contents = await handle.readFile("utf8");
+  } finally {
+    await handle.close();
+  }
+  const lines = contents.split("\n");
+  const entries: SessionStoreEntry[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!;
+    if (!line.trim()) continue;
+    try {
+      entries.push(decodeTranscriptEntry(line));
+    } catch (error) {
+      // A running Claude process may still be writing the last JSONL record.
+      if (index === lines.length - 1 && !contents.endsWith("\n")) break;
+      throw error;
+    }
+  }
+  const messages = await getSubagentMessages(input.sessionId, input.agentId, {
+    sessionStore: {
+      append: async () => {
+        throw new Error("Agent history is read-only.");
+      },
+      load: async () => entries,
+    },
+  });
+  const page = collectAgentHistory(input);
+  for (const message of messages) {
+    for (const entry of claudeHistoryEntries(message)) {
+      if (page.add(entry)) return page.result();
+    }
+  }
+  return page.result();
+}

--- a/apps/server/src/provider/Layers/claudeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.ts
@@ -27,7 +27,7 @@ const ContentBlock = Schema.Struct({
   content: Schema.optionalKey(Schema.Unknown),
   is_error: Schema.optionalKey(Schema.Boolean),
 });
-const decodeMessage = Schema.decodeUnknownSync(
+const decodeMessage = Schema.decodeUnknownOption(
   Schema.Struct({
     content: Schema.Union([Schema.String, Schema.Array(ContentBlock)]),
   }),
@@ -41,6 +41,7 @@ const decodeTextContent = Schema.decodeUnknownOption(
   ),
 );
 
+/** Return an empty history response with a recoverable explanation for the client. */
 const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
   status: "unavailable",
   entries: [],
@@ -48,6 +49,7 @@ const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
   message,
 });
 
+/** Missing transcript directories mean no saved history; other filesystem errors remain visible. */
 async function directoryEntries(path: string) {
   try {
     return await NodeFSP.readdir(path, { withFileTypes: true });
@@ -57,6 +59,7 @@ async function directoryEntries(path: string) {
   }
 }
 
+/** Use lstat so a symlink cannot redirect traversal outside the configured transcript store. */
 async function isDirectory(path: string) {
   try {
     return (await NodeFSP.lstat(path)).isDirectory();
@@ -84,6 +87,7 @@ async function findTranscript(
   return null;
 }
 
+/** Extract only textual tool results; image and other binary blocks are not activity text. */
 function resultText(content: unknown): string {
   if (typeof content === "string") return content;
   const blocks = decodeTextContent(content);
@@ -92,8 +96,11 @@ function resultText(content: unknown): string {
     : "";
 }
 
+/** Skip unsupported transcript records while retaining the rest of the saved conversation. */
 export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry[] {
-  const { content } = decodeMessage(message.message);
+  const decoded = decodeMessage(message.message);
+  if (decoded._tag === "None") return [];
+  const { content } = decoded.value;
   if (typeof content === "string")
     return content
       ? [

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -7,6 +7,7 @@ import { codexHistoryEntry, readCodexAgentHistory } from "./codexAgentHistory.ts
 
 const isAgentHistoryResult = Schema.is(OrchestrationGetAgentHistoryResult);
 
+/** Build native snapshots with explicit ancestry and enough items to exercise page boundaries. */
 function thread(id: string, parent: string | null, count = 1): V2ThreadReadResponse {
   return {
     thread: {
@@ -52,7 +53,7 @@ describe("saved Codex agent history", () => {
         id: "edit",
         status: "completed",
         changes: [
-          { path: "src/X.jsx", kind: { type: "update", movePath: null }, diff: "-old\n+new" },
+          { path: "src/X.jsx", kind: { type: "update", move_path: null }, diff: "-old\n+new" },
         ],
       }),
     ).toMatchObject({

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import type { V2ThreadReadResponse } from "effect-codex-app-server/schema";
 import { OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
-import { readCodexAgentHistory } from "./codexAgentHistory.ts";
+import { codexHistoryEntry, readCodexAgentHistory } from "./codexAgentHistory.ts";
 
 const isAgentHistoryResult = Schema.is(OrchestrationGetAgentHistoryResult);
 
@@ -45,6 +45,27 @@ function thread(id: string, parent: string | null, count = 1): V2ThreadReadRespo
 }
 
 describe("saved Codex agent history", () => {
+  it("uses native reasoning text when no summary is supplied and omits empty markers", () => {
+    expect(
+      codexHistoryEntry({
+        type: "reasoning",
+        id: "r",
+        summary: [],
+        content: ["Checking the schema."],
+      }),
+    ).toMatchObject({ title: "Reasoning", detail: "Checking the schema." });
+    expect(
+      codexHistoryEntry({
+        type: "reasoning",
+        id: "r",
+        summary: ["Reviewing validation."],
+        content: ["Other text"],
+      }),
+    ).toMatchObject({ title: "Reasoning summary", detail: "Reviewing validation." });
+    expect(
+      codexHistoryEntry({ type: "reasoning", id: "r", summary: [" "], content: [] }),
+    ).toBeNull();
+  });
   it.effect("reads a stopped nested child's history with bounded, nonoverlapping pages", () =>
     Effect.gen(function* () {
       const calls: Array<[string, boolean]> = [];

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import type { V2ThreadReadResponse } from "effect-codex-app-server/schema";
+import { OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { readCodexAgentHistory } from "./codexAgentHistory.ts";
+
+const isAgentHistoryResult = Schema.is(OrchestrationGetAgentHistoryResult);
+
+function thread(id: string, parent: string | null, count = 1): V2ThreadReadResponse {
+  return {
+    thread: {
+      id,
+      cliVersion: "test",
+      createdAt: 0,
+      updatedAt: 0,
+      cwd: "/workspace",
+      ephemeral: false,
+      modelProvider: "openai",
+      preview: "",
+      sessionId: "session",
+      status: { type: "idle" },
+      source: parent
+        ? { subAgent: { thread_spawn: { parent_thread_id: parent, depth: 1 } } }
+        : "appServer",
+      turns: [
+        {
+          id: "turn",
+          status: "completed",
+          error: null,
+          items: Array.from({ length: count }, (_, index) => ({
+            id: `item-${index}`,
+            type: "commandExecution" as const,
+            command: `read file ${index}`,
+            cwd: "/workspace",
+            commandActions: [],
+            status: "completed" as const,
+            exitCode: 0,
+            aggregatedOutput: "x".repeat(9000),
+          })),
+        },
+      ],
+    },
+  };
+}
+
+describe("saved Codex agent history", () => {
+  it.effect("reads a stopped nested child's history with bounded, nonoverlapping pages", () =>
+    Effect.gen(function* () {
+      const calls: Array<[string, boolean]> = [];
+      const readThread = (id: string, includeTurns: boolean) => {
+        calls.push([id, includeTurns]);
+        return Effect.succeed(thread(id, id === "child" ? "coordinator" : "parent", 53));
+      };
+      const first = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 0,
+        readThread,
+      });
+      expect(calls).toEqual([
+        ["child", false],
+        ["coordinator", false],
+        ["child", true],
+      ]);
+      expect(first.entries).toHaveLength(50);
+      expect(first.nextOffset).toBe(50);
+      expect(first.entries[0]?.truncated).toBe(true);
+      expect(first.entries[0]?.detail).toHaveLength(8000);
+      expect(isAgentHistoryResult(first)).toBe(true);
+      const next = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: first.nextOffset!,
+        readThread,
+      });
+      expect(next.entries.map((entry) => entry.id)).toEqual([
+        "turn:item-50",
+        "turn:item-51",
+        "turn:item-52",
+      ]);
+      expect(next.nextOffset).toBeNull();
+    }),
+  );
+
+  for (const scenario of ["unrelated", "cycle", "parent"] as const) {
+    it.effect(`rejects ${scenario} without loading conversation content`, () =>
+      Effect.gen(function* () {
+        const calls: boolean[] = [];
+        const result = yield* readCodexAgentHistory({
+          parentThreadId: "parent",
+          agentId: scenario === "parent" ? "parent" : "child",
+          offset: 0,
+          readThread: (id, includeTurns) => {
+            calls.push(includeTurns);
+            return Effect.succeed(thread(id, scenario === "cycle" ? "child" : null));
+          },
+        });
+        expect(result.status).toBe("unavailable");
+        expect(result.entries).toEqual([]);
+        expect(calls).not.toContain(true);
+      }),
+    );
+  }
+
+  it.effect("surfaces provider read failures instead of claiming there is no activity", () =>
+    Effect.gen(function* () {
+      const error = new Error("history missing");
+      const result = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 0,
+        readThread: () => Effect.fail(error),
+      }).pipe(Effect.flip);
+      expect(result).toBe(error);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -45,6 +45,22 @@ function thread(id: string, parent: string | null, count = 1): V2ThreadReadRespo
 }
 
 describe("saved Codex agent history", () => {
+  it("labels file edits with their paths while preserving the patch for expansion", () => {
+    expect(
+      codexHistoryEntry({
+        type: "fileChange",
+        id: "edit",
+        status: "completed",
+        changes: [
+          { path: "src/X.jsx", kind: { type: "update", movePath: null }, diff: "-old\n+new" },
+        ],
+      }),
+    ).toMatchObject({
+      kind: "file-edit",
+      title: "Edit src/X.jsx",
+      detail: "src/X.jsx\n-old\n+new",
+    });
+  });
   it("uses native reasoning text when no summary is supplied and omits empty markers", () => {
     expect(
       codexHistoryEntry({

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -20,13 +20,17 @@ export function codexHistoryEntry(
       );
     case "agentMessage":
       return agentHistoryEntry(item.id, "assistant", "Agent", item.text);
-    case "reasoning":
+    case "reasoning": {
+      const summary = (item.summary ?? []).join("\n").trim();
+      const content = (item.content ?? []).join("\n").trim();
+      if (!summary && !content) return null;
       return agentHistoryEntry(
         item.id,
         "reasoning",
-        "Reasoning summary",
-        (item.summary ?? []).join("\n"),
+        summary ? "Reasoning summary" : "Reasoning",
+        summary || content,
       );
+    }
     case "plan":
       return agentHistoryEntry(item.id, "assistant", "Plan", item.text);
     case "commandExecution":

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -7,6 +7,7 @@ import type {
 
 import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
 
+/** Normalize native items for all history views, preserving displayable reasoning and bounded tool detail. */
 export function codexHistoryEntry(
   item: V2ThreadReadResponse__ThreadItem,
 ): AgentHistoryEntry | null {
@@ -88,6 +89,7 @@ export function codexHistoryEntry(
   }
 }
 
+/** Report an unverified child without returning any of its saved content. */
 const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
   status: "unavailable",
   entries: [],

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -50,8 +50,8 @@ export function codexHistoryEntry(
     case "fileChange":
       return agentHistoryEntry(
         item.id,
-        "tool",
-        "File changes",
+        "file-edit",
+        `Edit ${item.changes.map((change) => change.path).join(", ")}`,
         item.changes.map((change) => `${change.path}\n${change.diff}`).join("\n\n"),
       );
     case "mcpToolCall":

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -1,0 +1,134 @@
+import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import type {
+  V2ThreadReadResponse,
+  V2ThreadReadResponse__ThreadItem,
+} from "effect-codex-app-server/schema";
+
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+export function codexHistoryEntry(
+  item: V2ThreadReadResponse__ThreadItem,
+): AgentHistoryEntry | null {
+  switch (item.type) {
+    case "userMessage":
+      return agentHistoryEntry(
+        item.id,
+        "user",
+        "Prompt",
+        item.content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n"),
+      );
+    case "agentMessage":
+      return agentHistoryEntry(item.id, "assistant", "Agent", item.text);
+    case "reasoning":
+      return agentHistoryEntry(
+        item.id,
+        "reasoning",
+        "Reasoning summary",
+        (item.summary ?? []).join("\n"),
+      );
+    case "plan":
+      return agentHistoryEntry(item.id, "assistant", "Plan", item.text);
+    case "commandExecution":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        item.command,
+        [
+          item.aggregatedOutput,
+          item.exitCode === null || item.exitCode === undefined
+            ? null
+            : `Exit code: ${item.exitCode}`,
+        ]
+          .filter((value) => value !== null && value !== undefined)
+          .join("\n"),
+      );
+    case "fileChange":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        "File changes",
+        item.changes.map((change) => `${change.path}\n${change.diff}`).join("\n\n"),
+      );
+    case "mcpToolCall":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        `${item.server}: ${item.tool}`,
+        JSON.stringify(
+          { arguments: item.arguments, result: item.result, error: item.error },
+          null,
+          2,
+        ),
+      );
+    case "dynamicToolCall":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        item.tool,
+        JSON.stringify({ arguments: item.arguments, result: item.contentItems }, null, 2),
+      );
+    case "webSearch":
+      return agentHistoryEntry(item.id, "tool", `Search: ${item.query}`);
+    case "collabAgentToolCall":
+      return agentHistoryEntry(item.id, "tool", item.tool, item.prompt ?? item.status);
+    case "imageView":
+      return agentHistoryEntry(item.id, "tool", `View image: ${item.path}`);
+    case "imageGeneration":
+      return agentHistoryEntry(item.id, "tool", "Generate image", item.savedPath ?? item.status);
+    case "enteredReviewMode":
+    case "exitedReviewMode":
+      return agentHistoryEntry(item.id, "assistant", "Review", item.review);
+    default:
+      return null;
+  }
+}
+
+const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
+  status: "unavailable",
+  entries: [],
+  nextOffset: null,
+  message,
+});
+
+/** Verify native ancestry before reading content, including nested children. No resume/start calls. */
+export const readCodexAgentHistory = Effect.fn("readCodexAgentHistory")(function* <E>(input: {
+  parentThreadId: string;
+  agentId: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+  readThread: (threadId: string, includeTurns: boolean) => Effect.Effect<V2ThreadReadResponse, E>;
+}) {
+  const seen = new Set<string>([input.parentThreadId]);
+  let currentId = input.agentId;
+  let belongsToParent = false;
+  for (let depth = 0; depth < 32; depth++) {
+    if (seen.has(currentId)) break;
+    seen.add(currentId);
+    const { thread } = yield* input.readThread(currentId, false);
+    const source = thread.source;
+    if (
+      typeof source !== "object" ||
+      !("subAgent" in source) ||
+      typeof source.subAgent !== "object" ||
+      !("thread_spawn" in source.subAgent)
+    )
+      break;
+    currentId = source.subAgent.thread_spawn.parent_thread_id;
+    if (currentId === input.parentThreadId) {
+      belongsToParent = true;
+      break;
+    }
+  }
+  if (!belongsToParent)
+    return unavailable("This agent does not belong to the saved provider session.");
+  const { thread } = yield* input.readThread(input.agentId, true);
+  const page = collectAgentHistory(input);
+  for (const turn of thread.turns) {
+    for (const item of turn.items) {
+      const entry = codexHistoryEntry(item);
+      if (entry && page.add({ ...entry, id: `${turn.id}:${entry.id}` })) return page.result();
+    }
+  }
+  return page.result();
+});

--- a/apps/server/src/provider/Layers/grokAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { grokHistoryEntries, grokSubagentTask, readGrokAgentHistory } from "./grokAgentHistory.ts";
+
+const envelope = (update: Record<string, unknown>, sessionId = "child") => ({
+  method: "session/update",
+  params: { sessionId, update },
+});
+describe("Grok saved child history", () => {
+  it("folds chunks and tool results, excluding unrelated sessions", () => {
+    const entries = grokHistoryEntries(
+      [
+        envelope({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Hello " },
+        }),
+        envelope({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "world" },
+        }),
+        envelope({
+          sessionUpdate: "tool_call",
+          toolCallId: "tool",
+          title: "Read file",
+          rawInput: { path: "a.ts" },
+        }),
+        envelope({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool",
+          content: [{ type: "content", content: { type: "text", text: "file contents" } }],
+        }),
+        envelope(
+          {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "parent secret" },
+          },
+          "parent",
+        ),
+      ],
+      "child",
+    );
+    expect(entries.map((entry) => [entry.kind, entry.detail])).toEqual([
+      ["assistant", "Hello world"],
+      ["tool", "file contents"],
+    ]);
+  });
+  it("preserves truncation through status-only updates", () => {
+    const entries = grokHistoryEntries(
+      [
+        envelope({
+          sessionUpdate: "tool_call",
+          toolCallId: "tool",
+          content: [{ content: { text: "x".repeat(9000) } }],
+        }),
+        envelope({ sessionUpdate: "tool_call_update", toolCallId: "tool", status: "completed" }),
+      ],
+      "child",
+    );
+    expect(entries[0]?.truncated).toBe(true);
+    expect(entries[0]?.detail).toHaveLength(8000);
+  });
+  it.effect("verifies ancestry before reading and pages visible rows", () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      const updates = Array.from({ length: 52 }, (_, index) =>
+        envelope({ sessionUpdate: "tool_call", toolCallId: String(index), title: `Tool ${index}` }),
+      );
+      const request = (method: string) => {
+        calls.push(method);
+        return Effect.succeed(
+          method.endsWith("state")
+            ? { summary: { parent_session_id: "parent", session_kind: "subagent" } }
+            : { updates },
+        );
+      };
+      const first = yield* readGrokAgentHistory({
+        parentSessionId: "parent",
+        agentId: "child",
+        cwd: "/workspace",
+        offset: 0,
+        request,
+      });
+      expect(first.entries).toHaveLength(50);
+      expect(first.nextOffset).toBe(50);
+      const last = yield* readGrokAgentHistory({
+        parentSessionId: "parent",
+        agentId: "child",
+        cwd: "/workspace",
+        offset: 50,
+        request,
+      });
+      expect(last.entries.map((entry) => entry.title)).toEqual(["Tool 50", "Tool 51"]);
+      expect(last.nextOffset).toBeNull();
+      expect(calls).toEqual([
+        "_x.ai/session/state",
+        "_x.ai/session/updates",
+        "_x.ai/session/state",
+        "_x.ai/session/updates",
+      ]);
+    }),
+  );
+  it.effect("does not read unrelated or cyclic child transcripts", () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      const result = yield* readGrokAgentHistory({
+        parentSessionId: "parent",
+        agentId: "child",
+        cwd: "/workspace",
+        offset: 0,
+        request: (method) => {
+          calls.push(method);
+          return Effect.succeed({
+            summary: { parent_session_id: "child", session_kind: "subagent" },
+          });
+        },
+      });
+      expect(result.status).toBe("unavailable");
+      expect(calls).toEqual(["_x.ai/session/state"]);
+    }),
+  );
+  it("maps native child lifecycle to stable IDs without leaking other sessions", () => {
+    const spawn = {
+      sessionId: "parent",
+      update: {
+        sessionUpdate: "subagent_spawned",
+        child_session_id: "child",
+        parent_session_id: "parent",
+        description: "Review",
+      },
+    };
+    expect(grokSubagentTask(spawn, "parent")).toMatchObject({
+      type: "task.started",
+      payload: { taskId: "child", agentId: "child", description: "Review" },
+    });
+    expect(grokSubagentTask(spawn, "unrelated")).toBeUndefined();
+    expect(
+      grokSubagentTask(
+        {
+          sessionId: "parent",
+          update: {
+            sessionUpdate: "subagent_finished",
+            child_session_id: "child",
+            status: "cancelled",
+          },
+        },
+        "parent",
+      ),
+    ).toMatchObject({ type: "task.completed", payload: { taskId: "child", status: "stopped" } });
+  });
+});

--- a/apps/server/src/provider/Layers/grokAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.test.ts
@@ -7,6 +7,21 @@ const envelope = (update: Record<string, unknown>, sessionId = "child") => ({
   params: { sessionId, update },
 });
 describe("Grok saved child history", () => {
+  it("retains edit classification through result-only updates", () => {
+    const entries = grokHistoryEntries(
+      [
+        envelope({
+          sessionUpdate: "tool_call",
+          toolCallId: "edit",
+          kind: "edit",
+          title: "Edit X.jsx",
+        }),
+        envelope({ sessionUpdate: "tool_call_update", toolCallId: "edit", rawOutput: "patch" }),
+      ],
+      "child",
+    );
+    expect(entries[0]).toMatchObject({ kind: "file-edit", title: "Edit X.jsx" });
+  });
   it("folds chunks and tool results, excluding unrelated sessions", () => {
     const entries = grokHistoryEntries(
       [

--- a/apps/server/src/provider/Layers/grokAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.test.ts
@@ -7,6 +7,50 @@ const envelope = (update: Record<string, unknown>, sessionId = "child") => ({
   params: { sessionId, update },
 });
 describe("Grok saved child history", () => {
+  it.effect("skips malformed update envelopes but preserves valid history", () =>
+    Effect.gen(function* () {
+      const result = yield* readGrokAgentHistory({
+        parentSessionId: "parent",
+        agentId: "child",
+        cwd: "/workspace",
+        offset: 0,
+        request: (method) =>
+          Effect.succeed(
+            method.endsWith("state")
+              ? { summary: { parent_session_id: "parent", session_kind: "subagent" } }
+              : {
+                  updates: [
+                    null,
+                    { method: "session/update", params: null },
+                    {},
+                    envelope({
+                      sessionUpdate: "agent_message_chunk",
+                      content: { type: "text", text: "Valid answer" },
+                    }),
+                  ],
+                },
+          ),
+      });
+      expect(result.entries.map((entry) => entry.detail)).toEqual(["Valid answer"]);
+    }),
+  );
+  it.effect("fails closed when the CLI omits ancestry metadata", () =>
+    Effect.gen(function* () {
+      const methods: string[] = [];
+      const result = yield* readGrokAgentHistory({
+        parentSessionId: "parent",
+        agentId: "child",
+        cwd: "/workspace",
+        offset: 0,
+        request: (method) => {
+          methods.push(method);
+          return Effect.succeed({});
+        },
+      });
+      expect(result.status).toBe("unavailable");
+      expect(methods).toEqual(["_x.ai/session/state"]);
+    }),
+  );
   it("retains edit classification through result-only updates", () => {
     const entries = grokHistoryEntries(
       [

--- a/apps/server/src/provider/Layers/grokAgentHistory.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.ts
@@ -148,7 +148,7 @@ export function grokHistoryEntries(
           : (previous?.detail ?? ""));
     const normalized = agentHistoryEntry(
       `${childId}:tool:${id}`,
-      "tool",
+      update.kind === "edit" || previous?.kind === "file-edit" ? "file-edit" : "tool",
       text(update.title) || previous?.title || "Tool",
       detail,
     );

--- a/apps/server/src/provider/Layers/grokAgentHistory.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.ts
@@ -10,21 +10,27 @@ import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
 
 const RecordValue = Schema.Record(Schema.String, Schema.Unknown);
 const decodeRecord = Schema.decodeUnknownOption(RecordValue);
+/** Treat non-object extension payloads as absent rather than casting untrusted protocol data. */
 function record(value: unknown) {
   const decoded = decodeRecord(value);
   return decoded._tag === "Some" ? decoded.value : {};
 }
+/** Keep unknown extension values out of display text. */
 function text(value: unknown) {
   return typeof value === "string" ? value : "";
 }
 const State = Schema.Struct({
-  summary: Schema.Struct({
-    parent_session_id: Schema.optional(Schema.String),
-    session_kind: Schema.optional(Schema.String),
-  }),
+  summary: Schema.optional(
+    Schema.Struct({
+      parent_session_id: Schema.optional(Schema.String),
+      session_kind: Schema.optional(Schema.String),
+    }),
+  ),
 });
+const UpdateEnvelope = Schema.Struct({ method: Schema.String, params: RecordValue });
+const decodeUpdateEnvelope = Schema.decodeUnknownOption(UpdateEnvelope);
 const Updates = Schema.Struct({
-  updates: Schema.Array(Schema.Struct({ method: Schema.String, params: RecordValue })),
+  updates: Schema.Array(Schema.Unknown),
 });
 export const GrokSubagentNotification = Schema.Struct({
   sessionId: Schema.String,
@@ -81,6 +87,7 @@ export function grokSubagentTask(
   }
 }
 
+/** Read ACP text content without exposing non-text blocks as serialized objects. */
 function contentText(value: unknown): string {
   if (!Array.isArray(value)) return text(record(value).text);
   return value
@@ -94,7 +101,7 @@ function contentText(value: unknown): string {
 
 /** Fold ACP chunks and tool updates before paging visible entries. */
 export function grokHistoryEntries(
-  updates: (typeof Updates.Type)["updates"],
+  updates: ReadonlyArray<typeof UpdateEnvelope.Type>,
   childId: string,
 ): AgentHistoryEntry[] {
   const entries: AgentHistoryEntry[] = [];
@@ -164,6 +171,7 @@ export function grokHistoryEntries(
   return entries;
 }
 
+/** Verify every parent link before retrieving a child’s persisted, rewind-filtered updates. */
 export const readGrokAgentHistory = Effect.fn("readGrokAgentHistory")(function* <E>(input: {
   parentSessionId: string;
   agentId: string;
@@ -189,9 +197,9 @@ export const readGrokAgentHistory = Effect.fn("readGrokAgentHistory")(function* 
     const state = yield* input
       .request("_x.ai/session/state", { sessionId: current, cwd: input.cwd })
       .pipe(Effect.flatMap(Schema.decodeUnknownEffect(State)));
-    if (current === input.agentId && !state.summary.session_kind?.startsWith("subagent"))
+    if (current === input.agentId && !state.summary?.session_kind?.startsWith("subagent"))
       return unavailable("The selected session is not a saved subagent.");
-    if (!state.summary.parent_session_id)
+    if (!state.summary?.parent_session_id)
       return unavailable("This agent does not belong to the thread.");
     current = state.summary.parent_session_id;
   }
@@ -199,7 +207,13 @@ export const readGrokAgentHistory = Effect.fn("readGrokAgentHistory")(function* 
   const response = yield* input
     .request("_x.ai/session/updates", { sessionId: input.agentId, cwd: input.cwd })
     .pipe(Effect.flatMap(Schema.decodeUnknownEffect(Updates)));
-  const entries = grokHistoryEntries(response.updates, input.agentId);
+  const entries = grokHistoryEntries(
+    response.updates.flatMap((update) => {
+      const decoded = decodeUpdateEnvelope(update);
+      return decoded._tag === "Some" ? [decoded.value] : [];
+    }),
+    input.agentId,
+  );
   const page = collectAgentHistory(input);
   for (const entry of entries) {
     if (page.add(entry)) break;

--- a/apps/server/src/provider/Layers/grokAgentHistory.ts
+++ b/apps/server/src/provider/Layers/grokAgentHistory.ts
@@ -1,0 +1,208 @@
+import type {
+  AgentHistoryEntry,
+  OrchestrationGetAgentHistoryResult,
+  TaskStartedPayload,
+  TaskCompletedPayload,
+} from "@t3tools/contracts";
+import { RuntimeTaskId } from "@t3tools/contracts";
+import { Effect, Schema } from "effect";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+const RecordValue = Schema.Record(Schema.String, Schema.Unknown);
+const decodeRecord = Schema.decodeUnknownOption(RecordValue);
+function record(value: unknown) {
+  const decoded = decodeRecord(value);
+  return decoded._tag === "Some" ? decoded.value : {};
+}
+function text(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+const State = Schema.Struct({
+  summary: Schema.Struct({
+    parent_session_id: Schema.optional(Schema.String),
+    session_kind: Schema.optional(Schema.String),
+  }),
+});
+const Updates = Schema.Struct({
+  updates: Schema.Array(Schema.Struct({ method: Schema.String, params: RecordValue })),
+});
+export const GrokSubagentNotification = Schema.Struct({
+  sessionId: Schema.String,
+  update: RecordValue,
+});
+
+/** Grok's durable child id is also its subagent id; retain it for history reads. */
+export function grokSubagentTask(
+  notification: typeof GrokSubagentNotification.Type,
+  parentSessionId: string,
+):
+  | { type: "task.started"; payload: TaskStartedPayload }
+  | { type: "task.completed"; payload: TaskCompletedPayload }
+  | undefined {
+  if (notification.sessionId !== parentSessionId) return;
+  const update = notification.update;
+  const id = text(update.child_session_id);
+  if (!id || id === parentSessionId) return;
+  const linkage = {
+    taskId: RuntimeTaskId.make(id),
+    agentId: id,
+    agentKind: "agent" as const,
+    timelineBypass: true,
+  };
+  if (update.sessionUpdate === "subagent_spawned" && update.parent_session_id === parentSessionId) {
+    return {
+      type: "task.started",
+      payload: {
+        ...linkage,
+        ...(text(update.description).trim()
+          ? { description: text(update.description).trim(), title: text(update.description).trim() }
+          : {}),
+        ...(text(update.model).trim() ? { model: text(update.model).trim() } : {}),
+      },
+    };
+  }
+  if (update.sessionUpdate === "subagent_finished") {
+    const status =
+      update.status === "completed"
+        ? "completed"
+        : update.status === "failed"
+          ? "failed"
+          : "stopped";
+    return {
+      type: "task.completed",
+      payload: {
+        ...linkage,
+        status,
+        ...(text(update.output).trim() || text(update.error).trim()
+          ? { summary: text(update.output).trim() || text(update.error).trim() }
+          : {}),
+      },
+    };
+  }
+}
+
+function contentText(value: unknown): string {
+  if (!Array.isArray(value)) return text(record(value).text);
+  return value
+    .map((part) => {
+      const item = record(part);
+      return text(item.text) || text(record(item.content).text);
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Fold ACP chunks and tool updates before paging visible entries. */
+export function grokHistoryEntries(
+  updates: (typeof Updates.Type)["updates"],
+  childId: string,
+): AgentHistoryEntry[] {
+  const entries: AgentHistoryEntry[] = [];
+  const tools = new Map<string, number>();
+  let messageKind: AgentHistoryEntry["kind"] | undefined;
+  for (const envelope of updates) {
+    if (envelope.method !== "session/update" || envelope.params.sessionId !== childId) continue;
+    const update = record(envelope.params.update);
+    const type = update.sessionUpdate;
+    const kind =
+      type === "agent_message_chunk"
+        ? "assistant"
+        : type === "user_message_chunk"
+          ? "user"
+          : type === "agent_thought_chunk"
+            ? "reasoning"
+            : undefined;
+    if (kind) {
+      const chunk = contentText(update.content);
+      if (!chunk) continue;
+      const previous = entries.at(-1);
+      if (messageKind === kind && previous) {
+        entries[entries.length - 1] = {
+          ...agentHistoryEntry(previous.id, kind, previous.title, previous.detail + chunk),
+          truncated: previous.truncated || previous.detail.length + chunk.length > 8000,
+        };
+      } else
+        entries.push(
+          agentHistoryEntry(
+            `${childId}:message:${entries.length}`,
+            kind,
+            kind === "assistant" ? "Assistant" : kind === "user" ? "User" : "Reasoning",
+            chunk,
+          ),
+        );
+      messageKind = kind;
+      continue;
+    }
+    messageKind = undefined;
+    if (type !== "tool_call" && type !== "tool_call_update") continue;
+    const id = text(update.toolCallId);
+    if (!id) continue;
+    const index = tools.get(id);
+    const previous = index === undefined ? undefined : entries[index];
+    const detail =
+      contentText(update.content) ||
+      (update.rawOutput !== undefined
+        ? JSON.stringify(update.rawOutput)
+        : update.rawInput !== undefined
+          ? JSON.stringify(update.rawInput)
+          : (previous?.detail ?? ""));
+    const normalized = agentHistoryEntry(
+      `${childId}:tool:${id}`,
+      "tool",
+      text(update.title) || previous?.title || "Tool",
+      detail,
+    );
+    const entry =
+      previous?.truncated && detail === previous.detail
+        ? { ...normalized, truncated: true }
+        : normalized;
+    if (index === undefined) {
+      tools.set(id, entries.length);
+      entries.push(entry);
+    } else entries[index] = entry;
+  }
+  return entries;
+}
+
+export const readGrokAgentHistory = Effect.fn("readGrokAgentHistory")(function* <E>(input: {
+  parentSessionId: string;
+  agentId: string;
+  cwd: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+  request: (method: string, params: unknown) => Effect.Effect<unknown, E>;
+}) {
+  const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
+    status: "unavailable",
+    entries: [],
+    nextOffset: null,
+    message,
+  });
+  if (input.agentId === input.parentSessionId)
+    return unavailable("Select a child agent to read its history.");
+  let current = input.agentId;
+  const seen = new Set<string>();
+  while (current !== input.parentSessionId) {
+    if (seen.has(current) || seen.size >= 32)
+      return unavailable("Could not verify this agent belongs to the thread.");
+    seen.add(current);
+    const state = yield* input
+      .request("_x.ai/session/state", { sessionId: current, cwd: input.cwd })
+      .pipe(Effect.flatMap(Schema.decodeUnknownEffect(State)));
+    if (current === input.agentId && !state.summary.session_kind?.startsWith("subagent"))
+      return unavailable("The selected session is not a saved subagent.");
+    if (!state.summary.parent_session_id)
+      return unavailable("This agent does not belong to the thread.");
+    current = state.summary.parent_session_id;
+  }
+  // The native reader filters rewound branches. Offset is in visible rows, not raw ACP chunks.
+  const response = yield* input
+    .request("_x.ai/session/updates", { sessionId: input.agentId, cwd: input.cwd })
+    .pipe(Effect.flatMap(Schema.decodeUnknownEffect(Updates)));
+  const entries = grokHistoryEntries(response.updates, input.agentId);
+  const page = collectAgentHistory(input);
+  for (const entry of entries) {
+    if (page.add(entry)) break;
+  }
+  return page.result();
+});

--- a/apps/server/src/provider/Layers/openCodeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/openCodeAgentHistory.test.ts
@@ -108,3 +108,39 @@ it.effect("honors native revert boundaries and maps text, reasoning and failed t
     expect(result.entries[2]?.detail).toContain('"error": "failed"');
   }),
 );
+
+it.effect("labels edits by file path", () =>
+  Effect.gen(function* () {
+    const result = yield* readOpenCodeAgentHistory({
+      parentSessionId: "parent",
+      agentId: "child",
+      offset: 0,
+      readSession: (id) => Effect.succeed({ id, parentID: "parent" }),
+      readMessages: () =>
+        Effect.succeed([
+          {
+            info: { id: "message", role: "assistant" as const },
+            parts: [
+              {
+                type: "tool" as const,
+                id: "edit",
+                callID: "edit",
+                sessionID: "child",
+                messageID: "message",
+                tool: "edit",
+                state: {
+                  status: "completed" as const,
+                  input: { filePath: "src/X.jsx", newString: "new" },
+                  output: "patched",
+                  title: "edit",
+                  metadata: {},
+                  time: { start: 1, end: 2 },
+                },
+              },
+            ],
+          },
+        ]),
+    });
+    expect(result.entries[0]).toMatchObject({ kind: "file-edit", title: "Edit src/X.jsx" });
+  }),
+);

--- a/apps/server/src/provider/Layers/openCodeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/openCodeAgentHistory.test.ts
@@ -1,0 +1,110 @@
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import type { Part } from "@opencode-ai/sdk/v2";
+import { readOpenCodeAgentHistory } from "./openCodeAgentHistory.ts";
+
+const parts = Array.from({ length: 53 }, (_, i): Part => ({
+  type: "tool",
+  id: `part-${i}`,
+  callID: `call-${i}`,
+  sessionID: "child",
+  messageID: "message",
+  tool: "bash",
+  state: {
+    status: "completed",
+    input: { command: "pwd" },
+    output: "x".repeat(9000),
+    title: "pwd",
+    metadata: {},
+    time: { start: 1, end: 2 },
+  },
+}));
+
+it.effect("reads nested children with bounded, stable pages and tool results", () =>
+  Effect.gen(function* () {
+    const readSession = (id: string) =>
+      Effect.succeed({ id, parentID: id === "child" ? "nested" : "parent" });
+    const readMessages = () =>
+      Effect.succeed([{ info: { id: "message", role: "assistant" as const }, parts }]);
+    const input = {
+      parentSessionId: "parent",
+      agentId: "child",
+      offset: 0,
+      readSession,
+      readMessages,
+    };
+    const first = yield* readOpenCodeAgentHistory(input);
+    expect(first.entries).toHaveLength(50);
+    expect(first.nextOffset).toBe(50);
+    expect(first.entries[0]).toMatchObject({ id: "message:part-0", kind: "tool", truncated: true });
+    expect(first.entries[0]?.detail).toHaveLength(8000);
+    const second = yield* readOpenCodeAgentHistory({ ...input, offset: 50 });
+    expect(second.entries.map((entry) => entry.id)).toEqual([
+      "message:part-50",
+      "message:part-51",
+      "message:part-52",
+    ]);
+    expect(second.nextOffset).toBeNull();
+  }),
+);
+
+for (const scenario of ["unrelated", "cycle", "parent"] as const) {
+  it.effect(`rejects ${scenario} before reading messages`, () =>
+    Effect.gen(function* () {
+      const result = yield* readOpenCodeAgentHistory({
+        parentSessionId: "parent",
+        agentId: scenario === "parent" ? "parent" : "child",
+        offset: 0,
+        readSession: (id) =>
+          Effect.succeed({ id, ...(scenario === "cycle" ? { parentID: "child" } : {}) }),
+        readMessages: () => Effect.die("must not read messages"),
+      });
+      expect(result.status).toBe("unavailable");
+    }),
+  );
+}
+
+it.effect("honors native revert boundaries and maps text, reasoning and failed tools", () =>
+  Effect.gen(function* () {
+    const base = { sessionID: "child", messageID: "message" };
+    const result = yield* readOpenCodeAgentHistory({
+      parentSessionId: "parent",
+      agentId: "child",
+      offset: 0,
+      readSession: (id) =>
+        Effect.succeed({ id, parentID: "parent", revert: { messageID: "removed" } }),
+      readMessages: () =>
+        Effect.succeed([
+          {
+            info: { id: "message", role: "user" as const },
+            parts: [
+              { ...base, id: "text", type: "text" as const, text: "Prompt" },
+              {
+                ...base,
+                id: "reason",
+                type: "reasoning" as const,
+                text: "Thinking",
+                time: { start: 1 },
+              },
+              {
+                ...base,
+                id: "error",
+                callID: "error",
+                type: "tool" as const,
+                tool: "bash",
+                state: {
+                  status: "error" as const,
+                  input: {},
+                  error: "failed",
+                  time: { start: 1, end: 2 },
+                },
+              },
+            ],
+          },
+          { info: { id: "removed", role: "assistant" as const }, parts },
+        ]),
+    });
+    expect(result.entries.map((entry) => entry.kind)).toEqual(["user", "reasoning", "tool"]);
+    expect(result.entries[2]?.detail).toContain('"error": "failed"');
+  }),
+);

--- a/apps/server/src/provider/Layers/openCodeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/openCodeAgentHistory.ts
@@ -3,6 +3,7 @@ import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3t
 import * as Effect from "effect/Effect";
 import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
 
+/** Keep message order while normalizing displayable parts; internal step and token metadata stay hidden. */
 function historyEntry(role: Message["role"], part: Part): AgentHistoryEntry | null {
   switch (part.type) {
     case "text":

--- a/apps/server/src/provider/Layers/openCodeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/openCodeAgentHistory.ts
@@ -1,0 +1,83 @@
+import type { Message, Part, Session } from "@opencode-ai/sdk/v2";
+import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+function historyEntry(role: Message["role"], part: Part): AgentHistoryEntry | null {
+  switch (part.type) {
+    case "text":
+      return agentHistoryEntry(part.id, role, role === "user" ? "Prompt" : "Agent", part.text);
+    case "reasoning":
+      return agentHistoryEntry(part.id, "reasoning", "Reasoning", part.text);
+    case "tool":
+      return agentHistoryEntry(
+        part.id,
+        "tool",
+        part.tool,
+        JSON.stringify(
+          {
+            input: part.state.input,
+            status: part.state.status,
+            ...(part.state.status === "completed" ? { output: part.state.output } : {}),
+            ...(part.state.status === "error" ? { error: part.state.error } : {}),
+          },
+          null,
+          2,
+        ),
+      );
+    default:
+      return null;
+  }
+}
+
+/** Read only descendants of the saved session, including nested agents, without resuming them. */
+export const readOpenCodeAgentHistory = Effect.fn("readOpenCodeAgentHistory")(function* <E>(input: {
+  parentSessionId: string;
+  agentId: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+  readSession: (
+    id: string,
+  ) => Effect.Effect<Pick<Session, "id" | "parentID" | "revert"> | undefined, E>;
+  readMessages: (
+    id: string,
+  ) => Effect.Effect<
+    ReadonlyArray<{ info: Pick<Message, "id" | "role">; parts: ReadonlyArray<Part> }>,
+    E
+  >;
+}): Effect.fn.Return<OrchestrationGetAgentHistoryResult, E> {
+  const seen = new Set([input.parentSessionId]);
+  let currentId = input.agentId;
+  let belongsToParent = false;
+  let revertMessageId: string | undefined;
+  for (let depth = 0; depth < 32; depth++) {
+    if (seen.has(currentId)) break;
+    seen.add(currentId);
+    const session = yield* input.readSession(currentId);
+    if (currentId === input.agentId) revertMessageId = session?.revert?.messageID;
+    if (!session?.parentID) break;
+    currentId = session.parentID;
+    if (currentId === input.parentSessionId) {
+      belongsToParent = true;
+      break;
+    }
+  }
+  if (!belongsToParent)
+    return {
+      status: "unavailable",
+      entries: [],
+      nextOffset: null,
+      message: "This agent does not belong to the saved provider session.",
+    };
+  const messages = yield* input.readMessages(input.agentId);
+  const page = collectAgentHistory(input);
+  for (const message of messages) {
+    if (message.info.id === revertMessageId) break;
+    for (const part of message.parts) {
+      const entry = historyEntry(message.info.role, part);
+      if (entry && page.add({ ...entry, id: `${message.info.id}:${entry.id}` }))
+        return page.result();
+    }
+  }
+  return page.result();
+});

--- a/apps/server/src/provider/Layers/openCodeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/openCodeAgentHistory.ts
@@ -9,11 +9,13 @@ function historyEntry(role: Message["role"], part: Part): AgentHistoryEntry | nu
       return agentHistoryEntry(part.id, role, role === "user" ? "Prompt" : "Agent", part.text);
     case "reasoning":
       return agentHistoryEntry(part.id, "reasoning", "Reasoning", part.text);
-    case "tool":
+    case "tool": {
+      const fileEdit = part.tool === "edit" || part.tool === "write" || part.tool === "apply_patch";
+      const path = part.state.input.filePath ?? part.state.input.file_path;
       return agentHistoryEntry(
         part.id,
-        "tool",
-        part.tool,
+        fileEdit ? "file-edit" : "tool",
+        fileEdit && typeof path === "string" ? `Edit ${path}` : part.tool,
         JSON.stringify(
           {
             input: part.state.input,
@@ -25,6 +27,7 @@ function historyEntry(role: Message["role"], part: Part): AgentHistoryEntry | nu
           2,
         ),
       );
+    }
     default:
       return null;
   }

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -8,6 +8,8 @@
  * @module ProviderAdapter
  */
 import type {
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
   ApprovalRequestId,
   ProviderApprovalDecision,
   ProviderDriverKind,
@@ -126,9 +128,15 @@ export interface ProviderAdapterShape<TError> {
    */
   readonly hasSession: (threadId: ThreadId) => Effect.Effect<boolean>;
 
-  /**
-   * Read a provider thread snapshot.
-   */
+  /** Omitted when this provider cannot retrieve saved child history. Never resumes a session. */
+  readonly getAgentHistory?: (
+    input: OrchestrationGetAgentHistoryInput & {
+      readonly resumeCursor: unknown;
+      readonly cwd?: string | undefined;
+    },
+  ) => Effect.Effect<OrchestrationGetAgentHistoryResult, TError>;
+
+  /** Read a provider thread snapshot. */
   readonly readThread: (threadId: ThreadId) => Effect.Effect<ProviderThreadSnapshot, TError>;
 
   /**

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -12,6 +12,8 @@
  * @module ProviderService
  */
 import type {
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
   ProviderInterruptTurnInput,
   ProviderInstanceId,
   ProviderRespondToRequestInput,
@@ -121,9 +123,12 @@ export interface ProviderServiceShape {
     readonly numTurns: number;
   }) => Effect.Effect<void, ProviderServiceError>;
 
-  /**
-   * Upload a thread and return the provider's shareable feedback identifier.
-   */
+  /** Read saved child history without recovering or resuming the parent session. */
+  readonly getAgentHistory: (
+    input: OrchestrationGetAgentHistoryInput,
+  ) => Effect.Effect<OrchestrationGetAgentHistoryResult, ProviderServiceError>;
+
+  /** Upload a thread and return the provider's shareable feedback identifier. */
   readonly uploadFeedback: (
     input: ProviderUploadFeedbackInput,
   ) => Effect.Effect<ProviderUploadFeedbackResult, ProviderServiceError>;

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -68,6 +68,7 @@ const makeProviderService = (liveThreadIds: ReadonlyArray<ThreadId> = []) =>
     assertConversationRollbackSupported: () => Effect.die("unused"),
     getInstanceInfo: () => Effect.die("unused"),
     rollbackConversation: () => Effect.die("unused"),
+    getAgentHistory: () => Effect.die("unused"),
     uploadFeedback: () => Effect.die("unused"),
     streamEvents: Stream.empty,
   }) satisfies ProviderService.ProviderService["Service"];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -43,6 +43,7 @@ import {
   OrchestrationSearchThreadsError,
   OrchestrationGetTurnDiffError,
   ORCHESTRATION_WS_METHODS,
+  OrchestrationGetAgentHistoryError,
   ProjectId,
   type ProjectEntriesFailure,
   type ProjectFileFailure,
@@ -1374,6 +1375,19 @@ const makeWsRpcLayer = (
                       message: "Failed to dispatch orchestration command",
                       cause,
                     }),
+              ),
+            ),
+            { "rpc.aggregate": "orchestration" },
+          ),
+        [ORCHESTRATION_WS_METHODS.getAgentHistory]: (input) =>
+          observeRpcEffect(
+            ORCHESTRATION_WS_METHODS.getAgentHistory,
+            providerService.getAgentHistory(input).pipe(
+              Effect.mapError(
+                () =>
+                  new OrchestrationGetAgentHistoryError({
+                    message: "Could not load agent history from this environment.",
+                  }),
               ),
             ),
             { "rpc.aggregate": "orchestration" },

--- a/apps/web/src/components/AgentsPanel.logic.test.ts
+++ b/apps/web/src/components/AgentsPanel.logic.test.ts
@@ -1,0 +1,110 @@
+import { deriveAgentPanelModel } from "@t3tools/client-runtime/state/subagentRuntime";
+import type { RuntimeSubagent } from "@t3tools/client-runtime/state/subagentRuntime";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  allPanelAgents,
+  expansionsAfterCollapse,
+  finishedAgents,
+  isLiveAgent,
+} from "./AgentsPanel.logic";
+
+function agent(overrides: Partial<RuntimeSubagent> & { id: string }): RuntimeSubagent {
+  return {
+    kind: "subagent",
+    title: overrides.id,
+    role: null,
+    model: null,
+    effort: null,
+    status: "running",
+    activationCount: 1,
+    usage: null,
+    progress: null,
+    lastToolName: null,
+    result: null,
+    error: null,
+    outputFile: null,
+    parentAgentId: null,
+    agentIndex: null,
+    phaseIndex: null,
+    phaseTitle: null,
+    attempt: null,
+    workflowName: null,
+    phases: [],
+    runHandles: null,
+    recentActivity: [],
+    firstSeenAt: "2026-02-23T00:00:00.000Z",
+    startedAt: "2026-02-23T00:00:00.000Z",
+    completedAt: null,
+    updatedAt: "2026-02-23T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isLiveAgent", () => {
+  it("treats idle as settled: a resting agent is not work in flight", () => {
+    expect(isLiveAgent(agent({ id: "a", status: "running" }))).toBe(true);
+    expect(isLiveAgent(agent({ id: "b", status: "waiting" }))).toBe(true);
+    expect(isLiveAgent(agent({ id: "c", status: "idle" }))).toBe(false);
+    expect(isLiveAgent(agent({ id: "d", status: "completed" }))).toBe(false);
+    expect(isLiveAgent(agent({ id: "e", status: "failed" }))).toBe(false);
+  });
+});
+
+describe("finishedAgents", () => {
+  it("collects settled members from every phase and from direct spawns", () => {
+    const model = deriveAgentPanelModel({
+      agents: [
+        agent({ id: "wf", kind: "workflow", status: "running" }),
+        agent({ id: "m1", parentAgentId: "wf", phaseIndex: 0, status: "completed" }),
+        agent({ id: "m2", parentAgentId: "wf", phaseIndex: 0, status: "running" }),
+        agent({ id: "m3", parentAgentId: "wf", phaseIndex: 1, status: "failed" }),
+        agent({ id: "direct-live", status: "running" }),
+        agent({ id: "direct-done", status: "completed" }),
+      ],
+    });
+
+    expect(finishedAgents(model).map((entry) => entry.id)).toEqual(["m1", "m3", "direct-done"]);
+    // The coordinator is a container for its members, not a row of its own:
+    // counting it would report one more agent than is running and double its
+    // members' usage in the panel total.
+    expect(allPanelAgents(model).map((entry) => entry.id)).toEqual([
+      "m1",
+      "m2",
+      "m3",
+      "direct-done",
+      "direct-live",
+    ]);
+  });
+
+  it("keeps roster order when an agent settles, so cards never reshuffle", () => {
+    const before = deriveAgentPanelModel({
+      agents: [
+        agent({ id: "first", firstSeenAt: "2026-02-23T00:00:00.000Z", status: "completed" }),
+        agent({ id: "second", firstSeenAt: "2026-02-23T00:00:01.000Z", status: "running" }),
+        agent({ id: "third", firstSeenAt: "2026-02-23T00:00:02.000Z", status: "completed" }),
+      ],
+    });
+    const after = deriveAgentPanelModel({
+      agents: [
+        agent({ id: "first", firstSeenAt: "2026-02-23T00:00:00.000Z", status: "completed" }),
+        agent({ id: "second", firstSeenAt: "2026-02-23T00:00:01.000Z", status: "completed" }),
+        agent({ id: "third", firstSeenAt: "2026-02-23T00:00:02.000Z", status: "completed" }),
+      ],
+    });
+
+    expect(finishedAgents(before).map((entry) => entry.id)).toEqual(["first", "third"]);
+    expect(finishedAgents(after).map((entry) => entry.id)).toEqual(["first", "second", "third"]);
+  });
+});
+
+describe("expansionsAfterCollapse", () => {
+  it("closes cards inside the collapsed section and leaves the rest open", () => {
+    const expanded = new Set(["a", "b", "c"]);
+    const next = expansionsAfterCollapse(expanded, [agent({ id: "b" }), agent({ id: "c" })]);
+
+    expect([...next]).toEqual(["a"]);
+    // The caller's set is never mutated: React state has to change identity.
+    expect([...expanded]).toEqual(["a", "b", "c"]);
+  });
+});

--- a/apps/web/src/components/AgentsPanel.logic.ts
+++ b/apps/web/src/components/AgentsPanel.logic.ts
@@ -18,10 +18,12 @@ export function isLiveAgent(agent: RuntimeSubagent): boolean {
   return !isTerminalSubagentStatus(agent.status) && agent.status !== "idle";
 }
 
+/** Flatten phase members in their displayed order, followed by unphased members. */
 export function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
   return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
 }
 
+/** Give fleet totals and finished grouping the same roster order as the panel. */
 export function allPanelAgents(model: AgentPanelModel): ReadonlyArray<RuntimeSubagent> {
   return [...model.workflows.flatMap(workflowMembers), ...model.directAgents];
 }

--- a/apps/web/src/components/AgentsPanel.logic.ts
+++ b/apps/web/src/components/AgentsPanel.logic.ts
@@ -1,0 +1,52 @@
+/**
+ * Roster shape for the Agents panel, kept out of the component so the rules
+ * that decide where an agent appears can be tested directly.
+ */
+import type {
+  AgentPanelModel,
+  AgentPanelWorkflowGroup,
+  RuntimeSubagent,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+import { isTerminalSubagentStatus } from "@t3tools/client-runtime/state/subagentRuntime";
+
+/**
+ * Live = still worth watching. Idle counts as settled: a resting Codex child
+ * looks done unless resumed, and parking it under Finished keeps the live
+ * sections honest about what is actually running.
+ */
+export function isLiveAgent(agent: RuntimeSubagent): boolean {
+  return !isTerminalSubagentStatus(agent.status) && agent.status !== "idle";
+}
+
+export function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
+  return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
+}
+
+export function allPanelAgents(model: AgentPanelModel): ReadonlyArray<RuntimeSubagent> {
+  return [...model.workflows.flatMap(workflowMembers), ...model.directAgents];
+}
+
+/**
+ * Finished agents leave their phase and collect in one section, so the roster
+ * spends its height on live work. Order is the roster's own (spawn order),
+ * never re-sorted by outcome — a card must not move because it settled.
+ */
+export function finishedAgents(model: AgentPanelModel): ReadonlyArray<RuntimeSubagent> {
+  return allPanelAgents(model).filter((agent) => !isLiveAgent(agent));
+}
+
+/**
+ * Collapsing a section hides its cards, so anything expanded inside it must
+ * close: reopening the section would otherwise restore a state the user could
+ * not see themselves leaving behind.
+ */
+export function expansionsAfterCollapse(
+  expanded: ReadonlySet<string>,
+  collapsedMembers: ReadonlyArray<RuntimeSubagent>,
+): ReadonlySet<string> {
+  const next = new Set(expanded);
+  for (const member of collapsedMembers) {
+    next.delete(member.id);
+  }
+  return next;
+}

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -312,7 +312,7 @@ function RecentAgentTools({
           <span className="block truncate font-mono text-[.8125rem] text-foreground/70">
             {entry.title}
           </span>
-          {entry.detail ? (
+          {entry.detail && entry.kind !== "file-edit" ? (
             <span className="mt-0.5 block truncate text-xs text-muted-foreground">
               {entry.detail}
             </span>
@@ -576,31 +576,47 @@ function AgentHistory({
           No saved activity is available yet. Refresh to check again.
         </p>
       ) : null}
-      {history.data?.entries.map((entry) => (
-        <div key={entry.id} className="min-w-0 rounded-md border border-border bg-card px-2.5 py-2">
-          <p
-            className={cn(
-              "whitespace-pre-wrap break-words text-xs text-foreground/80",
-              entry.kind === "tool" && "font-mono",
-            )}
+      {history.data?.entries.map((entry) => {
+        const tool = entry.kind === "tool" || entry.kind === "file-edit";
+        const detail = (
+          <>
+            {entry.detail ? (
+              <pre
+                className={cn(
+                  "mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground",
+                  tool ? "font-mono" : "font-sans",
+                )}
+              >
+                {entry.detail}
+              </pre>
+            ) : null}
+            {entry.truncated ? (
+              <p className="mt-1 text-xs text-muted-foreground">Long entry shortened.</p>
+            ) : null}
+          </>
+        );
+        return tool ? (
+          <details
+            key={entry.id}
+            className="min-w-0 rounded-md border border-border bg-card px-2.5 py-2"
           >
-            {entry.title}
-          </p>
-          {entry.detail ? (
-            <pre
-              className={cn(
-                "mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground",
-                entry.kind === "tool" ? "font-mono" : "font-sans",
-              )}
-            >
-              {entry.detail}
-            </pre>
-          ) : null}
-          {entry.truncated ? (
-            <p className="mt-1 text-xs text-muted-foreground">Long entry shortened.</p>
-          ) : null}
-        </div>
-      ))}
+            <summary className="cursor-pointer break-words font-mono text-xs text-foreground/80">
+              {entry.title}
+            </summary>
+            {detail}
+          </details>
+        ) : (
+          <div
+            key={entry.id}
+            className="min-w-0 rounded-md border border-border bg-card px-2.5 py-2"
+          >
+            <p className="whitespace-pre-wrap break-words text-xs text-foreground/80">
+              {entry.title}
+            </p>
+            {detail}
+          </div>
+        );
+      })}
       <div className="flex items-center justify-between gap-2">
         <Button
           size="xs"

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -3,60 +3,74 @@
  * and the ONLY place the roster renders (the chat carries one CTA row per
  * spawn batch).
  *
- * Visualization rules (from live-test feedback):
- * - Spawn order is stable. Activity and completion update rows in place.
- * - Agent rows reserve three fixed lines for identity, activity, and metrics;
- *   changing data must never change their height.
- * - Workflow expansion is presentation state. A live run stays expanded when
- *   it settles; older collapsed runs can still be opened at run granularity.
- * - Static status dots, DOM-write elapsed timers, plain token counters.
+ * Shape, from design review:
+ * - One agent is one card: title + model/effort + a state chip, over a strip
+ *   carrying the tool it is on right now, its cost, and its clock.
+ * - Finished agents leave the run and collect under a Finished disclosure, so
+ *   the roster keeps live work at full size.
+ * - An expanded card reads its latest saved tools; "Open full activity"
+ *   opens the newest history page, with older pages available on demand.
+ * - State reads as a word, never as colour alone; the clock tints while an
+ *   agent works and the chip names the outcome when it stops.
+ * - Spawn order is stable. Activity and completion update cards in place.
+ * - Static status text, DOM-write elapsed timers, one width transition per
+ *   tool change. No continuously repainting animation.
  */
 import { useAtomValue } from "@effect/atom-react";
 import type {
   AgentPanelModel,
-  AgentPanelWorkflowGroup,
   RuntimeSubagent,
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import {
   formatSubagentModelLabel,
   formatSubagentTokenCount,
 } from "@t3tools/client-runtime/state/subagentRuntime";
-import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { Bot, Braces, Check, ChevronDown, ChevronRight, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import type { EnvironmentId, OrchestrationThreadActivity, ThreadId } from "@t3tools/contracts";
+import { Braces, Bot, ChevronDown, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 
 import { cn } from "~/lib/utils";
+import { deriveAgentWorkEntries } from "~/session-logic";
+import { useEnvironmentQuery } from "~/state/query";
 import { orchestrationEnvironment } from "~/state/orchestration";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Button } from "~/components/ui/button";
+import { workEntryDisplayLabel } from "./chat/MessagesTimeline.logic";
+import {
+  allPanelAgents,
+  expansionsAfterCollapse,
+  finishedAgents,
+  isLiveAgent,
+} from "./AgentsPanel.logic";
 
 /**
- * In-flight states all present as Working (one steady state, per the
- * monitoring-pill design: detail belongs in the activity sub-line, and a
- * stalled/waiting/queued subagent is still the fleet doing its job, not a
- * user problem). Only settled states differentiate.
+ * In-flight states all present as Working (one steady state: a stalled,
+ * waiting or queued subagent is still the fleet doing its job, not a user
+ * problem). Only settled states differentiate, and each names its outcome.
  */
-const STATUS_VISUALS: Record<RuntimeSubagent["status"], { dotClass: string; label: string }> = {
-  pending: { dotClass: "bg-info", label: "Working" },
-  running: { dotClass: "bg-info", label: "Working" },
-  waiting: { dotClass: "bg-info", label: "Working" },
-  // Idle reads as settled (muted, not sky): a resting Codex child looks done
-  // unless resumed — live-test: sky idle dots read as stuck in-progress.
-  idle: { dotClass: "bg-muted-foreground/50", label: "Idle · resumable" },
-  completed: { dotClass: "bg-success", label: "Completed" },
-  failed: { dotClass: "bg-destructive", label: "Failed" },
-  cancelled: { dotClass: "bg-muted-foreground/60", label: "Stopped" },
-  interrupted: { dotClass: "bg-muted-foreground/60", label: "Stopped" },
+const STATUS_LABELS: Record<RuntimeSubagent["status"], string> = {
+  pending: "Working",
+  running: "Working",
+  waiting: "Working",
+  idle: "Idle",
+  completed: "Done",
+  failed: "Failed",
+  cancelled: "Stopped",
+  interrupted: "Stopped",
 };
 
-function StatusDot({ status }: { status: RuntimeSubagent["status"] }) {
-  return (
-    <span
-      aria-hidden
-      className={cn("size-1.5 shrink-0 rounded-full", STATUS_VISUALS[status].dotClass)}
-    />
-  );
-}
+const CHIP_CLASSES: Record<RuntimeSubagent["status"], string> = {
+  pending: "bg-info/12 text-info-foreground",
+  running: "bg-info/12 text-info-foreground",
+  waiting: "bg-info/12 text-info-foreground",
+  idle: "bg-muted-foreground/12 text-muted-foreground",
+  completed: "bg-success/14 text-success-foreground",
+  failed: "bg-destructive/12 text-destructive-foreground",
+  cancelled: "bg-muted-foreground/12 text-muted-foreground",
+  interrupted: "bg-muted-foreground/12 text-muted-foreground",
+};
+
+const isLive = isLiveAgent;
 
 function formatElapsedSeconds(totalSeconds: number): string {
   const seconds = Math.max(0, Math.floor(totalSeconds));
@@ -84,7 +98,7 @@ function elapsedBetween(startedAt: string, endIso: string | null): string {
  * Elapsed time for the current activation. Live agents self-tick via DOM
  * writes (zero React commits per tick); settled agents freeze at completedAt.
  */
-function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
+function AgentElapsed({ agent, className }: { agent: RuntimeSubagent; className?: string }) {
   const textRef = useRef<HTMLSpanElement>(null);
   const live = agent.status === "running" || agent.status === "waiting";
   const startedAt = agent.startedAt;
@@ -107,155 +121,345 @@ function AgentElapsed({ agent }: { agent: RuntimeSubagent }) {
     return null;
   }
   return (
-    <span ref={textRef} className="tabular-nums">
+    <span ref={textRef} className={cn("tabular-nums", live && "text-info-foreground", className)}>
       {elapsedBetween(startedAt, live ? null : agent.completedAt)}
     </span>
   );
 }
 
 /**
- * Status-dependent activity line. Live rows lead with what is happening now;
- * settled rows lead with the outcome. Errors are the only inline previews on
- * failed rows because they explain a red row at a glance.
+ * Swaps a live line's text so the trailing chevron travels to its new position
+ * instead of teleporting. One width+opacity transition per tool change — a
+ * handful of frames every few seconds, confined to this inline-block, so
+ * layout never escapes it. Reduced motion swaps outright.
  */
-function agentActivityText(agent: RuntimeSubagent): string | null {
-  const live =
-    agent.status === "running" || agent.status === "pending" || agent.status === "waiting";
-  if (live) {
-    return (
-      agent.progress ??
-      (agent.lastToolName ? `▸ ${agent.lastToolName}` : null) ??
-      agent.result ??
-      agent.error
-    );
-  }
+function GlideText({ text, className }: { text: string; className?: string }) {
+  const nodeRef = useRef<HTMLSpanElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+    if (!node || node.textContent === text) {
+      return;
+    }
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      node.textContent = text;
+      return;
+    }
+    clearTimeout(timerRef.current);
+    const from = node.getBoundingClientRect().width;
+    node.style.transition = "none";
+    node.style.width = "auto";
+    node.textContent = text;
+    const to = node.getBoundingClientRect().width;
+    node.style.width = `${from}px`;
+    node.style.opacity = "0.35";
+    void node.offsetWidth;
+    node.style.transition = "width 260ms cubic-bezier(.2,.7,.3,1), opacity 200ms ease";
+    node.style.width = `${to}px`;
+    node.style.opacity = "1";
+    // A change arriving mid-flight orphans transitionend and would leave a
+    // stale inline width behind, which clips the next line.
+    timerRef.current = setTimeout(() => {
+      node.style.transition = "";
+      node.style.width = "";
+    }, 300);
+  }, [text]);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
   return (
-    agent.error ??
-    agent.result ??
-    agent.progress ??
-    (agent.lastToolName ? `▸ ${agent.lastToolName}` : null)
+    <span
+      ref={nodeRef}
+      className={cn("inline-block overflow-hidden whitespace-nowrap align-baseline", className)}
+    >
+      {text}
+    </span>
   );
 }
 
-/** Flat, non-interactive agent status line. No unfold. */
-function AgentRow({ agent }: { agent: RuntimeSubagent }) {
-  const visuals = STATUS_VISUALS[agent.status];
-  const statusLabel =
-    agent.kind === "subagent_batch" && agent.status === "idle" ? "Idle" : visuals.label;
-  const activity = agentActivityText(agent);
-  const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
-  const role =
-    agent.role?.trim().toLocaleLowerCase() === agent.title.trim().toLocaleLowerCase()
-      ? null
-      : agent.role;
-  const metadata = [
-    modelLabel,
-    agent.usage ? `${formatSubagentTokenCount(agent.usage.totalTokens)} tok` : "— tok",
-    agent.usage?.toolUses !== undefined ? `${agent.usage.toolUses} tools` : null,
-    agent.activationCount > 1 ? `run ${agent.activationCount}` : null,
-  ].filter((value): value is string => value !== null);
+/** What the agent is on right now, or the last thing it touched. */
+function currentStepText(agent: RuntimeSubagent): string | null {
+  if (agent.lastToolName) {
+    return agent.lastToolName;
+  }
+  return agent.progress ?? agent.recentActivity.at(-1)?.summary ?? null;
+}
+
+/**
+ * Settled agents lead with their outcome, live ones with what they are doing.
+ * The two are set differently: a tool line is a machine value and reads as
+ * mono, a result is the agent's own prose and does not.
+ */
+function cardSubtitle(agent: RuntimeSubagent): { text: string; mono: boolean } | null {
+  if (isLive(agent)) {
+    const step = currentStepText(agent);
+    return step === null ? null : { text: step, mono: true };
+  }
+  const outcome = agent.error ?? agent.result;
+  if (outcome !== null) {
+    return { text: outcome, mono: false };
+  }
+  const step = currentStepText(agent);
+  return step === null ? null : { text: step, mono: true };
+}
+
+function AgentChip({ agent }: { agent: RuntimeSubagent }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-sm px-1.5 py-px text-[.6875rem] leading-[1.4]",
+        CHIP_CLASSES[agent.status],
+      )}
+    >
+      {STATUS_LABELS[agent.status]}
+    </span>
+  );
+}
+
+/**
+ * The agent's own work log, derived only when a card is open. Rows come from
+ * the same derivation the chat uses, so an agent's tools render like the
+ * thread's own.
+ */
+function AgentSteps({
+  activities,
+  agentId,
+  workspaceRoot,
+  limit,
+}: {
+  activities: ReadonlyArray<OrchestrationThreadActivity>;
+  agentId: string;
+  workspaceRoot: string | undefined;
+  limit?: number;
+}) {
+  const entries = useMemo(() => {
+    const derived = deriveAgentWorkEntries(activities, agentId);
+    return limit === undefined ? derived : derived.slice(-limit);
+  }, [activities, agentId, limit]);
+
+  if (entries.length === 0) {
+    return (
+      <p className="px-0.5 py-1 text-xs text-muted-foreground">
+        No recent tool activity is available here. Open full activity to check the agent's saved
+        history.
+      </p>
+    );
+  }
 
   return (
-    <div className="grid h-[3.875rem] grid-cols-[0.375rem_minmax(0,1fr)_auto] grid-rows-[1.25rem_1.125rem_1rem] items-center gap-x-2 rounded-md px-1.5 py-1">
-      <span className="col-start-1 row-start-1 flex items-center">
-        <StatusDot status={agent.status} />
-      </span>
-      <span className="col-start-2 row-start-1 flex min-w-0 items-baseline gap-2">
-        <span className="min-w-0 truncate text-sm font-medium">{agent.title}</span>
-        {role ? (
-          <span className="max-w-28 shrink-0 truncate rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground">
-            {role}
+    <div className="flex flex-col gap-1.5">
+      {entries.map((entry) => (
+        <div
+          key={entry.id}
+          className={cn(
+            "rounded-md border border-border bg-card px-2.5 py-1.5 text-[.8125rem] leading-normal",
+            entry.tone === "error" && "border-destructive/35",
+          )}
+        >
+          <span className="block truncate font-mono text-[.95em] text-foreground/70">
+            {workEntryDisplayLabel(entry, workspaceRoot)}
           </span>
-        ) : null}
-      </span>
-      <span className="col-start-3 row-start-1 min-w-14 text-right font-mono text-[.7rem] text-muted-foreground/80">
-        <span className="inline-flex items-center gap-1">
-          <AgentElapsed agent={agent} />
-          {agent.status === "completed" ? (
-            <Check aria-hidden className="size-3 text-success" />
+          {entry.detail ? (
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {entry.detail}
+            </span>
           ) : null}
-        </span>
-      </span>
-      <span
-        className={cn(
-          "col-start-2 col-end-4 row-start-2 block truncate text-xs",
-          agent.status === "failed" ? "text-destructive-foreground" : "text-muted-foreground",
-        )}
-      >
-        {activity ?? statusLabel}
-      </span>
-      <span className="col-start-2 col-end-4 row-start-3 truncate font-mono text-[.7rem] tabular-nums text-muted-foreground/70">
-        {metadata.join(" · ")}
-      </span>
-      <span className="sr-only">{statusLabel}</span>
+        </div>
+      ))}
     </div>
   );
 }
 
-function workflowIsLive(group: AgentPanelWorkflowGroup): boolean {
-  const status = group.workflow.status;
+/** Only expanded cards query saved tools. Hidden windows and in-flight reads do not poll. */
+function RecentAgentTools({
+  agent,
+  environmentId,
+  threadId,
+}: {
+  agent: RuntimeSubagent;
+  environmentId: EnvironmentId;
+  threadId: ThreadId;
+}) {
+  const history = useEnvironmentQuery(
+    orchestrationEnvironment.agentHistory({
+      environmentId,
+      input: { threadId, agentId: agent.id, offset: 0, view: "recent-tools" },
+    }),
+  );
+  const refresh = useEffectEvent(() => {
+    if (document.visibilityState === "visible" && !history.isPending) history.refresh();
+  });
+  const live = isLiveAgent(agent);
+  useEffect(() => {
+    refresh();
+    if (!live) return;
+    const timer = window.setInterval(refresh, 10000);
+    document.addEventListener("visibilitychange", refresh);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", refresh);
+    };
+  }, [live]);
+  const entries = history.data?.entries ?? [];
   return (
-    status !== "completed" &&
-    status !== "failed" &&
-    status !== "cancelled" &&
-    status !== "interrupted"
+    <div className="flex min-w-0 flex-col gap-1.5">
+      {entries.map((entry) => (
+        <div
+          key={entry.id}
+          className="min-w-0 rounded-md border border-border bg-card px-2.5 py-1.5"
+        >
+          <span className="block truncate font-mono text-[.8125rem] text-foreground/70">
+            {entry.title}
+          </span>
+          {entry.detail ? (
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+              {entry.detail}
+            </span>
+          ) : null}
+        </div>
+      ))}
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground" role="status">
+          {history.isPending
+            ? "Loading recent tools…"
+            : (history.error ?? history.data?.message ?? "No tool activity yet.")}
+        </p>
+      ) : null}
+    </div>
   );
 }
 
-function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
-  return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
+/** One agent. Opens in place; the full log is a deliberate second step. */
+function AgentCard({
+  agent,
+  activities,
+  workspaceRoot,
+  expanded,
+  onToggle,
+  onOpen,
+  environmentId,
+  threadId,
+}: {
+  agent: RuntimeSubagent;
+  activities: ReadonlyArray<OrchestrationThreadActivity>;
+  workspaceRoot: string | undefined;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpen: () => void;
+  environmentId: EnvironmentId | null;
+  threadId: ThreadId | null;
+}) {
+  const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
+  const step = cardSubtitle(agent);
+  const tokens = agent.usage?.totalTokens ?? 0;
+  const live = isLive(agent);
+
+  return (
+    <section className="overflow-hidden rounded-md border border-border bg-card">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className="grid w-full grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-2 gap-y-1 px-3 pt-2.5 text-left hover:bg-accent/40"
+      >
+        <span className="truncate text-[.8125rem] font-medium">{agent.title}</span>
+        {modelLabel ? (
+          <span className="min-w-0 truncate font-mono text-[.65rem] text-muted-foreground/75">
+            {modelLabel}
+          </span>
+        ) : (
+          <span />
+        )}
+        <AgentChip agent={agent} />
+        <span className="-mx-3 col-span-3 flex items-center gap-2 border-t border-border/70 px-3 py-1.5 text-[.6875rem] text-muted-foreground">
+          {step ? (
+            live ? (
+              <GlideText text={step.text} className="min-w-0 font-mono text-info-foreground" />
+            ) : (
+              <span className={cn("min-w-0 truncate", step.mono && "font-mono")}>{step.text}</span>
+            )
+          ) : (
+            <span className="min-w-0 truncate">{STATUS_LABELS[agent.status]}</span>
+          )}
+          <span className="ml-auto flex shrink-0 items-center gap-2 font-mono">
+            {tokens > 0 ? <span>{formatSubagentTokenCount(tokens)} tok</span> : null}
+            <AgentElapsed agent={agent} />
+            <ChevronRight
+              aria-hidden
+              className={cn(
+                "size-3.5 text-muted-foreground/70 transition-[rotate] duration-150 motion-reduce:transition-none",
+                expanded && "rotate-90",
+              )}
+            />
+          </span>
+        </span>
+      </button>
+      {expanded ? (
+        <div className="border-t border-border/70">
+          <div className="p-3">
+            {environmentId && threadId ? (
+              <RecentAgentTools agent={agent} environmentId={environmentId} threadId={threadId} />
+            ) : (
+              <AgentSteps
+                activities={activities}
+                agentId={agent.id}
+                workspaceRoot={workspaceRoot}
+                limit={5}
+              />
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onOpen}
+            aria-label={`Open full activity for ${agent.title}`}
+            className="flex w-full items-center justify-between border-t border-border/70 px-3 py-2 text-left text-xs text-muted-foreground hover:bg-accent/50 focus-visible:outline-2 focus-visible:outline-ring"
+          >
+            Open full activity
+            <ChevronRight aria-hidden className="size-3" />
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
 }
 
-/**
- * Phase rail: the run's shape at a glance. One segment per phase in order,
- * separated by chevrons; each segment shows title + one dot per member.
- * The whole arc (done → live → pending) is visible without scrolling the
- * member list.
- */
-function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
-  if (group.phases.length === 0) {
-    return null;
-  }
+/** Collapsible heading. Collapsing also closes anything expanded inside it. */
+function Section({
+  title,
+  meta,
+  folded,
+  open,
+  onToggle,
+  children,
+}: {
+  title: string;
+  meta: string;
+  folded: string;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="flex flex-wrap items-center gap-x-1 gap-y-1 px-1.5 pb-1 pt-1.5">
-      {group.phases.map((phase, index) => (
-        <div key={phase.index} className="flex items-center gap-1">
-          {index > 0 ? (
-            <ChevronRight aria-hidden className="size-3 text-muted-foreground/40" />
-          ) : null}
-          <div
-            className={cn(
-              "flex items-center gap-1 rounded-sm border px-1.5 py-0.5",
-              phase.state === "running"
-                ? "border-info/40"
-                : phase.state === "done"
-                  ? "border-success/30"
-                  : "border-border/50",
-            )}
-          >
-            <span
-              className={cn(
-                "font-mono text-[.65rem]",
-                phase.state === "running"
-                  ? "text-info-foreground"
-                  : phase.state === "done"
-                    ? "text-success-foreground"
-                    : "text-muted-foreground/70",
-              )}
-            >
-              {phase.state === "done" ? "✓ " : ""}
-              {phase.title}
-            </span>
-            <span className="flex items-center gap-0.5">
-              {phase.members.length === 0 ? (
-                <span className="font-mono text-[.6rem] text-muted-foreground/50">–</span>
-              ) : (
-                phase.members.map((member) => <StatusDot key={member.id} status={member.status} />)
-              )}
-            </span>
-          </div>
-        </div>
-      ))}
+    <div className="flex flex-col gap-2.5">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex items-center gap-1.5 rounded-sm px-1 pt-1 text-left text-xs text-muted-foreground hover:text-foreground"
+      >
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            "size-3 shrink-0 transition-[rotate] duration-150 motion-reduce:transition-none",
+            !open && "-rotate-90",
+          )}
+        />
+        <span className="font-medium text-foreground/75">{title}</span>
+        <span>{meta}</span>
+        {open ? null : <span className="ml-auto font-mono text-[.6875rem]">{folded}</span>}
+      </button>
+      {open ? children : null}
     </div>
   );
 }
@@ -279,7 +483,7 @@ function WorkflowScriptView({
     orchestrationEnvironment.workflowScript({ environmentId, input: { threadId, scriptPath } }),
   );
   return (
-    <div className="mx-1.5 mb-1 rounded-md border border-border/60 bg-background/60">
+    <div className="rounded-md border border-border/60 bg-background/60">
       <div className="flex items-center gap-2 border-b border-border/50 px-2 py-1">
         <Braces aria-hidden className="size-3 text-muted-foreground" />
         <span className="truncate font-mono text-[.65rem] text-muted-foreground">
@@ -311,226 +515,278 @@ function WorkflowScriptView({
   );
 }
 
-/**
- * Collapsible phase section. A phase opens when it becomes active, then keeps
- * that shape as it settles so completion never yanks rows out from under the
- * user. Manual toggles stick until a later activation begins.
- */
-function PhaseSection({
-  phase,
-  defaultOpen = false,
+/** History belongs to the selected environment; it is fetched only while this view is open. */
+function AgentHistory({
+  agentId,
+  environmentId,
+  threadId,
 }: {
-  phase: AgentPanelWorkflowGroup["phases"][number];
-  defaultOpen?: boolean;
+  agentId: string;
+  environmentId: EnvironmentId;
+  threadId: ThreadId;
 }) {
-  const [open, setOpen] = useState(defaultOpen || phase.state === "running");
-  const previousState = useRef(phase.state);
-
+  const [offset, setOffset] = useState<number | null>(null);
+  const bottom = useRef<HTMLDivElement>(null);
+  const history = useEnvironmentQuery(
+    orchestrationEnvironment.agentHistory({
+      environmentId,
+      input: {
+        threadId,
+        agentId,
+        offset: offset ?? 0,
+        ...(offset === null ? { view: "latest" as const } : {}),
+      },
+    }),
+  );
+  const pageOffset = offset ?? history.data?.startOffset ?? 0;
   useEffect(() => {
-    if (previousState.current !== "running" && phase.state === "running") {
-      setOpen(true);
-    }
-    previousState.current = phase.state;
-  }, [phase.state]);
-
+    if (offset === null && history.data && !history.isPending)
+      bottom.current?.scrollIntoView({ block: "end" });
+  }, [offset, history.data, history.isPending]);
   return (
-    <div>
-      <button
-        type="button"
-        onClick={() => setOpen((value) => !value)}
-        aria-expanded={open}
-        className={cn(
-          "mt-2 flex w-full items-center gap-1.5 rounded-sm px-1.5 text-left text-[.65rem] font-medium uppercase tracking-wider hover:bg-accent/40",
-          phase.state === "done"
-            ? "text-success-foreground"
-            : phase.state === "running"
-              ? "text-info-foreground"
-              : "text-muted-foreground/70",
-        )}
-      >
-        {open ? (
-          <ChevronDown aria-hidden className="size-3 shrink-0" />
-        ) : (
-          <ChevronRight aria-hidden className="size-3 shrink-0" />
-        )}
-        {phase.state === "done" ? <Check aria-hidden className="size-3" /> : null}
-        <span>{phase.title}</span>
-        <span className="font-normal normal-case text-muted-foreground/70">
-          {phase.state === "pending" && phase.members.length === 0
-            ? "pending"
-            : phase.state === "done"
-              ? `${phase.settledCount} done`
-              : `${phase.activeCount} active · ${phase.settledCount} done`}
-        </span>
-        {!open && phase.members.length > 0 ? (
-          <span className="ml-auto flex items-center gap-0.5">
-            {phase.members.map((member) => (
-              <StatusDot key={member.id} status={member.status} />
-            ))}
-          </span>
-        ) : null}
-      </button>
-      {open ? phase.members.map((member) => <AgentRow key={member.id} agent={member} />) : null}
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>Saved agent activity</span>
+        <Button
+          size="xs"
+          variant="ghost-muted"
+          disabled={history.isPending}
+          onClick={history.refresh}
+        >
+          Refresh
+        </Button>
+      </div>
+      {history.isPending ? (
+        <p role="status" className="text-xs text-muted-foreground">
+          Loading activity…
+        </p>
+      ) : null}
+      {history.error ? (
+        <p role="alert" className="text-xs text-destructive-foreground">
+          {history.error}
+        </p>
+      ) : null}
+      {history.data?.message ? (
+        <p className="text-xs text-muted-foreground">{history.data.message}</p>
+      ) : null}
+      {history.data?.status === "ready" &&
+      history.data.entries.length === 0 &&
+      !history.isPending ? (
+        <p className="text-xs text-muted-foreground">
+          No saved activity is available yet. Refresh to check again.
+        </p>
+      ) : null}
+      {history.data?.entries.map((entry) => (
+        <div key={entry.id} className="min-w-0 rounded-md border border-border bg-card px-2.5 py-2">
+          <p
+            className={cn(
+              "whitespace-pre-wrap break-words text-xs text-foreground/80",
+              entry.kind === "tool" && "font-mono",
+            )}
+          >
+            {entry.title}
+          </p>
+          {entry.detail ? (
+            <pre
+              className={cn(
+                "mt-1 whitespace-pre-wrap break-words text-xs text-muted-foreground",
+                entry.kind === "tool" ? "font-mono" : "font-sans",
+              )}
+            >
+              {entry.detail}
+            </pre>
+          ) : null}
+          {entry.truncated ? (
+            <p className="mt-1 text-xs text-muted-foreground">Long entry shortened.</p>
+          ) : null}
+        </div>
+      ))}
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          size="xs"
+          variant="ghost-muted"
+          disabled={pageOffset === 0 || history.isPending}
+          onClick={() => setOffset(Math.max(0, pageOffset - 50))}
+        >
+          Previous
+        </Button>
+        <Button
+          size="xs"
+          variant="ghost-muted"
+          disabled={history.data?.nextOffset == null || history.isPending}
+          onClick={() => {
+            if (history.data?.nextOffset != null) setOffset(history.data.nextOffset);
+          }}
+        >
+          Next
+        </Button>
+      </div>
+      <div ref={bottom} />
     </div>
   );
 }
 
-/** Expanded workflow: phase rail + full phase tree. */
-function ExpandedWorkflowSection({
-  group,
+/** The whole agent: its full work log, its cost, and how to get back. */
+function AgentActivityView({
+  agent,
   environmentId,
   threadId,
-  onCollapse,
+  onBack,
 }: {
-  group: AgentPanelWorkflowGroup;
+  agent: RuntimeSubagent;
   environmentId: EnvironmentId | null;
   threadId: ThreadId | null;
-  onCollapse: () => void;
+  onBack: () => void;
 }) {
-  const [scriptOpen, setScriptOpen] = useState(false);
-  const members = workflowMembers(group);
-  const settled = members.filter(
-    (member) =>
-      member.status === "completed" ||
-      member.status === "failed" ||
-      member.status === "cancelled" ||
-      member.status === "interrupted",
-  ).length;
-  const scriptPath = group.workflow.runHandles?.scriptPath;
-  const canShowScript = scriptPath !== undefined && environmentId !== null && threadId !== null;
+  const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
+  const tokens = agent.usage?.totalTokens ?? 0;
+  const summary = agent.error ?? agent.result;
+
   return (
-    <section className="rounded-lg border border-border/50 bg-card/30 p-1.5">
-      <div className="flex items-center gap-2 px-1.5 pt-0.5 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
-        <StatusDot status={group.workflow.status} />
-        <span className="min-w-0 truncate">
-          {group.workflow.workflowName ?? group.workflow.title}
-        </span>
-        {canShowScript ? (
-          <button
-            type="button"
-            onClick={() => setScriptOpen((value) => !value)}
-            className={cn(
-              "rounded-sm border border-border/60 px-1 font-mono normal-case hover:text-foreground",
-              scriptOpen && "text-foreground",
-            )}
-            aria-expanded={scriptOpen}
-          >
-            {"{}"} script
-          </button>
-        ) : null}
-        <span className="ml-auto font-mono normal-case text-muted-foreground/80">
-          {settled}/{members.length} settled
-        </span>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 font-mono text-[.6875rem] text-muted-foreground/80">
         <Button
           size="icon-micro"
           variant="ghost-muted"
-          onClick={onCollapse}
-          aria-label="Collapse workflow"
+          onClick={onBack}
+          aria-label="Back to all agents"
         >
-          <ChevronDown aria-hidden className="size-3" />
+          <ChevronLeft aria-hidden className="size-3" />
         </Button>
+        <span className="ml-auto tabular-nums">
+          {tokens > 0 ? `${formatSubagentTokenCount(tokens)} tok` : "no tokens"}
+        </span>
+        {agent.usage?.toolUses !== undefined ? (
+          <span className="border-l border-border pl-2 tabular-nums">
+            {agent.usage.toolUses} tools
+          </span>
+        ) : null}
       </div>
-      <PhaseRail group={group} />
-      {scriptOpen && canShowScript ? (
-        <WorkflowScriptView
-          environmentId={environmentId}
-          threadId={threadId}
-          scriptPath={scriptPath}
-          onClose={() => setScriptOpen(false)}
-        />
-      ) : null}
-      {group.phases.map((phase) => (
-        <PhaseSection key={phase.index} phase={phase} defaultOpen={!workflowIsLive(group)} />
-      ))}
-      {group.unphasedMembers.map((member) => (
-        <AgentRow key={member.id} agent={member} />
-      ))}
-      {group.phases.length === 0 && group.unphasedMembers.length === 0 ? (
-        <AgentRow agent={group.workflow} />
-      ) : null}
-    </section>
+      <div className="flex flex-col gap-0.5 border-b border-border/60 px-3 py-2.5">
+        <div className="flex items-baseline gap-2">
+          <h2 className="min-w-0 truncate text-[.9375rem] font-semibold tracking-[-0.006em]">
+            {agent.title}
+          </h2>
+          {modelLabel ? (
+            <span className="ml-auto shrink-0 font-mono text-[.6875rem] text-muted-foreground/80">
+              {modelLabel}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-baseline gap-2 text-xs text-muted-foreground">
+          <span className={cn(isLive(agent) && "font-medium text-info-foreground")}>
+            {STATUS_LABELS[agent.status]}
+          </span>
+          <AgentElapsed agent={agent} className="ml-auto font-mono text-[.6875rem]" />
+        </div>
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex flex-col gap-1.5 p-3">
+          {environmentId !== null && threadId !== null ? (
+            <AgentHistory
+              key={`${environmentId}:${threadId}:${agent.id}`}
+              agentId={agent.id}
+              environmentId={environmentId}
+              threadId={threadId}
+            />
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Connect to the thread's environment to load agent history.
+            </p>
+          )}
+          {summary ? (
+            <p
+              className={cn(
+                "rounded-md border border-border bg-card/55 px-2.5 py-2 text-[.8125rem] leading-normal",
+                agent.error ? "text-destructive-foreground" : "text-foreground/85",
+              )}
+            >
+              {summary}
+            </p>
+          ) : null}
+        </div>
+      </ScrollArea>
+    </div>
   );
 }
 
-/**
- * Collapsed workflow: one summary line. The parent owns expansion so a live
- * workflow keeps its shape when it settles.
- */
-function CollapsedWorkflowSection({
-  group,
-  onExpand,
-}: {
-  group: AgentPanelWorkflowGroup;
-  onExpand: () => void;
-}) {
-  const members = workflowMembers(group);
-  const failed = members.filter((member) => member.status === "failed").length;
-  // Coordinator usage may already aggregate members (panel-footer rule):
-  // count it only when there are no member rows to sum.
-  const totalTokens = members.reduce(
-    (sum, member) => sum + (member.usage?.totalTokens ?? 0),
-    members.length === 0 ? (group.workflow.usage?.totalTokens ?? 0) : 0,
-  );
-  const elapsed =
-    group.workflow.startedAt && group.workflow.completedAt
-      ? elapsedBetween(group.workflow.startedAt, group.workflow.completedAt)
-      : null;
+/** Progress meter: fixed width, segments share it, so 30 agents read like 5. */
+function FleetMeter({ agents }: { agents: ReadonlyArray<RuntimeSubagent> }) {
   return (
-    <section>
-      <button
-        type="button"
-        onClick={onExpand}
-        className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-accent/40"
-        aria-expanded={false}
-      >
-        <StatusDot status={failed > 0 ? "failed" : group.workflow.status} />
-        <span className="truncate text-sm">
-          {group.workflow.workflowName ?? group.workflow.title}
-        </span>
-        <span className="ml-auto flex items-center gap-1.5 font-mono text-[.7rem] text-muted-foreground/80">
-          {failed > 0 ? <span className="text-destructive-foreground">{failed} failed</span> : null}
-          <span>{members.length} agents</span>
-          <span className="tabular-nums">· {formatSubagentTokenCount(totalTokens)} tok</span>
-          {elapsed ? <span className="tabular-nums">· {elapsed}</span> : null}
-          <ChevronRight aria-hidden className="size-3" />
-        </span>
-      </button>
-    </section>
+    <span aria-hidden className="flex w-14 shrink-0 gap-0.5">
+      {agents.map((agent) => (
+        <span
+          key={agent.id}
+          className={cn(
+            "h-[3px] min-w-0.5 flex-1 rounded-[1px]",
+            agent.status === "completed"
+              ? "bg-success"
+              : isLive(agent)
+                ? "bg-info"
+                : "bg-muted-foreground/25",
+          )}
+        />
+      ))}
+    </span>
   );
 }
 
-/** A workflow's open state is presentation state, not a status derivative. */
-function WorkflowSection({
-  group,
-  environmentId,
-  threadId,
-}: {
-  group: AgentPanelWorkflowGroup;
-  environmentId: EnvironmentId | null;
-  threadId: ThreadId | null;
-}) {
-  const [open, setOpen] = useState(() => workflowIsLive(group));
-  return open ? (
-    <ExpandedWorkflowSection
-      group={group}
-      environmentId={environmentId}
-      threadId={threadId}
-      onCollapse={() => setOpen(false)}
-    />
-  ) : (
-    <CollapsedWorkflowSection group={group} onExpand={() => setOpen(true)} />
-  );
-}
+/** Stable identity: a literal default would break the derivation's memo. */
+const NO_ACTIVITIES: ReadonlyArray<OrchestrationThreadActivity> = [];
 
 export function AgentsPanel({
   model,
+  activities = NO_ACTIVITIES,
+  workspaceRoot,
   environmentId = null,
   threadId = null,
 }: {
   model: AgentPanelModel;
+  activities?: ReadonlyArray<OrchestrationThreadActivity>;
+  workspaceRoot?: string | undefined;
   environmentId?: EnvironmentId | null;
   threadId?: ThreadId | null;
 }) {
+  const [openAgentId, setOpenAgentId] = useState<string | null>(null);
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [collapsedSections, setCollapsedSections] = useState<ReadonlySet<string>>(() => new Set());
+  const [scriptWorkflowId, setScriptWorkflowId] = useState<string | null>(null);
+
+  const allAgents = useMemo(() => allPanelAgents(model), [model]);
+  const openAgent = allAgents.find((agent) => agent.id === openAgentId) ?? null;
+  const finished = useMemo(() => finishedAgents(model), [model]);
+
+  const toggleExpanded = (id: string) =>
+    setExpandedIds((current) => {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+
+  const toggleSection = (key: string, members: ReadonlyArray<RuntimeSubagent>) =>
+    setCollapsedSections((current) => {
+      const next = new Set(current);
+      if (!next.delete(key)) {
+        next.add(key);
+        setExpandedIds((expanded) => expansionsAfterCollapse(expanded, members));
+      }
+      return next;
+    });
+
+  const renderCard = (agent: RuntimeSubagent) => (
+    <AgentCard
+      key={agent.id}
+      agent={agent}
+      environmentId={environmentId}
+      threadId={threadId}
+      activities={activities}
+      workspaceRoot={workspaceRoot}
+      expanded={expandedIds.has(agent.id)}
+      onToggle={() => toggleExpanded(agent.id)}
+      onOpen={() => setOpenAgentId(agent.id)}
+    />
+  );
+
   if (!model.hasAgents) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
@@ -544,42 +800,115 @@ export function AgentsPanel({
     );
   }
 
+  if (openAgent) {
+    return (
+      <AgentActivityView
+        agent={openAgent}
+        environmentId={environmentId}
+        threadId={threadId}
+        onBack={() => setOpenAgentId(null)}
+      />
+    );
+  }
+
+  const liveDirect = model.directAgents.filter(isLive);
+
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-xs text-muted-foreground">
+        {model.liveCount > 0 ? (
+          <span className="text-info-foreground">{model.liveCount} working</span>
+        ) : (
+          <span>All agents finished</span>
+        )}
+        <FleetMeter agents={allAgents} />
+        {model.totalTokens > 0 ? (
+          <span className="ml-auto border-l border-border pl-2 font-mono text-[.6875rem] tabular-nums">
+            {formatSubagentTokenCount(model.totalTokens)} tok
+          </span>
+        ) : null}
+      </div>
+
       <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-2 p-2">
-          {model.workflows.map((group) => (
-            <WorkflowSection
-              key={group.workflow.id}
-              group={group}
-              environmentId={environmentId}
-              threadId={threadId}
-            />
-          ))}
-          {model.directAgents.length > 0 ? (
-            <section>
-              <div className="px-1.5 pt-1 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
-                Direct spawns
+        <div className="flex flex-col gap-2.5 p-2.5">
+          {model.workflows.map((group) => {
+            const scriptPath = group.workflow.runHandles?.scriptPath;
+            const canShowScript =
+              scriptPath !== undefined && environmentId !== null && threadId !== null;
+            return (
+              <div key={group.workflow.id} className="flex flex-col gap-2.5">
+                <div className="flex items-center gap-2 px-1 pt-0.5">
+                  <span className="min-w-0 truncate text-[.8125rem] font-semibold">
+                    {group.workflow.workflowName ?? group.workflow.title}
+                  </span>
+                  {canShowScript ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setScriptWorkflowId((current) =>
+                          current === group.workflow.id ? null : group.workflow.id,
+                        )
+                      }
+                      aria-expanded={scriptWorkflowId === group.workflow.id}
+                      className="ml-auto rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground hover:text-foreground"
+                    >
+                      {"{}"} script
+                    </button>
+                  ) : null}
+                </div>
+                {scriptWorkflowId === group.workflow.id && canShowScript ? (
+                  <WorkflowScriptView
+                    environmentId={environmentId}
+                    threadId={threadId}
+                    scriptPath={scriptPath}
+                    onClose={() => setScriptWorkflowId(null)}
+                  />
+                ) : null}
+                {group.phases.map((phase) => {
+                  const live = phase.members.filter(isLive);
+                  if (live.length === 0) return null;
+                  const key = `${group.workflow.id}:${phase.index}`;
+                  return (
+                    <Section
+                      key={key}
+                      title={phase.title}
+                      meta={`${live.length} working`}
+                      folded={`${phase.members.length} agents, ${phase.settledCount} done`}
+                      open={!collapsedSections.has(key)}
+                      onToggle={() => toggleSection(key, phase.members)}
+                    >
+                      {live.map(renderCard)}
+                    </Section>
+                  );
+                })}
+                {group.unphasedMembers.filter(isLive).map(renderCard)}
               </div>
-              {model.directAgents.map((agent) => (
-                <AgentRow key={agent.id} agent={agent} />
-              ))}
-            </section>
+            );
+          })}
+
+          {liveDirect.length > 0 ? (
+            <div className="flex flex-col gap-2.5">
+              <div className="px-1 pt-0.5 text-xs text-muted-foreground">
+                Spawned directly{" "}
+                <span className="font-mono text-[.6875rem]">{liveDirect.length}</span>
+              </div>
+              {liveDirect.map(renderCard)}
+            </div>
+          ) : null}
+
+          {finished.length > 0 ? (
+            <Section
+              title="Finished"
+              meta={`${finished.length}`}
+              folded={`${finished.length} agents`}
+              open={!collapsedSections.has("finished")}
+              onToggle={() => toggleSection("finished", finished)}
+            >
+              {finished.map(renderCard)}
+            </Section>
           ) : null}
         </div>
       </ScrollArea>
-      <footer className="flex items-center justify-between border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
-        <span className="flex items-center gap-2">
-          {model.runningCount + model.waitingCount > 0 ? (
-            <span className="text-info-foreground">
-              ● {model.runningCount + model.waitingCount} working
-            </span>
-          ) : null}
-          {model.idleCount > 0 ? <span>{model.idleCount} idle</span> : null}
-          {model.settledCount > 0 ? <span>{model.settledCount} settled</span> : null}
-        </span>
-        <span className="tabular-nums">Σ {formatSubagentTokenCount(model.totalTokens)} tok</span>
-      </footer>
     </div>
   );
 }

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -204,6 +204,7 @@ function cardSubtitle(agent: RuntimeSubagent): { text: string; mono: boolean } |
   return step === null ? null : { text: step, mono: true };
 }
 
+/** Pair each status color with a readable label so color is never the only status signal. */
 function AgentChip({ agent }: { agent: RuntimeSubagent }) {
   return (
     <span
@@ -750,6 +751,7 @@ function FleetMeter({ agents }: { agents: ReadonlyArray<RuntimeSubagent> }) {
 /** Stable identity: a literal default would break the derivation's memo. */
 const NO_ACTIVITIES: ReadonlyArray<OrchestrationThreadActivity> = [];
 
+/** Keep expansion local to the roster while routing saved history through the selected environment. */
 export function AgentsPanel({
   model,
   activities = NO_ACTIVITIES,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8066,6 +8066,8 @@ export default function ChatView(props: ChatViewProps) {
     ) : renderedRightPanelSurface?.kind === "agents" ? (
       <AgentsPanel
         model={agentPanelModel}
+        activities={threadActivities}
+        workspaceRoot={activeWorkspaceRoot ?? undefined}
         environmentId={activeThreadRef?.environmentId ?? null}
         threadId={activeThreadRef?.threadId ?? null}
       />

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -15,6 +15,7 @@ import {
   deriveActivePlanState,
   deriveTimelineEntries,
   deriveTimelineEntriesWithState,
+  deriveAgentWorkEntries,
   deriveWorkLogEntries,
   findLatestProposedPlan,
   hasActionableProposedPlan,
@@ -2373,5 +2374,105 @@ describe("session activity performance", () => {
       command: "git diff",
       toolLifecycleStatus: "completed",
     });
+  });
+});
+
+describe("deriveAgentWorkEntries", () => {
+  it("returns only the tool rows attributed to that agent, in order", () => {
+    const activities = [
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Read",
+        sequence: 1,
+        payload: {
+          itemType: "file_read",
+          toolCallId: "t1",
+          title: "Read a.ts",
+          agentId: "agent-1",
+        },
+      }),
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Read",
+        sequence: 2,
+        payload: {
+          itemType: "file_read",
+          toolCallId: "t2",
+          title: "Read b.ts",
+          agentId: "agent-2",
+        },
+      }),
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Read",
+        sequence: 3,
+        payload: { itemType: "file_read", toolCallId: "t3", title: "Read c.ts" },
+      }),
+      makeActivity({
+        kind: "tool.completed",
+        summary: "Grep",
+        sequence: 4,
+        payload: { itemType: "file_search", toolCallId: "t4", title: "Grep x", agentId: "agent-1" },
+      }),
+    ];
+
+    expect(deriveAgentWorkEntries(activities, "agent-1").map((entry) => entry.toolTitle)).toEqual([
+      "Read a.ts",
+      "Grep x",
+    ]);
+    expect(deriveAgentWorkEntries(activities, "agent-2").map((entry) => entry.toolTitle)).toEqual([
+      "Read b.ts",
+    ]);
+  });
+
+  it("collapses a tool's in-progress row into its completed row", () => {
+    const entries = deriveAgentWorkEntries(
+      [
+        makeActivity({
+          kind: "tool.updated",
+          summary: "Bash",
+          sequence: 1,
+          payload: {
+            itemType: "command_execution",
+            toolCallId: "t1",
+            title: "vp test",
+            status: "in_progress",
+            agentId: "agent-1",
+          },
+        }),
+        makeActivity({
+          kind: "tool.completed",
+          summary: "Bash",
+          sequence: 2,
+          payload: {
+            itemType: "command_execution",
+            toolCallId: "t1",
+            title: "vp test",
+            status: "completed",
+            agentId: "agent-1",
+          },
+        }),
+      ],
+      "agent-1",
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ toolCallId: "t1", toolLifecycleStatus: "completed" });
+  });
+
+  it("ignores an agent's own task rows: the roster already reports them", () => {
+    const entries = deriveAgentWorkEntries(
+      [
+        makeActivity({
+          kind: "task.progress",
+          summary: "Working",
+          sequence: 1,
+          payload: { taskId: "agent-1", description: "Working", agentKind: "agent" },
+        }),
+      ],
+      "agent-1",
+    );
+
+    expect(entries).toEqual([]);
   });
 });

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -472,6 +472,36 @@ export function deriveWorkLogEntries(
   return collapseDerivedWorkLogEntries(entries);
 }
 
+/**
+ * Work log for a single agent: the tool rows the thread's own work log
+ * deliberately hides. isAgentInternalActivity drops anything carrying
+ * `payload.agentId` from the parent timeline (quiet-timeline guarantee), and
+ * this is where those rows are re-homed. Derivation is shared with the parent
+ * work log, so an agent's tools render exactly like the thread's own.
+ *
+ * Callers derive this lazily, for the one agent a user opened — the roster
+ * never needs it.
+ */
+export function deriveAgentWorkEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  agentId: string,
+): WorkLogEntry[] {
+  const entries: DerivedWorkLogEntry[] = [];
+  for (const activity of [...activities].toSorted(compareActivitiesByOrder)) {
+    // tool.started is superseded by the updated/completed row for the same
+    // toolCallId, exactly as in the parent work log.
+    if (activity.kind !== "tool.updated" && activity.kind !== "tool.completed") continue;
+    const payload =
+      activity.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : null;
+    if (!payload || payload.agentId !== agentId) continue;
+    if (isPlanBoundaryToolActivity(activity)) continue;
+    entries.push(toDerivedWorkLogEntry(activity));
+  }
+  return collapseDerivedWorkLogEntries(entries);
+}
+
 /** Adapters forward unknown wire-only SDK messages (background_tasks_changed,
  *  commands_changed, ...) as runtime warnings. The suffix comes from
  *  describeUnknownSdkMessage in the Claude adapter; a row with no displayable

--- a/docs/user/providers-claude.md
+++ b/docs/user/providers-claude.md
@@ -99,3 +99,12 @@ config directory and put the router's endpoint and credential variables in that
 instance's **Environment variables**. The router must run where the environment
 can reach it. Follow the [Claude Code Router instructions](https://github.com/musistudio/claude-code-router)
 for its installation and routing configuration.
+
+## Subagent history
+
+On web and desktop, open the Agents panel, expand a subagent, and choose
+**Open full activity** to read its saved messages and tool activity. History
+comes from the configured Claude instance on the connected computer and can
+remain available after the session stops. Opening it does not resume Claude.
+Use **Refresh** for newly saved activity and **Next** for subsequent pages.
+Long entries are shortened and marked.

--- a/docs/user/providers-codex.md
+++ b/docs/user/providers-codex.md
@@ -78,3 +78,13 @@ In an existing Codex thread, send `/feedback` with an optional description, for
 example `/feedback The agent stopped before finishing the tests`. This uploads
 the conversation and Codex logs to OpenAI. The returned thread ID can be shared
 with OpenAI support.
+
+## Subagent history
+
+On web and desktop, open the Agents panel, expand a subagent, and choose
+**Open full activity** to read its saved conversation and tool activity. This
+also works after the session stops, provided Codex still has its saved history
+on the connected computer. Opening history does not resume the agent.
+
+Use **Refresh** for newly saved activity and **Next** for subsequent pages.
+Long entries are shortened and marked. Claude also supports this history view.

--- a/docs/user/providers-opencode.md
+++ b/docs/user/providers-opencode.md
@@ -20,6 +20,17 @@ fail, check the URL, credentials, and OpenCode version, then refresh provider st
 After a lost connection, send another prompt to reconnect to the same OpenCode
 session.
 
+## Agent history
+
+In the web or desktop Agents panel, expand an agent and choose **Open full
+activity** to read its saved conversation and tool activity. History comes from
+the OpenCode server configured for that environment and can be read after the
+agent stops. Opening history does not resume the agent.
+
+Use **Refresh** for newer activity and **Next** for more entries. Agents created
+before T3 Code began tracking OpenCode child sessions do not appear retroactively
+in the panel.
+
 ## Approvals
 
 OpenCode follows the shared [permission modes](./permission-modes.md). **Auto** has

--- a/packages/client-runtime/src/state/orchestration.ts
+++ b/packages/client-runtime/src/state/orchestration.ts
@@ -12,6 +12,12 @@ export function createOrchestrationEnvironmentAtoms<R, E>(
       label: "environment-data:orchestration:turn-diff",
       tag: ORCHESTRATION_WS_METHODS.getTurnDiff,
     }),
+    agentHistory: createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:orchestration:agent-history",
+      tag: ORCHESTRATION_WS_METHODS.getAgentHistory,
+      staleTimeMs: 0,
+      idleTtlMs: 0,
+    }),
     workflowScript: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:orchestration:workflow-script",
       tag: ORCHESTRATION_WS_METHODS.getWorkflowScript,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -27,6 +27,7 @@ import { ProviderInstanceId } from "./providerInstance.ts";
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
   getWorkflowScript: "orchestration.getWorkflowScript",
+  getAgentHistory: "orchestration.getAgentHistory",
   getTurnDiff: "orchestration.getTurnDiff",
   getFullThreadDiff: "orchestration.getFullThreadDiff",
   searchThreads: "orchestration.searchThreads",
@@ -1958,6 +1959,38 @@ export const OrchestrationSearchThreadsResult = Schema.Struct({
 });
 export type OrchestrationSearchThreadsResult = typeof OrchestrationSearchThreadsResult.Type;
 
+/** Provider history is read on demand, independently of retained thread activities. */
+export const OrchestrationGetAgentHistoryInput = Schema.Struct({
+  threadId: ThreadId,
+  agentId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  offset: NonNegativeInt,
+  view: Schema.optional(Schema.Literals(["recent-tools", "latest"])),
+});
+export type OrchestrationGetAgentHistoryInput = typeof OrchestrationGetAgentHistoryInput.Type;
+
+export const AgentHistoryEntry = Schema.Struct({
+  id: Schema.String,
+  kind: Schema.Literals(["tool", "assistant", "user", "reasoning"]),
+  title: Schema.String.check(Schema.isMaxLength(500)),
+  detail: Schema.String.check(Schema.isMaxLength(8000)),
+  truncated: Schema.Boolean,
+});
+export type AgentHistoryEntry = typeof AgentHistoryEntry.Type;
+
+export const OrchestrationGetAgentHistoryResult = Schema.Struct({
+  status: Schema.Literals(["ready", "unavailable", "unsupported"]),
+  entries: Schema.Array(AgentHistoryEntry).check(Schema.isMaxLength(50)),
+  nextOffset: Schema.NullOr(NonNegativeInt),
+  startOffset: Schema.optional(NonNegativeInt),
+  message: Schema.NullOr(Schema.String),
+});
+export type OrchestrationGetAgentHistoryResult = typeof OrchestrationGetAgentHistoryResult.Type;
+
+export class OrchestrationGetAgentHistoryError extends Schema.TaggedError<OrchestrationGetAgentHistoryError>()(
+  "OrchestrationGetAgentHistoryError",
+  { message: Schema.String },
+) {}
+
 export const OrchestrationGetWorkflowScriptInput = Schema.Struct({
   threadId: ThreadId,
   /** Absolute path from the workflow's runHandles.scriptPath. The server
@@ -2010,6 +2043,10 @@ export const OrchestrationRpcSchemas = {
   dispatchCommand: {
     input: ClientOrchestrationCommand,
     output: DispatchResult,
+  },
+  getAgentHistory: {
+    input: OrchestrationGetAgentHistoryInput,
+    output: OrchestrationGetAgentHistoryResult,
   },
   getWorkflowScript: {
     input: OrchestrationGetWorkflowScriptInput,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1970,7 +1970,7 @@ export type OrchestrationGetAgentHistoryInput = typeof OrchestrationGetAgentHist
 
 export const AgentHistoryEntry = Schema.Struct({
   id: Schema.String,
-  kind: Schema.Literals(["tool", "assistant", "user", "reasoning"]),
+  kind: Schema.Literals(["tool", "file-edit", "assistant", "user", "reasoning"]),
   title: Schema.String.check(Schema.isMaxLength(500)),
   detail: Schema.String.check(Schema.isMaxLength(8000)),
   truncated: Schema.Boolean,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -92,6 +92,7 @@ import {
   OrchestrationGetTurnDiffInput,
   OrchestrationRpcSchemas,
   OrchestrationGetWorkflowScriptError,
+  OrchestrationGetAgentHistoryError,
 } from "./orchestration.ts";
 import {
   ProviderUploadFeedbackError,
@@ -1068,6 +1069,12 @@ const WsOrchestrationDispatchCommandRpc = Rpc.make(ORCHESTRATION_WS_METHODS.disp
   error: Schema.Union([OrchestrationDispatchCommandError, EnvironmentAuthorizationError]),
 });
 
+const WsOrchestrationGetAgentHistoryRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getAgentHistory, {
+  payload: OrchestrationRpcSchemas.getAgentHistory.input,
+  success: OrchestrationRpcSchemas.getAgentHistory.output,
+  error: Schema.Union([OrchestrationGetAgentHistoryError, EnvironmentAuthorizationError]),
+});
+
 const WsOrchestrationGetWorkflowScriptRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getWorkflowScript, {
   payload: OrchestrationRpcSchemas.getWorkflowScript.input,
   success: OrchestrationRpcSchemas.getWorkflowScript.output,
@@ -1297,6 +1304,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeResourceTelemetryRpc,
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetWorkflowScriptRpc,
+  WsOrchestrationGetAgentHistoryRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,
   WsOrchestrationSearchThreadsRpc,


### PR DESCRIPTION
## What changed and why

The Agents panel showed a roster with status and a current activity label, but no way to inspect a child agent’s saved work. This change adds expandable recent-tool cards and a full history view, read from the selected agent’s environment server.

Expanded cards show the latest five tools in compact boxes, with a muted full-width **Open full activity** footer. Visible expanded cards refresh every 10 seconds while the agent is active, without overlapping requests. Full activity opens on the newest 50-entry page, scrolls to the bottom, and supports older pages and refresh. Tool output and file patches are collapsed behind clickable titles in full activity; native file edits name the affected paths. Empty Codex reasoning markers are omitted; native reasoning text is used when the summary is absent.

The typed, read-authorized WebSocket endpoint routes through the persisted provider-instance binding without recovering or resuming an agent session. Provider adapters verify child ancestry and normalize bounded entries:

| Provider | Saved history source |
| --- | --- |
| Codex | Native `thread/read` |
| Claude | SDK reconstruction of the configured instance's saved child transcript |
| OpenCode | Native child session and message APIs; adds Task lifecycle tracking |
| Grok | Native saved session metadata/updates extensions; adds child lifecycle tracking |
| Cursor / Antigravity | Explicitly unsupported: their current T3 ACP paths lack a verified child-history read path and reliable child identity |

Web and desktop share the panel. The endpoint and query are environment-scoped for remote connections. This does not add a mobile Agents surface or backfill previously untracked child cards. Grok requires a CLI exposing its session-history extensions.

## Validation

- 335 focused history, provider adapter, service, and panel-logic tests pass on the upstream-based branch.
- Targeted server/web typechecks and lint pass.
- Earlier focused provider adapter tests covered stopped-session reads, configured homes, native lifecycle events, and initialize-only transport closure.
- Linux x64 AppImage built; the tester exercised recent tools and full history in the desktop client.
- Codex and Claude saved-history readers were checked against local native history. OpenCode had no saved child session locally; Grok CLI was unavailable, so those paths have protocol-backed tests but still need native end-to-end validation.

History is read on demand. Codex, OpenCode fallback reads, and Grok share read-only transports per provider instance and directory, with a 30-second idle lifetime, a bounded pool, and cleanup on failure or adapter shutdown. Response entries are bounded, but some native readers still load the saved transcript before selecting the requested page. Saved-history views are snapshots rather than a child event-stream subscription.

## UI evidence

| Before — original Agents tab | After — default collapsed overview |
| --- | --- |
| <img width="400" alt="Original Agents roster" src="https://github.com/user-attachments/assets/923e50ff-a3a4-4bfa-b81b-ff12d4e6283f" /> | <img width="400" alt="Default collapsed agent cards" src="https://github.com/user-attachments/assets/c76422d9-b51a-4964-9dee-d75327587c1f" /> |
| **After — expanded recent tools** | **After — full agent details** |
| <img width="400" alt="Expanded recent-tool preview" src="https://github.com/user-attachments/assets/dfd3fa24-0588-49ea-8ca1-e8a7b9209542" /> | <img width="400" alt="Full agent activity with expandable tool output" src="https://github.com/user-attachments/assets/d885b8f6-b8e3-4794-a927-2ba112c75de3" /> |

Interaction recording: expand recent tools, open full history at the bottom, expand/collapse a file patch, and return to the roster. Playback is sped up.

https://github.com/user-attachments/assets/48ee5606-5318-41ea-a713-1f841ba21770

Model: GPT-6 Astra. Harness: Codex.


## Closes discussions

- https://github.com/pingdotgg/t3code/discussions/11000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Agents panel with expandable live-agent cards, activity details, elapsed time, and a Finished section.
  - Added “Open full activity” to view saved subagent conversations and tool activity.
  - Added history pagination, refresh, recent-tools filtering, and expandable file-edit details.
  - Supported saved history for Claude, Codex, Grok, and OpenCode without resuming sessions.
  - Improved tracking of child-agent task start and completion activity.

- **Documentation**
  - Added provider-specific guidance for viewing and navigating subagent history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
