### PR TITLE
fix(server): pin GitLab merges to current SHA

### DIFF
--- a/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.test.ts
@@ -69,6 +69,7 @@ function notes(count: number, firstId: number): string {
 /** Who opened the merge request, and somebody already reviewing it. */
 const author = { id: 1, username: "bilal" };
 const reviewer = { id: 5, username: "octocat" };
+const diffRefs = { base_sha: "base", head_sha: "head", start_sha: "start" };
 
 /** One merge request as `/merge_requests/:iid` answers with it. */
 function mergeRequestJson(overrides: Record<string, unknown>): string {
@@ -390,7 +391,9 @@ layer("GitLabPullRequestCli.layer", (it) => {
 
   it.effect("merges immediately rather than leaving auto-merge armed", () =>
     Effect.gen(function* () {
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output(mergeRequestJson({ diff_refs: diffRefs }))))
+        .mockReturnValueOnce(Effect.succeed(output("")));
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
 
       yield* cli.runMergeRequestAction({
@@ -401,7 +404,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
         mergeMethod: "squash",
       });
 
-      expect(argsOfCall(0)).toEqual([
+      expect(argsOfCall(1)).toEqual([
         "mr",
         "merge",
         "7",
@@ -410,13 +413,17 @@ layer("GitLabPullRequestCli.layer", (it) => {
         "--auto-merge=false",
         "--yes",
         "--squash",
+        "--sha",
+        "head",
       ]);
     }),
   );
 
   it.effect("arms auto-merge with the same strategy a merge would have used", () =>
     Effect.gen(function* () {
-      mockedExecute.mockReturnValueOnce(Effect.succeed(output("")));
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output(mergeRequestJson({ diff_refs: diffRefs }))))
+        .mockReturnValueOnce(Effect.succeed(output("")));
       const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
 
       yield* cli.runMergeRequestAction({
@@ -427,7 +434,7 @@ layer("GitLabPullRequestCli.layer", (it) => {
         mergeMethod: "squash",
       });
 
-      expect(argsOfCall(0)).toEqual([
+      expect(argsOfCall(1)).toEqual([
         "mr",
         "merge",
         "7",
@@ -436,7 +443,35 @@ layer("GitLabPullRequestCli.layer", (it) => {
         "--auto-merge=true",
         "--yes",
         "--squash",
+        "--sha",
+        "head",
       ]);
+    }),
+  );
+
+  it.effect.each([
+    { action: "merge", label: "merge" },
+    { action: "enable-auto-merge", label: "arm auto-merge" },
+  ] as const)("does not $label without the current diff revisions", ({ action }) =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(output(mergeRequestJson({ diff_refs: null }))),
+      );
+      const cli = yield* GitLabPullRequestCli.GitLabPullRequestCli;
+
+      const error = yield* Effect.flip(
+        cli.runMergeRequestAction({
+          cwd: "/w",
+          repository: "acme/web",
+          number: 7,
+          action,
+          mergeMethod: "squash",
+        }),
+      );
+
+      assert.strictEqual(error._tag, "GitLabDiffRefsUnavailableError");
+      assert.strictEqual(mockedExecute.mock.calls.length, 1);
+      expect(argsOfCall(0)).toEqual(["api", "projects/acme%2Fweb/merge_requests/7"]);
     }),
   );
 

--- a/apps/server/src/pullRequest/GitLabPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitLabPullRequestCli.ts
@@ -1273,6 +1273,27 @@ export const make = Effect.gen(function* () {
         }).pipe(Effect.asVoid);
       }
       const [subcommand, ...flags] = actionArgs(input.action, input.mergeMethod);
+      // GitLab projects can require the current source SHA for every merge attempt.
+      if (input.action === "merge" || input.action === "enable-auto-merge") {
+        return getDiffRefs(input).pipe(
+          Effect.flatMap((refs) =>
+            gitlab.execute({
+              cwd: input.cwd,
+              args: [
+                "mr",
+                subcommand!,
+                String(input.number),
+                "--repo",
+                input.repository,
+                ...flags,
+                "--sha",
+                refs.headSha,
+              ],
+            }),
+          ),
+          Effect.asVoid,
+        );
+      }
       return gitlab
         .execute({
           cwd: input.cwd,


### PR DESCRIPTION
## What Changed

GitLab merge and auto-merge actions now read the merge request diff refs immediately before invoking glab, then pass the current head revision with --sha. If GitLab cannot provide diff refs, the action fails before any merge command runs.

Focused tests cover immediate merge, auto-merge, SHA forwarding, and the missing-revision failure path.

## Why

GitLab projects can require every merge request to include the current source SHA. T3 previously invoked glab mr merge without that guard, so valid Merge clicks could be rejected with the generic host-refused message even when access, checks, and conflicts were all fine.

Reusing the existing diff-ref reader keeps the change inside the GitLab adapter and leaves the shared contracts and clients unchanged.

## Validation

- 56 focused GitLab pull-request tests pass
- Changed files pass formatting and lint
- The server typecheck passes

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes; screenshots and video are not applicable

Built with GPT-5.6-sol in the Codex harness through T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge and auto-merge actions now target the merge request’s current source revision.
  * These actions fail clearly when the source revision cannot be determined, preventing unintended merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->