### PR TITLE
fix(server): use workspace-scoped Bitbucket permissions API

### DIFF
--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -855,7 +855,9 @@ layer("BitbucketPullRequestApi.layer", (it) => {
 
       assert.isFalse(yield* api.getRepositoryPermission({ repository: "acme/web" }));
 
-      expect(callAt(0).url).toContain("/user/permissions/repositories");
+      expect(new URL(callAt(0).url, "https://api.bitbucket.org").pathname).toBe(
+        "/user/workspaces/acme/permissions/repositories",
+      );
       assert.strictEqual(filterOfCall(0), 'repository.full_name="acme/web"');
     }),
   );
@@ -873,45 +875,28 @@ layer("BitbucketPullRequestApi.layer", (it) => {
     }),
   );
 
-  it.effect(
-    "reads a removed permissions endpoint as granted rather than failing the merge on it",
-    () =>
+  for (const status of [401, 403, 404, 410]) {
+    it.effect(`preserves HTTP ${status} from the workspace permissions endpoint`, () =>
       Effect.gen(function* () {
-        // Bitbucket retired /user/permissions/repositories under CHANGE-2770: every account now
-        // gets HTTP 410 here, whatever it may do.
         mockedRequest.mockReturnValue(
           Effect.fail(
             new BitbucketApi.BitbucketResponseError({
               operation: "request",
-              status: 410,
+              status,
               responseBodyLength: 0,
             }),
           ),
         );
         const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
 
-        assert.isTrue(yield* api.getRepositoryPermission({ repository: "acme/web" }));
+        const error = yield* Effect.flip(api.getRepositoryPermission({ repository: "acme/web" }));
+        assert.strictEqual(error._tag, "BitbucketResponseError");
+        if (error._tag === "BitbucketResponseError") {
+          assert.strictEqual(error.status, status);
+        }
       }),
-  );
-
-  it.effect("still fails the permission read on a failure that is not the removed endpoint", () =>
-    Effect.gen(function* () {
-      mockedRequest.mockReturnValue(
-        Effect.fail(
-          new BitbucketApi.BitbucketResponseError({
-            operation: "request",
-            status: 401,
-            responseBodyLength: 0,
-          }),
-        ),
-      );
-      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
-
-      const error = yield* Effect.flip(api.getRepositoryPermission({ repository: "acme/web" }));
-
-      assert.strictEqual(error._tag, "BitbucketResponseError");
-    }),
-  );
+    );
+  }
 
   it.effect("reads the workspace's people and marks whoever is already a reviewer", () =>
     Effect.gen(function* () {

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.test.ts
@@ -862,6 +862,22 @@ layer("BitbucketPullRequestApi.layer", (it) => {
     }),
   );
 
+  it.effect("matches repository permissions after normalizing whitespace around segments", () =>
+    Effect.gen(function* () {
+      mockedRequest.mockImplementation((input) => {
+        const url = new URL(input.url, "https://api.bitbucket.org");
+        const matches =
+          url.pathname === "/user/workspaces/acme/permissions/repositories" &&
+          url.searchParams.get("q") === 'repository.full_name="acme/web"';
+        return Effect.succeed(response(valuePage(matches ? [{ permission: "read" }] : [])));
+      });
+      const api = yield* BitbucketPullRequestApi.BitbucketPullRequestApi;
+
+      // An unmatched, empty permission page is treated as unknown and would allow this attempt.
+      assert.isFalse(yield* api.getRepositoryPermission({ repository: " acme / web " }));
+    }),
+  );
+
   it.effect("escapes a repository name before it goes inside a filter literal", () =>
     Effect.gen(function* () {
       // @effect-diagnostics-next-line preferSchemaOverJson:off

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -373,16 +373,19 @@ export const make = Effect.gen(function* () {
   const bitbucket = yield* BitbucketApi.BitbucketApi;
 
   /**
-   * The repository's own path, and the workspace above it — which the people who may review are
-   * kept on rather than on the repository, so both are handed over at once.
+   * The repository's API path and normalized segments, used for workspace reads and filters.
    */
   const withRepository = <A>(
     repository: string,
-    use: (path: string, workspace: string) => Effect.Effect<A, BitbucketPullRequestApiError>,
+    use: (
+      path: string,
+      workspace: string,
+      slug: string,
+    ) => Effect.Effect<A, BitbucketPullRequestApiError>,
   ): Effect.Effect<A, BitbucketPullRequestApiError> => {
     const segments = repositorySegments(repository);
     return Result.isSuccess(segments)
-      ? use(repositoryPathOf(segments.success), segments.success.workspace)
+      ? use(repositoryPathOf(segments.success), segments.success.workspace, segments.success.slug)
       : Effect.fail(segments.failure);
   };
 
@@ -568,11 +571,11 @@ export const make = Effect.gen(function* () {
     // Ask for the caller's effective permission within this workspace. The full name identifies
     // the repository by its slug, even when its display name differs.
     getRepositoryPermission: (input) =>
-      withRepository(input.repository, (_path, workspace) =>
+      withRepository(input.repository, (_path, workspace, slug) =>
         readPage({
           operation: "getRepositoryPermission",
           url: `/user/workspaces/${encodeURIComponent(workspace)}/permissions/repositories?q=${encodeURIComponent(
-            `repository.full_name="${filterLiteral(input.repository.trim())}"`,
+            `repository.full_name="${filterLiteral(`${workspace}/${slug}`)}"`,
           )}`,
           decode: decodeRepositoryPermissionJson,
         }),

--- a/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestApi.ts
@@ -109,16 +109,6 @@ export type BitbucketPullRequestApiError =
   | BitbucketDiffCommitError;
 
 /**
- * `/user/permissions/repositories` answering CHANGE-2770's removal notice rather than a
- * permission — Bitbucket sends this for every account now, not only ones it would have refused.
- */
-function isRepositoryPermissionRemovedError(
-  error: BitbucketPullRequestApiError,
-): error is BitbucketApi.BitbucketResponseError {
-  return error._tag === "BitbucketResponseError" && error.status === 410;
-}
-
-/**
  * Bitbucket's own ceiling. Asking for more does not fail — it answers with an empty page and no
  * error at all, so this is a number to respect rather than to push against.
  */
@@ -575,26 +565,18 @@ export const make = Effect.gen(function* () {
         }),
       ),
 
-    // Nothing on the repository, the pull request or the workspace states what the credentials
-    // may do, so this endpoint is the one request Bitbucket makes unavoidable. It is asked
-    // alongside the reads the detail was already making, so it costs no round trip of its own.
-    //
-    // Bitbucket permanently removed this endpoint (CHANGE-2770): every account now gets HTTP 410
-    // in place of an answer, whatever it may do. That is the deprecated-endpoint signal, not a
-    // permission being refused, so it is read the same way an unreachable read already is
-    // elsewhere — as a permission that could not be learned, which grants rather than blocks, and
-    // leaves the actual merge or write to say why if the account may not do it. Any other failure
-    // (a bad token, a network fault, an unreadable body) still fails as it did before.
+    // Ask for the caller's effective permission within this workspace. The full name identifies
+    // the repository by its slug, even when its display name differs.
     getRepositoryPermission: (input) =>
-      withRepository(input.repository, () =>
+      withRepository(input.repository, (_path, workspace) =>
         readPage({
           operation: "getRepositoryPermission",
-          url: `/user/permissions/repositories?q=${encodeURIComponent(
+          url: `/user/workspaces/${encodeURIComponent(workspace)}/permissions/repositories?q=${encodeURIComponent(
             `repository.full_name="${filterLiteral(input.repository.trim())}"`,
           )}`,
           decode: decodeRepositoryPermissionJson,
         }),
-      ).pipe(Effect.catchIf(isRepositoryPermissionRemovedError, () => Effect.succeed(true))),
+      ),
 
     getPullRequestDiff: (input) =>
       input.commit !== undefined && !isCommitSha(input.commit)

--- a/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/BitbucketPullRequestProvider.ts
@@ -113,7 +113,10 @@ export const make = Effect.gen(function* () {
         ...bitbucketProviderFailure(error),
         // Every Bitbucket failure states its own fact; this names the operation around it, so
         // the two do not stack into "failed in x: failed in y: ...".
-        detail: error.detail,
+        detail:
+          operation === "getViewerPermissions"
+            ? `Could not check your Bitbucket repository permissions. ${error.detail}`
+            : error.detail,
         cause: error,
       });
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -17,6 +17,9 @@ import type {
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
 import * as SourceControlRateLimit from "../sourceControl/SourceControlRateLimit.ts";
+import * as BitbucketApi from "../sourceControl/BitbucketApi.ts";
+import * as BitbucketPullRequestApi from "./BitbucketPullRequestApi.ts";
+import * as BitbucketPullRequestProvider from "./BitbucketPullRequestProvider.ts";
 import {
   PullRequestProviderError,
   type ProviderChangeRequest,
@@ -1093,6 +1096,129 @@ it.effect("refuses an action this viewer may not take, and says what access it t
     // What the author keeps whatever their access is still theirs to take.
     yield* service.runAction({ ...reference, action: "close" });
     assert.strictEqual(ran, "close");
+  }),
+);
+
+for (const permission of ["read", "write", "admin"] as const) {
+  it.effect(`checks Bitbucket workspace permissions before merging with ${permission} access`, () =>
+    Effect.gen(function* () {
+      const calls: Array<Parameters<BitbucketApi.BitbucketApi["Service"]["request"]>[0]> = [];
+      const provider = yield* BitbucketPullRequestProvider.make.pipe(
+        Effect.provide(
+          BitbucketPullRequestApi.layer.pipe(
+            Layer.provide(
+              Layer.mock(BitbucketApi.BitbucketApi)({
+                request: (input) => {
+                  calls.push(input);
+                  const url = new URL(input.url, "https://api.bitbucket.org");
+                  if (url.pathname === "/user/workspaces/acme/permissions/repositories") {
+                    assert.strictEqual(
+                      url.searchParams.get("q"),
+                      'repository.full_name="acme/web"',
+                    );
+                    return Effect.succeed({
+                      body: JSON.stringify({
+                        values: [
+                          { repository: { name: "Web App", full_name: "acme/web" }, permission },
+                        ],
+                      }),
+                      truncated: false,
+                    });
+                  }
+                  if (
+                    input.method === "POST" &&
+                    url.pathname === "/repositories/acme/web/pullrequests/1/merge"
+                  ) {
+                    return Effect.succeed({ body: "{}", truncated: false });
+                  }
+                  return Effect.die(`Unexpected Bitbucket request: ${input.method} ${input.url}`);
+                },
+              }),
+            ),
+          ),
+        ),
+      );
+      const service = yield* makeService({
+        projects: [
+          project({
+            id: "p1",
+            title: "web",
+            workspaceRoot: "/a",
+            repository: "acme/web",
+            provider: "bitbucket",
+            host: "bitbucket.org",
+          }),
+        ],
+        providers: [
+          {
+            ...provider,
+            getChangeRequestSummary: () =>
+              Effect.succeed({ ...changeRequest(1, "2026-07-02T00:00:00Z"), state: "merged" }),
+          },
+        ],
+      });
+      const merge = service.runAction({
+        projectId: "p1" as ProjectId,
+        repository: "acme/web",
+        number: 1,
+        action: "merge",
+        mergeMethod: "squash",
+      });
+      if (permission === "read") {
+        const error = yield* Effect.flip(merge);
+        assert.include(error.message, "You need write access on this repository to merge.");
+        assert.strictEqual(calls.length, 1);
+      } else {
+        yield* merge;
+        assert.strictEqual(calls.length, 2);
+        assert.strictEqual(calls[1]?.body, '{"merge_strategy":"squash"}');
+      }
+    }),
+  );
+}
+
+it.effect("identifies a Bitbucket permission lookup failure before attempting a merge", () =>
+  Effect.gen(function* () {
+    const provider = yield* BitbucketPullRequestProvider.make.pipe(
+      Effect.provide(
+        Layer.mock(BitbucketPullRequestApi.BitbucketPullRequestApi)({
+          getRepositoryPermission: () =>
+            Effect.fail(
+              new BitbucketApi.BitbucketResponseError({
+                operation: "request",
+                status: 404,
+                responseBodyLength: 0,
+              }),
+            ),
+          runAction: () => Effect.die("A failed permission check must not attempt a merge"),
+        }),
+      ),
+    );
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "web",
+          workspaceRoot: "/a",
+          repository: "acme/web",
+          provider: "bitbucket",
+          host: "bitbucket.org",
+        }),
+      ],
+      providers: [provider],
+    });
+    const error = yield* Effect.flip(
+      service.runAction({
+        projectId: "p1" as ProjectId,
+        repository: "acme/web",
+        number: 1,
+        action: "merge",
+      }),
+    );
+    assert.include(
+      error.message,
+      "Could not check your Bitbucket repository permissions. Bitbucket returned HTTP 404.",
+    );
   }),
 );
 

--- a/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
+++ b/apps/server/src/pullRequest/bitbucketPullRequestJson.ts
@@ -160,9 +160,8 @@ const RawViewerSchema = Schema.Struct({
 });
 
 /**
- * `/user/permissions/repositories` filtered to one repository, which is the only place Bitbucket
- * states what the credentials may do with it: nothing on the repository, the pull request or the
- * workspace carries it. One row, or none where Bitbucket names no permission for this account.
+ * The caller's workspace-scoped repository permissions, filtered to one repository.
+ * One row, or none where Bitbucket names no permission for this account.
  */
 const RawRepositoryPermissionsSchema = Schema.Struct({
   values: Schema.optional(


### PR DESCRIPTION
## What Changed

Use Bitbucket’s supported workspace-scoped repository permissions endpoint, retaining the full-name filter so repository display names do not affect matching. Remove the obsolete HTTP 410 fallback and identify permission lookup failures in the error message.

## Why

With valid Bitbucket credentials, open a mergeable PR in T3 and click **Merge**. The retired `/2.0/user/permissions/repositories` endpoint can return HTTP 404, aborting the permission check before any merge request is sent. The workaround in #6525 handles only 410.

The fix uses `/2.0/user/workspaces/{workspace}/permissions/repositories` to check the caller’s effective permissions before merging.

## Validation

- 189 focused tests passed, including read/write/admin access and failed permission checks.
- Targeted lint and server typecheck passed.
- Reporter confirmed the fix works in the UI of an isolated test server.

Implemented with GPT-6 using the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bitbucket repository permissions are now checked against the correct workspace and normalized repository name.
  - Merge actions now correctly require write or administrator access; read-only access is blocked.
  - Permission-check failures are surfaced clearly instead of being treated as successful access.
  - Bitbucket permission errors now include a more specific explanation.

- **Documentation**
  - Updated permission descriptions to clarify workspace-scoped repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->