### PR TITLE
fix(web): submit PR comments with Cmd/Ctrl+Enter

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -19,7 +19,7 @@ import {
   TagIcon,
   UsersIcon,
 } from "lucide-react";
-import { useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 
 import { useAtomCommand } from "~/state/use-atom-command";
 import { pullRequestEnvironment } from "~/state/pullRequests";
@@ -372,16 +372,6 @@ function CommentComposer({
     onCommented();
   };
 
-  const handleCommentKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.nativeEvent.isComposing || event.keyCode === 229 || event.shiftKey || event.altKey) {
-      return;
-    }
-    if (!isCommentSubmitShortcut(event, body, submitting !== null || actionPending)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (!event.repeat) void submit("comment");
-  };
-
   return (
     <div className="mt-3 space-y-2">
       <Textarea
@@ -393,7 +383,12 @@ function CommentComposer({
         placeholder="Leave a comment"
         aria-label="Comment on this pull request"
         onChange={(event) => setBody(event.target.value)}
-        onKeyDown={handleCommentKeyDown}
+        onKeyDown={(event) => {
+          if (isCommentSubmitShortcut(event, body, submitting !== null || actionPending)) {
+            event.preventDefault();
+            void submit("comment");
+          }
+        }}
       />
       <div className="flex justify-end gap-2">
         {followUpAction === null ? null : (

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -19,7 +19,7 @@ import {
   TagIcon,
   UsersIcon,
 } from "lucide-react";
-import { useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 
 import { useAtomCommand } from "~/state/use-atom-command";
 import { pullRequestEnvironment } from "~/state/pullRequests";
@@ -27,6 +27,7 @@ import { cn } from "~/lib/utils";
 import { useOpenLink } from "~/browser/useOpenLink";
 import { formatRelativeTimeLabel } from "~/timestampFormat";
 
+import { isCommentSubmitShortcut } from "../diffs/commentSubmitShortcut";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { Textarea } from "../ui/textarea";
@@ -371,6 +372,16 @@ function CommentComposer({
     onCommented();
   };
 
+  const handleCommentKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.nativeEvent.isComposing || event.keyCode === 229 || event.shiftKey || event.altKey) {
+      return;
+    }
+    if (!isCommentSubmitShortcut(event, body, submitting !== null || actionPending)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (!event.repeat) void submit("comment");
+  };
+
   return (
     <div className="mt-3 space-y-2">
       <Textarea
@@ -382,19 +393,7 @@ function CommentComposer({
         placeholder="Leave a comment"
         aria-label="Comment on this pull request"
         onChange={(event) => setBody(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.nativeEvent.isComposing || event.keyCode === 229) return;
-          if (
-            event.key === "Enter" &&
-            (event.metaKey || event.ctrlKey) &&
-            !event.shiftKey &&
-            !event.altKey
-          ) {
-            event.preventDefault();
-            event.stopPropagation();
-            if (!event.repeat) void submit("comment");
-          }
-        }}
+        onKeyDown={handleCommentKeyDown}
       />
       <div className="flex justify-end gap-2">
         {followUpAction === null ? null : (

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -382,6 +382,19 @@ function CommentComposer({
         placeholder="Leave a comment"
         aria-label="Comment on this pull request"
         onChange={(event) => setBody(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+          if (
+            event.key === "Enter" &&
+            (event.metaKey || event.ctrlKey) &&
+            !event.shiftKey &&
+            !event.altKey
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (!event.repeat) void submit("comment");
+          }
+        }}
       />
       <div className="flex justify-end gap-2">
         {followUpAction === null ? null : (

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -76,6 +76,9 @@ Open **Pull requests** to review changes and comments, request reviewers, check 
 or merge. You can edit review titles and descriptions and your own comments where the host allows it.
 GitLab calls these merge requests.
 
+In web and desktop, press `Cmd+Enter` on macOS or `Ctrl+Enter` on Windows/Linux to post a new
+pull request comment. Press `Enter` to insert a newline.
+
 GitHub, GitLab, and Azure DevOps support auto-merge while checks are outstanding. GitHub also
 supports approving waiting fork workflows and opening a revert pull request for a merged change.
 


### PR DESCRIPTION
## What Changed

Cmd+Enter / Ctrl+Enter now posts a new PR comment in web and desktop. Enter still adds a newline.

## Why

Posting a comment should work from the keyboard. Related: #10660 handles editing descriptions and existing comments.

## UI Changes

Before: the shortcut did nothing.
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/b3514ed1-6fd8-468c-87a1-fea36ae40de4" />

After: the comment appears and the draft clears.
<img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/b69d9768-25da-45b3-b1d7-b4b0dd656da2" />

Video:

https://github.com/user-attachments/assets/477ac1a2-7e41-4430-ac6e-3833bd0e5f14




## Validation

Shortcut helper tests, web typecheck, formatting, and focused lint passed (one existing lint warning). Browser checks on the initial implementation passed with a local GitHub fixture: both shortcuts, newlines, empty drafts, key repeats, text composition, pending requests, and failed submissions keeping the draft.

## Checklist

- [x] Small and focused
- [x] Explained what changed and why
- [x] Upload before/after screenshots
- [x] Upload interaction video

Made with GPT-6 in the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for submitting pull request comments: `Cmd+Enter` on macOS and `Ctrl+Enter` on Windows/Linux.
  - Pressing `Enter` continues to insert a new line.
- **Documentation**
  - Added guidance for using pull request comment submission shortcuts in web and desktop clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->