### PR TITLE
fix(server): explain a disabled tailnet Serve instead of timing out

### DIFF
--- a/apps/server/src/cli/pair.ts
+++ b/apps/server/src/cli/pair.ts
@@ -104,6 +104,15 @@ export class MagicDnsNameMissingError extends Schema.TaggedError<MagicDnsNameMis
   }
 }
 
+export class TailscaleServeNotEnabledError extends Schema.TaggedError<TailscaleServeNotEnabledError>()(
+  "TailscaleServeNotEnabledError",
+  {},
+) {
+  override get message(): string {
+    return "Tailscale Serve is not enabled on your tailnet. Enable HTTPS certificates at https://login.tailscale.com/admin/dns, then run this command again.";
+  }
+}
+
 export class ServesOtherEnvironmentError extends Schema.TaggedError<ServesOtherEnvironmentError>()(
   "ServesOtherEnvironmentError",
   { servePort: Schema.Number },
@@ -364,6 +373,12 @@ const resolveTailscalePairingBase = Effect.fn("pair.resolveTailscalePairingBase"
     );
     if (status.magicDnsName === null) {
       return yield* new MagicDnsNameMissingError();
+    }
+    // Without the HTTPS capability `tailscale serve` prints an enablement URL
+    // and blocks on it forever, so letting it run only buys a timeout that
+    // names neither the setting nor where to change it.
+    if (status.httpsServeEnabled === false) {
+      return yield* new TailscaleServeNotEnabledError();
     }
     const baseUrl = buildTailscaleHttpsBaseUrl({
       magicDnsName: status.magicDnsName,

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -149,7 +149,34 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.100.100.100"],
+        httpsServeEnabled: null,
       });
+    }),
+  );
+
+  it.effect("reads the HTTPS serve capability from the status capability map", () =>
+    Effect.gen(function* () {
+      const enabled = yield* parseTailscaleStatus(
+        `{"Self":{"CapMap":{"https":null,"funnel":null}}}`,
+      );
+      assert.equal(enabled.httpsServeEnabled, true);
+
+      const disabled = yield* parseTailscaleStatus(`{"Self":{"CapMap":{"funnel":null}}}`);
+      assert.equal(disabled.httpsServeEnabled, false);
+    }),
+  );
+
+  // A missing or malformed capability map must not read as "disabled": callers
+  // refuse to run `tailscale serve` on false, so guessing would break a tailnet
+  // that is actually fine.
+  it.effect("reports an unknown HTTPS serve capability rather than guessing", () =>
+    Effect.gen(function* () {
+      assert.equal((yield* parseTailscaleStatus(`{"Self":{}}`)).httpsServeEnabled, null);
+      assert.equal((yield* parseTailscaleStatus("{}")).httpsServeEnabled, null);
+      assert.equal(
+        (yield* parseTailscaleStatus(`{"Self":{"CapMap":["https"]}}`)).httpsServeEnabled,
+        null,
+      );
     }),
   );
 
@@ -191,6 +218,7 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.90.1.2"],
+        httpsServeEnabled: null,
       });
     });
   });

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -131,6 +131,7 @@ export class TailscaleStatusParseError extends Schema.TaggedError<TailscaleStatu
 const TailscaleStatusSelf = Schema.Struct({
   DNSName: Schema.optional(Schema.Unknown),
   TailscaleIPs: Schema.optional(Schema.Unknown),
+  CapMap: Schema.optional(Schema.Unknown),
 });
 
 const TailscaleStatusJson = Schema.Struct({
@@ -142,6 +143,29 @@ export type TailscaleStatusJson = typeof TailscaleStatusJson.Type;
 export interface TailscaleStatus {
   readonly magicDnsName: string | null;
   readonly tailnetIpv4Addresses: readonly string[];
+  /**
+   * Whether the control plane grants this node the capability that
+   * `tailscale serve --https` requires. `null` means `tailscale status` did not
+   * report a capability map at all: an older CLI or an unexpected shape must
+   * not read as "disabled", because that would block a working tailnet.
+   */
+  readonly httpsServeEnabled: boolean | null;
+}
+
+/**
+ * Capability the control plane grants once a tailnet enables HTTPS
+ * certificates. Without it `tailscale serve` prints an enablement URL and then
+ * blocks until someone visits it, which reads to a caller as an unexplained
+ * timeout rather than a setting it can name.
+ */
+const HTTPS_SERVE_CAPABILITY = "https";
+
+function readHttpsServeEnabled(status: TailscaleStatusJson): boolean | null {
+  const capabilities = status.Self?.CapMap;
+  if (typeof capabilities !== "object" || capabilities === null || Array.isArray(capabilities)) {
+    return null;
+  }
+  return Object.hasOwn(capabilities, HTTPS_SERVE_CAPABILITY);
 }
 
 const collectStdout = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -212,6 +236,7 @@ export const parseTailscaleStatus = (
       return {
         magicDnsName: normalizeMagicDnsName(parsed),
         tailnetIpv4Addresses,
+        httpsServeEnabled: readHttpsServeEnabled(parsed),
       };
     }),
   );


