### PR TITLE
fix(server): skip imports of native agent sessions

### DIFF
--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -85,7 +85,7 @@ export class ProviderSessionRuntimeRepository extends Context.Service<
     readonly upsert: (
       runtime: ProviderSessionRuntime,
       options?: ProviderSessionRuntimeUpsertOptions,
-    ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
+    ) => Effect.Effect<boolean, ProviderSessionRuntimeRepositoryError>;
 
     /** Record one source file without replacing the current session state. */
     readonly recordImportedTranscript: (
@@ -235,10 +235,12 @@ export const make = Effect.gen(function* () {
       `,
   });
 
-  const insertRuntimeRow = SqlSchema.void({
+  // A no-op conflict update lets RETURNING report allowed reuse without changing the binding.
+  const insertRuntimeRow = SqlSchema.findOneOption({
     Request: ProviderSessionRuntimeDbRowSchema.mapFields(
       Struct.assign({ unlessNativeSessionId: Schema.NullOr(Schema.String) }),
     ),
+    Result: Schema.Struct({ threadId: ThreadId }),
     execute: (runtime) =>
       sql`
         INSERT INTO provider_session_runtime (
@@ -278,7 +280,8 @@ export const make = Effect.gen(function* () {
               END)
             END = ${runtime.unlessNativeSessionId}
         )
-        ON CONFLICT (thread_id) DO NOTHING
+        ON CONFLICT (thread_id) DO UPDATE SET thread_id = provider_session_runtime.thread_id
+        RETURNING thread_id AS "threadId"
       `,
   });
 
@@ -383,8 +386,8 @@ export const make = Effect.gen(function* () {
       ? insertRuntimeRow({
           ...runtime,
           unlessNativeSessionId: options.unlessNativeSessionId ?? null,
-        })
-      : upsertRuntimeRow(runtime)
+        }).pipe(Effect.map(Option.isSome))
+      : upsertRuntimeRow(runtime).pipe(Effect.as(true))
     ).pipe(
       Effect.mapError(
         toPersistenceSqlOrDecodeError(

--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -67,6 +67,7 @@ export type RecordImportedTranscriptInput = typeof RecordImportedTranscriptInput
 
 export interface ProviderSessionRuntimeUpsertOptions {
   readonly onConflict?: "update" | "ignore";
+  readonly unlessNativeSessionId?: string;
 }
 
 /**
@@ -235,7 +236,9 @@ export const make = Effect.gen(function* () {
   });
 
   const insertRuntimeRow = SqlSchema.void({
-    Request: ProviderSessionRuntimeDbRowSchema,
+    Request: ProviderSessionRuntimeDbRowSchema.mapFields(
+      Struct.assign({ unlessNativeSessionId: Schema.NullOr(Schema.String) }),
+    ),
     execute: (runtime) =>
       sql`
         INSERT INTO provider_session_runtime (
@@ -249,7 +252,7 @@ export const make = Effect.gen(function* () {
           resume_cursor_json,
           runtime_payload_json
         )
-        VALUES (
+        SELECT
           ${runtime.threadId},
           ${runtime.providerName},
           ${runtime.providerInstanceId},
@@ -263,6 +266,17 @@ export const make = Effect.gen(function* () {
             THEN json_remove(${runtime.runtimePayload}, '$.importedTranscripts')
             ELSE ${runtime.runtimePayload}
           END
+        WHERE ${runtime.unlessNativeSessionId} IS NULL OR NOT EXISTS (
+          SELECT 1 FROM provider_session_runtime
+          WHERE thread_id NOT LIKE 'import:%'
+            AND provider_name = ${runtime.providerName}
+            AND COALESCE(provider_instance_id, provider_name) = ${runtime.providerInstanceId}
+            AND CASE WHEN json_valid(resume_cursor_json) THEN
+              json_extract(resume_cursor_json, CASE provider_name
+                WHEN 'claudeAgent' THEN '$.resume'
+                WHEN 'codex' THEN '$.threadId'
+              END)
+            END = ${runtime.unlessNativeSessionId}
         )
         ON CONFLICT (thread_id) DO NOTHING
       `,
@@ -365,7 +379,13 @@ export const make = Effect.gen(function* () {
   });
 
   const upsert: ProviderSessionRuntimeRepository["Service"]["upsert"] = (runtime, options) =>
-    (options?.onConflict === "ignore" ? insertRuntimeRow(runtime) : upsertRuntimeRow(runtime)).pipe(
+    (options?.onConflict === "ignore"
+      ? insertRuntimeRow({
+          ...runtime,
+          unlessNativeSessionId: options.unlessNativeSessionId ?? null,
+        })
+      : upsertRuntimeRow(runtime)
+    ).pipe(
       Effect.mapError(
         toPersistenceSqlOrDecodeError(
           "ProviderSessionRuntimeRepository.upsert:query",

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -198,7 +198,7 @@ const runImport = (input: {
 
 it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
   describe("importRecentAgentThreads", () => {
-    it.effect("uses the project root and stores provider-specific resume cursors", () =>
+    it.effect("imports sessions owned by another provider instance", () =>
       Effect.gen(function* () {
         const commands: Array<OrchestrationCommand> = [];
         const bindings: Array<ProviderSessionDirectory.ProviderRuntimeBinding> = [];
@@ -233,7 +233,16 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           recordImportedTranscript: () => Effect.void,
           getBinding: () => Effect.succeed(Option.none()),
           listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
+          listBindings: () =>
+            Effect.succeed([
+              {
+                threadId: ThreadId.make("native-other-instance"),
+                provider: ProviderDriverKind.make("codex"),
+                providerInstanceId: ProviderInstanceId.make("codex-other"),
+                resumeCursor: { threadId: "codex-session" },
+                lastSeenAt: "2026-08-24T10:00:00.000Z",
+              },
+            ]),
         });
 
         const result = yield* runImport({
@@ -338,7 +347,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           recordImportedTranscript: () => Effect.die("unused"),
           getBinding: () => Effect.die("must not read a scanner skip binding"),
           listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
+          listBindings: () => Effect.succeed([]),
         });
 
         const result = yield* runImport({
@@ -416,7 +425,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           getBinding: () =>
             Effect.succeed(bindings[0] === undefined ? Option.none() : Option.some(bindings[0])),
           listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
+          listBindings: () => Effect.succeed([]),
         });
         const snapshots = makeSnapshotsLayer({
           project: makeProject(),
@@ -457,7 +466,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           recordImportedTranscript: () => Effect.void,
           getBinding: () => Effect.succeed(Option.some(runningBinding)),
           listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
+          listBindings: () => Effect.succeed([]),
         });
         const engine = OrchestrationEngine.OrchestrationEngineService.of({
           dispatch: () => Effect.die("must not replay history or settle active work"),
@@ -512,7 +521,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           recordImportedTranscript: () => Effect.die("unused"),
           getBinding: () => Effect.succeed(Option.none()),
           listThreadIds: () => Effect.die("unused"),
-          listBindings: () => Effect.die("unused"),
+          listBindings: () => Effect.succeed([]),
         });
 
         const result = yield* runImport({
@@ -580,6 +589,67 @@ const integrationLayer = Layer.mergeAll(
 );
 
 it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
+  for (const source of ["codex", "claudeAgent"] as const) {
+    it.effect(`does not import a ${source} session already owned by a native thread`, () =>
+      Effect.gen(function* () {
+        const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+        const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const projectId = ProjectId.make(`native-import-${source}`);
+        const threadId = ThreadId.make(`native-${source}`);
+        const thread = {
+          ...makeThread(source),
+          providerSessionId:
+            source === "codex" ? "native-codex-session" : "123e4567-e89b-42d3-a456-426614174001",
+        };
+        yield* engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.make(`create-${projectId}`),
+          projectId,
+          title: "Native project",
+          workspaceRoot: `/tmp/${projectId}`,
+          defaultModelSelection: null,
+          createdAt: thread.createdAt,
+        });
+        yield* engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make(`create-${threadId}`),
+          threadId,
+          projectId,
+          title: "Native conversation",
+          modelSelection: { instanceId: thread.providerInstanceId, model: "default" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt: thread.createdAt,
+        });
+        yield* directory.upsert({
+          threadId,
+          provider: ProviderDriverKind.make(source),
+          providerInstanceId: thread.providerInstanceId,
+          status: "stopped",
+          resumeCursor:
+            source === "codex"
+              ? { threadId: thread.providerSessionId }
+              : { threadId, resume: thread.providerSessionId },
+        });
+        const before = yield* snapshots.getThreadDetailById(threadId);
+        const result = yield* importRecentAgentThreads({ projectId }).pipe(
+          Effect.provideService(AgentSessionScanner.AgentSessionScanner, {
+            scan: Effect.die("unused"),
+            recentThreads: () => Stream.succeed(makeThreadOutcome(thread)),
+          }),
+        );
+        const importedId = ThreadId.make(`import:${source}:${thread.providerSessionId}`);
+        expect(result).toEqual({ importedCount: 0, skippedCount: 1 });
+        expect(yield* snapshots.getThreadDetailById(importedId)).toEqual(Option.none());
+        expect(yield* directory.getBinding(importedId)).toEqual(Option.none());
+        expect(yield* snapshots.getThreadDetailById(threadId)).toEqual(before);
+      }),
+    );
+  }
+
   it.effect("imports once after the real engine persists an old rejected receipt", () =>
     Effect.gen(function* () {
       const engine = yield* OrchestrationEngine.OrchestrationEngineService;

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -231,7 +231,10 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           upsert: (binding) => Effect.sync(() => void bindings.push(binding)),
           getProvider: () => Effect.die("unused"),
           recordImportedTranscript: () => Effect.void,
-          getBinding: () => Effect.succeed(Option.none()),
+          getBinding: (threadId) =>
+            Effect.succeed(
+              Option.fromUndefinedOr(bindings.find((binding) => binding.threadId === threadId)),
+            ),
           listThreadIds: () => Effect.die("unused"),
           listBindings: () =>
             Effect.succeed([
@@ -590,64 +593,93 @@ const integrationLayer = Layer.mergeAll(
 
 it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
   for (const source of ["codex", "claudeAgent"] as const) {
-    it.effect(`does not import a ${source} session already owned by a native thread`, () =>
-      Effect.gen(function* () {
-        const engine = yield* OrchestrationEngine.OrchestrationEngineService;
-        const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
-        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
-        const projectId = ProjectId.make(`native-import-${source}`);
-        const threadId = ThreadId.make(`native-${source}`);
-        const thread = {
-          ...makeThread(source),
-          providerSessionId:
-            source === "codex" ? "native-codex-session" : "123e4567-e89b-42d3-a456-426614174001",
-        };
-        yield* engine.dispatch({
-          type: "project.create",
-          commandId: CommandId.make(`create-${projectId}`),
-          projectId,
-          title: "Native project",
-          workspaceRoot: `/tmp/${projectId}`,
-          defaultModelSelection: null,
-          createdAt: thread.createdAt,
-        });
-        yield* engine.dispatch({
-          type: "thread.create",
-          commandId: CommandId.make(`create-${threadId}`),
-          threadId,
-          projectId,
-          title: "Native conversation",
-          modelSelection: { instanceId: thread.providerInstanceId, model: "default" },
-          runtimeMode: "full-access",
-          interactionMode: "default",
-          branch: null,
-          worktreePath: null,
-          createdAt: thread.createdAt,
-        });
-        yield* directory.upsert({
-          threadId,
-          provider: ProviderDriverKind.make(source),
-          providerInstanceId: thread.providerInstanceId,
-          status: "stopped",
-          resumeCursor:
-            source === "codex"
-              ? { threadId: thread.providerSessionId }
-              : { threadId, resume: thread.providerSessionId },
-        });
-        const before = yield* snapshots.getThreadDetailById(threadId);
-        const result = yield* importRecentAgentThreads({ projectId }).pipe(
-          Effect.provideService(AgentSessionScanner.AgentSessionScanner, {
-            scan: Effect.die("unused"),
-            recentThreads: () => Stream.succeed(makeThreadOutcome(thread)),
-          }),
-        );
-        const importedId = ThreadId.make(`import:${source}:${thread.providerSessionId}`);
-        expect(result).toEqual({ importedCount: 0, skippedCount: 1 });
-        expect(yield* snapshots.getThreadDetailById(importedId)).toEqual(Option.none());
-        expect(yield* directory.getBinding(importedId)).toEqual(Option.none());
-        expect(yield* snapshots.getThreadDetailById(threadId)).toEqual(before);
-      }),
-    );
+    for (const timing of ["before scan", "before reservation"] as const) {
+      it.effect(`skips native ${source} sessions bound ${timing}`, () =>
+        Effect.gen(function* () {
+          const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+          const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+          const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+          const projectId = ProjectId.make(`native-import-${source}-${timing}`);
+          const threadId = ThreadId.make(`native-${source}-${timing}`);
+          const thread = {
+            ...makeThread(source),
+            providerSessionId:
+              source === "codex"
+                ? `native-codex-session-${timing}`
+                : timing === "before scan"
+                  ? "123e4567-e89b-42d3-a456-426614174001"
+                  : "123e4567-e89b-42d3-a456-426614174002",
+          };
+          yield* engine.dispatch({
+            type: "project.create",
+            commandId: CommandId.make(`create-${projectId}`),
+            projectId,
+            title: "Native project",
+            workspaceRoot: `/tmp/${projectId}`,
+            defaultModelSelection: null,
+            createdAt: thread.createdAt,
+          });
+          yield* engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make(`create-${threadId}`),
+            threadId,
+            projectId,
+            title: "Native conversation",
+            modelSelection: { instanceId: thread.providerInstanceId, model: "default" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: thread.createdAt,
+          });
+          const bindNative = directory.upsert({
+            threadId,
+            provider: ProviderDriverKind.make(source),
+            providerInstanceId: thread.providerInstanceId,
+            status: "stopped",
+            resumeCursor:
+              source === "codex"
+                ? { threadId: thread.providerSessionId }
+                : { threadId, resume: thread.providerSessionId },
+          });
+          if (timing === "before scan") yield* bindNative;
+          const before = yield* snapshots.getThreadDetailById(threadId);
+          const result = yield* importRecentAgentThreads({ projectId }).pipe(
+            Effect.provideService(ProviderSessionDirectory.ProviderSessionDirectory, {
+              ...directory,
+              upsert: (binding, options) =>
+                bindNative.pipe(Effect.andThen(directory.upsert(binding, options))),
+            }),
+            Effect.provideService(AgentSessionScanner.AgentSessionScanner, {
+              scan: Effect.die("unused"),
+              recentThreads: () => Stream.succeed(makeThreadOutcome(thread)),
+            }),
+          );
+          const importedId = ThreadId.make(`import:${source}:${thread.providerSessionId}`);
+          expect(result).toEqual({ importedCount: 0, skippedCount: 1 });
+          expect(yield* snapshots.getThreadDetailById(importedId)).toEqual(Option.none());
+          expect(yield* directory.getBinding(importedId)).toEqual(Option.none());
+          expect(yield* snapshots.getThreadDetailById(threadId)).toEqual(before);
+          const otherInstance = ProviderInstanceId.make(`${source}-other`);
+          const otherThreadId = ThreadId.make(
+            `import:${otherInstance}:${thread.providerSessionId}`,
+          );
+          yield* directory.upsert(
+            {
+              threadId: otherThreadId,
+              provider: ProviderDriverKind.make(source),
+              providerInstanceId: otherInstance,
+              resumeCursor:
+                source === "codex"
+                  ? { threadId: thread.providerSessionId }
+                  : { resume: thread.providerSessionId },
+            },
+            { onConflict: "ignore", unlessNativeSessionId: thread.providerSessionId },
+          );
+          expect(Option.isSome(yield* directory.getBinding(otherThreadId))).toBe(true);
+        }),
+      );
+    }
   }
 
   it.effect("imports once after the real engine persists an old rejected receipt", () =>

--- a/apps/server/src/project/AgentSessionImporter.test.ts
+++ b/apps/server/src/project/AgentSessionImporter.test.ts
@@ -228,7 +228,7 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
           latestSequence: Effect.succeed(0),
         });
         const directory = ProviderSessionDirectory.ProviderSessionDirectory.of({
-          upsert: (binding) => Effect.sync(() => void bindings.push(binding)),
+          upsert: (binding) => Effect.sync(() => bindings.push(binding)).pipe(Effect.as(true)),
           getProvider: () => Effect.die("unused"),
           recordImportedTranscript: () => Effect.void,
           getBinding: (threadId) =>
@@ -420,8 +420,8 @@ it.layer(NodeServices.layer)("AgentSessionImporter", (it) => {
                 }),
               );
             }
-            bindings.push(binding);
-            return Effect.void;
+            if (bindings.length === 0) bindings.push(binding);
+            return Effect.succeed(true);
           },
           getProvider: () => Effect.die("unused"),
           recordImportedTranscript: () => Effect.void,
@@ -677,6 +677,121 @@ it.layer(integrationLayer)("AgentSessionImporter integration", (it) => {
             { onConflict: "ignore", unlessNativeSessionId: thread.providerSessionId },
           );
           expect(Option.isSome(yield* directory.getBinding(otherThreadId))).toBe(true);
+        }),
+      );
+    }
+  }
+
+  for (const source of ["codex", "claudeAgent"] as const) {
+    for (const owner of ["same instance", "other instance", "none"] as const) {
+      it.effect(`rechecks a reserved ${source} import with native owner in ${owner}`, () =>
+        Effect.gen(function* () {
+          const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+          const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+          const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+          const projectId = ProjectId.make(`retry-native-${source}-${owner}`);
+          const nativeId = ThreadId.make(`native-${projectId}`);
+          const thread = {
+            ...makeThread(source),
+            providerSessionId:
+              source === "codex"
+                ? `retry-native-${owner}`
+                : owner === "same instance"
+                  ? "123e4567-e89b-42d3-a456-426614174011"
+                  : owner === "other instance"
+                    ? "123e4567-e89b-42d3-a456-426614174012"
+                    : "123e4567-e89b-42d3-a456-426614174013",
+          };
+          const importedId = ThreadId.make(`import:${source}:${thread.providerSessionId}`);
+          yield* engine.dispatch({
+            type: "project.create",
+            commandId: CommandId.make(`create-${projectId}`),
+            projectId,
+            title: "Retry native ownership",
+            workspaceRoot: `/tmp/${projectId}`,
+            defaultModelSelection: null,
+            createdAt: thread.createdAt,
+          });
+          yield* engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make(`create-${nativeId}`),
+            threadId: nativeId,
+            projectId,
+            title: "Native conversation",
+            modelSelection: { instanceId: thread.providerInstanceId, model: "default" },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: thread.createdAt,
+          });
+          const scanner = AgentSessionScanner.AgentSessionScanner.of({
+            scan: Effect.die("unused"),
+            recentThreads: () => Stream.succeed(makeThreadOutcome(thread)),
+          });
+          const failed = yield* importRecentAgentThreads({ projectId }).pipe(
+            Effect.provideService(AgentSessionScanner.AgentSessionScanner, scanner),
+            Effect.provideService(OrchestrationEngine.OrchestrationEngineService, {
+              ...engine,
+              dispatch: (command) =>
+                command.type === "thread.create"
+                  ? Effect.fail(
+                      new OrchestrationCommandInvariantError({
+                        commandType: command.type,
+                        detail: "Injected thread creation failure after reservation.",
+                      }),
+                    )
+                  : engine.dispatch(command),
+            }),
+          );
+          expect(failed).toEqual({ importedCount: 0, skippedCount: 1 });
+          expect(yield* snapshots.getThreadDetailById(importedId)).toEqual(Option.none());
+          const reservation = yield* directory.getBinding(importedId);
+          expect(Option.getOrThrow(reservation).status).toBe("stopped");
+          const nativeBefore = yield* snapshots.getThreadDetailById(nativeId);
+
+          const result = yield* importRecentAgentThreads({ projectId }).pipe(
+            Effect.provideService(AgentSessionScanner.AgentSessionScanner, {
+              ...scanner,
+              recentThreads: () =>
+                Stream.fromEffect(
+                  Effect.gen(function* () {
+                    if (owner !== "none") {
+                      yield* directory.upsert({
+                        threadId: nativeId,
+                        provider: ProviderDriverKind.make(source),
+                        providerInstanceId:
+                          owner === "same instance"
+                            ? thread.providerInstanceId
+                            : ProviderInstanceId.make(`${source}-other`),
+                        status: "running",
+                        resumeCursor:
+                          source === "codex"
+                            ? { threadId: thread.providerSessionId }
+                            : { threadId: nativeId, resume: thread.providerSessionId },
+                      });
+                    }
+                    return makeThreadOutcome(thread);
+                  }).pipe(Effect.orDie),
+                ),
+            }),
+          );
+          expect(yield* snapshots.getThreadDetailById(nativeId)).toEqual(nativeBefore);
+          if (owner === "same instance") {
+            expect(result).toEqual({ importedCount: 0, skippedCount: 1 });
+            expect(yield* snapshots.getThreadDetailById(importedId)).toEqual(Option.none());
+            expect(yield* directory.getBinding(importedId)).toEqual(reservation);
+          } else {
+            expect(result).toEqual({ importedCount: 1, skippedCount: 0 });
+            expect(
+              Option.getOrThrow(yield* snapshots.getThreadDetailById(importedId)).messages.map(
+                (message) => message.text,
+              ),
+            ).toEqual(thread.messages.map((message) => message.text));
+            expect(Option.getOrThrow(yield* directory.getBinding(importedId)).resumeCursor).toEqual(
+              Option.getOrThrow(reservation).resumeCursor,
+            );
+          }
         }),
       );
     }

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -21,6 +21,7 @@ import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
@@ -133,6 +134,26 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
     completedSources.map((entry) => entry.source),
   );
   const importedThreadIds = new Set<ThreadId>();
+  const nativeSessions = new Set<string>();
+  const bindings = yield* directory
+    .listBindings()
+    .pipe(
+      Effect.mapError((cause) => new AgentSessionScanError({ operation: "read-projects", cause })),
+    );
+  for (const binding of bindings) {
+    if (binding.threadId.startsWith("import:") || !Predicate.isObject(binding.resumeCursor)) {
+      continue;
+    }
+    const sessionId =
+      binding.provider === "claudeAgent"
+        ? binding.resumeCursor.resume
+        : binding.provider === "codex"
+          ? binding.resumeCursor.threadId
+          : undefined;
+    if (typeof sessionId === "string" && binding.providerInstanceId !== undefined) {
+      nativeSessions.add(`${binding.providerInstanceId}\0${sessionId}`);
+    }
+  }
   let importedCount = 0;
   let skippedCount = 0;
 
@@ -164,6 +185,10 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
         return;
       }
       const thread = outcome.thread;
+      if (nativeSessions.has(`${thread.providerInstanceId}\0${thread.providerSessionId}`)) {
+        skippedCount += 1;
+        return;
+      }
       const threadId = ThreadId.make(
         `import:${thread.providerInstanceId}:${thread.providerSessionId}`,
       );

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -244,27 +244,24 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
           return yield* new AgentSessionThreadModifiedError({ threadId });
         }
 
-        // Install the cursor before the thread becomes visible. A concurrent
-        // real session can replace it, while insert-ignore keeps this import
-        // from replacing that newer binding.
-        if (Option.isNone(existingBinding)) {
-          yield* directory.upsert(
-            {
-              threadId,
-              provider,
-              providerInstanceId: thread.providerInstanceId,
-              status: "stopped",
-              runtimeMode: DEFAULT_RUNTIME_MODE,
-              resumeCursor:
-                thread.source === "codex"
-                  ? { threadId: thread.providerSessionId }
-                  : { threadId, resume: thread.providerSessionId },
-              runtimePayload: { cwd: workspaceRoot },
-            },
-            { onConflict: "ignore", unlessNativeSessionId: thread.providerSessionId },
-          );
-          if (Option.isNone(yield* directory.getBinding(threadId))) return false;
-        }
+        // Check native ownership even when retrying an old reservation, without
+        // replacing a binding that a real session may have updated.
+        const reserved = yield* directory.upsert(
+          {
+            threadId,
+            provider,
+            providerInstanceId: thread.providerInstanceId,
+            status: "stopped",
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            resumeCursor:
+              thread.source === "codex"
+                ? { threadId: thread.providerSessionId }
+                : { threadId, resume: thread.providerSessionId },
+            runtimePayload: { cwd: workspaceRoot },
+          },
+          { onConflict: "ignore", unlessNativeSessionId: thread.providerSessionId },
+        );
+        if (!reserved) return false;
 
         if (Option.isNone(existingThread)) {
           yield* engine.dispatch({

--- a/apps/server/src/project/AgentSessionImporter.ts
+++ b/apps/server/src/project/AgentSessionImporter.ts
@@ -261,8 +261,9 @@ export const importRecentAgentThreads = Effect.fn("importRecentAgentThreads")(fu
                   : { threadId, resume: thread.providerSessionId },
               runtimePayload: { cwd: workspaceRoot },
             },
-            { onConflict: "ignore" },
+            { onConflict: "ignore", unlessNativeSessionId: thread.providerSessionId },
           );
+          if (Option.isNone(yield* directory.getBinding(threadId))) return false;
         }
 
         if (Option.isNone(existingThread)) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -221,7 +221,7 @@ function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolea
 }
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
-  upsert: () => Effect.void,
+  upsert: () => Effect.succeed(true),
   recordImportedTranscript: () => Effect.die("unused"),
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -519,7 +519,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
 };
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
-  upsert: () => Effect.void,
+  upsert: () => Effect.succeed(true),
   recordImportedTranscript: () => Effect.die("unused"),
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -4762,7 +4762,7 @@ const getBinding = vi.fn((threadId: ThreadId) =>
 );
 const boundedListing = makeProviderServiceLayer({
   directory: {
-    upsert: () => Effect.void,
+    upsert: () => Effect.succeed(true),
     recordImportedTranscript: () => Effect.die("unused"),
     getProvider: () => Effect.die("ProviderService.listSessions does not use getProvider"),
     getBinding,

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -125,7 +125,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
         issue: "providerInstanceId is required for provider session runtime bindings.",
       });
     }
-    yield* repository
+    return yield* repository
       .upsert(
         {
           threadId: resolvedThreadId,

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -43,15 +43,16 @@ export type ProviderSessionDirectoryWriteError =
 
 export interface ProviderSessionDirectoryUpsertOptions {
   readonly onConflict?: "update" | "ignore";
-  // For insert-ignore imports, reserve only if no native binding owns this session.
+  // For insert-ignore imports, allow insertion or reuse only without a native owner.
   readonly unlessNativeSessionId?: string;
 }
 
 export interface ProviderSessionDirectoryShape {
+  // Returns false when native ownership blocks an import reservation.
   readonly upsert: (
     binding: ProviderRuntimeBinding,
     options?: ProviderSessionDirectoryUpsertOptions,
-  ) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
+  ) => Effect.Effect<boolean, ProviderSessionDirectoryWriteError>;
 
   /** Record an imported file without changing the current provider session. */
   readonly recordImportedTranscript: (input: {

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -43,6 +43,8 @@ export type ProviderSessionDirectoryWriteError =
 
 export interface ProviderSessionDirectoryUpsertOptions {
   readonly onConflict?: "update" | "ignore";
+  // For insert-ignore imports, reserve only if no native binding owns this session.
+  readonly unlessNativeSessionId?: string;
 }
 
 export interface ProviderSessionDirectoryShape {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -796,7 +796,7 @@ const buildAppUnderTest = (options?: {
             ...options?.layers?.antigravityInstallation,
           }),
           Layer.mock(ProviderSessionDirectory.ProviderSessionDirectory)({
-            upsert: () => Effect.void,
+            upsert: () => Effect.succeed(true),
             getBinding: () => Effect.succeed(Option.none()),
             listThreadIds: () => Effect.succeed([]),
             listBindings: () => Effect.succeed([]),

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -150,7 +150,7 @@ it.effect("marks active running sessions that have persisted resume state", () =
             }),
           ),
         ),
-      upsert: (binding) => Effect.sync(() => upserts.push(binding)),
+      upsert: (binding) => Effect.sync(() => upserts.push(binding)).pipe(Effect.as(true)),
       recordImportedTranscript: () => Effect.die("unused"),
       getProvider: () => Effect.die("unused"),
       listThreadIds: () => Effect.die("unused"),
@@ -279,6 +279,7 @@ it.effect.each(
               Effect.flatMap((firstMarkerCleared) =>
                 firstMarkerCleared ? Deferred.succeed(continuationCleared, undefined) : Effect.void,
               ),
+              Effect.as(true),
             ),
           recordImportedTranscript: () => Effect.die("unused"),
           getProvider: () => Effect.die("unused"),
@@ -412,7 +413,7 @@ it.effect("does not continue archived or deleted marked sessions", () => {
           }),
         );
       },
-      upsert: () => Effect.void,
+      upsert: () => Effect.succeed(true),
       recordImportedTranscript: () => Effect.die("unused"),
       getProvider: () => Effect.die("unused"),
       listThreadIds: () => Effect.die("unused"),
@@ -468,7 +469,7 @@ it.effect("retries continuation preparation before settling a persistent failure
             },
           }),
         ),
-      upsert: () => Effect.void,
+      upsert: () => Effect.succeed(true),
       recordImportedTranscript: () => Effect.die("unused"),
       getProvider: () => Effect.die("unused"),
       listThreadIds: () => Effect.die("unused"),
@@ -540,7 +541,7 @@ it.effect("reconciles multiple active and archived orphans but skips live sessio
             }),
           ),
         ),
-      upsert: (binding) => Effect.sync(() => upserts.push(binding)),
+      upsert: (binding) => Effect.sync(() => upserts.push(binding)).pipe(Effect.as(true)),
       recordImportedTranscript: () => Effect.die("unused"),
       getProvider: () => Effect.die("unused"),
       listThreadIds: () => Effect.die("unused"),
@@ -658,7 +659,7 @@ it.effect("retries failed projections and continues after a persistent failure",
     threads: [transient, persistent, later],
     directory: {
       getBinding: () => Effect.succeed(Option.none()),
-      upsert: () => Effect.void,
+      upsert: () => Effect.succeed(true),
       recordImportedTranscript: () => Effect.die("unused"),
       getProvider: () => Effect.die("unused"),
       listThreadIds: () => Effect.die("unused"),
@@ -774,6 +775,7 @@ for (const scenario of [
         upsert: (binding) =>
           Effect.sync(() => {
             upserts.push(binding);
+            return true;
           }),
         recordImportedTranscript: () => Effect.die("unused"),
         getProvider: () => Effect.die("unused"),
@@ -846,8 +848,10 @@ for (const preparedStatus of [
           upsert: (next: ProviderSessionDirectory.ProviderRuntimeBinding) =>
             Effect.gen(function* () {
               binding = next;
-              if (binding.status !== "starting" || sends.length === 0) return;
-              yield* Deferred.succeed(cleared, undefined);
+              if (binding.status === "starting" && sends.length > 0) {
+                yield* Deferred.succeed(cleared, undefined);
+              }
+              return true;
             }),
           recordImportedTranscript: () => Effect.die("unused"),
           getProvider: () => Effect.die("unused"),
@@ -954,6 +958,7 @@ it.effect("settles failed opt-in recovery without retrying the provider turn", (
         upsert: (next) =>
           Effect.sync(() => {
             binding = next;
+            return true;
           }),
         recordImportedTranscript: () => Effect.die("unused"),
         getProvider: () => Effect.die("unused"),


### PR DESCRIPTION
Bulk import could create a second thread for a Claude or Codex session already owned by a native T3 thread. The importer only checked the generated `import:` thread ID.

Read runtime bindings once per import batch to skip known native sessions, scoped to the provider instance. Check native ownership again atomically in the SQLite insert that reserves each new import binding, covering bindings created during transcript scanning. Existing import retries keep their current behavior.

Fixes #10933's same-environment duplication. This does not remove existing duplicates or deduplicate across environments. Project discovery keeps its existing path-based meaning; related #10631 handles individual Claude attachment.

Validation: reproduced duplicate creation before the initial fix and reproduced the concurrent binding race before this follow-up, for both providers. All 26 importer and directory tests pass, including unchanged native threads, no duplicate bindings, and provider-instance isolation. Server typecheck and targeted lint pass. No UI changes.

Implemented with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented native Claude and Codex sessions from being imported again.
  * Existing native sessions are now skipped without creating duplicate imported threads or bindings.
  * Improved session import handling when sessions are already associated with another provider instance.
  * Session imports now safely handle timing differences when native session associations are created during an import.
  * Improved reliability when an import fails before a native session is fully established, preserving the correct session ownership and reservation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->