### PR TITLE
fix(desktop): hold-to-quit no longer strands the quit

### DIFF
--- a/apps/desktop/src/window/QuitHold.test.ts
+++ b/apps/desktop/src/window/QuitHold.test.ts
@@ -178,12 +178,33 @@ describe("makeQuitShortcutHandler", () => {
     await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
     await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
     harness.preventDefault.mockClear();
-    await harness.send(makeInput({ meta: false, isAutoRepeat: true }));
-    expect(harness.preventDefault).toHaveBeenCalledTimes(1);
-    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS * 2);
+    // Repeats without the modifier prove Q is still down, so they hold the
+    // quit back for as long as they keep arriving.
+    await harness.holdFor(QUIT_HOLD_RELEASE_GRACE_MS * 2, { meta: false });
+    expect(harness.preventDefault).toHaveBeenCalled();
     expect(harness.quit).not.toHaveBeenCalled();
     await harness.send(makeInput({ type: "keyUp", meta: false }));
     expect(harness.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it("commits a concealed hold when the last Q repeat is never released", async () => {
+    // macOS can drop the final Q keyUp. The quit must land on its own once
+    // repeats stop, rather than sitting armed until an unrelated key arrives.
+    const harness = makeHarness();
+    await harness.send(makeInput({}));
+    await harness.holdFor(QUIT_HOLD_DURATION_MS + 200);
+    await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
+    await harness.send(makeInput({ meta: false, isAutoRepeat: true }));
+
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS);
+    expect(harness.quit).toHaveBeenCalledTimes(1);
+
+    // A lone Cmd tap afterwards must not quit a second time.
+    harness.quit.mockClear();
+    await harness.send(makeInput({ key: "Meta" }));
+    await harness.send(makeInput({ type: "keyUp", key: "Meta", meta: false }));
+    vi.advanceTimersByTime(QUIT_HOLD_RELEASE_GRACE_MS * 4);
+    expect(harness.quit).not.toHaveBeenCalled();
   });
 
   it("does not quit when the hold stops before the duration", async () => {

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -126,10 +126,7 @@ export function makeQuitShortcutHandler(
     if (quitOnRelease) {
       event.preventDefault();
       // A Q keydown proves the key is still down whether or not the modifier
-      // is still held, so it only pushes the quiet period back. Disarming the
-      // watchdog here instead stranded the quit whenever macOS dropped the
-      // final Q keyUp, leaving the window concealed until an unrelated
-      // modifier tap released the stale request and quit out of nowhere.
+      // is still held, so it only pushes the quiet period back.
       if (key === "q") quitAfterQuietPeriod();
       return;
     }

--- a/apps/desktop/src/window/QuitHold.ts
+++ b/apps/desktop/src/window/QuitHold.ts
@@ -125,13 +125,12 @@ export function makeQuitShortcutHandler(
     }
     if (quitOnRelease) {
       event.preventDefault();
-      if (key === "q") {
-        if (modifierDown) {
-          quitAfterQuietPeriod();
-        } else {
-          clearWatchdog();
-        }
-      }
+      // A Q keydown proves the key is still down whether or not the modifier
+      // is still held, so it only pushes the quiet period back. Disarming the
+      // watchdog here instead stranded the quit whenever macOS dropped the
+      // final Q keyUp, leaving the window concealed until an unrelated
+      // modifier tap released the stale request and quit out of nowhere.
+      if (key === "q") quitAfterQuietPeriod();
       return;
     }
 


### PR DESCRIPTION
On macOS, holding Cmd+Q past the hold threshold concealed the window but never quit, and a lone Cmd tap some time later quit the app instantly. Once the hold completed, a Q auto-repeat arriving after the modifier keyUp ran `clearWatchdog()` and left the handler waiting for a Q keyUp that macOS does not reliably deliver, so the quit sat armed indefinitely with no timer behind it — and the next modifier keyUp, from any unrelated Cmd press, revived it.

A Q keydown proves the key is still physically down whether or not the modifier is still held, so it now pushes the quiet period back instead of disarming it. Continued repeats keep the app alive exactly as before; when they stop, the quiet period commits the quit, and `quitOnRelease` can no longer outlive the gesture.

Verified: `vp test run` on `apps/desktop/src/window/QuitHold.test.ts` — 31 passed, and the new case fails against the pre-fix module (`expected quit to be called 1 times, but got 0`). `vp run --filter @t3tools/desktop typecheck` — exit 0, no new diagnostics. `vp lint` and `vp fmt --check` on both changed files — clean. Note: `vite-plus/test` resolves to a second vitest instance on this Linux sandbox, so every suite in the repo fails to load with `Cannot read properties of undefined (reading 'config')` on `origin/main` too; the runs above used an equivalent copy importing `vitest` directly, discarded afterwards.

Desktop-only: the quit accelerator is intercepted in the Electron main process `before-input-event` handler, so there is no web or mobile equivalent to fix.

Fixes #9259

Done by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quit shortcut handling when key-release events are missed.
  - Repeated key presses now keep the pending quit active until the final release.
  - Prevented an additional quit from being triggered by a subsequent modifier-key tap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
