### PR TITLE
docs(keybindings): clarify modifier aliases

### DIFF
--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -32,7 +32,8 @@ Project scripts use `script.{id}.run`, such as `script.test.run`.
 
 Join modifiers and a key with `+`, such as `mod+shift+d` or `ctrl+l`.
 `mod` means Command on macOS and Control elsewhere. Other modifiers are
-`cmd` / `meta`, `ctrl` / `control`, `alt` / `option`, and `shift`.
+`cmd` and `meta`, `ctrl` and `control`, and `alt` and `option`. Each pair is
+equivalent. Use `shift` for the Shift key.
 
 ## When conditions
 


### PR DESCRIPTION
The keybindings guide listed modifier aliases with slash notation but did not say whether each name was interchangeable.

This change states that each alias pair is equivalent and calls out Shift separately.

Verification: skipped at request. The repository pre-commit hook was bypassed because this worktree does not resolve vite-plus.

Prepared by gpt-5.6-sol through the Codex harness in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that modifier aliases are equivalent pairs.
  - Specified that `shift` refers to the Shift key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->