### PR TITLE
fix(server): repair legacy client settlement timestamps

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -61,6 +61,7 @@ import Migration0046 from "./Migrations/046_RepairAutomaticSettlementTimestamps.
 import Migration0047 from "./Migrations/047_ProjectionProjectIcon.ts";
 import Migration0048 from "./Migrations/048_ProjectionThreadBranchPullRequest.ts";
 import Migration0049 from "./Migrations/049_ProjectionThreadsActiveOrderKey.ts";
+import Migration0050 from "./Migrations/050_RepairClientSettlementTimestamps.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -122,6 +123,7 @@ const migrationEntries = [
   [47, "ProjectionProjectIcon", Migration0047],
   [48, "ProjectionThreadBranchPullRequest", Migration0048],
   [49, "ProjectionThreadsActiveOrderKey", Migration0049],
+  [50, "RepairClientSettlementTimestamps", Migration0050],
 ] as const;
 
 export const migrationManifest = migrationEntries.map(([id, name]) => [id, name] as const);

--- a/apps/server/src/persistence/Migrations/050_RepairClientSettlementTimestamps.test.ts
+++ b/apps/server/src/persistence/Migrations/050_RepairClientSettlementTimestamps.test.ts
@@ -1,0 +1,140 @@
+import { assert, it } from "@effect/vitest";
+import * as NodeSqliteClient from "@t3tools/shared/nodeSqliteClient";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import migrateClientSettlements from "./050_RepairClientSettlementTimestamps.ts";
+
+it.layer(NodeSqliteClient.layerMemory())("050_RepairClientSettlementTimestamps", (it) => {
+  it.effect("repairs legacy sweeps after 046 without rewriting manual or newer settlements", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 45 });
+      const createdAt = "2026-04-14T00:00:00.000Z";
+      const messageAt = "2026-04-14T13:21:02.000Z";
+      const requestedAt = "2026-07-01T14:55:00.000Z";
+      const startedAt = "2026-07-01T14:56:00.000Z";
+      const completedAt = "2026-07-01T14:56:47.000Z";
+      const laterAt = "2026-09-08T00:00:00.000Z";
+      const expected = new Map<string, string | null>();
+
+      const cohorts = [
+        { name: "sweep", at: "2026-09-04T13:33:00.000Z", count: 34 },
+        { name: "manual", at: "2026-09-03T00:00:00.000Z", count: 1 },
+        { name: "small", at: "2026-09-03T01:00:00.000Z", count: 9 },
+        { name: "slow", at: "2026-09-03T02:00:00.000Z", count: 10 },
+        { name: "repeated", at: "2026-09-03T03:00:00.000Z", count: 10 },
+        { name: "boundary", at: "2026-09-03T04:00:00.000Z", count: 10 },
+        { name: "new-client", at: "2026-09-04T13:33:00.000Z", count: 10 },
+        { name: "no-origin", at: "2026-09-04T13:33:00.000Z", count: 10 },
+        { name: "late", at: "2026-09-05T00:00:00.000Z", count: 10 },
+      ];
+      for (const [cohortIndex, cohort] of cohorts.entries()) {
+        for (let index = 0; index < cohort.count; index++) {
+          const threadId = `${cohort.name}-${cohort.name === "repeated" ? 0 : index}`;
+          const occurredAt = DateTime.makeUnsafe(cohort.at).pipe(
+            DateTime.add({
+              milliseconds:
+                cohort.name === "boundary" && index === 9
+                  ? 120_000
+                  : index * (cohort.name === "slow" ? 20_000 : 2_500),
+            }),
+            DateTime.formatIso,
+          );
+          const appVersion = cohort.name === "new-client" ? "0.0.40" : `0.0.${35 + (index % 4)}`;
+          if (cohort.name !== "repeated" || index === 0) {
+            yield* sql`
+              INSERT INTO projection_threads (
+                thread_id, project_id, title, model_selection_json,
+                created_at, updated_at, settled_override, settled_at
+              ) VALUES (
+                ${threadId}, ${`project-${index % 3}`}, ${threadId},
+                '{"instanceId":"codex","model":"gpt-5.6-sol"}',
+                ${createdAt}, ${occurredAt}, 'settled', ${occurredAt}
+              )
+            `;
+            expected.set(
+              threadId,
+              cohort.name === "sweep" || cohort.name === "boundary" ? createdAt : occurredAt,
+            );
+          }
+          const commandId = `00000000-0000-4000-8000-${String(cohortIndex * 100 + index).padStart(12, "0")}`;
+          yield* sql`
+            INSERT INTO orchestration_events (
+              event_id, aggregate_kind, stream_id, stream_version, event_type, occurred_at,
+              command_id, correlation_id, actor_kind, payload_json, metadata_json
+            ) VALUES (
+              ${`event-${commandId}`}, 'thread', ${threadId}, ${index}, 'thread.settled', ${occurredAt},
+              ${commandId}, ${commandId}, 'client',
+              json_object('threadId', ${threadId}, 'settledAt', ${occurredAt}, 'updatedAt', ${occurredAt}),
+              CASE WHEN ${cohort.name} = 'no-origin' THEN '{}'
+                ELSE json_object('origin', json_object('appVersion', ${appVersion})) END
+            )
+          `;
+        }
+      }
+
+      yield* sql`
+        INSERT INTO projection_thread_messages (
+          message_id, thread_id, role, text, is_streaming, created_at, updated_at
+        ) VALUES
+          ('user', 'sweep-1', 'user', 'Prompt', 0, ${messageAt}, ${messageAt}),
+          ('assistant', 'sweep-1', 'assistant', 'Reply', 0, ${completedAt}, ${completedAt}),
+          ('later', 'sweep-1', 'user', 'Later prompt', 0, ${laterAt}, ${laterAt}),
+          ('invalid', 'sweep-1', 'user', 'Invalid date', 0, 'invalid', 'invalid')
+      `;
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id, turn_id, state, requested_at, started_at, completed_at, checkpoint_files_json
+        ) VALUES
+          ('sweep-2', 'requested', 'pending', ${requestedAt}, NULL, NULL, '[]'),
+          ('sweep-3', 'started', 'running', ${requestedAt}, ${startedAt}, NULL, '[]'),
+          ('sweep-4', 'completed', 'completed', ${requestedAt}, ${startedAt}, ${completedAt}, '[]'),
+          ('sweep-4', 'later', 'completed', ${laterAt}, ${laterAt}, ${laterAt}, '[]')
+      `;
+      expected.set("sweep-1", messageAt);
+      expected.set("sweep-2", requestedAt);
+      expected.set("sweep-3", startedAt);
+      expected.set("sweep-4", completedAt);
+      yield* sql`UPDATE projection_threads SET settled_at = ${laterAt} WHERE thread_id = 'sweep-5'`;
+      expected.set("sweep-5", laterAt);
+      yield* sql`
+        UPDATE projection_threads SET settled_override = 'active', settled_at = NULL
+        WHERE thread_id = 'sweep-6'
+      `;
+      expected.set("sweep-6", null);
+
+      const eventsBefore = yield* sql`SELECT * FROM orchestration_events ORDER BY sequence`;
+      yield* runMigrations({ toMigrationInclusive: 49 });
+      const threadsBefore = yield* sql<{ readonly thread_id: string }>`
+        SELECT * FROM projection_threads ORDER BY thread_id
+      `;
+      assert.deepStrictEqual(
+        yield* sql`SELECT settled_at FROM projection_threads WHERE thread_id = 'sweep-1'`,
+        [{ settled_at: "2026-09-04T13:33:02.500Z" }],
+      );
+
+      yield* runMigrations();
+      const threadsAfter = yield* sql`SELECT * FROM projection_threads ORDER BY thread_id`;
+      assert.deepStrictEqual(
+        threadsAfter,
+        threadsBefore.map((thread) => ({
+          ...thread,
+          settled_at: expected.get(thread.thread_id),
+        })),
+      );
+      assert.deepStrictEqual(
+        yield* sql`SELECT * FROM orchestration_events ORDER BY sequence`,
+        eventsBefore,
+      );
+      assert.deepStrictEqual(yield* runMigrations(), []);
+      yield* migrateClientSettlements;
+      assert.deepStrictEqual(
+        yield* sql`SELECT * FROM projection_threads ORDER BY thread_id`,
+        threadsAfter,
+      );
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/050_RepairClientSettlementTimestamps.ts
+++ b/apps/server/src/persistence/Migrations/050_RepairClientSettlementTimestamps.ts
@@ -1,0 +1,86 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+// Follow up 046 for the client-attributed sweeps reported in #10937. Manual
+// settles have the same event shape, so require the affected client versions,
+// a pre-September-5 stamp, and at least 10 distinct threads within two minutes.
+// ponytail: burst detection is heuristic and quadratic in this bounded cohort;
+// exact classification would need provenance those old clients did not record.
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    WITH legacy_settlements AS MATERIALIZED (
+      SELECT
+        stream_id AS thread_id,
+        occurred_at,
+        unixepoch(occurred_at, 'subsec') AS occurred_seconds
+      FROM orchestration_events
+      WHERE aggregate_kind = 'thread'
+        AND event_type = 'thread.settled'
+        AND actor_kind = 'client'
+        AND json_type(payload_json, '$.settledAt') = 'text'
+        AND json_extract(payload_json, '$.settledAt') = occurred_at
+        AND json_extract(metadata_json, '$.origin.appVersion') IN ('0.0.35', '0.0.36', '0.0.37', '0.0.38')
+        AND julianday(occurred_at) < julianday('2026-09-05T00:00:00.000Z')
+    ),
+    sweeps AS MATERIALIZED (
+      SELECT occurred_seconds AS started_seconds
+      FROM legacy_settlements AS first
+      WHERE (
+        SELECT COUNT(DISTINCT other.thread_id)
+        FROM legacy_settlements AS other
+        WHERE other.occurred_seconds BETWEEN first.occurred_seconds AND first.occurred_seconds + 120
+      ) >= 10
+    ),
+    automatic_settlements AS (
+      SELECT * FROM legacy_settlements AS legacy
+      WHERE EXISTS (
+        SELECT 1 FROM sweeps
+        WHERE legacy.occurred_seconds BETWEEN sweeps.started_seconds AND sweeps.started_seconds + 120
+      )
+    ),
+    activity_timestamps AS (
+      SELECT thread_id, created_at AS activity_at
+      FROM projection_thread_messages
+      WHERE role = 'user'
+      UNION ALL
+      SELECT thread_id, requested_at
+      FROM projection_turns
+      UNION ALL
+      SELECT thread_id, started_at
+      FROM projection_turns
+      WHERE started_at IS NOT NULL
+      UNION ALL
+      SELECT thread_id, completed_at
+      FROM projection_turns
+      WHERE completed_at IS NOT NULL
+    )
+    UPDATE projection_threads AS thread
+    SET settled_at = (
+      SELECT COALESCE(
+        (
+          SELECT activity.activity_at
+          FROM activity_timestamps AS activity
+          WHERE activity.thread_id = thread.thread_id
+            AND julianday(activity.activity_at) IS NOT NULL
+            AND julianday(activity.activity_at) <= julianday(automatic.occurred_at)
+          ORDER BY julianday(activity.activity_at) DESC
+          LIMIT 1
+        ),
+        thread.created_at
+      )
+      FROM automatic_settlements AS automatic
+      WHERE automatic.thread_id = thread.thread_id
+        AND automatic.occurred_at = thread.settled_at
+      LIMIT 1
+    )
+    WHERE thread.settled_override = 'settled'
+      AND EXISTS (
+        SELECT 1
+        FROM automatic_settlements AS automatic
+        WHERE automatic.thread_id = thread.thread_id
+          AND automatic.occurred_at = thread.settled_at
+      )
+  `;
+});


### PR DESCRIPTION
Migration 046 leaves old client-attributed auto-settle sweeps dated at the sweep time, burying recent threads in Settled.

Add migration 050 to repair bursts of at least 10 distinct threads within two minutes, from clients 0.0.35–0.0.38 before September 5, 2026. Reuse 046's last-activity calculation and matching-stamp guard. Event history and later manual re-settles stay unchanged.

This is a bounded heuristic: bulk manual settlements with the same legacy shape are indistinguishable. Smaller or unversioned cohorts are left alone.

Reproduced with a failing SQLite regression before the fix. Both migration tests now pass, including a 95-thread fixture covering burst and date boundaries, manual settlements, activity cutoffs, unchanged history, and repeat runs. Server typecheck, targeted lint, and formatting pass.

Closes #10937.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected settlement timestamps for eligible legacy client activity, using the most recent preceding user or turn activity when available.
  - Preserved manually recorded and newer settlement timestamps.
  - Improved historical settlement data accuracy without changing related orchestration events.
  - Reapplying the update does not produce additional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->