### PR TITLE
fix(shared): detect Windows CLIs installed after the app's PATH snapshot

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -333,6 +333,7 @@ describe("DesktopShellEnvironment", () => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
@@ -344,6 +345,47 @@ describe("DesktopShellEnvironment", () => {
       assert.equal(
         env.FNM_MULTISHELL_PATH,
         "C:\\Users\\testuser\\AppData\\Local\\fnm_multishells\\123",
+      );
+    }),
+  );
+
+  it.effect("reads the persisted Windows PATH stores and the WinGet links directory", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        PATH: "C:\\Windows\\System32",
+        LOCALAPPDATA: "C:\\Users\\testuser\\AppData\\Local",
+      };
+      const scripts: Array<string> = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          scripts.push(command.args.at(-1) ?? "");
+          return envOutput({ PATH: "C:\\Windows\\System32" });
+        },
+      });
+
+      // A Start Menu launch inherits a PATH snapshot taken before `winget
+      // install` ran, so the persisted stores are the only place the new entry
+      // exists.
+      const script = scripts.join("\n");
+      assert.include(script, "foreach ($target in @('User', 'Machine'))");
+      assert.include(script, "-not [Environment]::GetEnvironmentVariable($entry.Key, 'Process')");
+      assert.include(
+        script,
+        "[Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')",
+      );
+      assert.include(
+        script,
+        "@('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('PATH', $_) } catch { $null } }",
+      );
+      assert.include(script, "$value = $candidates -join ';'");
+      assert.include(script, "$value = @($candidates)[0]");
+      assert.include(
+        env.PATH ?? "",
+        "C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
       );
     }),
   );

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -209,7 +209,12 @@ const knownWindowsCliDirs = (env: NodeJS.ProcessEnv): ReadonlyArray<string> => [
   ...trimNonEmpty(env.LOCALAPPDATA).pipe(
     Option.match({
       onNone: () => [],
-      onSome: (value) => [`${value}\\Programs\\nodejs`, `${value}\\Volta\\bin`, `${value}\\pnpm`],
+      onSome: (value) => [
+        `${value}\\Programs\\nodejs`,
+        `${value}\\Volta\\bin`,
+        `${value}\\pnpm`,
+        `${value}\\Microsoft\\WinGet\\Links`,
+      ],
     }),
   ),
   ...trimNonEmpty(env.USERPROFILE).pipe(
@@ -246,13 +251,43 @@ const capturePosixEnvironmentCommand = (names: ReadonlyArray<string>) =>
     })
     .join("; ");
 
