### PR TITLE
fix(web): prevent seams in the topbar scroll fade

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -359,7 +359,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   -webkit-mask-position: top, bottom, right;
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-size:
-    100% var(--workspace-titlebar-scroll-fade-height),
+    100% calc(var(--workspace-titlebar-scroll-fade-height) + 1px),
     100% calc(100% - var(--workspace-titlebar-scroll-fade-height)),
     var(--app-scrollbar-width) 100%;
   mask-image:
@@ -377,7 +377,7 @@ html[data-mobile-composer-route-transition="true"]::view-transition-old(t3-mobil
   mask-position: top, bottom, right;
   mask-repeat: no-repeat;
   mask-size:
-    100% var(--workspace-titlebar-scroll-fade-height),
+    100% calc(var(--workspace-titlebar-scroll-fade-height) + 1px),
     100% calc(100% - var(--workspace-titlebar-scroll-fade-height)),
     var(--app-scrollbar-width) 100%;
 }


### PR DESCRIPTION
## What Changed

Overlap the gradient and solid layers of the topbar scroll mask by 1px, in both `mask-size` and `-webkit-mask-size`.

## Why

Text scrolling under the workspace title bar can acquire a thin dark line where the mask layers meet. At a 17px interface font, the 1.5rem fade is 25.5px high; rasterization can leave a partially transparent row at that fractional boundary. The overlap closes that gap.

The shared utility covers the message timeline, Settings, and pull-request views on web and desktop.

This uses the same approach as the still-open #7787. The screenshots below independently reproduce the issue and verify the fix.

## UI Changes

Captured from the actual T3 Code Electron app with an isolated profile and invented workspace, chat, and browser content. Iris dark theme, 17px interface font, 100% zoom, 1440 × 960 window. Each pair changes only this PR's fix.

| Before | After |
| --- | --- |
| ![Before](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/topbar-before.png) | ![After](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/topbar-after.png) |

<details>
<summary>Full app captures</summary>

Before:

![Full app before](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/topbar-before-full.png)

After:

![Full app after](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/topbar-after-full.png)

</details>

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck` (full workspace)
- From `apps/web`: `bun run test src/components/chat/MessagesTimeline.test.tsx` — 46 tests passed.
- Reproduced the line through real chat text in the desktop test instance and verified that the overlap removes it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change

No animation or interaction behavior changes; a video is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the title bar fade mask to provide smoother scrolling transitions at the top and bottom edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->