### PR TITLE
fix(web): name the step that registers a mobile client

### DIFF
--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
@@ -94,8 +94,9 @@ function EmptyMobileClients() {
       <EmptyHeader>
         <EmptyTitle className="text-[1.0625rem] leading-6">No mobile clients</EmptyTitle>
         <EmptyDescription className="text-[0.8125rem] leading-[1.125rem]">
-          Sign in to T3 Code on your iPhone to register it for push notifications and Live
-          Activities.
+          Install T3 Code on your phone and sign in to T3 Connect with this account to register it
+          for push notifications and Live Activities. Pairing a phone directly to an environment
+          over your LAN or Tailscale does not register it here.
         </EmptyDescription>
       </EmptyHeader>
     </Empty>

--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
@@ -95,8 +95,8 @@ function EmptyMobileClients() {
         <EmptyTitle className="text-[1.0625rem] leading-6">No mobile clients</EmptyTitle>
         <EmptyDescription className="text-[0.8125rem] leading-[1.125rem]">
           Install T3 Code on your phone and sign in to T3 Connect with this account to register it
-          for push notifications and Live Activities. Pairing a phone directly to an environment
-          over your LAN or Tailscale does not register it here.
+          for push notifications and Live Activities. Registration follows that sign-in, whichever
+          connection the phone uses to reach your environments.
         </EmptyDescription>
       </EmptyHeader>
     </Empty>


### PR DESCRIPTION
## Problem

The **Mobile clients** empty state reads:

> Sign in to T3 Code on your iPhone to register it for push notifications and Live Activities.

That is satisfiable in a way that does nothing. Signing in to the mobile app and pairing it to an environment — over a LAN address or a Tailscale link — is a reasonable reading of "sign in to T3 Code on your iPhone", and it leaves this page empty.

Registration needs a T3 Connect token. Without one, `remoteRegistration.ts:369` skips it and logs `relay device registration skipped; user is not signed in`. So a user who has done everything the sentence asks lands on an empty page with nothing to act on and no way to tell which part is missing.

I hit this myself: phone paired over Tailscale, fully working — I could start a session on my desktop from it — and this page still said "No mobile clients" and told me to do the thing I had already done.

## Fix

Copy only. Name the sign-in that registers a device, and rule out the one that doesn't:

> Install T3 Code on your phone and sign in to T3 Connect with this account to register it for push notifications and Live Activities. Pairing a phone directly to an environment over your LAN or Tailscale does not register it here.

The second sentence mirrors the guarantee already documented in `docs/user/mobile-notifications.md`:

> Background delivery requires T3 Connect; a direct or Tailscale connection alone does not enable push notifications.

No logic, props, or layout change — `EmptyMobileClients` has no conditional branches, so the rendered result differs only in this string.

## On the before/after images

`CONTRIBUTING.md` asks for before/after images. I have the before (attached below) but could not capture the after in a dev build, and would rather say so than pad the PR with a misleading substitute.

The panel is a Clerk `UserButton.UserProfilePage`, so it only renders for a signed-in Clerk session. The web dev server cannot get one: the production Clerk instance rejects a localhost origin outright.

```
Origin: http://localhost:5733  -> HTTP 400  {"code":"origin_invalid"}
Origin: https://app.t3.codes   -> HTTP 200
```

`isLoaded` therefore stays `false` and the sign-in never mounts. `pnpm dev:desktop` should route around this through `@clerk/electron`, and the shell does load — `@clerk/electron/react` resolves and Vite pre-bundles it — but sign-in still did not come up in a dev desktop build, which looked unrelated to this change and not worth chasing further.

Happy to add the after image if a maintainer can produce it, or to drop this if the copy is not wanted.

## Verification

- `vp lint` clean on the changed file.
- `tsc --noEmit` clean in `apps/web`.

Written by Claude Opus 5 in Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the empty mobile clients message with clearer instructions to install T3 Code, sign in to T3 Connect, and register the phone using the same account.
  - Clarified that registration occurs regardless of which connection is used to access environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->