### PR TITLE
fix(server): pause idle PR polling and coordinate refreshes

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -396,6 +396,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(
         Layer.succeed(ThreadPullRequestReactor.ThreadPullRequestReactor, {
           start: () => Effect.void,
+          refresh: () => Effect.void,
           drain: Effect.void,
         }),
       ),

--- a/apps/server/src/auth/SessionStore.test.ts
+++ b/apps/server/src/auth/SessionStore.test.ts
@@ -399,6 +399,7 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
 
       const beforeConnect = yield* sessions.listActive();
       expect(beforeConnect[0]?.lastConnectedAt).toBeNull();
+      expect(yield* sessions.hasConnectedClients).toBe(false);
 
       yield* TestClock.adjust(Duration.seconds(1));
       yield* sessions.markConnected(issued.sessionId);
@@ -406,6 +407,7 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
       const firstConnectedAt = firstConnect[0]?.lastConnectedAt;
 
       expect(firstConnect[0]?.connected).toBe(true);
+      expect(yield* sessions.hasConnectedClients).toBe(true);
       expect(firstConnectedAt).not.toBeNull();
 
       yield* TestClock.adjust(Duration.seconds(1));
@@ -415,7 +417,9 @@ it.layer(NodeServices.layer)("SessionStore.layer", (it) => {
       expect(stillConnected[0]?.lastConnectedAt?.toString()).toBe(firstConnectedAt?.toString());
 
       yield* sessions.markDisconnected(issued.sessionId);
+      expect(yield* sessions.hasConnectedClients).toBe(true);
       yield* sessions.markDisconnected(issued.sessionId);
+      expect(yield* sessions.hasConnectedClients).toBe(false);
       const afterDisconnect = yield* sessions.listActive();
 
       expect(afterDisconnect[0]?.connected).toBe(false);

--- a/apps/server/src/auth/SessionStore.ts
+++ b/apps/server/src/auth/SessionStore.ts
@@ -402,6 +402,7 @@ export class SessionStore extends Context.Service<
       sessionId: AuthSessionId,
     ) => Effect.Effect<number, SessionCredentialInternalError>;
     readonly markConnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
+    readonly hasConnectedClients: Effect.Effect<boolean>;
     readonly markDisconnected: (sessionId: AuthSessionId) => Effect.Effect<void, never>;
     readonly recordClientConnection: (
       sessionId: AuthSessionId,
@@ -976,6 +977,9 @@ export const make = Effect.gen(function* () {
     revoke,
     revokeAllExcept,
     markConnected,
+    hasConnectedClients: Ref.get(connectedSessionsRef).pipe(
+      Effect.map((sessions) => sessions.size > 0),
+    ),
     markDisconnected,
     recordClientConnection,
   });

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -73,6 +73,7 @@ describe("OrchestrationReactor", () => {
               started.push("thread-pull-request-reactor");
               return Effect.void;
             },
+            refresh: () => Effect.void,
             drain: Effect.void,
           }),
         ),

--- a/apps/server/src/orchestration/PullRequestSyncReactor.test.ts
+++ b/apps/server/src/orchestration/PullRequestSyncReactor.test.ts
@@ -24,6 +24,8 @@ import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
 
 import { PullRequestService } from "../pullRequest/PullRequestService.ts";
