### PR TITLE
fix(desktop): keep annotation comment direction independent of host page

### DIFF
--- a/apps/desktop/src/preview/PickPreload.ts
+++ b/apps/desktop/src/preview/PickPreload.ts
@@ -436,6 +436,7 @@ function startAnnotation(): void {
   let finished = false;
   const host = document.createElement("div");
   host.setAttribute(OVERLAY_ATTRIBUTE, "");
+  host.setAttribute("dir", "ltr");
   host.style.cssText = `position:fixed;inset:0;z-index:${Z_INDEX_OVERLAY};pointer-events:none`;
   applyAnnotationTheme(host, annotationTheme);
   const shadowRoot = host.attachShadow({ mode: "closed" });
@@ -445,6 +446,7 @@ function startAnnotation(): void {
 
   const root = document.createElement("div");
   root.setAttribute(OVERLAY_ATTRIBUTE, "");
+  root.setAttribute("dir", "ltr");
   root.className = "fixed inset-0 font-sans text-foreground";
   root.style.cssText = "pointer-events:none";
   const cursorStyle = document.createElement("style");
@@ -494,6 +496,7 @@ function startAnnotation(): void {
 
   const comment = document.createElement("textarea");
   comment.placeholder = "Describe the change…";
+  comment.setAttribute("dir", "auto");
   comment.rows = 1;
   comment.className =
     "min-h-8 max-h-24 min-w-0 flex-1 resize-none overflow-y-hidden border-0 border-b border-b-transparent bg-transparent px-0 py-1.5 font-sans text-sm leading-5 text-foreground outline-none ring-0 placeholder:text-muted-foreground focus:border-b-primary focus:outline-none focus:ring-0";


### PR DESCRIPTION
## What Changed

The preview annotation overlay now forces its own `dir="ltr"` on the overlay host, so the toolbar, editor, and element labels keep a stable layout regardless of the inspected page's direction. The comment textarea uses `dir="auto"`, so Arabic, Hebrew, Persian, and other RTL comments start from the right and keep readable bidi ordering, while LTR comments are unchanged.

Fixes #4644

## Why

The annotation `<textarea>` had no `dir` attribute and the overlay inherited direction from the inspected document. On an LTR page an Arabic comment was anchored to the left and ordered incorrectly. On an RTL page the whole annotation chrome mirrored: tool order reversed, the Attach button moved, and element labels got pushed off the right edge of the viewport.

Isolating the overlay from the host document and letting the comment field infer direction from its content is the smallest change that fixes both.

## UI Changes

Arabic comment on an LTR host page. Before: text is anchored to the left of the field.

![Before, LTR page](https://raw.githubusercontent.com/abdelrhmanehab10/t3code/pr-assets/rtl-annotation-4644/before-ltr.png)

After: the comment starts from the right, toolbar unchanged.

![After, LTR page](https://raw.githubusercontent.com/abdelrhmanehab10/t3code/pr-assets/rtl-annotation-4644/after-ltr.png)

RTL host page. Before: the overlay mirrors along with the page, and the element label is pushed off screen.

![Before, RTL page](https://raw.githubusercontent.com/abdelrhmanehab10/t3code/pr-assets/rtl-annotation-4644/before-rtl.png)

After: the overlay keeps its LTR layout while the page stays RTL.

![After, RTL page](https://raw.githubusercontent.com/abdelrhmanehab10/t3code/pr-assets/rtl-annotation-4644/after-rtl.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable)

Reviewed and verified with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text direction handling in the annotation overlay.
  * Overlay controls now display left-to-right consistently, while comment text automatically follows the direction of the entered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->