### PR TITLE
fix(desktop): keep annotation comment direction independent of host page

### DIFF
--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -436,6 +436,7 @@ function startAnnotation(): void {
   let finished = false;
   const host = document.createElement("div");
   host.setAttribute(OVERLAY_ATTRIBUTE, "");
+  host.setAttribute("dir", "ltr");
   host.style.cssText = `position:fixed;inset:0;z-index:${Z_INDEX_OVERLAY};pointer-events:none`;
   applyAnnotationTheme(host, annotationTheme);
   const shadowRoot = host.attachShadow({ mode: "closed" });
@@ -445,6 +446,7 @@ function startAnnotation(): void {
 
   const root = document.createElement("div");
   root.setAttribute(OVERLAY_ATTRIBUTE, "");
+  root.setAttribute("dir", "ltr");
   root.className = "fixed inset-0 font-sans text-foreground";
   root.style.cssText = "pointer-events:none";
   const cursorStyle = document.createElement("style");
@@ -494,6 +496,7 @@ function startAnnotation(): void {
 
   const comment = document.createElement("textarea");
   comment.placeholder = "Describe the change…";
+  comment.setAttribute("dir", "auto");
   comment.rows = 1;
   comment.className =
     "min-h-8 max-h-24 min-w-0 flex-1 resize-none overflow-y-hidden border-0 border-b border-b-transparent bg-transparent px-0 py-1.5 font-sans text-sm leading-5 text-foreground outline-none ring-0 placeholder:text-muted-foreground focus:border-b-primary focus:outline-none focus:ring-0";


### PR DESCRIPTION
## Summary
- Preview annotation comments inherited the inspected page's text `dir`, so RTL comments (Arabic, Hebrew, Persian) were misaligned on LTR pages, and forcing the host page to RTL mirrored the whole annotation toolbar instead of just the comment text.
- Pin the overlay `host`/`root` elements to `dir="ltr"` so the annotation chrome (toolbar, editor, Attach button order) has a stable layout regardless of the inspected page's direction.
- Set `dir="auto"` on the comment `<textarea>` so its direction is inferred from the actual typed content instead of inherited from the page.

Fixes #4644

## Test plan
- [x] `pnpm typecheck` in `apps/desktop` — no new errors introduced (verified against a clean checkout, which has the same pre-existing unrelated errors in `scripts/lib/*`)
- [ ] Manual repro per the issue: open an LTR page, start annotation, type an Arabic comment, confirm it now renders RTL while toolbar/Attach button stay in place
- [ ] Manual repro on an RTL host page: confirm toolbar/editor chrome no longer mirrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text direction handling in the annotation overlay and comment input for better support of mixed-language content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->