### PR TITLE
fix(usage): flag unpriced model activity instead of showing $0.00

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -2,6 +2,7 @@ import { EnvironmentId, USAGE_CONTRACT_VERSION } from "@t3tools/contracts";
 import { useNavigation } from "@react-navigation/native";
 import {
   isCompatibleUsageContractVersion,
+  isModelCostUnknown,
   type DailyTotals,
   type MergedUsage,
 } from "@t3tools/shared/usageMerge";
@@ -607,10 +608,14 @@ function ModelsSection(props: { readonly merged: MergedUsage }) {
               {model.model}
             </Text>
             <Text className="text-sm text-foreground-muted">
-              {formatPercent(model.costShare)} of cost · {formatTokens(model.totalTokens)} tokens
+              {isModelCostUnknown(model)
+                ? `no known rates · ${formatTokens(model.totalTokens)} tokens`
+                : `${formatPercent(model.costShare)} of cost · ${formatTokens(model.totalTokens)} tokens`}
             </Text>
           </View>
-          <Text className="text-base tabular-nums text-foreground">{formatUsd(model.costUsd)}</Text>
+          <Text className="text-base tabular-nums text-foreground">
+            {isModelCostUnknown(model) ? "Unpriced" : formatUsd(model.costUsd)}
+          </Text>
         </View>
       ))}
     </SettingsSection>

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -87,6 +87,7 @@ const modelTotals = Object.freeze([
     costUsd: 10,
     totalTokens: 100,
     records: 1,
+    unpricedRecords: 0,
     costShare: 10 / 16,
   },
   {
@@ -95,6 +96,7 @@ const modelTotals = Object.freeze([
     costUsd: 5,
     totalTokens: 1_000,
     records: 1,
+    unpricedRecords: 0,
     costShare: 5 / 16,
   },
   {
@@ -103,7 +105,17 @@ const modelTotals = Object.freeze([
     costUsd: 1,
     totalTokens: 1_000,
     records: 1,
+    unpricedRecords: 0,
     costShare: 1 / 16,
+  },
+  {
+    model: "unpriced-model",
+    provider: "codex" as const,
+    costUsd: 0,
+    totalTokens: 500,
+    records: 2,
+    unpricedRecords: 2,
+    costShare: 0,
   },
 ]);
 
@@ -190,6 +202,17 @@ describe("UsagePage model breakdown", () => {
     expect(body).toMatch(/expensive-model.*token-heavy-model.*token-heavy-cheaper-model/);
   });
 
+  it("flags a model with no known rates instead of showing it as free", () => {
+    testState.breakdown = "model";
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+    const body = markup.match(/<tbody>(.*?)<\/tbody>/)?.[1] ?? "";
+    const unpricedRow = body.split("<tr").find((row) => row.includes("unpriced-model")) ?? "";
+
+    expect(unpricedRow).toContain("Unpriced");
+    expect(unpricedRow).not.toContain("$0.00");
+  });
+
   it("sorts models by token usage when the token metric is selected", () => {
     testState.metric = "tokens";
     testState.breakdown = "model";
@@ -202,6 +225,7 @@ describe("UsagePage model breakdown", () => {
       "expensive-model",
       "token-heavy-model",
       "token-heavy-cheaper-model",
+      "unpriced-model",
     ]);
   });
 });

--- a/apps/web/src/components/usage/UsagePage.tsx
+++ b/apps/web/src/components/usage/UsagePage.tsx
@@ -15,6 +15,7 @@ import { useMemo, useRef, useState } from "react";
 
 import {
   isCompatibleUsageContractVersion,
+  isModelCostUnknown,
   type DailyTotals,
   type HourlyTotals,
 } from "@t3tools/shared/usageMerge";
@@ -363,9 +364,13 @@ export function UsagePage() {
                           : formatTokens(merged.totalTokens)}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {metric === "cost"
-                          ? `${formatCount(merged.sessions)} sessions · API estimate`
-                          : `${formatCount(merged.sessions)} sessions`}
+                        {metric !== "cost"
+                          ? `${formatCount(merged.sessions)} sessions`
+                          : merged.costQuality.unpricedShare > 0
+                            ? `${formatCount(merged.sessions)} sessions · API estimate excludes ${formatPercent(
+                                merged.costQuality.unpricedShare,
+                              )} unpriced records`
+                            : `${formatCount(merged.sessions)} sessions · API estimate`}
                       </span>
                     </div>
 
@@ -511,10 +516,14 @@ export function UsagePage() {
                                 </span>
                               </td>
                               <td className="py-2 text-right text-foreground tabular-nums">
-                                {formatUsd(model.costUsd)}
+                                {isModelCostUnknown(model) ? (
+                                  <span className="text-muted-foreground">Unpriced</span>
+                                ) : (
+                                  formatUsd(model.costUsd)
+                                )}
                               </td>
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
-                                {formatPercent(model.costShare)}
+                                {isModelCostUnknown(model) ? "—" : formatPercent(model.costShare)}
                               </td>
                               <td className="py-2 text-right text-muted-foreground tabular-nums">
                                 {formatTokens(model.totalTokens)}

--- a/packages/shared/src/usageMerge.test.ts
+++ b/packages/shared/src/usageMerge.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
+import { isModelCostUnknown, mergeUsage, type EnvironmentUsage } from "./usageMerge.ts";
 
 function bucket(overrides: Partial<UsageBucket> = {}): UsageBucket {
   return {
@@ -219,6 +219,38 @@ describe("mergeUsage", () => {
     expect(merged.providers[0]?.costShare).toBeCloseTo(0.75, 5);
     expect(merged.costQuality.unpricedShare).toBeCloseTo(0.5, 5);
     expect(merged.costQuality.cacheSavingsUsd).toBe(4);
+  });
+
+  it("marks a model with no known rates as unpriced rather than free", () => {
+    const merged = mergeUsage(
+      [
+        environment(
+          "env-a",
+          summary(
+            [
+              bucket({ costUsd: 75 }),
+              bucket({
+                provider: "codex",
+                model: "unknown-model",
+                costUsd: 0,
+                costSource: "unpriced",
+                unpricedRecords: 5,
+              }),
+            ],
+            [
+              { provider: "claude", hostId: "mac", homePath: "/a/.claude" },
+              { provider: "codex", hostId: "mac", homePath: "/a/.codex" },
+            ],
+          ),
+        ),
+      ],
+      USAGE_CONTRACT_VERSION,
+    );
+
+    expect(merged.models.find((model) => model.model === "unknown-model")?.unpricedRecords).toBe(5);
+    expect(merged.models.filter(isModelCostUnknown).map((model) => model.model)).toEqual([
+      "unknown-model",
+    ]);
   });
 
   it("keeps two machines apart when hostname and home path collide", () => {

--- a/packages/shared/src/usageMerge.ts
+++ b/packages/shared/src/usageMerge.ts
@@ -37,7 +37,20 @@ export interface ModelTotals {
   readonly costUsd: number;
   readonly totalTokens: number;
   readonly records: number;
+  /**
+   * Records whose tokens are counted here but which contributed nothing to
+   * `costUsd`. When it equals `records` the cost is unknown, not zero.
+   */
+  readonly unpricedRecords: number;
   readonly costShare: number;
+}
+
+/**
+ * A model whose every record lacked rates has an unknown cost, not a zero one.
+ * Clients must not present its `costUsd` as a real dollar figure.
+ */
+export function isModelCostUnknown(model: ModelTotals): boolean {
+  return model.records > 0 && model.unpricedRecords >= model.records;
 }
 
 export interface DailyTotals {
@@ -249,7 +262,13 @@ export function mergeUsage(
   >();
   const modelAccumulator = new Map<
     string,
-    { provider: UsageProviderKind; costUsd: number; totalTokens: number; records: number }
+    {
+      provider: UsageProviderKind;
+      costUsd: number;
+      totalTokens: number;
+      records: number;
+      unpricedRecords: number;
+    }
   >();
   const dailyAccumulator = new Map<
     string,
@@ -319,10 +338,12 @@ export function mergeUsage(
         costUsd: 0,
         totalTokens: 0,
         records: 0,
+        unpricedRecords: 0,
       };
       model.costUsd += bucket.costUsd;
       model.totalTokens += tokens;
       model.records += bucket.records;
+      model.unpricedRecords += bucket.unpricedRecords;
       modelAccumulator.set(modelKey, model);
 
       const day = dailyAccumulator.get(bucket.day) ?? {
@@ -381,6 +402,7 @@ export function mergeUsage(
       costUsd: totals.costUsd,
       totalTokens: totals.totalTokens,
       records: totals.records,
+      unpricedRecords: totals.unpricedRecords,
       costShare: costUsd === 0 ? 0 : totals.costUsd / costUsd,
     }))
     .sort((a, b) => b.costUsd - a.costUsd || b.totalTokens - a.totalTokens);


### PR DESCRIPTION
The Usage page treated a model with no entry in the rate table as if it cost nothing: the server sets `costSource: "unpriced"` and counts `unpricedRecords`, but the client formatted the resulting zero as a literal `$0.00` and never showed the unpriced coverage it already receives.

`mergeUsage` now carries `unpricedRecords` per model and exports `isModelCostUnknown`. Web and mobile model rows render "Unpriced" instead of `$0.00` when every record for that model lacked rates, and the web cost headline says what share of records the estimate leaves out, so a mixed total reads as a lower bound.

Verified: `vitest run packages/shared/src/usageMerge.test.ts` 13 passed; `vitest run apps/web/src/components/usage/UsagePage.test.tsx` 5 passed; `vp run --filter @t3tools/{shared,web,mobile,client-runtime} typecheck` clean; `vp lint` on the five changed files clean.

Fixes #5799

UI evidence: verified in the web app against a copy of real usage data. A model whose records all lack rates (`<synthetic>`) now reads `Unpriced` with `—` for share instead of `$0.00 / 0.0%`, and the cost headline reads `372 sessions · API estimate excludes 0.1% unpriced records`. Rows whose provider reported a cost of zero (`costSource: providerReported`) still show `$0.00`, which this change does not touch.

Before (`main`): every rate-less row reads `$0.00 / 0.0%`.

![before: usage table shows $0.00 and 0.0% for models with no rate](https://uploads-production-47e4.up.railway.app/files/5a1c1de5-4a7c-49a5-a0bd-ed0f44e05264/11021-before-main.png)

After (this PR): the rate-less row reads `Unpriced` and the cost headline names the excluded share.

![after: unpriced row and the excluded-share footnote in the cost headline](https://uploads-production-47e4.up.railway.app/files/223de40e-03fe-4dc0-95b5-42564cfbdc00/11021-after-pr.png)

Done by Claude Opus 5 (1M context) in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage summaries now distinguish models without known pricing from models with zero cost.
  - Unpriced models are labeled **“Unpriced”** or **“no known rates”** instead of appearing free.
  - Token totals remain visible for unpriced models, while cost-share and USD values are shown only when pricing is available.
  - Usage percentages and model ordering now accurately include unpriced records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


