### PR TITLE
fix(mobile): prevent Android chat rows overlapping during sync

### DIFF
--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -2866,13 +2866,16 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
               entry.type === "message" ? `message:${entry.message.role}` : entry.type
             }
             getFixedItemSize={getFixedItemSize}
-            // LegendList swaps its position and size component types when this
-            // becomes undefined, remounting the feed and replaying row entrances.
-            // Keep those containers mounted while ordinary updates stay immediate.
+            // Android can retain stale native row positions when layout transitions
+            // race the measurements arriving during sync, even with duration 0.
+            // Keep its rows on LegendList's non-animated positioning path. On iOS,
+            // keep a transition installed between disclosures so containers don't remount.
             itemLayoutAnimation={
-              disclosureToggleSettling
-                ? THREAD_FEED_LAYOUT_TRANSITION
-                : THREAD_FEED_IMMEDIATE_TRANSITION
+              Platform.OS === "android"
+                ? undefined
+                : disclosureToggleSettling
+                  ? THREAD_FEED_LAYOUT_TRANSITION
+                  : THREAD_FEED_IMMEDIATE_TRANSITION
             }
             onItemSizeChanged={handleItemSizeChanged}
             // Measure rows well before they scroll into view so estimate→actual


### PR DESCRIPTION
Loading an Android chat during sync can leave assistant text drawn over the preceding attachment and timestamp until refresh. Reproduced the intermittent overlap with an attachment-only user message followed by a long assistant response.

Use LegendList's non-animated row positioning on Android instead of Reanimated layout transitions, including zero-duration transitions. Keep that choice stable during command expansion/collapse so the list does not swap container types and remount rows. iOS retains its existing transition path.

Validation: Android API 36 before/after with fresh conversations, plus a successful hardware-accelerated run with a command disclosure. iPhone 17 Pro / iOS 26.5 rendered the same fixture correctly, including delayed attachment loading. Mobile typecheck, 31 focused feed tests, formatting, and targeted lint passed (lint reports existing warnings). The failure was intermittent; subsequent upstream loads also sometimes passed, so these checks establish an Android reproduction, not proof that every iOS timing scenario is unaffected.

Recording limitation: native Android screen recording repeatedly stalled the emulator, including a System UI non-response. Before/after simulator screenshots are attached; a usable motion recording could not be captured.

| Android before | Android after |
| --- | --- |
| ![Assistant overlaps attachment](https://codex-file-host.shawnadedeji.workers.dev/files/2026-09-09/a7dd04dcd070-android-before.png) | ![Separate message rows](https://codex-file-host.shawnadedeji.workers.dev/files/2026-09-09/498af1d5c065-fixed-6.png) |

[iOS verification screenshot](https://codex-file-host.shawnadedeji.workers.dev/files/2026-09-09/bfb02e376744-ios-after.png)

Model: GPT-6. Harness: Codex.