### PR DESCRIPTION
## Problem

When a tailnet has not enabled HTTPS certificates, `tailscale serve` prints an enablement URL and then **blocks indefinitely** waiting for someone to visit it. It never exits, so `runTailscaleCommand` hits its 10s timeout and `t3 pair --tailscale` reports this:

```
ERROR (#5): TailscaleServeFailedError: tailscale serve failed for HTTPS port 443.
Run `tailscale serve --https=443 --bg <local-url>` by hand to see why.
  [cause]: TailscaleCommandTimeoutError: tailscale serve timed out after 10000ms.
    [cause]: TimeoutError: TimeoutError
```

Nothing there names the setting or where to change it, and the suggested command reproduces the hang rather than explaining it. Running it by hand is what surfaces the real reason:

```
Serve is not enabled on your tailnet.
To enable, visit:

	https://login.tailscale.com/f/serve?node=<node-id>
```

## Fix

`tailscale status --json` already reports the capability that gates serve, as `Self.CapMap["https"]`, and `resolveTailscalePairingBase` already reads that status to build the MagicDNS base URL — so the check costs no extra spawn and no extra latency. This matters on macOS in particular, where each CLI spawn can re-trigger Tailscale's TCC prompt.

A tailnet without the capability now fails immediately with a message that names the setting and the admin page:

> Tailscale Serve is not enabled on your tailnet. Enable HTTPS certificates at https://login.tailscale.com/admin/dns, then run this command again.

The new fact is deliberately tri-state. `httpsServeEnabled` is `null` when `tailscale status` reports no capability map at all, and only `false` when a map is present and lacks `https`. An older CLI or an unexpected JSON shape stays `null` and still attempts serve, so this cannot block a tailnet that is actually fine.

No raw CLI output is surfaced, matching the existing rule in this package that `tailscale` stderr carries auth keys and node identifiers and must not reach a log. The node-scoped enablement URL the CLI prints is deliberately **not** reproduced; the message points at the stable admin page instead.

## Scope

Limited to the `t3 pair --tailscale` path, which is where the failure is user-facing and fatal.

`serve --tailscale-serve` (`apps/server/src/server.ts`) reaches the same blocking CLI, but already catches the failure and logs a warning while the server keeps running, so it costs a 10s startup stall rather than a dead end. Adding the same guard there would mean a `tailscale status` spawn on every start with serve enabled — the TCC prompt cost noted above — so it is left out rather than folded into this change.

## Verification

- `vp test run` in `packages/tailscale` — 16 passed, including two new cases covering the enabled/disabled read and the unknown-rather-than-guess behavior.
- `tsc --noEmit` clean in `packages/tailscale` and `apps/server`.
- `vp lint` clean on all three changed files.
- Reproduced the original hang and the fixed message against a real tailnet (Tailscale 1.102.3, macOS), before and after enabling HTTPS certificates.

Written by Claude Opus 5 in Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Tailscale pairing behavior by detecting when HTTPS serving is disabled before attempting setup.
  - Prevents pairing from becoming blocked by an enablement prompt and provides a clear error instead.
  - Tailscale status handling now accurately reports whether HTTPS serving is enabled, disabled, or unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->