### PR TITLE
chore: add stack test follow-up marker

### DIFF
--- a/.github/stack-test/follow-up.txt
+++ b/.github/stack-test/follow-up.txt
@@ -1,0 +1,1 @@
+This follow-up marker depends on the base layer in this test stack.


### PR DESCRIPTION
This disposable PR adds a follow-up marker on top of the base test PR.

It creates one inert text file under .github/stack-test. This PR is expected to be closed after the stack test.

Created with GPT-5.6 Sol in the Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a follow-up marker documenting that the test stack depends on the base layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->