### PR TITLE
fix(mobile): prevent overlapping Android thread rows

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2866,13 +2866,16 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
               entry.type === "message" ? `message:${entry.message.role}` : entry.type
             }
             getFixedItemSize={getFixedItemSize}
-            // LegendList swaps its position and size component types when this
-            // becomes undefined, remounting the feed and replaying row entrances.
-            // Keep those containers mounted while ordinary updates stay immediate.
+            // Android's animated list containers can retain overlapping row positions
+            // after thread switches or app resumes, even with a zero-duration transition.
+            // Keep Android on native layout. On iOS, keep animated containers mounted
+            // between disclosure toggles so rows do not remount and replay entrances.
             itemLayoutAnimation={
-              disclosureToggleSettling
-                ? THREAD_FEED_LAYOUT_TRANSITION
-                : THREAD_FEED_IMMEDIATE_TRANSITION
+              Platform.OS === "android"
+                ? undefined
+                : disclosureToggleSettling
+                  ? THREAD_FEED_LAYOUT_TRANSITION
+                  : THREAD_FEED_IMMEDIATE_TRANSITION
             }
             onItemSizeChanged={handleItemSizeChanged}
             // Measure rows well before they scroll into view so estimate→actual


### PR DESCRIPTION
## What Changed

Use LegendList's ordinary row positioning and sizing on Android. Work-detail expansion reflows immediately there; iOS keeps its existing disclosure transitions.

## Why

Fixes #5340. Long Android conversations can retain overlapping rows after switching threads or returning from another app. Even the existing zero-duration layout transition selects animated list containers. Keeping `itemLayoutAnimation` undefined on Android avoids that path consistently, without remounting the feed on resume.

Reproduced on a physical Redmi Note 8 Pro (Android 11) with the current native build and three seeded long conversations. With the change installed, eight thread switches and five returns from Android Settings kept messages separated. Mobile typecheck and targeted formatting/lint passed (lint has existing warnings outside this diff).

This only changes the shared Android thread feed. It applies across providers and connection modes; no server or contract changes are needed. Web, desktop, and iOS behavior is unchanged.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: overlapping Android thread rows](https://github-pr-attachments.none23.workers.dev/a/aa881baf-1a80-4f87-938b-2bafed91b258/current-alpha-settled.png) | ![After: Android thread rows use correct spacing](https://github-pr-attachments.none23.workers.dev/a/8c6c72ba-9465-46bb-b4fd-aea6d5b9bbf7/no-animation-alpha.png) |

### Video
#### Before

https://github.com/user-attachments/assets/eacaa9b4-3207-4a8a-9f41-4e59de600ec2

### After

https://github.com/user-attachments/assets/3cf4f0e3-b155-485d-86da-3df4e7ffa26d

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.

