### PR TITLE
feat(claude): show edit text in expanded tool entries

### DIFF
--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -19,6 +19,7 @@ import {
   extractCommandOutputText,
   extractWorkLogToolLifecycleStatus,
   formatFileChangeInput,
+  hasFileChangeInput,
   isWorktreeSetupActivity,
   liveActivityToolStatus,
   normalizeCompactToolLabel,
@@ -997,11 +998,8 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
 function workEntryCanExpand(entry: WorkLogEntry): boolean {
   if (entry.questionAnswer) return true;
   if (entry.agentSpawn) return agentSpawnMembers(entry.agentSpawn).length > 0;
-  if (
-    (entry.itemType === "mcp_tool_call" || entry.itemType === "file_change") &&
-    entry.toolData !== undefined
-  )
-    return true;
+  if (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) return true;
+  if (hasFileChangeInput(entry)) return true;
   if (entry.changedFiles?.some((path) => path.trim().length > 0)) return true;
   return Boolean((entry.rawCommand ?? entry.command)?.trim() || entry.detail?.trim());
 }

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -18,6 +18,7 @@ import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
   extractWorkLogToolLifecycleStatus,
+  formatFileChangeInput,
   isWorktreeSetupActivity,
   liveActivityToolStatus,
   normalizeCompactToolLabel,
@@ -579,6 +580,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     if (toolData !== undefined) {
       entry.toolData = toolData;
     }
+  } else if (itemType === "file_change") {
+    const data = asRecord(payload?.data);
+    if (data?.toolName === "Edit" || data?.toolName === "Write") entry.toolData = data;
   }
   if (itemType) {
     entry.itemType = itemType;
@@ -979,6 +983,8 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
   if ((entry.changedFiles?.length ?? 0) > 0) {
     appendBlock(entry.changedFiles!.join("\n"));
   }
+  const fileChangeInput = formatFileChangeInput(entry);
+  if (fileChangeInput !== null) blocks.push(fileChangeInput);
 
   return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
@@ -991,7 +997,11 @@ function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
 function workEntryCanExpand(entry: WorkLogEntry): boolean {
   if (entry.questionAnswer) return true;
   if (entry.agentSpawn) return agentSpawnMembers(entry.agentSpawn).length > 0;
-  if (entry.itemType === "mcp_tool_call" && entry.toolData !== undefined) return true;
+  if (
+    (entry.itemType === "mcp_tool_call" || entry.itemType === "file_change") &&
+    entry.toolData !== undefined
+  )
+    return true;
   if (entry.changedFiles?.some((path) => path.trim().length > 0)) return true;
   return Boolean((entry.rawCommand ?? entry.command)?.trim() || entry.detail?.trim());
 }

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -54,6 +54,7 @@ function collectChangedFiles(
 
   pushChangedFile(target, seen, record.path);
   pushChangedFile(target, seen, record.filePath);
+  pushChangedFile(target, seen, record.file_path);
   pushChangedFile(target, seen, record.relativePath);
   pushChangedFile(target, seen, record.filename);
   pushChangedFile(target, seen, record.newPath);
@@ -352,6 +353,8 @@ function projectAcpContent(value: unknown): Record<string, unknown> | undefined 
   return summary ? { content: summary } : undefined;
 }
 
+const FILE_CHANGE_TEXT_LIMIT = 4_096;
+
 /**
  * Removes activity payload fields that no current client reads while retaining
  * the full payload in persistence and the event store.
@@ -393,6 +396,29 @@ export function projectActivityPayload(
   const imagePath = projectViewedImagePath(data);
   if (imagePath) {
     projectedData.imagePath = imagePath;
+  }
+
+  if (
+    payload.itemType === "file_change" &&
+    (data.toolName === "Edit" || data.toolName === "Write")
+  ) {
+    const input = asRecord(data.input);
+    const truncated = asRecord(data.inputTruncated);
+    const projectedInput: Record<string, string> = {};
+    const inputTruncated: Record<string, boolean> = {};
+    for (const key of data.toolName === "Edit" ? ["old_string", "new_string"] : ["content"]) {
+      const value = input?.[key];
+      if (typeof value !== "string") continue;
+      // Keep verbatim text without retaining a large backing string or splitting a surrogate pair.
+      projectedInput[key] = Array.from(
+        value.slice(0, FILE_CHANGE_TEXT_LIMIT).replace(/[\uD800-\uDBFF]$/u, ""),
+      ).join("");
+      inputTruncated[key] = truncated?.[key] === true || value.length > projectedInput[key].length;
+    }
+    if (Object.keys(projectedInput).length > 0) {
+      projectedData.input = projectedInput;
+      projectedData.inputTruncated = inputTruncated;
+    }
   }
 
   const changedFiles: string[] = [];

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -410,9 +410,11 @@ export function projectActivityPayload(
       const value = input?.[key];
       if (typeof value !== "string") continue;
       // Keep verbatim text without retaining a large backing string or splitting a surrogate pair.
-      projectedInput[key] = Array.from(
-        value.slice(0, FILE_CHANGE_TEXT_LIMIT).replace(/[\uD800-\uDBFF]$/u, ""),
-      ).join("");
+      const end =
+        (value.codePointAt(FILE_CHANGE_TEXT_LIMIT - 1) ?? 0) > 0xffff
+          ? FILE_CHANGE_TEXT_LIMIT - 1
+          : FILE_CHANGE_TEXT_LIMIT;
+      projectedInput[key] = Array.from(value.slice(0, end)).join("");
       inputTruncated[key] = truncated?.[key] === true || value.length > projectedInput[key].length;
     }
     if (Object.keys(projectedInput).length > 0) {

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -9,6 +9,7 @@ import {
   type OrchestrationThreadActivity,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
+import { formatFileChangeInput } from "../../../packages/client-runtime/src/work-log/presentation.ts";
 
 import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
 import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
@@ -230,6 +231,85 @@ describe("projectActivityPayload", () => {
     expect(mobileRow?.getCopyText()).toBe(`Command run\n${command}\n\nfirst output line`);
   });
 
+  it.each([
+    {
+      toolName: "Edit",
+      input: { old_string: "  return false;\n", new_string: "  return true;\n" },
+    },
+    { toolName: "Edit", input: { old_string: "remove me", new_string: "" } },
+    { toolName: "Write", input: { content: "  export const ready = true;\n" } },
+  ])("retains verbatim $toolName input for expanded rows", ({ toolName, input }) => {
+    const source = makeActivity("claude-edit", "file_change", {
+      toolName,
+      input: { file_path: "src/example.ts", ...input, ignored: "x".repeat(10_000) },
+    });
+    const projected = projectActivityPayload(source);
+    expect(projected.payload).toMatchObject({
+      data: { input, files: [{ path: "src/example.ts" }] },
+    });
+    expect(projectActivityPayload(projected)).toEqual(projected);
+    expect(JSON.stringify(projected).length).toBeLessThan(1_000);
+
+    const [webEntry] = deriveWorkLogEntries([projected]);
+    expect(webEntry).toMatchObject({ toolData: { input } });
+    const [mobileGroup] = buildThreadFeed(makeThread([projected]));
+    expect(mobileGroup?.type).toBe("activity-group");
+    if (mobileGroup?.type !== "activity-group") return;
+    const [mobileRow] = mobileGroup.activities;
+    expect(mobileRow?.canExpand).toBe(true);
+    const expected =
+      "content" in input
+        ? `After\n${input.content}`
+        : `Before\n${input.old_string}\n\nAfter\n${input.new_string}`;
+    expect(formatFileChangeInput(webEntry!)).toBe(expected);
+    expect(mobileRow?.getFullDetail()).toContain(expected);
+    expect(mobileRow?.getCopyText()).toContain(expected);
+  });
+
+  it("bounds each field, preserves truncation on replay, and leaves persisted input intact", () => {
+    const input = { old_string: `${"a".repeat(4_095)}😀tail`, new_string: "b".repeat(4_096) };
+    const source = makeActivity("large-edit", "file_change", { toolName: "Edit", input });
+    const projected = projectActivityPayload(source);
+    expect(projected.payload).toMatchObject({
+      data: {
+        input: { old_string: "a".repeat(4_095), new_string: input.new_string },
+        inputTruncated: { old_string: true, new_string: false },
+      },
+    });
+    expect(projectActivityPayload(projected)).toEqual(projected);
+    expect(source.payload).toMatchObject({ data: { input } });
+    const [entry] = deriveWorkLogEntries([projected]);
+    expect(formatFileChangeInput(entry!)).toBe(
+      `Before (truncated)\n${"a".repeat(4_095)}\n\nAfter\n${input.new_string}`,
+    );
+
+    const write = projectActivityPayload(
+      makeActivity("large-write", "file_change", {
+        toolName: "Write",
+        input: { content: "x".repeat(100_000) },
+      }),
+    );
+    expect(write.payload).toMatchObject({
+      data: { input: { content: "x".repeat(4_096) }, inputTruncated: { content: true } },
+    });
+    expect(JSON.stringify(write).length).toBeLessThan(5_000);
+  });
+
+  it.each([undefined, null, [], { content: 123 }, { content: { text: "not a string" } }])(
+    "ignores malformed Write input: %j",
+    (input) => {
+      const projected = projectActivityPayload(
+        makeActivity("invalid-write", "file_change", {
+          toolName: "Write",
+          input,
+        }),
+      );
+      expect(projected.payload).toMatchObject({ data: { toolName: "Write" } });
+      const [entry] = deriveWorkLogEntries([projected]);
+      expect(formatFileChangeInput(entry!)).toBeNull();
+    },
+  );
+
   it("slims MCP tool data to the fields the expanded row renders", () => {
     expect(projectActivityPayload(fixtures[4]!).payload).toEqual({
       itemType: "mcp_tool_call",
@@ -321,8 +401,13 @@ describe("projectActivityPayload", () => {
     }
   });
 
-  it("projects snapshot and event transports without mutating their sources", () => {
-    const activity = fixtures[0]!;
+  it.each([
+    fixtures[0]!,
+    makeActivity("transport-edit", "file_change", {
+      toolName: "Edit",
+      input: { file_path: "src/example.ts", old_string: "before", new_string: "after" },
+    }),
+  ])("projects snapshot and event transports without mutating their sources", (activity) => {
     const thread = makeThread([activity]);
     const snapshot = { snapshotSequence: 7, thread };
     const projectedSnapshot = projectThreadDetailSnapshot(snapshot);

--- a/apps/server/test/ActivityPayloadProjection.test.ts
+++ b/apps/server/test/ActivityPayloadProjection.test.ts
@@ -9,7 +9,10 @@ import {
   type OrchestrationThreadActivity,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
-import { formatFileChangeInput } from "../../../packages/client-runtime/src/work-log/presentation.ts";
+import {
+  formatFileChangeInput,
+  hasFileChangeInput,
+} from "../../../packages/client-runtime/src/work-log/presentation.ts";
 
 import { buildThreadFeed, type ThreadFeedActivity } from "../../mobile/src/lib/threadActivity.ts";
 import { deriveLatestContextWindowSnapshot } from "../../web/src/lib/contextWindow.ts";
@@ -238,6 +241,7 @@ describe("projectActivityPayload", () => {
     },
     { toolName: "Edit", input: { old_string: "remove me", new_string: "" } },
     { toolName: "Write", input: { content: "  export const ready = true;\n" } },
+    { toolName: "Write", input: { content: "" } },
   ])("retains verbatim $toolName input for expanded rows", ({ toolName, input }) => {
     const source = makeActivity("claude-edit", "file_change", {
       toolName,
@@ -252,6 +256,7 @@ describe("projectActivityPayload", () => {
 
     const [webEntry] = deriveWorkLogEntries([projected]);
     expect(webEntry).toMatchObject({ toolData: { input } });
+    expect(hasFileChangeInput(webEntry!)).toBe(true);
     const [mobileGroup] = buildThreadFeed(makeThread([projected]));
     expect(mobileGroup?.type).toBe("activity-group");
     if (mobileGroup?.type !== "activity-group") return;
@@ -306,7 +311,46 @@ describe("projectActivityPayload", () => {
       );
       expect(projected.payload).toMatchObject({ data: { toolName: "Write" } });
       const [entry] = deriveWorkLogEntries([projected]);
+      expect(hasFileChangeInput(entry!)).toBe(false);
       expect(formatFileChangeInput(entry!)).toBeNull();
+      const withoutDetail = { ...projected, payload: { ...projected.payload, detail: undefined } };
+      const [mobileGroup] = buildThreadFeed(makeThread([withoutDetail]));
+      expect(mobileGroup?.type).toBe("activity-group");
+      if (mobileGroup?.type !== "activity-group") return;
+      expect(mobileGroup.activities[0]?.canExpand).toBe(false);
+      expect(mobileGroup.activities[0]?.getFullDetail()).toBeNull();
+
+      const withPath = {
+        ...withoutDetail,
+        payload: {
+          ...withoutDetail.payload,
+          data: { toolName: "Write", files: [{ path: "src/example.ts" }] },
+        },
+      };
+      const [pathGroup] = buildThreadFeed(makeThread([withPath]));
+      expect(pathGroup?.type).toBe("activity-group");
+      if (pathGroup?.type !== "activity-group") return;
+      expect(pathGroup.activities[0]?.canExpand).toBe(true);
+      expect(pathGroup.activities[0]?.getCopyText()).toContain("src/example.ts");
+    },
+  );
+
+  it.each(["\uD800", `${"x".repeat(4_095)}\uD800`, `${"x".repeat(4_095)}\uD800tail`])(
+    "preserves lone high surrogates without treating them as split pairs (%#)",
+    (content) => {
+      const projected = projectActivityPayload(
+        makeActivity("lone-surrogate", "file_change", {
+          toolName: "Write",
+          input: { content },
+        }),
+      );
+      expect(projected.payload).toMatchObject({
+        data: {
+          input: { content: content.slice(0, 4_096) },
+          inputTruncated: { content: content.length > 4_096 },
+        },
+      });
+      expect(projectActivityPayload(projected)).toEqual(projected);
     },
   );
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -10,6 +10,7 @@ import {
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import {
+  formatFileChangeInput,
   resolveWorkEntryToolPresentation,
   resolveViewedImageAsset,
   workEntryViewedImagePath,
@@ -3125,6 +3126,8 @@ function buildToolCallExpandedBody(
   if (changedFiles.length > 0) {
     addBlock([...new Set(changedFiles)].join("\n"));
   }
+  const fileChangeInput = formatFileChangeInput(workEntry);
+  if (fileChangeInput !== null) blocks.push(fileChangeInput);
   return blocks.length > 0 ? blocks.join("\n\n") : null;
 }
 
@@ -3312,7 +3315,8 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
   const canExpand =
     (showFailedIndicator && previewText.trim().length > 0) ||
-    (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
+    ((workEntry.itemType === "mcp_tool_call" || workEntry.itemType === "file_change") &&
+      workEntry.toolData !== undefined) ||
     Boolean(
       (!commandMatchesVisibleLabel &&
         (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -11,6 +11,7 @@ import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import {
   formatFileChangeInput,
+  hasFileChangeInput,
   resolveWorkEntryToolPresentation,
   resolveViewedImageAsset,
   workEntryViewedImagePath,
@@ -3315,8 +3316,8 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
   const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
   const canExpand =
     (showFailedIndicator && previewText.trim().length > 0) ||
-    ((workEntry.itemType === "mcp_tool_call" || workEntry.itemType === "file_change") &&
-      workEntry.toolData !== undefined) ||
+    (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
+    hasFileChangeInput(workEntry) ||
     Boolean(
       (!commandMatchesVisibleLabel &&
         (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -596,6 +596,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     if (toolData !== undefined) {
       entry.toolData = toolData;
     }
+  } else if (itemType === "file_change") {
+    const data = asRecord(payload?.data);
+    if (data?.toolName === "Edit" || data?.toolName === "Write") entry.toolData = data;
   }
   if (itemType) {
     entry.itemType = itemType;

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -166,6 +166,22 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+export function formatFileChangeInput(entry: WorkLogPresentationEntry): string | null {
+  if (entry.itemType !== "file_change") return null;
+  const data = asRecord(entry.toolData);
+  if (data?.toolName !== "Edit" && data?.toolName !== "Write") return null;
+  const input = asRecord(data.input);
+  const truncated = asRecord(data.inputTruncated);
+  const fields = data.toolName === "Edit" ? ["old_string", "new_string"] : ["content"];
+  const blocks = fields.flatMap((key) => {
+    const value = input?.[key];
+    if (typeof value !== "string") return [];
+    const label = key === "old_string" ? "Before" : "After";
+    return [`${label}${truncated?.[key] === true ? " (truncated)" : ""}\n${value}`];
+  });
+  return blocks.length > 0 ? blocks.join("\n\n") : null;
+}
+
 function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -166,6 +166,15 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+export function hasFileChangeInput(entry: WorkLogPresentationEntry): boolean {
+  if (entry.itemType !== "file_change") return false;
+  const data = asRecord(entry.toolData);
+  const input = asRecord(data?.input);
+  return data?.toolName === "Edit"
+    ? typeof input?.old_string === "string" || typeof input?.new_string === "string"
+    : data?.toolName === "Write" && typeof input?.content === "string";
+}
+
 export function formatFileChangeInput(entry: WorkLogPresentationEntry): string | null {
   if (entry.itemType !== "file_change") return null;
   const data = asRecord(entry.toolData);


### PR DESCRIPTION
Claude Edit/Write entries lose their input during payload slimming, so expanding them shows a path or truncated JSON instead of readable changes.

Keep up to 4,096 UTF-16 code units per input field, with per-field truncation flags, and render the verbatim text in the existing expanded rows on web/desktop and mobile. Edit shows Before/After; Write shows only After because its input has no previous content. Collect `file_path` while projecting the payload. Collapsed labels stay unchanged.

Fixes #10970.

Validation: regression cases reproduced missing text, empty expansion, and altered surrogate input before their fixes. All 242 focused projection, timeline, mobile, and shared presentation tests pass, including whitespace, empty replacements, Unicode boundaries, malformed input, repeat projection, and snapshot/live-event transport. All four scoped typechecks and formatting pass; targeted lint reports only existing warnings.

Reproduced and checked in isolated Chromium using seeded Claude tool events. Verified Edit, Write, truncation, and keyboard expand/collapse. Mobile is covered by fixtures; no native-device or live Claude session was run.

| Before | After |
| --- | --- |
| ![Expanded Edit without readable changes](https://github.com/user-attachments/assets/97e48054-9ad4-4edd-9799-f240e38c6e06) | ![Expanded Edit with verbatim before and after](https://github.com/user-attachments/assets/5d2b6f58-dc10-418b-abf2-43dd3b7cdaa5) |

![Write shows the supplied content](https://github.com/user-attachments/assets/dc394e02-ad49-4921-9cc9-32cd538dd28b)

https://github.com/user-attachments/assets/23279aa8-7846-4d1b-9a1a-8fac3e559fbc

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded file-change activity entries now display formatted details for Edit and Write operations.
  - Edit entries show “Before” and “After” content; Write entries show the resulting content.
  - File-change entries can now be expanded alongside other tool activity.

- **Improvements**
  - Large file-change inputs are safely truncated and labeled when displayed.
  - Expanded activity details are preserved consistently across supported activity transports.
  - File-change content handling now remains reliable for empty and unusually formatted inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
