### PR TITLE
fix(web): align floating browser preview corners

### DIFF
--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -61,6 +61,10 @@ const RESIZE_HANDLES: ReadonlyArray<{
   { direction: "southeast", className: "-bottom-2 -right-2 size-4 cursor-nwse-resize" },
 ];
 
+/**
+ * Floats the thread's browser surface over chat. Native clipping and the DOM
+ * frame use the same radius so their separately composited edges stay aligned.
+ */
 export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gestureRef = useRef<PointerGesture | null>(null);

--- a/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
+++ b/apps/web/src/components/preview/ThreadPreviewMiniPlayer.tsx
@@ -44,6 +44,8 @@ interface Props {
   readonly bottomInset: number;
 }
 
+const PREVIEW_MINI_PLAYER_CORNER_RADIUS = 12;
+
 // Invisible grab zones straddling each edge; the cursor is the only affordance.
 const RESIZE_HANDLES: ReadonlyArray<{
   readonly direction: BrowserViewportResizeDirection;
@@ -193,7 +195,13 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
           aria-label="Floating browser preview"
           data-preview-mini-player={tabId}
           className="pointer-events-none absolute select-none"
-          style={{ left: frame.x, top: frame.y, width: frame.width, height: frame.height }}
+          style={{
+            left: frame.x,
+            top: frame.y,
+            width: frame.width,
+            height: frame.height,
+            borderRadius: PREVIEW_MINI_PLAYER_CORNER_RADIUS,
+          }}
         >
           <div className="group pointer-events-auto absolute right-2 top-2 z-[49] size-3">
             <div
@@ -267,19 +275,19 @@ export function ThreadPreviewMiniPlayer({ threadRef, tabId, bottomInset }: Props
             </div>
           </div>
 
-          <div className="absolute inset-0 z-[47] rounded-xl bg-muted shadow-2xl/35" />
+          <div className="absolute inset-0 z-[47] rounded-[inherit] bg-muted shadow-2xl/35" />
           <BrowserSurfaceSlot
             tabId={runtimeTabId}
             visible={Boolean(desktopOverlay?.hasWebContents)}
-            cornerRadius={12}
+            cornerRadius={PREVIEW_MINI_PLAYER_CORNER_RADIUS}
             zIndex={PREVIEW_MINI_PLAYER_WEBVIEW_Z_INDEX}
             fitSourceContent
             layoutVersion={`${frame.x}:${frame.y}`}
             className="absolute inset-0"
           />
-          <div className="pointer-events-none absolute inset-0 z-[49] rounded-xl ring-1 ring-inset ring-border/80" />
+          <div className="pointer-events-none absolute inset-0 z-[49] rounded-[inherit] ring-1 ring-inset ring-border/80" />
           {!desktopOverlay?.hasWebContents ? (
-            <div className="pointer-events-none absolute inset-0 z-[49] flex items-center justify-center rounded-xl bg-muted text-xs text-muted-foreground">
+            <div className="pointer-events-none absolute inset-0 z-[49] flex items-center justify-center rounded-[inherit] bg-muted text-xs text-muted-foreground">
               Reconnecting preview…
             </div>
           ) : null}


### PR DESCRIPTION
## What Changed

Use one 12px radius for the floating browser preview's content, border, backdrop, and reconnecting placeholder. The surrounding layers inherit the radius from the preview frame.

## Why

The browser surface already uses a fixed 12px corner radius, while the surrounding `rounded-xl` layers scale with the interface font. At 17px, the border radius becomes 14.625px, placing its curve inside the browser content and leaving a visible double edge. Sharing the existing content radius keeps all layers aligned across interface font sizes.

## UI Changes

Captured from the actual T3 Code Electron app with an isolated profile and invented workspace, chat, and browser content. Iris dark theme, 17px interface font, 100% zoom, 1440 × 960 window. Each pair changes only this PR's fix.

| Before | After |
| --- | --- |
| ![Before](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/preview-before.png) | ![After](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/preview-after.png) |

<details>
<summary>Full app captures</summary>

Before:

![Full app before](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/preview-before-full.png)

After:

![Full app after](https://github.com/caezium/t3code/releases/download/pr-evidence-visual-fixes-2026-09-09/preview-after-full.png)

</details>

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck` (full workspace)
- From `apps/web`: `bun run test src/components/preview/previewMiniPlayerLayout.test.ts src/browser/browserSurfaceStore.test.ts` — 25 tests passed.
- Verified the actual built-in browser's floating preview with a 1280 × 800 sample page and a 360 × 225 preview frame. The border and content corners align after the change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change

No animation or interaction behavior changes; a video is not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual consistency by applying uniform corner rounding across the mini-player preview, including its background, border, and reconnecting overlay.
  * Kept the preview’s native and displayed edges aligned for a smoother, more polished appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->