### PR TITLE
fix(web): keep the current worktree on the new-local-thread shortcut

### DIFF
--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -11,6 +11,7 @@ import {
   hasExplicitComposerModelSelection,
   resolveNewDraftStartFromOrigin,
   resolveNewThreadModelSelectionOverride,
+  startNewLocalThreadFromContext,
   startNewThreadFromContext,
   type ChatThreadActionContext,
 } from "./chatThreadActions";
@@ -153,6 +154,54 @@ describe("chatThreadActions", () => {
 
     expect(didStart).toBe(true);
     expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
+  });
+
+  it("keeps the active thread's worktree for the new-local shortcut", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+
+    const didStart = await startNewLocalThreadFromContext(
+      createContext({
+        activeThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          branch: "feature/one",
+          worktreePath: "/tmp/worktrees/feature-one",
+        },
+        handleNewThread,
+      }),
+    );
+
+    expect(didStart).toBe(true);
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: "feature/one",
+      worktreePath: "/tmp/worktrees/feature-one",
+      envMode: "worktree",
+      startFromOrigin: false,
+    });
+  });
+
+  it("keeps a branch-only thread on the local checkout for the new-local shortcut", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+
+    await startNewLocalThreadFromContext(
+      createContext({
+        activeDraftThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          branch: "feature/two",
+          worktreePath: null,
+          envMode: "local",
+        },
+        handleNewThread,
+      }),
+    );
+
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: "feature/two",
+      worktreePath: null,
+      envMode: "local",
+      startFromOrigin: false,
+    });
   });
 
   it("does not start a thread when there is no project context", async () => {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -15,6 +15,15 @@ type ComposerModelSelectionState = Pick<
 interface ThreadContextLike {
   environmentId: EnvironmentId;
   projectId: ProjectId;
+  // Only the "new thread in this workspace" shortcut reads the checkout the
+  // context is sitting on; the generic new-thread paths ignore these.
+  branch?: string | null;
+  worktreePath?: string | null;
+}
+
+interface DraftThreadContextLike extends ThreadContextLike {
+  envMode?: DraftThreadEnvMode;
+  startFromOrigin?: boolean;
 }
 
 interface NewThreadHandler {
@@ -31,7 +40,7 @@ interface NewThreadHandler {
 }
 
 export interface ChatThreadActionContext {
-  readonly activeDraftThread: ThreadContextLike | null;
+  readonly activeDraftThread: DraftThreadContextLike | null;
   readonly activeThread: ThreadContextLike | undefined;
   readonly defaultProjectRef: ScopedProjectRef | null;
   readonly handleNewThread: NewThreadHandler;
@@ -98,5 +107,40 @@ export async function startNewThreadFromContext(
   }
 
   await context.handleNewThread(projectRef);
+  return true;
+}
+
+// The `chat.newLocal` shortcut (mod+shift+n) is the keyboard twin of the
+// thread menu's "New thread on <branch>": it starts a thread in the checkout
+// the user is already looking at, so a quick parallel task lands in the same
+// worktree instead of the project's configured defaults. Falls back to plain
+// defaults when nothing is open and only the default project applies.
+export async function startNewLocalThreadFromContext(
+  context: ChatThreadActionContext,
+): Promise<boolean> {
+  const projectRef = resolveThreadActionProjectRef(context);
+  if (!projectRef) {
+    return false;
+  }
+
+  const thread = context.activeThread;
+  const draft = context.activeDraftThread;
+  const source = thread ?? draft;
+  if (!source) {
+    await context.handleNewThread(projectRef);
+    return true;
+  }
+
+  const branch = source.branch ?? null;
+  const worktreePath = source.worktreePath ?? null;
+  await context.handleNewThread(projectRef, {
+    branch,
+    worktreePath,
+    // A draft still owns its env mode outright; a real thread only ever ran
+    // in its own worktree or the local checkout.
+    envMode: (thread ? undefined : draft?.envMode) ?? (worktreePath ? "worktree" : "local"),
+    // Reusing an existing checkout must never re-bootstrap it from origin.
+    startFromOrigin: false,
+  });
   return true;
 }

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -11,7 +11,10 @@ import { selectProjectGroupingSettings } from "../logicalProject";
 import { buildSidebarProjectSnapshots } from "../sidebarProjectGrouping";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { startNewThreadFromContext } from "../lib/chatThreadActions";
+import {
+  startNewLocalThreadFromContext,
+  startNewThreadFromContext,
+} from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -80,7 +83,7 @@ function ChatRouteGlobalShortcuts() {
       if (command === "chat.newLocal") {
         event.preventDefault();
         event.stopPropagation();
-        void startNewThreadFromContext({
+        void startNewLocalThreadFromContext({
           activeDraftThread,
           activeThread: activeThread ?? undefined,
           defaultProjectRef,


### PR DESCRIPTION
Cmd/Ctrl+Shift+N (`chat.newLocal`) routed through the generic `startNewThreadFromContext`, which inherits only the project by design, so a quick parallel chat started from a feature-branch thread silently landed on the project's configured new-thread defaults instead of the branch and worktree the user was looking at.

The shortcut now goes through its own `startNewLocalThreadFromContext`, which reads the active thread or draft's `branch`, `worktreePath`, and env mode and passes them to `handleNewThread` — the same explicit options the thread menu's "New thread on <branch>" already uses, with `startFromOrigin: false` so reusing a checkout never re-bootstraps it. Every other new-thread entry point (Cmd+N, the sidebar button, the command palette) keeps the #4411 project-defaults behavior.

Verified: `vp run --filter @t3tools/web typecheck` exit 0, no errors. `vitest run apps/web/src/lib/chatThreadActions.test.ts --pool=forks` 12 passed, including two new cases covering worktree inheritance and the branch-only local case (`vp test run` fails to boot its default thread pool in my environment, on unmodified `origin/main` files too, so I ran the same runner with `--pool=forks`). `vp lint` on the three changed files exit 0.

Out of scope: the sidebar's "new thread" button advertises the `chat.newLocal` shortcut label as the keyboard twin of shift+click in single-project setups. Shift+click still uses project defaults, so that tooltip pairing is now slightly loose; changing it would touch a second entry point's behavior, which this fix deliberately leaves alone.

Fixes #9656

UI evidence: pending (parent will attach)

Done by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starting a local chat thread now preserves the currently viewed branch and worktree.
  * Local threads retain the appropriate environment settings and remain on the local checkout rather than starting from the origin.

* **Bug Fixes**
  * Improved behavior when creating local threads from active chats or drafts.
  * Added fallback handling when no active thread or draft is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->