### PR TITLE
fix(mobile): prevent text leaking through Android glass

### DIFF
--- a/apps/mobile/src/components/AndroidAnchoredMenu.tsx
+++ b/apps/mobile/src/components/AndroidAnchoredMenu.tsx
@@ -1,5 +1,4 @@
 import type { MenuAction, MenuComponentProps } from "@react-native-menu/menu";
-import { BlurView } from "expo-blur";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { StyleProp, ViewStyle } from "react-native";
@@ -8,11 +7,11 @@ import { useKeyboardState } from "react-native-keyboard-controller";
 import Animated, { FadeIn } from "react-native-reanimated";
 
 import { appBlurTargetRef } from "../lib/appBlurTarget";
-import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
 import { cn } from "../lib/cn";
 import { type AppSymbolName, SymbolView } from "./AppSymbol";
 import { AppText as Text } from "./AppText";
 import { OverlayPortal } from "./OverlayPortal";
+import { GlassBackdrop } from "./GlassBackdrop";
 
 const MENU_WIDTH = 250;
 const SCREEN_MARGIN = 12;
@@ -79,8 +78,6 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
   const anchorRef = useRef<View>(null);
   const overlayRef = useRef<View>(null);
 
-  const { themeAppearance } = useAppearancePreferences();
-  const isDarkMode = themeAppearance === "dark";
   const keyboardVisible = useKeyboardState((state) => state.isVisible);
   const keyboardHeight = useKeyboardState((state) => state.height);
   const close = useCallback(() => {
@@ -227,16 +224,7 @@ export function AndroidAnchoredMenu(props: AndroidAnchoredMenuProps) {
                     : { bottom: (rootHeight ?? 0) - local.y + ANCHOR_GAP }),
                 }}
               >
-                {/* Frosted backdrop: blur of the app content behind the menu,
-                  washed with the translucent card tone so rows keep contrast. */}
-                <BlurView
-                  blurMethod="dimezisBlurView"
-                  blurTarget={appBlurTargetRef}
-                  intensity={40}
-                  tint={isDarkMode ? "dark" : "light"}
-                  className="absolute inset-0"
-                />
-                <View className="absolute inset-0 bg-card-translucent" />
+                <GlassBackdrop blurTarget={appBlurTargetRef} />
                 {/* keyboardShouldPersistTaps: the menu often opens over an
                   active editor; the first item tap must act, not just
                   dismiss the keyboard. */}

--- a/apps/mobile/src/components/GlassBackdrop.tsx
+++ b/apps/mobile/src/components/GlassBackdrop.tsx
@@ -1,0 +1,53 @@
+import { BlurView } from "expo-blur";
+import { useContext, type RefObject } from "react";
+import { Platform, StyleSheet, View, type ColorValue } from "react-native";
+
+import { useAppearancePreferences } from "../features/settings/appearance/AppearancePreferencesProvider";
+import { GlassBlurTargetContext } from "../lib/glassBlurTarget";
+import { themeColorWithAlpha } from "../lib/mobileTheme";
+
+/** Frosted backdrop for containers that clip their children to their shape. */
+export function GlassBackdrop(props: {
+  readonly fallbackColor?: ColorValue;
+  readonly blurTarget?: RefObject<View | null>;
+}) {
+  const { themeAppearance } = useAppearancePreferences();
+  const inheritedBlurTarget = useContext(GlassBlurTargetContext);
+  const target = props.blurTarget ?? inheritedBlurTarget;
+  const supportsBlur =
+    Platform.OS === "ios" ||
+    (Platform.OS === "android" && Platform.Version >= 31 && target !== undefined);
+  const colorStyle =
+    props.fallbackColor === undefined
+      ? undefined
+      : { backgroundColor: themeColorWithAlpha(String(props.fallbackColor), 1) };
+
+  return (
+    <>
+      {/* Android samples a separate target. An opaque backing prevents any
+          transparent pixels in that sample from exposing the unblurred feed.
+          iOS samples its actual backdrop, so a backing there would hide it. */}
+      {Platform.OS === "android" ? (
+        <View pointerEvents="none" className="absolute inset-0 bg-card" style={colorStyle} />
+      ) : null}
+      {supportsBlur ? (
+        <BlurView
+          pointerEvents="none"
+          blurTarget={target}
+          blurMethod="dimezisBlurViewSdk31Plus"
+          intensity={80}
+          tint={themeAppearance === "dark" ? "dark" : "default"}
+          style={StyleSheet.absoluteFill}
+        />
+      ) : null}
+      <View
+        pointerEvents="none"
+        className="absolute inset-0 bg-card"
+        style={[
+          colorStyle,
+          { opacity: supportsBlur ? (themeAppearance === "dark" ? 0.25 : 0.55) : 1 },
+        ]}
+      />
+    </>
+  );
+}

--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -1,9 +1,7 @@
-import { BlurView } from "expo-blur";
 import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
