### PR TITLE
fix(web): allow expanding duplicate tool call commands

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3309,13 +3309,12 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           workspaceRoot,
         })
       : null;
-  const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
   const canExpand =
     (showFailedIndicator && previewText.trim().length > 0) ||
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
     Boolean(
-      (!commandMatchesVisibleLabel &&
-        (workEntryRawCommand(workEntry) || workEntry.command?.trim())) ||
+      workEntryRawCommand(workEntry) ||
+      workEntry.command?.trim() ||
       workEntry.detail?.trim() ||
       workEntry.changedFiles?.length ||
       viewedImage,
@@ -3396,9 +3395,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
               <span
                 className={cn(
                   "min-w-0 flex-1",
-                  expanded || (commandMatchesVisibleLabel && !canExpand)
-                    ? "whitespace-pre-wrap break-words select-text"
-                    : "truncate",
+                  expanded ? "whitespace-pre-wrap break-words select-text" : "truncate",
                   headingClass,
                 )}
                 onClick={expanded ? stopRowToggle : undefined}


### PR DESCRIPTION
## What Changed

- Allow tool-call rows to expand when their command matches the visible preview text.
- Simplify mobile glass surfaces by removing blur-target plumbing and using explicit fallback styles.
- Remove the provider model bulk enable/disable control and its associated helper tests.

## Why

Duplicate tool call commands could appear non-expandable when the visible label matched the command text. Expansion now depends on whether additional content is available, so duplicate commands remain inspectable.

The mobile glass cleanup reduces unnecessary blur-target complexity, while provider model settings retain their existing per-model controls.

Implemented with Codex (GPT-5).

## UI Changes

Before/after screenshots are not included. This change affects web tool-call expansion and mobile/settings UI behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved work-entry expansion in the chat timeline. Entries can now expand consistently when they include commands, details, changed files, or viewed images—even when the displayed label matches the command.
  * Updated label wrapping behavior to respond consistently to the entry’s expanded or collapsed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->