### PR TITLE
feat(web): auto-reconcile external agent sessions on project open

### DIFF
--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { RpcClientError } from "effect/unstable/rpc";
 
-import { selectUnreconciledProjects } from "./useAgentSessionAutoReconcile";
+import { classifyImportFailure, selectUnreconciledProjects } from "./useAgentSessionAutoReconcile";
 
 function makeProject(
   environmentId: string,
@@ -85,5 +88,66 @@ describe("selectUnreconciledProjects", () => {
     const reAdded = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
     const afterReAdd = selectUnreconciledProjects(reAdded, reconciled);
     expect(afterReAdd).toHaveLength(0);
+  });
+});
+
+describe("classifyImportFailure", () => {
+  it("classifies an interrupted result as interrupted", () => {
+    const result = AsyncResult.failure(Cause.interrupt());
+    expect(classifyImportFailure(result)).toBe("interrupted");
+  });
+
+  it("classifies an RpcClientError as unsupported-server", () => {
+    const rpcError = new RpcClientError.RpcClientError({
+      reason: new RpcClientError.RpcClientDefect({
+        message: "unknown method",
+        cause: new Error("socket closed"),
+      }),
+    });
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(rpcError)))).toBe(
+      "unsupported-server",
+    );
+  });
+
+  it("classifies AgentSessionImportProjectNotFoundError as expected", () => {
+    const error = { _tag: "AgentSessionImportProjectNotFoundError" as const, projectId: "proj-1" };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("expected");
+  });
+
+  it("classifies AgentSessionImportProjectChangedError as expected", () => {
+    const error = { _tag: "AgentSessionImportProjectChangedError" as const, projectId: "proj-1" };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("expected");
+  });
+
+  it("classifies AgentSessionScanError as expected", () => {
+    const error = { _tag: "AgentSessionScanError" as const, operation: "read-settings" };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("expected");
+  });
+
+  it("classifies EnvironmentRpcUnavailableError as expected", () => {
+    const error = { _tag: "EnvironmentRpcUnavailableError" as const, environmentId: "env-1" };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("expected");
+  });
+
+  it("classifies EnvironmentAuthorizationError as expected", () => {
+    const error = { _tag: "EnvironmentAuthorizationError" as const };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("expected");
+  });
+
+  it("classifies a die (defect) as unexpected", () => {
+    expect(classifyImportFailure(AsyncResult.failure(Cause.die(new Error("boom"))))).toBe(
+      "unexpected",
+    );
+  });
+
+  it("classifies an unknown tagged error as unexpected", () => {
+    const error = { _tag: "SomethingWeird" as const };
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(error)))).toBe("unexpected");
+  });
+
+  it("classifies a plain Error as unexpected", () => {
+    expect(classifyImportFailure(AsyncResult.failure(Cause.fail(new Error("plain"))))).toBe(
+      "unexpected",
+    );
   });
 });

--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
+
+import { selectUnreconciledProjects } from "./useAgentSessionAutoReconcile";
+
+function makeProject(
+  environmentId: string,
+  projectId: string,
+  workspaceRoot = `/home/user/${projectId}`,
+): EnvironmentProject {
+  return {
+    environmentId: environmentId as EnvironmentId,
+    id: projectId as ProjectId,
+    title: projectId,
+    workspaceRoot,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  } as EnvironmentProject;
+}
+
+describe("selectUnreconciledProjects", () => {
+  it("returns all projects when none have been reconciled", () => {
+    const reconciled = new Set<string>();
+    const projects = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
+    const result = selectUnreconciledProjects(projects, reconciled);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.id).toBe("proj-a");
+    expect(result[1]!.id).toBe("proj-b");
+  });
+
+  it("marks returned projects as reconciled", () => {
+    const reconciled = new Set<string>();
+    const projects = [makeProject("env-1", "proj-a")];
+    selectUnreconciledProjects(projects, reconciled);
+    expect(reconciled.has("env-1\0proj-a")).toBe(true);
+  });
+
+  it("skips already-reconciled projects on subsequent calls", () => {
+    const reconciled = new Set<string>();
+    const projects = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
+    selectUnreconciledProjects(projects, reconciled);
+    const result = selectUnreconciledProjects(projects, reconciled);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns only newly added projects", () => {
+    const reconciled = new Set<string>();
+    const initial = [makeProject("env-1", "proj-a")];
+    selectUnreconciledProjects(initial, reconciled);
+
+    const withNew = [...initial, makeProject("env-1", "proj-b")];
+    const result = selectUnreconciledProjects(withNew, reconciled);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("proj-b");
+  });
+
+  it("returns empty array when projects list is empty", () => {
+    const reconciled = new Set<string>();
+    const result = selectUnreconciledProjects([], reconciled);
+    expect(result).toHaveLength(0);
+  });
+
+  it("distinguishes projects with the same id across different environments", () => {
+    const reconciled = new Set<string>();
+    const projects = [makeProject("env-1", "proj-a"), makeProject("env-2", "proj-a")];
+    const result = selectUnreconciledProjects(projects, reconciled);
+    expect(result).toHaveLength(2);
+
+    const second = selectUnreconciledProjects(projects, reconciled);
+    expect(second).toHaveLength(0);
+  });
+
+  it("handles a project removed then re-added (stays reconciled)", () => {
+    const reconciled = new Set<string>();
+    const projects = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
+    selectUnreconciledProjects(projects, reconciled);
+
+    const removed = [makeProject("env-1", "proj-b")];
+    const afterRemove = selectUnreconciledProjects(removed, reconciled);
+    expect(afterRemove).toHaveLength(0);
+
+    const reAdded = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
+    const afterReAdd = selectUnreconciledProjects(reAdded, reconciled);
+    expect(afterReAdd).toHaveLength(0);
+  });
+});

