### PR TITLE
feat(web): add configurable composer focus shortcut

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6091,6 +6091,13 @@ export default function ChatView(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (command === "composer.focus") {
+        event.preventDefault();
+        event.stopPropagation();
+        focusComposer();
+        return;
+      }
+
       if (command === "thread.copyReference") {
         event.preventDefault();
         event.stopPropagation();
@@ -6292,6 +6299,7 @@ export default function ChatView(props: ChatViewProps) {
     supportsSettlement,
     confirmAndUnpinThread,
     copyActiveThreadReference,
+    focusComposer,
     previewPanelOpen,
     toggleRightPanel,
     toggleRightPanelMaximized,

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -204,6 +204,7 @@ describe("KeybindingsSettings.logic", () => {
     expect(options).toEqual(
       expect.arrayContaining([
         "chat.new",
+        "composer.focus",
         "rightPanel.toggleMaximized",
         "thread.stop",
         "script.setup-db.run",

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -738,6 +738,29 @@ describe("cross-command precedence", () => {
 });
 
 describe("resolveShortcutCommand", () => {
+  it.each(["MacIntel", "Win32", "Linux"])(
+    "resolves a custom composer-focus shortcut inside and outside terminals on %s",
+    (platform) => {
+      const keybindings = compile([
+        { shortcut: modShortcut("i", { shiftKey: true }), command: "composer.focus" },
+      ]);
+      const input = event({
+        key: "i",
+        shiftKey: true,
+        metaKey: platform === "MacIntel",
+        ctrlKey: platform !== "MacIntel",
+      });
+
+      for (const terminalFocus of [false, true]) {
+        assert.strictEqual(
+          resolveShortcutCommand(input, keybindings, { platform, context: { terminalFocus } }),
+          "composer.focus",
+        );
+        assert.isNull(resolveShortcutCommand(input, [], { platform }));
+      }
+    },
+  );
+
   it("resolves a custom stop-thread shortcut", () => {
     const keybindings = compile([{ shortcut: modShortcut("escape"), command: "thread.stop" }]);
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -53,6 +53,10 @@ a shortcut.
 
 ## Commands with special behavior
 
+`composer.focus` moves focus to the end of the current thread's composer, including
+from a terminal. It has no default shortcut; assign one with **Add keybinding** in
+**Settings → Keybindings**.
+
 `thread.stop` interrupts the running turn in the focused thread. It has no default
 shortcut; assign one in **Settings → Keybindings**.
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -84,6 +84,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedThemeEditor.command, "themeEditor.toggle");
 
+    const parsedComposerFocus = yield* decode(KeybindingRule, {
+      key: "mod+shift+i",
+      command: "composer.focus",
+    });
+    assert.strictEqual(parsedComposerFocus.command, "composer.focus");
+
     const parsedLocal = yield* decode(KeybindingRule, {
       key: "mod+shift+n",
       command: "chat.newLocal",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -72,6 +72,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "filePicker.toggle",
   "projectSearch.toggle",
   "themeEditor.toggle",
+  "composer.focus",
   "composer.stash",
   "chat.new",
   "chat.newLocal",


### PR DESCRIPTION
## What Changed

Add `composer.focus` to Settings → Keybindings → Add keybinding on web and desktop. Users choose the shortcut; there is no default. The existing chat shortcut handler focuses the composer at the end of its draft, including when a terminal has focus.

## Why

There was no configurable shortcut to return to the composer. This reuses the existing command list, settings editor, and composer focus method without adding another event listener.

## Validation

- 84 focused tests passed across keybinding resolution, Settings command options, and contract decoding, including macOS/Windows/Linux modifier matching.
- Web typecheck and targeted lint/format checks passed (existing unrelated lint warnings and typecheck suggestions remain).
- Playwright against an isolated local server with copied data: configured the shortcut through Settings, verified persistence after reload, focused from a terminal without changing the draft, typed at the end, and removed the binding to verify it no longer moves focus.
- Browser-tested the shared web/desktop renderer; the native Electron shell was not launched. No provider, mobile UI, or connection-mode changes.

## UI Changes

| Before | After |
| --- | --- |
| ![Before: no composer focus command](https://github.com/kcybe/t3code/releases/download/pr-evidence-composer-focus/before.png) | ![After: Composer Focus command available](https://github.com/kcybe/t3code/releases/download/pr-evidence-composer-focus/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable **composer focus** keyboard shortcut that moves focus to the current thread’s composer, including from a terminal.
  - Added `composer.focus` to the available keybinding commands. No shortcut is assigned by default; users can configure one in **Settings → Keybindings**.

- **Documentation**
  - Documented the composer focus command and configuration steps.

- **Tests**
  - Added coverage for custom shortcuts across macOS, Windows, and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->