### PR TITLE
fix(connect): stop reporting a loading cloud session as a sign-in change

### DIFF
--- a/packages/client-runtime/src/authorization/layer.test.ts
+++ b/packages/client-runtime/src/authorization/layer.test.ts
@@ -701,6 +701,29 @@ describe("RemoteEnvironmentAuthorization", () => {
     }),
   );
 
+  it.effect("retries instead of blocking while the cloud session has not loaded", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({
+        responses: [Response.json(DESCRIPTOR), accessToken("loaded-token")],
+      });
+      yield* Ref.set(harness.session, Option.none());
+      yield* Effect.gen(function* () {
+        const remote = yield* RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization;
+        const pending = yield* remote
+          .authorizeDpopHttp({ expectedEnvironmentId: ENVIRONMENT_ID })
+          .pipe(Effect.flip);
+        expect(pending).toMatchObject({
+          _tag: "ConnectionTransientError",
+          reason: "session-pending",
+        });
+        yield* Ref.set(harness.session, Option.some({ accountId: "account-1" }));
+        const loaded = yield* remote.authorizeDpopHttp({ expectedEnvironmentId: ENVIRONMENT_ID });
+        expect(loaded.httpAuthorization.accessToken).toBe("loaded-token");
+      }).pipe(Effect.provide(harness.layer));
+      expect(yield* Ref.get(harness.bootstrapCalls)).toBe(1);
+    }),
+  );
+
   it.effect("does not return or persist credentials after logout during renewal", () =>
     Effect.gen(function* () {
       const started = yield* Deferred.make<void>();
@@ -822,8 +845,8 @@ describe("RemoteEnvironmentAuthorization", () => {
           .authorizeDpopHttp({ expectedEnvironmentId: ENVIRONMENT_ID })
           .pipe(Effect.flip);
         expect(signedOut).toMatchObject({
-          _tag: "ConnectionBlockedError",
-          reason: "authentication",
+          _tag: "ConnectionTransientError",
+          reason: "session-pending",
         });
         yield* Ref.set(harness.session, Option.some({ accountId: "account-1" }));
         const signedIn = yield* remote.authorizeDpopHttp({ expectedEnvironmentId: ENVIRONMENT_ID });

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -227,6 +227,15 @@ export const make = Effect.gen(function* () {
       detail: "Your cloud sign-in changed. Sign in again to authorize the environment.",
     });
 
+  // A missing identity before an attempt captures one means the client has not
+  // finished loading its cloud session. Only a captured identity that goes away
+  // or changes is evidence of a sign-out or account switch.
+  const sessionPending = () =>
+    new ConnectionTransientError({
+      reason: "session-pending",
+      detail: "Waiting for the T3 Connect sign-in to load.",
+    });
+
   const assertSession = Effect.fnUntraced(function* (
     identity: ClientCapabilities.CloudSessionIdentity,
   ) {
@@ -339,7 +348,7 @@ export const make = Effect.gen(function* () {
   ) {
     const session = yield* cloudSession.identity;
     if (Option.isNone(session)) {
-      return yield* sessionChanged();
+      return yield* sessionPending();
     }
     const identity = session.value;
     const thumbprint = yield* signer.thumbprint.pipe(

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -64,6 +64,7 @@ export const ConnectionTransientReason = Schema.Literals([
   "endpoint-unavailable",
   "relay-unavailable",
   "remote-unavailable",
+  "session-pending",
 ]);
 export type ConnectionTransientReason = typeof ConnectionTransientReason.Type;
 


### PR DESCRIPTION
## What Changed

Relay authorization in `packages/client-runtime` now treats a missing cloud identity at the start of an attempt as a transient condition instead of a sign-in change. `getDpopToken` fails with a new `ConnectionTransientError` reason, `session-pending`, and the detail reads *Waiting for the T3 Connect sign-in to load.* The supervisor keeps retrying with normal backoff instead of parking in `blocked`.

`sessionChanged()` is unchanged for the case it was written for: an identity captured at the start of an attempt that later disappears or is replaced. The existing logout-during-renewal tests still expect the blocked error there. One existing assertion changed to the transient error because it authorizes with no identity at all, and one focused test covers the loading window: no identity yields the transient error, and the same call succeeds once the session lands.

## Why

Fixes #11004. On web and mobile the cloud identity is the `managedRelaySessionAtom` value, which stays `null` until Clerk loads and `ManagedRelayAuthProvider` finishes its activation promise chain. The connection supervisor can start attempting before that, and every attempt in the window failed with *Your cloud sign-in changed. Sign in again to authorize the environment.* The sign-in had not changed, and signing out and back in did nothing. On a slow host the window is wide enough to hit routinely, and the status line carried the stale reason into *Failed to connect. Reconnecting...* while the client was in fact recovering.

`CloudSession` cannot tell "not loaded yet" from "signed out" for a `None` identity, so the distinction used here is whether the attempt already captured an identity. A real sign-out is not left retrying forever: both auth providers remove relay environments from the catalog when the account goes away, so the supervisor stops attempting them.

Not changed: the 3s cached-endpoint websocket ticket timeout mentioned in the issue as a likely amplifier. It is a separate tuning question and this PR stays on the misdiagnosis.

Verified with the `layer.test.ts` file in client-runtime (24 tests), the client-runtime typecheck, and lint and format on the touched files.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable, no UI change)
- [x] I included a video for animation/interaction changes (not applicable)

Model: Claude Fable 5.1. Harness: Claude Code in T3 Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization now reports a temporary “session pending” status while cloud-session identity is still loading.
  * Authorization retries successfully once the session becomes available.
  * Session changes or sign-outs continue to be handled as authentication-blocked events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->