+/**
+ * Reads a variable from the process copy and from the persisted User and Machine
+ * stores. The process copy alone is a snapshot taken when the launching shell
+ * started, so an entry a package manager persisted afterwards (`winget install`
+ * appending to User PATH, say) stays invisible to a Start Menu launch until the
+ * user signs out. PATH keeps every source and is deduped downstream; any other
+ * variable takes the first store that has it. A store that cannot be read yields
+ * nothing rather than failing the whole probe.
+ */
+const windowsEnvironmentValueExpressions = (name: string): ReadonlyArray<string> => [
+  `$candidates = @('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('${name}', $_) } catch { $null } } | Where-Object { $_ }`,
+  name === "PATH" ? "$value = $candidates -join ';'" : "$value = @($candidates)[0]",
+];
+
+/**
+ * Fills gaps in this probe's own process block from the persisted stores before
+ * any value is read. Machine and User `PATH` are `REG_EXPAND_SZ`, and .NET expands
+ * their `%VAR%` references against the reading process, so an installer that
+ * persisted both a new variable and a `PATH` entry referencing it would otherwise
+ * yield a literal `%VAR%in` that resolves to nothing.
+ *
+ * Only names the process does not already carry are filled, and User is applied
+ * before Machine, which keeps the same Process before User before Machine order
+ * the capture below relies on. A value the launching shell set deliberately is
+ * never replaced. `PATH` is skipped outright: it is the value being measured.
+ */
+const windowsPersistedEnvironmentHydration =
+  "foreach ($target in @('User', 'Machine')) { try { foreach ($entry in ([Environment]::GetEnvironmentVariables($target)).GetEnumerator()) { if ($entry.Key -ne 'PATH' -and -not [Environment]::GetEnvironmentVariable($entry.Key, 'Process')) { [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process') } } } catch { } }";
+
 const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
   [
     "$ErrorActionPreference = 'Stop'",
+    windowsPersistedEnvironmentHydration,
     ...names.flatMap((name) => {
       return [
         `Write-Output '${startMarker(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+        ...windowsEnvironmentValueExpressions(name),
         "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
         `Write-Output '${endMarker(name)}'`,
       ];

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -236,6 +236,39 @@ describe("readEnvironmentFromWindowsShell", () => {
     });
   });
 
+  it("reads the persisted User and Machine stores, not only the process copy", () => {
+    const execFile = vi.fn<
+      (
+        file: string,
+        args: ReadonlyArray<string>,
+        options: { encoding: "utf8"; timeout: number },
+      ) => string
+    >(() => "__T3CODE_ENV_PATH_START__\nC:\\Tools\n__T3CODE_ENV_PATH_END__\n");
+
+    readEnvironmentFromWindowsShell(["PATH", "FNM_DIR"], execFile);
+
+    // A desktop launch inherits a PATH snapshot that predates `winget install`,
+    // so the persisted stores are the only place the new entry exists.
+    const command = execFile.mock.calls[0]?.[1]?.at(-1) ?? "";
+    // Machine PATH is REG_EXPAND_SZ, and .NET expands its `%VAR%` references
+    // against the reading process, so the persisted variables have to land in
+    // the probe's own block before any value is read - filling gaps only, so a
+    // value the launching shell set deliberately still wins.
+    expect(command).toContain("foreach ($target in @('User', 'Machine'))");
+    expect(command).toContain("-not [Environment]::GetEnvironmentVariable($entry.Key, 'Process')");
+    expect(command).toContain(
+      "[Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process')",
+    );
+    expect(command).toContain(
+      "@('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('PATH', $_) } catch { $null } }",
+    );
+    expect(command).toContain("$value = $candidates -join ';'");
+    expect(command).toContain(
+      "@('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('FNM_DIR', $_) } catch { $null } }",
+    );
+    expect(command).toContain("$value = @($candidates)[0]");
+  });
+
   it("omits -NoProfile when loadProfile is enabled", () => {
     const execFile = vi.fn<
       (
@@ -327,6 +360,7 @@ describe("resolveKnownWindowsCliDirs", () => {
       "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
       "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
       "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+      "C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
       "C:\\Users\\testuser\\.local\\bin",
       "C:\\Users\\testuser\\.bun\\bin",
       "C:\\Users\\testuser\\scoop\\shims",
@@ -587,6 +621,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",
@@ -635,6 +670,7 @@ effectIt.layer(NodeServices.layer)("resolveWindowsEnvironment", (it) => {
           "C:\\Users\\testuser\\AppData\\Local\\Programs\\nodejs",
           "C:\\Users\\testuser\\AppData\\Local\\Volta\\bin",
           "C:\\Users\\testuser\\AppData\\Local\\pnpm",
+          "C:\\Users\\testuser\\AppData\\Local\\Microsoft\\WinGet\\Links",
           "C:\\Users\\testuser\\.local\\bin",
           "C:\\Users\\testuser\\.bun\\bin",
           "C:\\Users\\testuser\\scoop\\shims",

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -247,9 +247,43 @@ function buildEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {
     .join("; ");
 }
 
+/**
+ * Reads a variable from the process copy and from the persisted User and Machine
+ * stores. The process copy alone is a snapshot taken when the launching shell
+ * started, so an entry a package manager persisted afterwards (`winget install`
+ * appending to User PATH, say) stays invisible to a Start Menu launch until the
+ * user signs out. PATH keeps every source and is deduped downstream; any other
+ * variable takes the first store that has it. A store that cannot be read yields
+ * nothing rather than failing the whole probe.
+ */
+function windowsEnvironmentValueExpressions(name: string): ReadonlyArray<string> {
+  return [
+    `$candidates = @('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('${name}', $_) } catch { $null } } | Where-Object { $_ }`,
+    name === "PATH"
+      ? `$value = $candidates -join '${WINDOWS_PATH_DELIMITER}'`
+      : "$value = @($candidates)[0]",
+  ];
+}
+
+/**
+ * Fills gaps in this probe's own process block from the persisted stores before
+ * any value is read. Machine and User `PATH` are `REG_EXPAND_SZ`, and .NET expands
+ * their `%VAR%` references against the reading process, so an installer that
+ * persisted both a new variable and a `PATH` entry referencing it would otherwise
+ * yield a literal `%VAR%in` that resolves to nothing.
+ *
+ * Only names the process does not already carry are filled, and User is applied
+ * before Machine, which keeps the same Process before User before Machine order
+ * the capture below relies on. A value the launching shell set deliberately is
+ * never replaced. `PATH` is skipped outright: it is the value being measured.
+ */
+const WINDOWS_PERSISTED_ENVIRONMENT_HYDRATION =
+  "foreach ($target in @('User', 'Machine')) { try { foreach ($entry in ([Environment]::GetEnvironmentVariables($target)).GetEnumerator()) { if ($entry.Key -ne 'PATH' -and -not [Environment]::GetEnvironmentVariable($entry.Key, 'Process')) { [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, 'Process') } } } catch { } }";
+
 function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): string {
   return [
     "$ErrorActionPreference = 'Stop'",
+    WINDOWS_PERSISTED_ENVIRONMENT_HYDRATION,
     ...names.flatMap((name) => {
       if (!SHELL_ENV_NAME_PATTERN.test(name)) {
         throw new Error(`Unsupported environment variable name: ${name}`);
@@ -257,7 +291,7 @@ function buildWindowsEnvironmentCaptureCommand(names: ReadonlyArray<string>): st
 
       return [
         `Write-Output '${envCaptureStart(name)}'`,
-        `$value = [Environment]::GetEnvironmentVariable('${name}')`,
+        ...windowsEnvironmentValueExpressions(name),
         "if ($null -ne $value -and $value.Length -gt 0) { Write-Output $value }",
         `Write-Output '${envCaptureEnd(name)}'`,
       ];
@@ -675,7 +709,7 @@ export function resolveKnownWindowsCliDirs(env: NodeJS.ProcessEnv): ReadonlyArra
   return [
     ...(appData ? [`${appData}\\npm`] : []),
     ...(localAppData ? [`${localAppData}\\Programs\\nodejs`, `${localAppData}\\Volta\\bin`] : []),
-    ...(localAppData ? [`${localAppData}\\pnpm`] : []),
+    ...(localAppData ? [`${localAppData}\\pnpm`, `${localAppData}\\Microsoft\\WinGet\\Links`] : []),
     ...(userProfile
       ? [`${userProfile}\\.local\\bin`, `${userProfile}\\.bun\\bin`, `${userProfile}\\scoop\\shims`]
       : []),


### PR DESCRIPTION
Fixes #10942.

## Problem

Windows PATH hydration reads only the **process** copy of the variable. Both probes build the same PowerShell line:

```powershell
$value = [Environment]::GetEnvironmentVariable('PATH')
```

- `packages/shared/src/shell.ts` — `buildWindowsEnvironmentCaptureCommand`, used by `resolveWindowsEnvironment` and so by `apps/server/src/os-jank.ts`
- `apps/desktop/src/shell/DesktopShellEnvironment.ts` — `captureWindowsEnvironmentCommand`

The no-target overload returns the spawned shell's own process environment, which it inherited from the T3 server, which inherited it from whatever launched the app. A Start Menu or shortcut launch inherits Explorer's copy, and Explorer's copy is a snapshot taken when that session started. `winget install glab.glab` appends to the persisted **User** PATH; nothing rewrites a running Explorer. So the entry exists in the registry, `glab` runs fine in a fresh terminal, and T3 still probes `glab --version` against a PATH that has never heard of it — reported as "not found on the server PATH".

WinGet's own shim directory is also absent from `resolveKnownWindowsCliDirs` / `knownWindowsCliDirs`, so the fallback list cannot cover the gap either.

## Change

**Read the persisted stores, not just the process copy.** Both probes now compose the value from `Process`, `User`, and `Machine`:

```powershell
$candidates = @('Process', 'User', 'Machine') | ForEach-Object { try { [Environment]::GetEnvironmentVariable('PATH', $_) } catch { $null } } | Where-Object { $_ }
$value = $candidates -join ';'
```

PATH keeps every source and is deduped by the existing `mergePathValues` / `mergePaths` step, so ordering and priority are unchanged — the persisted entries only ever land after the ones already resolved. Any other variable (`FNM_DIR`, `FNM_MULTISHELL_PATH`) takes the first store that has it, since joining those with `;` would corrupt them. A store that cannot be read yields nothing instead of failing the whole probe, so the result is never worse than today.

**Hydrate the probe from the persisted stores first.** Machine `PATH` is `REG_EXPAND_SZ` and .NET expands its `%VAR%` references against the *reading* process, so composing the stores is not enough on its own: an installer that persisted both a new variable and a `PATH` entry referencing it would still yield a literal `%VAR%in`. Each probe now fills gaps in its own process block from the persisted stores before reading anything. Only names the process does not already carry are filled, and User is applied before Machine, so the Process before User before Machine order the capture relies on still holds and a value the launching shell set deliberately is never replaced. `PATH` is skipped outright, being the value under measurement.

**Add WinGet's shim directory** (`%LOCALAPPDATA%\Microsoft\WinGet\Links`) to the known Windows CLI directories in both files, next to the existing npm / Volta / pnpm / scoop entries.

This is the durable fix the triage asked for, and it is not `glab`-specific: it covers every CLI discovered through `probeCli`, and the same WinGet-install-then-launch case in #7360.

## Verification

Confirmed on Windows 11 (PowerShell 5.1):

- `GetEnvironmentVariable('PATH')` returns only the process copy — 46 entries here, against 91 across all three stores before dedupe.
- Machine `PATH` is `REG_EXPAND_SZ` and carries 5 `%SystemRoot%` entries on this machine, so the expansion path is not hypothetical.
- `ExpandEnvironmentStrings` leaves an undefined `%VAR%` literal rather than dropping it, which is why the unhydrated version produced a dead entry instead of a wrong one.
- Running the exact script this change generates: exit 0, 125 `PATH` entries, zero unexpanded `%VAR%` remaining.
- With a variable that exists in the User store (`ANDROID_HOME`) deliberately overridden in the launching process, the probe returns the override, not the persisted value — precedence holds.

## Tests

- `packages/shared/src/shell.test.ts` — the generated PowerShell reads all three stores, joins PATH, and takes the first store for a non-PATH variable; `resolveKnownWindowsCliDirs` returns the WinGet links directory.
- `apps/desktop/src/shell/DesktopShellEnvironment.test.ts` — same assertions against the desktop probe, plus the hydrated `process.env.PATH` containing the WinGet links directory.

Full `packages/shared` suite passes (588 passed, 5 skipped) and `apps/server/src/os-jank.test.ts` passes.

For `apps/desktop` I ran the whole suite on a clean tree and again with this change: the failure set is identical (25 Linux compositor and POSIX-permission tests that cannot run on the Windows host I verified on), and passing tests go 1235 to 1236 — the new test is the only difference.

`vp fmt --check`, `vp lint`, and `tsc --noEmit` for both packages are clean.

No UI surface changes, so no screenshots.
