### PR TITLE
feat(web): add provider model bulk toggle

### DIFF
--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import type { ServerProviderModel } from "@t3tools/contracts";
 
-import { groupModelsForDisplay } from "./ProviderModelsSection";
+import { groupModelsForDisplay, nextHiddenModelsForBulkToggle } from "./ProviderModelsSection";
 
 function model(slug: string, isCustom = false): ServerProviderModel {
   return { slug, name: slug, isCustom, capabilities: null };
@@ -19,5 +19,22 @@ describe("groupModelsForDisplay", () => {
 
     // A custom model is never hidden, even if its slug is in the hidden set.
     expect(display.map((entry) => entry.slug)).toEqual(["c", "d", "b", "custom", "a"]);
+  });
+});
+
+describe("nextHiddenModelsForBulkToggle", () => {
+  it("hides every built-in model without hiding custom models", () => {
+    const models = [model("a"), model("b"), model("custom", true)];
+
+    expect(nextHiddenModelsForBulkToggle(models, ["a"])).toEqual(["a", "b"]);
+  });
+
+  it("shows every built-in model while preserving unrelated hidden entries", () => {
+    const models = [model("a"), model("b"), model("custom", true)];
+
+    expect(nextHiddenModelsForBulkToggle(models, ["a", "b", "legacy", "custom"])).toEqual([
+      "legacy",
+      "custom",
+    ]);
   });
 });

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -96,6 +96,21 @@ export function groupModelsForDisplay<
   ];
 }
 
+export function nextHiddenModelsForBulkToggle(
+  models: ReadonlyArray<Pick<ServerProviderModel, "slug" | "isCustom">>,
+  hiddenModels: ReadonlyArray<string>,
+): string[] {
+  const builtInSlugs = models.filter((model) => !model.isCustom).map((model) => model.slug);
+  const builtInSlugSet = new Set(builtInSlugs);
+  const allBuiltInModelsHidden = builtInSlugs.every((slug) => hiddenModels.includes(slug));
+
+  if (allBuiltInModelsHidden) {
+    return hiddenModels.filter((slug) => !builtInSlugSet.has(slug));
+  }
+
+  return [...new Set([...hiddenModels, ...builtInSlugs])];
+}
+
 interface ProviderModelsSectionProps {
   /** Identifier used to namespace input ids within the DOM. */
   readonly instanceId: ProviderInstanceId;
@@ -181,6 +196,8 @@ export function ProviderModelsSection({
     (model) => !model.isCustom && hiddenModelSet.has(model.slug),
   ).length;
   const builtInModels = useMemo(() => models.filter((model) => !model.isCustom), [models]);
+  const allBuiltInModelsHidden =
+    builtInModels.length > 0 && builtInModels.every((model) => hiddenModelSet.has(model.slug));
   const showFilter = models.length > FILTER_THRESHOLD;
   const normalizedFilter = filter.trim().toLowerCase();
   const isFiltering = showFilter && normalizedFilter.length > 0;
@@ -502,11 +519,27 @@ export function ProviderModelsSection({
             aria-label="Filter models"
           />
         ) : null}
-        <span className="text-xs text-muted-foreground">
-          {models.length} model{models.length === 1 ? "" : "s"}
-          {favoriteCount > 0 ? ` · ${favoriteCount} favorite${favoriteCount === 1 ? "" : "s"}` : ""}
-          {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
-        </span>
+        <div className="flex items-center gap-2">
+          {builtInModels.length > 0 ? (
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost-muted"
+              onClick={() =>
+                onHiddenModelsChange(nextHiddenModelsForBulkToggle(models, hiddenModels))
+              }
+            >
+              {allBuiltInModelsHidden ? "Enable all" : "Disable all"}
+            </Button>
+          ) : null}
+          <span className="text-xs text-muted-foreground">
+            {models.length} model{models.length === 1 ? "" : "s"}
+            {favoriteCount > 0
+              ? ` · ${favoriteCount} favorite${favoriteCount === 1 ? "" : "s"}`
+              : ""}
+            {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
+          </span>
+        </div>
       </div>
       <div
         ref={listRef}


### PR DESCRIPTION
## What Changed

Add a provider-level bulk toggle that disables every built-in model, then changes to enable them after they are all hidden.

## Why

Managing a provider with many models currently requires toggling each model one at a time.

## Evidence

https://github.com/user-attachments/assets/58adc73c-8f61-46ae-bda2-1a90e10c6556

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for UI changes
- [x] I included a video for animation/interaction changes

## Verification

- vp test run apps/web/src/components/settings/ProviderModelsSection.test.ts
- vp run --filter @t3tools/web typecheck

Built with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk toggle in provider settings to disable or enable all built-in models.
  * The toggle updates the model visibility list while preserving custom models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->