### PR TITLE
fix(web): middle-click pastes in the terminal on Linux

### DIFF
--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -167,13 +167,13 @@ describe("GhosttyTerminalSurface visibility", () => {
       resize() {
         for (const callback of resizeCallbacks) callback();
       },
-      pointer(type: string, clientX: number, buttons: number, shiftKey = false) {
+      pointer(type: string, clientX: number, buttons: number, shiftKey = false, button = 0) {
         canvas.dispatchEvent(
           Object.assign(new Event(type, { cancelable: true }), {
             clientX,
             clientY: 5,
             pointerId: 1,
-            button: 0,
+            button,
             buttons,
             shiftKey,
           }),
@@ -278,6 +278,38 @@ describe("GhosttyTerminalSurface visibility", () => {
     expect(surface.getSelection()).toBe("");
     expect(surface.getSelectionPosition()).toBeNull();
     expect(harness.renderedSnapshot.rowData[0]?.cells.some((cell) => cell.selected)).toBe(false);
+  });
+
+  it("pastes the current selection on a Linux middle click", async () => {
+    const harness = createHarness();
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+    const surface = await harness.create();
+    surface.write("hello world");
+    harness.flushFrame();
+    harness.pointer("pointerdown", 5, 1);
+    harness.pointer("pointermove", 37, 1);
+    harness.pointer("pointerup", 37, 0);
+    expect(surface.getSelection()).toBe("hello");
+
+    harness.onData.mockClear();
+    harness.pointer("pointerdown", 5, 4, false, 1);
+    await vi.waitFor(() => expect(harness.onData).toHaveBeenCalled());
+    expect(harness.onData.mock.calls.at(-1)?.[0]).toBe("hello");
+    expect(surface.getSelection()).toBe("hello");
+  });
+
+  it("forwards a middle click to an application that tracks the mouse", async () => {
+    const harness = createHarness();
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+    const surface = await harness.create();
+    surface.write("\x1b[?1000hhello world");
+    harness.flushFrame();
+
+    harness.onData.mockClear();
+    harness.pointer("pointerdown", 5, 4, false, 1);
+    // Legacy X10 report for a middle-button press at 1,1: the application gets
+    // the click instead of a paste.
+    expect(harness.onData.mock.calls.at(-1)?.[0]).toBe("\x1b[M!!!");
   });
 
   it("starts a selection when dragging from a link", async () => {

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -280,9 +280,10 @@ describe("GhosttyTerminalSurface visibility", () => {
     expect(harness.renderedSnapshot.rowData[0]?.cells.some((cell) => cell.selected)).toBe(false);
   });
 
-  it("pastes the current selection on a Linux middle click", async () => {
+  it("pastes the terminal selection, and only that, on a Linux middle click", async () => {
     const harness = createHarness();
-    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+    const readText = vi.fn(async () => "clipboard text");
+    vi.stubGlobal("navigator", { platform: "Linux x86_64", clipboard: { readText } });
     const surface = await harness.create();
     surface.write("hello world");
     harness.flushFrame();
@@ -296,20 +297,12 @@ describe("GhosttyTerminalSurface visibility", () => {
     await vi.waitFor(() => expect(harness.onData).toHaveBeenCalled());
     expect(harness.onData.mock.calls.at(-1)?.[0]).toBe("hello");
     expect(surface.getSelection()).toBe("hello");
-  });
 
-  it("forwards a middle click to an application that tracks the mouse", async () => {
-    const harness = createHarness();
-    vi.stubGlobal("navigator", { platform: "Linux x86_64" });
-    const surface = await harness.create();
-    surface.write("\x1b[?1000hhello world");
-    harness.flushFrame();
-
-    harness.onData.mockClear();
+    // Without a selection there is no primary buffer to paste; the clipboard
+    // holds what the user copied and must not be substituted.
+    surface.clearSelection();
     harness.pointer("pointerdown", 5, 4, false, 1);
-    // Legacy X10 report for a middle-button press at 1,1: the application gets
-    // the click instead of a paste.
-    expect(harness.onData.mock.calls.at(-1)?.[0]).toBe("\x1b[M!!!");
+    expect(readText).not.toHaveBeenCalled();
   });
 
   it("starts a selection when dragging from a link", async () => {

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -400,8 +400,8 @@ export function isTerminalPasteShortcut(
  * primary selection and use the button for autoscroll, so only desktops that
  * expect the gesture get it.
  */
-export function isTerminalMiddleClickPastePlatform(platform = navigator.platform): boolean {
-  return /linux|bsd|x11/i.test(platform);
+function isMiddleClickPastePlatform(): boolean {
+  return /linux|bsd/i.test(navigator.platform);
 }
 
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {
@@ -948,23 +948,17 @@ export class GhosttyTerminalSurface {
   }
 
   /**
-   * The middle-click paste source. A browser cannot read the X11/Wayland
-   * PRIMARY buffer, so the terminal's own selection stands in for it when the
-   * user highlighted here, and the system clipboard covers the rest. Both go
-   * through pasteFromClipboard, so a middle click joins the same paste race as
-   * every other paste path.
+   * Middle-click pastes the terminal's own selection, which is the only
+   * primary-selection-like buffer a browser can read. It goes through
+   * pasteFromClipboard so it joins the same paste race as every other path.
+   * With nothing selected here there is no buffer to paste, and CLIPBOARD is
+   * deliberately not substituted: middle-click must never emit text the user
+   * only ever copied.
    */
-  private pasteFromSelectionBuffer(): void {
+  private pasteTerminalSelection(): void {
     const selection = this.getSelection();
-    if (selection.length > 0) {
-      void this.pasteFromClipboard(() => Promise.resolve(selection));
-      return;
-    }
-    const clipboard = navigator.clipboard;
-    if (typeof clipboard?.readText !== "function") return;
-    void this.pasteFromClipboard(() => clipboard.readText()).catch(() => {
-      // Clipboard read denied; middle-click has no other source to fall back to.
-    });
+    if (selection.length === 0) return;
+    void this.pasteFromClipboard(() => Promise.resolve(selection));
   }
 
   hasSelection(): boolean {
@@ -1301,12 +1295,10 @@ export class GhosttyTerminalSurface {
       this.canvas.setPointerCapture(event.pointerId);
       return;
     }
-    if (event.button === 1 && isTerminalMiddleClickPastePlatform()) {
-      // Cancelling the pointer event also suppresses the compatibility
-      // mousedown, and with it Chromium's middle-click autoscroll.
-      event.preventDefault();
-      event.stopPropagation();
-      this.pasteFromSelectionBuffer();
+    if (event.button === 1 && isMiddleClickPastePlatform()) {
+      // Left uncancelled on purpose: cancelling pointerdown drops the
+      // compatibility mousedown, which is what activates a split pane.
+      this.pasteTerminalSelection();
       return;
     }
     if (event.button !== 0) return;
@@ -1552,6 +1544,10 @@ export class GhosttyTerminalSurface {
     if (this.canvas.hasPointerCapture(event.pointerId)) {
       this.canvas.releasePointerCapture(event.pointerId);
     }
+    if (event.button === 1 && isMiddleClickPastePlatform()) {
+      event.preventDefault();
+      return;
+    }
     if (event.button !== 0) return;
     if (!this.selectionMoved && this.selectionMode === "cell") {
       this.clearSelection();
@@ -1588,13 +1584,21 @@ export class GhosttyTerminalSurface {
   };
 
   private readonly onMouseDown = (event: MouseEvent) => {
-    // onPointerDown answers the middle button; cancelling it here too keeps
-    // Chromium's autoscroll from starting in browsers that still deliver the
-    // compatibility mousedown after a cancelled pointerdown.
-    if (event.button === 0 || (event.button === 1 && isTerminalMiddleClickPastePlatform())) {
+    // Cancelling the middle button here stops autoscroll while still letting
+    // the event bubble to the drawer handler that activates a split pane.
+    if (event.button === 0 || (event.button === 1 && isMiddleClickPastePlatform())) {
       event.preventDefault();
     }
     this.focus();
+  };
+
+  /**
+   * Chromium pastes PRIMARY into the focused editable on a middle mouseup, and
+   * the hidden textarea is focused, so leaving the default alive would deliver
+   * a second paste through onPaste on top of the one onPointerDown sent.
+   */
+  private readonly onMouseUp = (event: MouseEvent) => {
+    if (event.button === 1 && isMiddleClickPastePlatform()) event.preventDefault();
   };
 
   private readonly onContextMenu = (event: MouseEvent) => {
@@ -1686,6 +1690,7 @@ export class GhosttyTerminalSurface {
     this.canvas.addEventListener("pointercancel", this.onPointerUp);
     this.canvas.addEventListener("wheel", this.onWheel, { passive: false });
     this.canvas.addEventListener("mousedown", this.onMouseDown);
+    this.canvas.addEventListener("mouseup", this.onMouseUp);
     this.canvas.addEventListener("contextmenu", this.onContextMenu);
     this.scrollbar.addEventListener("pointerdown", this.onScrollbarPointerDown);
     this.scrollbar.addEventListener("pointermove", this.onScrollbarPointerMove);
@@ -1711,6 +1716,7 @@ export class GhosttyTerminalSurface {
     this.canvas.removeEventListener("pointercancel", this.onPointerUp);
     this.canvas.removeEventListener("wheel", this.onWheel);
     this.canvas.removeEventListener("mousedown", this.onMouseDown);
+    this.canvas.removeEventListener("mouseup", this.onMouseUp);
     this.canvas.removeEventListener("contextmenu", this.onContextMenu);
     this.scrollbar.removeEventListener("pointerdown", this.onScrollbarPointerDown);
     this.scrollbar.removeEventListener("pointermove", this.onScrollbarPointerMove);

--- a/apps/web/src/terminal/ghostty/surface.ts
+++ b/apps/web/src/terminal/ghostty/surface.ts
@@ -395,6 +395,15 @@ export function isTerminalPasteShortcut(
   return isMacPlatform(platform) ? event.metaKey : event.ctrlKey && event.shiftKey;
 }
 
+/**
+ * Middle-click paste is an X11/Wayland convention. macOS and Windows have no
+ * primary selection and use the button for autoscroll, so only desktops that
+ * expect the gesture get it.
+ */
+export function isTerminalMiddleClickPastePlatform(platform = navigator.platform): boolean {
+  return /linux|bsd|x11/i.test(platform);
+}
+
 export function isTerminalCompositionCommitInput(event: Pick<InputEvent, "inputType">): boolean {
   return (
     event.inputType === "" ||
@@ -938,6 +947,26 @@ export class GhosttyTerminalSurface {
     if (encoded.length > 0) this.options.onData(encoded);
   }
 
+  /**
+   * The middle-click paste source. A browser cannot read the X11/Wayland
+   * PRIMARY buffer, so the terminal's own selection stands in for it when the
+   * user highlighted here, and the system clipboard covers the rest. Both go
+   * through pasteFromClipboard, so a middle click joins the same paste race as
+   * every other paste path.
+   */
+  private pasteFromSelectionBuffer(): void {
+    const selection = this.getSelection();
+    if (selection.length > 0) {
+      void this.pasteFromClipboard(() => Promise.resolve(selection));
+      return;
+    }
+    const clipboard = navigator.clipboard;
+    if (typeof clipboard?.readText !== "function") return;
+    void this.pasteFromClipboard(() => clipboard.readText()).catch(() => {
+      // Clipboard read denied; middle-click has no other source to fall back to.
+    });
+  }
+
   hasSelection(): boolean {
     return this.core.selectionText().length > 0;
   }
@@ -1272,6 +1301,14 @@ export class GhosttyTerminalSurface {
       this.canvas.setPointerCapture(event.pointerId);
       return;
     }
+    if (event.button === 1 && isTerminalMiddleClickPastePlatform()) {
+      // Cancelling the pointer event also suppresses the compatibility
+      // mousedown, and with it Chromium's middle-click autoscroll.
+      event.preventDefault();
+      event.stopPropagation();
+      this.pasteFromSelectionBuffer();
+      return;
+    }
     if (event.button !== 0) return;
     const clickCount = this.recordSelectionClick(event);
     const link = this.linkAt(event.clientX, event.clientY);
@@ -1551,7 +1588,12 @@ export class GhosttyTerminalSurface {
   };
 
   private readonly onMouseDown = (event: MouseEvent) => {
-    if (event.button === 0) event.preventDefault();
+    // onPointerDown answers the middle button; cancelling it here too keeps
+    // Chromium's autoscroll from starting in browsers that still deliver the
+    // compatibility mousedown after a cancelled pointerdown.
+    if (event.button === 0 || (event.button === 1 && isTerminalMiddleClickPastePlatform())) {
+      event.preventDefault();
+    }
     this.focus();
   };
 


### PR DESCRIPTION
Middle-clicking the integrated terminal did nothing: `onPointerDown` in `apps/web/src/terminal/ghostty/surface.ts` returned early for any button but 0, so the standard Linux middle-click paste never ran and Chromium started autoscroll instead.

Middle click on Linux/BSD now pastes the terminal's own Ghostty selection through `pasteFromClipboard`, the same bracketed-paste path (and paste race token) used by `Ctrl+Shift+V`, `Shift+Insert`, and the right-click menu. With nothing selected in the terminal it does nothing: a browser cannot read the X11/Wayland PRIMARY buffer, and CLIPBOARD is deliberately not substituted, so this never emits text the user only copied. Applications that track the mouse (vim, less) still receive the middle-button press instead of a paste.

This covers in-terminal selections only. External PRIMARY is not wired: reading a highlight made in another Linux app needs Electron `clipboard.readText('selection')` (and a matching writer on selection change) plus a desktop IPC channel, which is not part of this PR. Middle-clicking with no terminal selection stays a no-op rather than pasting the wrong buffer.

Two details worth reviewing: `pointerdown` is intentionally left uncancelled, because cancelling it drops the compatibility `mousedown` that `ThreadTerminalDrawer` uses to activate an inactive split pane; and `mouseup` is cancelled, because Chromium otherwise pastes PRIMARY into the focused hidden textarea and would deliver a second paste through `onPaste`.

Verified: `vp test run src/terminal/ghostty/surface.test.ts` in `apps/web` — 54 passed, including a new case asserting the selection is pasted and that the clipboard is never read. `vp run --filter @t3tools/web typecheck` — exit 0, no errors. `vp lint apps/web/src/terminal/ghostty/surface.ts apps/web/src/terminal/ghostty/surface.test.ts` — exit 0. Not verified on a real X11 or Wayland session.

Mobile has no middle button; desktop wraps web and picks this up automatically.

Refs #10921

UI evidence: unverified. The browser preview host was unavailable in this session, so the changed interaction was not exercised in a real client. Scoped tests, typecheck, and lint pass; a reviewer should exercise the interaction locally before merge.

Done by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited terminal middle-click paste to Linux and BSD platforms.
  * Middle-click now pastes only the terminal’s current selection; it no longer falls back to the system clipboard.
  * Prevented unintended browser autoscrolling and duplicate paste behavior.
  * Preserved split-pane activation when middle-clicking in the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

