### PR TITLE
fix(web): show message copy buttons on touch devices

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1582,7 +1582,7 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
           markdownCwd={ctx.markdownCwd}
         />
       </div>
-      <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+      <div className="flex w-full max-w-[80%] items-center justify-end pe-1 text-xs tabular-nums opacity-0 transition-opacity duration-200 pointer-coarse:opacity-100 focus-within:opacity-100 group-hover:opacity-100">
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip>
             <TooltipTrigger render={<p className="text-muted-foreground text-xs tabular-nums" />}>
@@ -1734,7 +1734,7 @@ function AssistantMessageMeta({
         "flex items-center gap-2 text-xs tabular-nums transition-opacity duration-200",
         alwaysVisible
           ? "opacity-100"
-          : "opacity-0 focus-within:opacity-100 group-hover/assistant:opacity-100",
+          : "opacity-0 pointer-coarse:opacity-100 focus-within:opacity-100 group-hover/assistant:opacity-100",
         className,
       )}
     >


### PR DESCRIPTION
On mobile web the copy button on user and assistant messages was invisible: both action rows are `opacity-0` and only reveal on `hover`/`focus-within`, neither of which a touch browser produces, so there was no discoverable way to copy an agent response.

Both rows now stay at `opacity-100` under `@media (pointer: coarse)` using the `pointer-coarse:` Tailwind variant already used in `ChatComposer.tsx` and `KeybindingsSettings.tsx`. Hover/pointer-fine behavior is untouched, so desktop still reveals the row on hover. The timestamp and the revert button share those rows and become visible on touch too, which is the same discoverability win.

Verified: `vp run --filter @t3tools/web typecheck` passed with no errors; `vp lint apps/web/src/components/chat/MessagesTimeline.tsx` passed (only pre-existing warnings on unrelated lines); `vitest run src/components/chat/MessagesTimeline.test.tsx src/components/chat/MessagesTimeline.logic.test.ts` passed 147/147; compiled `pointer-coarse:opacity-100` through the repo's Tailwind 4.3.3 and confirmed it emits `@media (pointer: coarse) { .pointer-coarse\:opacity-100 { opacity: 100% } }`. No test added: the change is class-only and AGENTS.md rules out tests that assert rendered attributes.

Out of scope: `apps/mobile` is React Native and has its own copy affordance, and the timeline minimap / turn-nav arrows in the same file are already gated to `pointer: fine` on purpose.

Fixes #2804

UI evidence: unverified. The browser preview host was unavailable in this session, so the changed interaction was not exercised in a real client. Scoped tests, typecheck, and lint pass; a reviewer should exercise the interaction locally before merge.

Done by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message timestamps and copy controls now remain visible on touch devices instead of requiring hover or focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