+import { SessionStore } from "../auth/SessionStore.ts";
+import { ThreadPullRequestReactor } from "./ThreadPullRequestReactor.ts";
 import { ServerActivation } from "../serverActivation.ts";
 import {
   OrchestrationEngineService,
@@ -154,6 +156,7 @@ function makeSummary(
 interface HarnessOptions {
   readonly invalidate?: PullRequestService["Service"]["invalidate"];
   readonly snapshot: OrchestrationShellSnapshot;
+  readonly connected?: boolean;
   readonly summary?: (
     input: PullRequestRef,
   ) => Effect.Effect<PullRequestSummary, PullRequestOperationError>;
@@ -164,6 +167,9 @@ interface HarnessOptions {
 
 const makeHarness = Effect.fn("makePullRequestSyncHarness")(function* (options: HarnessOptions) {
   const activation = yield* Deferred.make<void>();
+  const connected = yield* Ref.make(options.connected ?? true);
+  const demandReads = yield* Queue.unbounded<void>();
+  const discoveryCalls = yield* Ref.make(0);
   const snapshots = yield* Ref.make(options.snapshot);
   const snapshotReads = yield* Queue.unbounded<void>();
   const syncCommands = yield* Ref.make<ReadonlyArray<SyncCommand>>([]);
@@ -200,6 +206,16 @@ const makeHarness = Effect.fn("makePullRequestSyncHarness")(function* (options: 
   };
 
   const dependencies = Layer.mergeAll(
+    Layer.mock(SessionStore)({
+      cookieName: "test-session",
+      legacyCookieName: undefined,
+      hasConnectedClients: Ref.get(connected).pipe(
+        Effect.tap(() => Queue.offer(demandReads, undefined)),
+      ),
+    }),
+    Layer.mock(ThreadPullRequestReactor)({
+      refresh: () => Ref.update(discoveryCalls, (n) => n + 1),
+    }),
     Layer.mock(ProjectionSnapshotQuery)({
       getShellSnapshot: () =>
         Queue.offer(snapshotReads, undefined).pipe(Effect.andThen(Ref.get(snapshots))),
@@ -221,6 +237,9 @@ const makeHarness = Effect.fn("makePullRequestSyncHarness")(function* (options: 
 
   return {
     activation,
+    connected,
+    demandReads,
+    discoveryCalls,
     snapshots,
     snapshotReads,
     syncCommands,
@@ -274,6 +293,71 @@ function applySync(
 }
 
 describe("PullRequestSyncReactor", () => {
+  it.effect("pauses both periodic jobs without clients and resumes after a client connects", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeHarness({
+          connected: false,
+          snapshot: makeSnapshot([makeThread("one", { pullRequests: [makeLink(7)] })]),
+        });
+        yield* Effect.gen(function* () {
+          const reactor = yield* PullRequestSyncReactor.PullRequestSyncReactor;
+          yield* reactor.start();
+          yield* Deferred.succeed(fixture.activation, undefined);
+          yield* Queue.take(fixture.demandReads);
+          yield* reactor.drain;
+          yield* TestClock.adjust("1 minute");
+          yield* Queue.take(fixture.demandReads);
+          yield* reactor.drain;
+          assert.deepStrictEqual(yield* Ref.get(fixture.summaryCalls), []);
+          assert.strictEqual(yield* Ref.get(fixture.discoveryCalls), 0);
+          yield* Ref.set(fixture.connected, true);
+          yield* TestClock.adjust("1 minute");
+          yield* Queue.take(fixture.demandReads);
+          yield* Queue.take(fixture.snapshotReads);
+          yield* reactor.drain;
+          assert.strictEqual((yield* Ref.get(fixture.summaryCalls)).length, 1);
+          assert.strictEqual(yield* Ref.get(fixture.discoveryCalls), 1);
+          yield* Ref.set(fixture.connected, false);
+          yield* TestClock.adjust("1 minute");
+          yield* Queue.take(fixture.demandReads);
+          yield* reactor.drain;
+          assert.strictEqual((yield* Ref.get(fixture.summaryCalls)).length, 1);
+          assert.strictEqual(yield* Ref.get(fixture.discoveryCalls), 1);
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
+  it.effect("refreshes only the requested PR while disconnected", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeHarness({
+          connected: false,
+          snapshot: makeSnapshot([makeThread("one", { pullRequests: [makeLink(7), makeLink(8)] })]),
+        });
+        yield* Effect.gen(function* () {
+          const reactor = yield* PullRequestSyncReactor.PullRequestSyncReactor;
+          yield* reactor.start();
+          yield* Deferred.succeed(fixture.activation, undefined);
+          yield* Queue.take(fixture.demandReads);
+          yield* reactor.drain;
+          yield* reactor.requestSync({
+            host: "github.com",
+            repository: "owner/repository",
+            number: 7,
+          });
+          yield* reactor.drain;
+          assert.deepStrictEqual(
+            (yield* Ref.get(fixture.summaryCalls)).map((ref) => ref.number),
+            [7],
+          );
+          assert.strictEqual(yield* Ref.get(fixture.discoveryCalls), 0);
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
   it.effect("retries a failed stack read after the summary becomes terminal", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/orchestration/PullRequestSyncReactor.ts
+++ b/apps/server/src/orchestration/PullRequestSyncReactor.ts
@@ -25,6 +25,8 @@ import type * as Scope from "effect/Scope";
 
 import * as PullRequestService from "../pullRequest/PullRequestService.ts";
 import { forkParked } from "../serverActivation.ts";
+import { SessionStore } from "../auth/SessionStore.ts";
+import { ThreadPullRequestReactor } from "./ThreadPullRequestReactor.ts";
 import * as OrchestrationEngine from "./Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "./Services/ProjectionSnapshotQuery.ts";
 
@@ -127,6 +129,8 @@ export const make = Effect.gen(function* () {
   const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const pullRequests = yield* PullRequestService.PullRequestService;
   const crypto = yield* Crypto.Crypto;
+  const sessions = yield* SessionStore;
+  const discovery = yield* ThreadPullRequestReactor;
 
   const lastSyncedAt = new Map<string, number>();
   const requested = new Map<string, number>();
@@ -149,7 +153,11 @@ export const make = Effect.gen(function* () {
     <E>(cause: Cause.Cause<E>): Effect.Effect<void, E> =>
       Cause.hasInterruptsOnly(cause) ? Effect.failCause(cause) : Effect.logWarning(message, fields);
 
-  const sweep = Effect.fn("PullRequestSyncReactor.sweep")(function* () {
+  const sweep = Effect.fn("PullRequestSyncReactor.sweep")(function* (background: boolean) {
+    if (background) {
+      if (!(yield* sessions.hasConnectedClients)) return;
+      yield* discovery.refresh();
+    }
     const snapshot = yield* snapshots.getShellSnapshot();
     const now = yield* DateTime.now;
     const nowMs = DateTime.toEpochMillis(now);
@@ -292,7 +300,7 @@ export const make = Effect.gen(function* () {
     yield* Effect.forEach(
       groups,
       ([key, entries]) =>
-        isDue(key, entries, nowMs)
+        (background ? isDue(key, entries, nowMs) : requested.has(key))
           ? syncGroup(key, entries).pipe(
               Effect.catchCause(logSkipped("pull request sync skipped", { key })),
             )
@@ -301,8 +309,8 @@ export const make = Effect.gen(function* () {
     );
   });
 
-  const worker = yield* makeDrainableWorker(() =>
-    sweep().pipe(Effect.catchCause(logSkipped("pull request sync sweep failed", {}))),
+  const worker = yield* makeDrainableWorker((background: boolean) =>
+    sweep(background).pipe(Effect.catchCause(logSkipped("pull request sync sweep failed", {}))),
   );
 
   const start: PullRequestSyncReactor["Service"]["start"] = Effect.fn(
@@ -310,7 +318,7 @@ export const make = Effect.gen(function* () {
   )(function* () {
     yield* forkParked(
       Effect.gen(function* () {
-        yield* worker.enqueue(undefined);
+        yield* worker.enqueue(true);
         yield* worker.drain;
       }).pipe(Effect.repeat(Schedule.spaced("1 minute")), Effect.asVoid),
     );
@@ -319,7 +327,7 @@ export const make = Effect.gen(function* () {
   const requestSync: PullRequestSyncReactor["Service"]["requestSync"] = (key) =>
     Effect.suspend(() => {
       requested.set(threadPullRequestKeyOf(key), ++requestGeneration);
-      return worker.enqueue(undefined);
+      return worker.enqueue(false);
     });
 
   return { start, drain: worker.drain, requestSync } satisfies PullRequestSyncReactor["Service"];

--- a/apps/server/src/orchestration/ThreadPullRequestReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadPullRequestReactor.test.ts
@@ -224,6 +224,7 @@ const makeHarness = Effect.fn("makeThreadPullRequestHarness")(function* (options
     const reactor = yield* ThreadPullRequestReactor.ThreadPullRequestReactor;
     yield* reactor.start();
     yield* Deferred.succeed(activation, undefined);
+    yield* reactor.refresh();
     yield* Queue.take(reads);
     yield* reactor.drain;
     return reactor;
@@ -242,7 +243,7 @@ const makeHarness = Effect.fn("makeThreadPullRequestHarness")(function* (options
 });
 
 describe("ThreadPullRequestReactor", () => {
-  it.effect("discovers saved branch PRs without a client and shares branch lookups", () =>
+  it.effect("discovers saved branch PRs on a coordinated refresh and shares branch lookups", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fixture = yield* makeHarness({
@@ -269,6 +270,7 @@ describe("ThreadPullRequestReactor", () => {
           );
 
           yield* TestClock.adjust("1 minute");
+          yield* reactor.refresh();
           yield* Queue.take(fixture.reads);
           yield* reactor.drain;
           expect(yield* Ref.get(fixture.commands)).toHaveLength(2);
@@ -518,10 +520,12 @@ describe("ThreadPullRequestReactor", () => {
             expect(yield* Ref.get(fixture.commands)).toHaveLength(0);
             yield* Ref.set(online, true);
             yield* TestClock.adjust("1 minute");
+            yield* reactor.refresh();
             yield* Queue.take(fixture.reads);
             yield* reactor.drain;
             expect((yield* Ref.get(fixture.commands))[0]?.threadId).toBe("backfill");
             yield* TestClock.adjust("1 minute");
+            yield* reactor.refresh();
             yield* Queue.take(fixture.reads);
             yield* reactor.drain;
             expect((yield* Ref.get(fixture.branchCalls)).map((call) => call.branch)).toEqual([
@@ -552,6 +556,7 @@ describe("ThreadPullRequestReactor", () => {
             attempt++
           ) {
             yield* TestClock.adjust("1 minute");
+            yield* reactor.refresh();
             yield* Queue.take(fixture.reads);
             yield* reactor.drain;
           }

--- a/apps/server/src/orchestration/ThreadPullRequestReactor.ts
+++ b/apps/server/src/orchestration/ThreadPullRequestReactor.ts
@@ -16,7 +16,6 @@ import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
-import * as Schedule from "effect/Schedule";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 
@@ -32,6 +31,7 @@ export class ThreadPullRequestReactor extends Context.Service<
   {
     readonly start: () => Effect.Effect<void, never, Scope.Scope>;
     readonly drain: Effect.Effect<void>;
+    readonly refresh: () => Effect.Effect<void>;
   }
 >()("t3/orchestration/ThreadPullRequestReactor") {}
 
@@ -350,21 +350,16 @@ export const make = Effect.gen(function* () {
   const start = Effect.fn("ThreadPullRequestReactor.start")(function* () {
     const events = yield* engine.subscribeDomainEvents;
     yield* forkParked(Stream.runForEach(events, processEvent));
-    // Run without client demand. Saved branch lookups share GitManager's
-    // provider cache and retry backoff with status and automatic settlement.
-    yield* forkParked(
-      Effect.gen(function* () {
-        yield* worker.enqueue({ threadId: null, refresh: false, backfill: true });
-        yield* worker.drain;
-        yield* Effect.gen(function* () {
-          yield* worker.enqueue({ threadId: null, refresh: false });
-          yield* worker.drain;
-        }).pipe(Effect.repeat(Schedule.spaced("1 minute")), Effect.delay("1 minute"));
-      }).pipe(Effect.asVoid),
-    );
   });
 
-  return { start, drain: worker.drain } satisfies ThreadPullRequestReactor["Service"];
+  let backfill = true;
+  const refresh = Effect.fn("ThreadPullRequestReactor.refresh")(function* () {
+    yield* worker.enqueue({ threadId: null, refresh: false, backfill });
+    backfill = false;
+    yield* worker.drain;
+  });
+
+  return { start, refresh, drain: worker.drain } satisfies ThreadPullRequestReactor["Service"];
 });
 
 export const layer = Layer.effect(ThreadPullRequestReactor, make);

--- a/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.test.ts
@@ -25,6 +25,7 @@ import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
 
+import { SessionStore } from "../auth/SessionStore.ts";
 import { GitManager, type GitBranchPullRequest } from "../git/GitManager.ts";
 import {
   PullRequestService,
@@ -152,6 +153,7 @@ function makeBranchPullRequest(
 }
 
 interface HarnessOptions {
+  readonly connected?: boolean;
   readonly snapshot: OrchestrationShellSnapshot;
   readonly settings?: ServerSettings;
   readonly branchPullRequest?: GitManager["Service"]["branchPullRequest"];
@@ -237,6 +239,11 @@ const makeHarness = Effect.fn("makeThreadSettlementHarness")(function* (options:
   });
 
   const dependencies = Layer.mergeAll(
+    Layer.mock(SessionStore)({
+      cookieName: "test",
+      legacyCookieName: undefined,
+      hasConnectedClients: Effect.succeed(options.connected ?? true),
+    }),
     Layer.mock(ProjectionSnapshotQuery)({
       getShellSnapshot: () =>
         Ref.updateAndGet(snapshotReadCount, (count) => count + 1).pipe(
@@ -302,6 +309,37 @@ const startHarness = Effect.fn("startThreadSettlementHarness")(function* (
 });
 
 describe("ThreadSettlementReactor", () => {
+  it.effect("keeps inactivity settlement local while disconnected", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(NOW));
+        const fixture = yield* makeHarness({
+          connected: false,
+          snapshot: makeSnapshot([
+            makeThread("old", { latestUserMessageAt: "2026-08-01T00:00:00.000Z", branch: "old" }),
+            makeThread("recent", { latestUserMessageAt: NOW, branch: "recent" }),
+          ]),
+          settings: {
+            ...DEFAULT_SERVER_SETTINGS,
+            sidebarAutoSettleAfterDays: 7,
+            sidebarAutoSettleOnMerge: true,
+          },
+          branchPullRequest: () => Effect.die("idle server must not read GitHub"),
+          pullRequestSummary: () => Effect.die("idle server must not read GitHub"),
+        });
+        yield* Effect.gen(function* () {
+          const reactor = yield* ThreadSettlementReactor.ThreadSettlementReactor;
+          yield* startHarness(reactor, fixture.activation, fixture.snapshotReads);
+          assert.deepEqual(
+            (yield* Ref.get(fixture.commands)).map((command) => command.threadId),
+            ["old"],
+          );
+          assert.deepEqual(yield* Ref.get(fixture.branchCalls), []);
+        }).pipe(Effect.provide(fixture.layer));
+      }),
+    ),
+  );
+
   it.effect(
     "settles all-terminal links from snapshots and keeps open or unsynced links active",
     () =>

--- a/apps/server/src/orchestration/ThreadSettlementReactor.ts
+++ b/apps/server/src/orchestration/ThreadSettlementReactor.ts
@@ -10,6 +10,7 @@ import * as Layer from "effect/Layer";
 import * as Schedule from "effect/Schedule";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
+import { SessionStore } from "../auth/SessionStore.ts";
 
 import * as GitManager from "../git/GitManager.ts";
 import * as PullRequestService from "../pullRequest/PullRequestService.ts";
@@ -41,6 +42,7 @@ export const make = Effect.gen(function* () {
   const pullRequests = yield* PullRequestService.PullRequestService;
   const crypto = yield* Crypto.Crypto;
   const fileSystem = yield* FileSystem.FileSystem;
+  const sessions = yield* SessionStore;
 
   const sweep = Effect.fn("ThreadSettlementReactor.sweep")(function* (
     mergedPullRequest: PullRequestService.PullRequestMergeEvent | null,
@@ -106,6 +108,8 @@ export const make = Effect.gen(function* () {
     ))
       .filter((thread) => thread !== null)
       .filter((thread) => !thread.pullRequests.some((link) => link.source !== "stack-dismissed"));
+
+    if (mergedPullRequest === null && !(yield* sessions.hasConnectedClients)) return;
 
     // Use the same cwd as PR discovery so both paths share GitManager's cache.
     const lookupCwdByThreadId = new Map<string, string>();


### PR DESCRIPTION
An idle server continued polling GitHub every minute, and branch discovery and linked PR refresh each owned a separate polling loop. Backend restarts repeated their startup work.

PullRequestSyncReactor now owns the periodic loop and coordinates branch discovery. Background GitHub reads pause when no authenticated clients are connected, including legacy settlement lookups. Local inactivity settlement and explicit or agent-triggered work still run. Explicit PR sync refreshes only the requested references.

Validation: focused reactor and SessionStore tests passed; scoped server typecheck passed.

Implemented with GPT-6 in Codex.