-import { useContext, type ReactNode, type Ref, type RefObject } from "react";
+import type { ReactNode, Ref, RefObject } from "react";
 import {
   Platform,
-  StyleSheet,
   useColorScheme,
   View,
   type ColorValue,
@@ -13,8 +11,7 @@ import {
 import { withUniwind } from "uniwind";
 
 import { cn } from "../lib/cn";
-import { GlassBlurTargetContext } from "../lib/glassBlurTarget";
-import { themeColorWithAlpha } from "../lib/mobileTheme";
+import { GlassBackdrop } from "./GlassBackdrop";
 
 // Explicit mappings keep the native glassEffectStyle enum out of style-array conversion.
 const ThemedGlassView = withUniwind(GlassView, {
@@ -51,13 +48,6 @@ export function GlassSurface({
   ...props
 }: GlassSurfaceProps) {
   const isDarkMode = useColorScheme() === "dark";
-  const inheritedBlurTarget = useContext(GlassBlurTargetContext);
-  const target = blurTarget ?? inheritedBlurTarget;
-  const supportsBlur =
-    Platform.OS === "ios" ||
-    (Platform.OS === "android" && Platform.Version >= 31 && target !== undefined);
-  const backgroundColor =
-    fallbackColor === undefined ? undefined : themeColorWithAlpha(String(fallbackColor), 1);
   const supportsGlass = Platform.OS === "ios" && isGlassEffectAPIAvailable();
   const surfaceStyle: ViewStyle = {
     borderRadius: 32,
@@ -113,21 +103,7 @@ export function GlassSurface({
       )}
       style={[surfaceStyle, style]}
     >
-      {supportsBlur ? (
-        <BlurView
-          pointerEvents="none"
-          blurTarget={target}
-          blurMethod="dimezisBlurViewSdk31Plus"
-          intensity={80}
-          tint={isDarkMode ? "dark" : "default"}
-          style={StyleSheet.absoluteFill}
-        />
-      ) : null}
-      <View
-        pointerEvents="none"
-        className="absolute inset-0 bg-card"
-        style={{ backgroundColor, opacity: supportsBlur ? (isDarkMode ? 0.25 : 0.55) : 1 }}
-      />
+      <GlassBackdrop blurTarget={blurTarget} fallbackColor={fallbackColor} />
       {children}
     </View>
   );


### PR DESCRIPTION
Android glass popups can expose sharp conversation text through transparent pixels in the captured backdrop. Follow-up to [#10964](https://github.com/pingdotgg/t3code/pull/10964), covering the composer suggestions and Android menus as well as the composer itself.

Add a shared `GlassBackdrop` with an opaque themed backing beneath Android's sampled blur. Preserve the theme fill when no explicit fallback color is provided, and choose the tint from the app's appearance preference. Skills, slash commands, file suggestions, attachment menus, and terminal controls now share the same fallback. Android below API 31 uses a solid fill; iOS keeps its actual-backdrop blur and native Liquid Glass path.

### Verification

- Pixel 9 emulator, Android 16 / API 36: composer, skills/commands/files in Material You light and dark; skills in T3 light; attachment menus in both appearances; terminal keyboard control and options menu in dark. Skill selection and popup dismissal checked.
- Used the supplied T3 Code 1.1.1 (37) production AAB. The fixed test APK retains its native code and replaces only the embedded production Hermes bundle and update manifest, signed locally for the emulator. This is not a published EAS build.
- The original artifact already blurred on this emulator: the physical phone's exact leak remains unreproduced. These captures demonstrate appearance and coverage, not a reproduced before/after failure. The skills captures use the same fixture, viewport, and popup with a small background scroll/cursor difference.
- Mobile typecheck, production Android Hermes export, formatting and whitespace checks passed. Targeted lint has only two existing warnings in `AndroidAnchoredMenu`. No iOS or pre-API-31 runtime verification.
- Source audit: Android status/working controls, header fallbacks and git progress overlays already use solid backgrounds; model settings is a solid screen. No web, desktop, provider or connection-contract changes.

### Before / after: skills in Material You light

| Before: supplied production artifact | After: shared backed blur |
| --- | --- |
| ![Before: production skills popup](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a9c1a3f05a8daad8/production-skills-original.png) | ![After: fixed skills popup](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4b956a352398cb70/release-fixed-skills-light.png) |

### Additional coverage

| Material You dark skills | Light attachment menu over file suggestions |
| --- | --- |
| ![Dark skills](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/5613831f466c7ec4/release-fixed-skills-dark.png) | ![Attachment menu and files](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/04a86ccf2f638c39/release-fixed-attachment-light.png) |

| T3 light skills | Dark terminal menu |
| --- | --- |
| ![T3 light skills](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c0289f988130e880/release-fixed-skills-t3-light.png) | ![Terminal menu](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/43acd27fa15a9b5e/release-fixed-terminal-menu-dark.png) |

### Scrolling and popup transitions

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/527c43cfd1be2389/release-fixed-scroll.mp4

Implemented and reviewed with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the appearance and consistency of translucent glass backgrounds across supported mobile platforms.
  * Updated anchored menus to use the shared glass background treatment.
  * Enhanced fallback rendering so surfaces remain visually appropriate when blur effects are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->