--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
@@ -5,7 +5,12 @@ import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { RpcClientError } from "effect/unstable/rpc";
 
-import { classifyImportFailure, selectUnreconciledProjects } from "./useAgentSessionAutoReconcile";
+import {
+  classifyImportFailure,
+  isDefinitiveOutcome,
+  projectReconcileKey,
+  selectUnreconciledProjects,
+} from "./useAgentSessionAutoReconcile";
 
 function makeProject(
   environmentId: string,
@@ -34,35 +39,31 @@ describe("selectUnreconciledProjects", () => {
     expect(result[1]!.id).toBe("proj-b");
   });
 
-  it("marks returned projects as reconciled", () => {
+  it("does not mutate the reconciled set", () => {
     const reconciled = new Set<string>();
     const projects = [makeProject("env-1", "proj-a")];
     selectUnreconciledProjects(projects, reconciled);
-    expect(reconciled.has("env-1\0proj-a")).toBe(true);
+    expect(reconciled.size).toBe(0);
   });
 
-  it("skips already-reconciled projects on subsequent calls", () => {
-    const reconciled = new Set<string>();
-    const projects = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
-    selectUnreconciledProjects(projects, reconciled);
-    const result = selectUnreconciledProjects(projects, reconciled);
+  it("skips projects already in the reconciled set", () => {
+    const project = makeProject("env-1", "proj-a");
+    const reconciled = new Set([projectReconcileKey(project)]);
+    const result = selectUnreconciledProjects([project], reconciled);
     expect(result).toHaveLength(0);
   });
 
-  it("returns only newly added projects", () => {
-    const reconciled = new Set<string>();
-    const initial = [makeProject("env-1", "proj-a")];
-    selectUnreconciledProjects(initial, reconciled);
-
-    const withNew = [...initial, makeProject("env-1", "proj-b")];
-    const result = selectUnreconciledProjects(withNew, reconciled);
+  it("returns only projects not yet reconciled", () => {
+    const projA = makeProject("env-1", "proj-a");
+    const projB = makeProject("env-1", "proj-b");
+    const reconciled = new Set([projectReconcileKey(projA)]);
+    const result = selectUnreconciledProjects([projA, projB], reconciled);
     expect(result).toHaveLength(1);
     expect(result[0]!.id).toBe("proj-b");
   });
 
   it("returns empty array when projects list is empty", () => {
-    const reconciled = new Set<string>();
-    const result = selectUnreconciledProjects([], reconciled);
+    const result = selectUnreconciledProjects([], new Set());
     expect(result).toHaveLength(0);
   });
 
@@ -71,23 +72,21 @@ describe("selectUnreconciledProjects", () => {
     const projects = [makeProject("env-1", "proj-a"), makeProject("env-2", "proj-a")];
     const result = selectUnreconciledProjects(projects, reconciled);
     expect(result).toHaveLength(2);
-
-    const second = selectUnreconciledProjects(projects, reconciled);
-    expect(second).toHaveLength(0);
   });
 
-  it("handles a project removed then re-added (stays reconciled)", () => {
+  it("allows retry when a project is not marked reconciled after failure", () => {
     const reconciled = new Set<string>();
-    const projects = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
-    selectUnreconciledProjects(projects, reconciled);
+    const projects = [makeProject("env-1", "proj-a")];
 
-    const removed = [makeProject("env-1", "proj-b")];
-    const afterRemove = selectUnreconciledProjects(removed, reconciled);
-    expect(afterRemove).toHaveLength(0);
+    const first = selectUnreconciledProjects(projects, reconciled);
+    expect(first).toHaveLength(1);
 
-    const reAdded = [makeProject("env-1", "proj-a"), makeProject("env-1", "proj-b")];
-    const afterReAdd = selectUnreconciledProjects(reAdded, reconciled);
-    expect(afterReAdd).toHaveLength(0);
+    const second = selectUnreconciledProjects(projects, reconciled);
+    expect(second).toHaveLength(1);
+
+    reconciled.add(projectReconcileKey(projects[0]!));
+    const third = selectUnreconciledProjects(projects, reconciled);
+    expect(third).toHaveLength(0);
   });
 });
 
@@ -149,5 +148,23 @@ describe("classifyImportFailure", () => {
     expect(classifyImportFailure(AsyncResult.failure(Cause.fail(new Error("plain"))))).toBe(
       "unexpected",
     );
+  });
+});
+
+describe("isDefinitiveOutcome", () => {
+  it("treats expected failures as definitive (no retry)", () => {
+    expect(isDefinitiveOutcome("expected")).toBe(true);
+  });
+
+  it("treats unsupported-server as non-definitive (retry after upgrade)", () => {
+    expect(isDefinitiveOutcome("unsupported-server")).toBe(false);
+  });
+
+  it("treats unexpected failures as non-definitive (retry)", () => {
+    expect(isDefinitiveOutcome("unexpected")).toBe(false);
+  });
+
+  it("treats interrupted as non-definitive (retry)", () => {
+    expect(isDefinitiveOutcome("interrupted")).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
@@ -1,10 +1,16 @@
 import { useEffect, useRef } from "react";
 
+import {
+  isAtomCommandInterrupted,
+  squashAtomCommandFailure,
+  type AtomCommandResult,
+} from "@t3tools/client-runtime/state/runtime";
+import { isRpcClientError } from "@t3tools/client-runtime/rpc";
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
+
 import { agentSessionImport } from "../state/agentSessions";
 import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entities";
 import { useAtomCommand } from "../state/use-atom-command";
-
-import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
 
 /**
  * Return the subset of `projects` that have not yet been reconciled according
@@ -25,21 +31,66 @@ export function selectUnreconciledProjects(
   return pending;
 }
 
+const EXPECTED_FAILURE_TAGS = new Set([
+  "AgentSessionImportProjectNotFoundError",
+  "AgentSessionImportProjectChangedError",
+  "AgentSessionScanError",
+  "EnvironmentRpcUnavailableError",
+  "EnvironmentAuthorizationError",
+]);
+
+/**
+ * Classify a failed import result so the hook can log the right diagnostic.
+ *
+ * - `"unsupported-server"` — the RPC method does not exist on this server
+ *   (pre-#5362 build, e.g. t3@0.0.38). No retry will help; warn once.
+ * - `"interrupted"` — the effect was cancelled (unmount / environment switch).
+ * - `"expected"` — a typed domain error (project not found, workspace mismatch,
+ *   scan error). Normal on misconfigured or empty agent homes.
+ * - `"unexpected"` — an unrecognised defect. Worth logging for debugging.
+ */
+export function classifyImportFailure(
+  result: AtomCommandResult<unknown, unknown>,
+): "unsupported-server" | "interrupted" | "expected" | "unexpected" {
+  if (result._tag === "Success") return "expected";
+  if (isAtomCommandInterrupted(result)) return "interrupted";
+
+  const squashed = squashAtomCommandFailure(result);
+
+  if (isRpcClientError(squashed)) return "unsupported-server";
+
+  if (
+    squashed != null &&
+    typeof squashed === "object" &&
+    "_tag" in squashed &&
+    typeof squashed._tag === "string" &&
+    EXPECTED_FAILURE_TAGS.has(squashed._tag)
+  ) {
+    return "expected";
+  }
+
+  return "unexpected";
+}
+
 /**
  * Automatically imports external agent sessions (Claude Code, Codex) for every
  * known project once the environment shells are bootstrapped. Runs once per
- * project per mount cycle and silently skips failures so the UI never blocks on
- * a missing or unreadable agent home directory.
+ * project per mount cycle.
  *
  * Reuses the existing `agentSessions.import` RPC, which is idempotent: threads
  * whose `import:` id already exists are skipped by the server, and the
  * per-source file-identity watermark prevents re-reading unchanged transcripts.
+ *
+ * Requires a server build that includes #5362 (agentSessions.scan /
+ * agentSessions.import RPCs). Older servers (e.g. t3@0.0.38) do not expose
+ * these methods; the hook detects this and logs a one-time warning.
  */
 export function useAgentSessionAutoReconcile(): void {
   const projects = useProjects();
   const bootstrapped = useAllEnvironmentShellsBootstrapped();
   const importSessions = useAtomCommand(agentSessionImport, { reportFailure: false });
   const reconciledRef = useRef(new Set<string>());
+  const unsupportedServersRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!bootstrapped) return;
@@ -51,13 +102,57 @@ export function useAgentSessionAutoReconcile(): void {
     const run = async () => {
       for (const project of pending) {
         if (cancelled) return;
-        await importSessions({
+
+        if (unsupportedServersRef.current.has(project.environmentId)) continue;
+
+        const result = await importSessions({
           environmentId: project.environmentId,
           input: {
             projectId: project.id,
             expectedWorkspaceRoot: project.workspaceRoot,
           },
-        }).catch(() => {});
+        });
+
+        if (cancelled) return;
+
+        if (result._tag === "Success") {
+          if (result.value.importedCount > 0) {
+            console.info(
+              `[auto-reconcile] Imported ${result.value.importedCount} agent session(s) for project "${project.title}" (${project.id})`,
+            );
+          }
+          continue;
+        }
+
+        const kind = classifyImportFailure(result);
+
+        if (kind === "interrupted") continue;
+
+        if (kind === "unsupported-server") {
+          unsupportedServersRef.current.add(project.environmentId);
+          console.warn(
+            `[auto-reconcile] Server for environment "${project.environmentId}" does not support agentSessions.import. ` +
+              `Auto-reconcile of external agent sessions requires a server build that includes PR #5362 ` +
+              `(shipped after t3@0.0.38). Upgrade the server to enable automatic session import.`,
+          );
+          continue;
+        }
+
+        const squashed = squashAtomCommandFailure(result);
+        const errorMessage =
+          squashed instanceof Error ? squashed.message : JSON.stringify(squashed);
+
+        if (kind === "expected") {
+          console.warn(
+            `[auto-reconcile] Could not import agent sessions for project "${project.title}" ` +
+              `(${project.id}, env ${project.environmentId}, root "${project.workspaceRoot}"): ${errorMessage}`,
+          );
+        } else {
+          console.error(
+            `[auto-reconcile] Unexpected error importing agent sessions for project "${project.title}" ` +
+              `(${project.id}, env ${project.environmentId}, root "${project.workspaceRoot}"): ${errorMessage}`,
+          );
+        }
       }
     };
     void run();

--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
@@ -12,20 +12,26 @@ import { agentSessionImport } from "../state/agentSessions";
 import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entities";
 import { useAtomCommand } from "../state/use-atom-command";
 
+/** Stable key for a project in a specific environment. */
+export function projectReconcileKey(project: {
+  readonly environmentId: string;
+  readonly id: string;
+}): string {
+  return `${project.environmentId}\0${project.id}`;
+}
+
 /**
- * Return the subset of `projects` that have not yet been reconciled according
- * to `reconciled`. Each returned project is added to `reconciled` as a side
- * effect so the caller can track which projects still need work.
+ * Return the subset of `projects` not yet in `reconciled`.
+ * Does **not** mark them reconciled — the caller must do so after a
+ * definitive outcome so transient failures allow retry.
  */
 export function selectUnreconciledProjects(
   projects: ReadonlyArray<EnvironmentProject>,
-  reconciled: Set<string>,
+  reconciled: ReadonlySet<string>,
 ): ReadonlyArray<EnvironmentProject> {
   const pending: EnvironmentProject[] = [];
   for (const project of projects) {
-    const key = `${project.environmentId}\0${project.id}`;
-    if (reconciled.has(key)) continue;
-    reconciled.add(key);
+    if (reconciled.has(projectReconcileKey(project))) continue;
     pending.push(project);
   }
   return pending;
@@ -73,9 +79,18 @@ export function classifyImportFailure(
 }
 
 /**
+ * Whether the failure kind is definitive enough to mark the project reconciled
+ * and not retry. Transient failures (unsupported-server, unexpected, interrupted)
+ * leave the project eligible for retry after a server upgrade or remount.
+ */
+export function isDefinitiveOutcome(kind: ReturnType<typeof classifyImportFailure>): boolean {
+  return kind === "expected";
+}
+
+/**
  * Automatically imports external agent sessions (Claude Code, Codex) for every
  * known project once the environment shells are bootstrapped. Runs once per
- * project per mount cycle.
+ * project per mount cycle for successful imports; retries on transient failures.
  *
  * Reuses the existing `agentSessions.import` RPC, which is idempotent: threads
  * whose `import:` id already exists are skipped by the server, and the
@@ -103,6 +118,8 @@ export function useAgentSessionAutoReconcile(): void {
       for (const project of pending) {
         if (cancelled) return;
 
+        const key = projectReconcileKey(project);
+
         if (unsupportedServersRef.current.has(project.environmentId)) continue;
 
         const result = await importSessions({
@@ -116,11 +133,11 @@ export function useAgentSessionAutoReconcile(): void {
         if (cancelled) return;
 
         if (result._tag === "Success") {
-          if (result.value.importedCount > 0) {
-            console.info(
-              `[auto-reconcile] Imported ${result.value.importedCount} agent session(s) for project "${project.title}" (${project.id})`,
-            );
-          }
+          reconciledRef.current.add(key);
+          console.info(
+            `[auto-reconcile] project "${project.title}" (${project.id}, root "${project.workspaceRoot}"): ` +
+              `imported ${result.value.importedCount}, skipped ${result.value.skippedCount}`,
+          );
           continue;
         }
 
@@ -130,12 +147,21 @@ export function useAgentSessionAutoReconcile(): void {
 
         if (kind === "unsupported-server") {
           unsupportedServersRef.current.add(project.environmentId);
+          for (const key of reconciledRef.current) {
+            if (key.startsWith(`${project.environmentId}\0`)) {
+              reconciledRef.current.delete(key);
+            }
+          }
           console.warn(
             `[auto-reconcile] Server for environment "${project.environmentId}" does not support agentSessions.import. ` +
-              `Auto-reconcile of external agent sessions requires a server build that includes PR #5362 ` +
-              `(shipped after t3@0.0.38). Upgrade the server to enable automatic session import.`,
+              `Auto-reconcile requires a server build that includes PR #5362 (shipped after t3@0.0.38). ` +
+              `Upgrade the server to enable automatic session import.`,
           );
           continue;
+        }
+
+        if (isDefinitiveOutcome(kind)) {
+          reconciledRef.current.add(key);
         }
 
         const squashed = squashAtomCommandFailure(result);

--- a/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
+++ b/apps/web/src/hooks/useAgentSessionAutoReconcile.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+
+import { agentSessionImport } from "../state/agentSessions";
+import { useAllEnvironmentShellsBootstrapped, useProjects } from "../state/entities";
+import { useAtomCommand } from "../state/use-atom-command";
+
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/models";
+
+/**
+ * Return the subset of `projects` that have not yet been reconciled according
+ * to `reconciled`. Each returned project is added to `reconciled` as a side
+ * effect so the caller can track which projects still need work.
+ */
+export function selectUnreconciledProjects(
+  projects: ReadonlyArray<EnvironmentProject>,
+  reconciled: Set<string>,
+): ReadonlyArray<EnvironmentProject> {
+  const pending: EnvironmentProject[] = [];
+  for (const project of projects) {
+    const key = `${project.environmentId}\0${project.id}`;
+    if (reconciled.has(key)) continue;
+    reconciled.add(key);
+    pending.push(project);
+  }
+  return pending;
+}
+
+/**
+ * Automatically imports external agent sessions (Claude Code, Codex) for every
+ * known project once the environment shells are bootstrapped. Runs once per
+ * project per mount cycle and silently skips failures so the UI never blocks on
+ * a missing or unreadable agent home directory.
+ *
+ * Reuses the existing `agentSessions.import` RPC, which is idempotent: threads
+ * whose `import:` id already exists are skipped by the server, and the
+ * per-source file-identity watermark prevents re-reading unchanged transcripts.
+ */
+export function useAgentSessionAutoReconcile(): void {
+  const projects = useProjects();
+  const bootstrapped = useAllEnvironmentShellsBootstrapped();
+  const importSessions = useAtomCommand(agentSessionImport, { reportFailure: false });
+  const reconciledRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!bootstrapped) return;
+
+    const pending = selectUnreconciledProjects(projects, reconciledRef.current);
+    if (pending.length === 0) return;
+
+    let cancelled = false;
+    const run = async () => {
+      for (const project of pending) {
+        if (cancelled) return;
+        await importSessions({
+          environmentId: project.environmentId,
+          input: {
+            projectId: project.id,
+            expectedWorkspaceRoot: project.workspaceRoot,
+          },
+        }).catch(() => {});
+      }
+    };
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [bootstrapped, importSessions, projects]);
+}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from "react";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { useClientSettings, useLegacySidebarEnabled } from "../hooks/useSettings";
 import { openCommandPalette } from "../commandPaletteBus";
+import { useAgentSessionAutoReconcile } from "../hooks/useAgentSessionAutoReconcile";
 import { useProjects } from "../state/entities";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { selectProjectGroupingSettings } from "../logicalProject";
@@ -175,6 +176,7 @@ function ChatRouteGlobalShortcuts() {
 }
 
 function ChatRouteLayout() {
+  useAgentSessionAutoReconcile();
   return (
     <>
       <ChatRouteGlobalShortcuts />


### PR DESCRIPTION
## What Changed

Added always-on automatic reconciliation of external agent sessions (Claude Code, Codex) when projects become available on a connected environment.

A new `useAgentSessionAutoReconcile` hook is mounted in the chat layout route. When environment shells bootstrap, it calls the existing idempotent `agentSessions.import` RPC for every known project, surfacing agent work already on disk in the thread list — without requiring a manual "Import agent sessions…" action.

**Related Ideas discussions:**
- https://github.com/pingdotgg/t3code/discussions/6994
- https://github.com/pingdotgg/t3code/discussions/6680

**Note:** Reopened after backlog sweep close of #10386. Rebased onto current `main` (head `09f86ffa7`). Still wanted — dual-machine Connect + Claude RC history visibility; E2E verified on box against `0.0.39-nightly` with fixtures under `/workspace/charlie-evosim/…`.

### What shipped
- `useAgentSessionAutoReconcile` hook: watches the project list, triggers `agentSessions.import` once per project per mount cycle
- Failure classification + logging (no silent swallow); only mark reconciled after definitive outcomes so server upgrades can retry
- Hook mounted in `ChatRouteLayout` (`_chat.tsx`)
- Unit tests for selection + failure classification

### Out of scope
- Connect-cloud / account-wide session inbox
- Live attach to running `claude --remote-control`
- Cross-environment merged thread list

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI chrome — invisible background reconciliation
- [x] Rebased onto current `main`

### Maintainer manual QA checklist

1. Open existing project whose `workspaceRoot` matches agent session `cwd` on disk
2. Without using the Import UI, external sessions appear (or appear shortly after open) with history
3. Re-open / re-reconcile does not duplicate `import:` threads (thread **id** prefix `import:`; title may be human-readable)
4. Opening a thread does not auto-start a provider turn
5. Mismatched `expectedWorkspaceRoot` fails clearly / skips safely
6. Server must include #5362 (`agentSessions.import`); pre-#5362 servers log unsupported-server once

### Test commands

```
npx vp test run apps/web/src/hooks/useAgentSessionAutoReconcile.test.ts
npx vp test run apps/server/src/project/AgentSessionImporter.test.ts
npx vp test run apps/server/src/project/AgentSessionScanner.test.ts
npx vp run --filter web typecheck
```

Supersedes / continues #10386.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically imports agent sessions for applicable environment projects when opening chat.
  - Retries interrupted or unexpected import failures up to three times, with delays between attempts.
  - Rechecks server support after startup and handles temporarily unavailable environments.
- **Bug Fixes**
  - Prevents already reconciled projects from being imported again.
  - Distinguishes unsupported servers from other connection and protocol failures.
  - Prevents retry attempts from continuing after leaving the chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->