### PR TITLE
fix(web): keep long completed commands compact and expandable

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -41,7 +41,11 @@ function singleToolCallLabel(entry: WorkLogEntry): string {
   const toolPresentation = resolveWorkEntryToolPresentation(entry, "completed");
   if (toolPresentation) return toolPresentation.displayName;
   const command = entry.command?.trim();
-  if (command) return command;
+  if (command) {
+    return /[\r\n]/.test(command) || command.length > 120
+      ? liveWorkEntryLabel(entry, undefined, false)
+      : command;
+  }
   const heading = normalizeCompactToolLabel(entry.toolTitle || entry.label);
   return `${heading.charAt(0).toUpperCase()}${heading.slice(1)}`;
 }

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -37,6 +37,10 @@ const TIMELINE_MINIMAP_MAX_HEIGHT_CSS = "calc(100vh - 18rem)";
 const TIMELINE_CONTENT_MAX_WIDTH = 768;
 const TIMELINE_MINIMAP_PERSISTENT_GUTTER = 48;
 
+/**
+ * Returns the collapsed label for a completed tool call, summarizing multiline
+ * commands and commands longer than 120 characters to keep the timeline compact.
+ */
 function singleToolCallLabel(entry: WorkLogEntry): string {
   const toolPresentation = resolveWorkEntryToolPresentation(entry, "completed");
   if (toolPresentation) return toolPresentation.displayName;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1267,6 +1267,65 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
   });
 
+  it.each([
+    { command: "python3 - <<'PY'\nprint('verification complete')\nPY", detail: undefined },
+    { command: "python3 - <<'PY'\nprint('verification complete')\nPY", detail: "" },
+    {
+      command: "python3 - <<'PY'\r\nprint('verification complete')\r\nPY",
+      detail: "Script finished successfully",
+    },
+    { command: `python3 -c "print('${"x".repeat(120)}')"`, detail: undefined },
+  ])(
+    "keeps a long completed command compact and expandable with output $detail",
+    async ({ command, detail }) => {
+      vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+      vi.stubGlobal("requestAnimationFrame", () => 0);
+      vi.stubGlobal("cancelAnimationFrame", () => {});
+      let renderer: ReactTestRenderer | undefined;
+      try {
+        await act(() => {
+          renderer = create(
+            <MessagesTimeline
+              {...buildProps()}
+              timelineEntries={[
+                {
+                  id: "completed-script",
+                  kind: "work",
+                  createdAt: MESSAGE_CREATED_AT,
+                  entry: {
+                    id: "completed-script-work",
+                    createdAt: MESSAGE_CREATED_AT,
+                    label: "Ran command",
+                    tone: "tool",
+                    itemType: "command_execution",
+                    toolLifecycleStatus: "completed",
+                    command,
+                    ...(detail === undefined ? {} : { detail }),
+                  },
+                },
+              ]}
+            />,
+          );
+        });
+        const toggle = renderer!.root.findAllByProps({
+          role: "button",
+          "aria-label": "Ran python3",
+        });
+        expect(toggle).toHaveLength(1);
+        expect(JSON.stringify(renderer!.toJSON())).not.toContain("print('");
+        await act(() => toggle[0]!.props.onClick());
+        const expandedText = renderer!.root
+          .findAllByType("pre")
+          .map((node) => node.children.join(""))
+          .join("\n");
+        expect(expandedText).toContain(command);
+        if (detail) expect(expandedText).toContain(detail);
+      } finally {
+        await act(() => renderer?.unmount());
+      }
+    },
+  );
+
   it("keeps mixed-success tool groups neutral", () => {
     const markup = renderToStaticMarkup(
       <MessagesTimeline


### PR DESCRIPTION
## What Changed

Completed standalone commands containing line breaks or more than 120 characters use a compact label such as `Ran python3`. The full command remains available through expansion, even when it produced no output. Short one-line commands retain their existing labels.

## Why

Fixes #10879. A successful Python heredoc with no output previously filled the timeline with the entire script and had no expansion control.

Validation: four regression cases red → green, including missing/empty/nonempty output and long single-line commands; 151 affected tests pass; web typecheck and focused lint pass.

## UI Changes

Same seeded no-output heredoc in an isolated dev environment. Browser verification confirmed expansion preserves the full command and collapse restores the compact row.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/46b819f3-936c-4d11-a298-fa5eaa47af89) | ![After](https://github.com/user-attachments/assets/90fc8899-9f5c-4c78-a5f8-d5e8571e206e) |

Expansion demo:

https://github.com/user-attachments/assets/ab699512-86eb-40fa-8d50-b499833af794

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Long or multiline command executions now display a compact “Ran” label instead of exposing the full command inline.
  - Users can expand the entry to view the complete command and any additional details when needed.

- **Tests**
  - Added coverage for long commands, heredoc commands, empty details, CRLF line endings, and expandable command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->