### PR TITLE
fix(web): let a stalled title regeneration be retried

### DIFF
--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -1021,6 +1021,7 @@ export function HomeScreen(props: HomeScreenProps) {
               onDeleteThread={props.onDeleteThread}
               onRegenerateThreadTitle={handleRegenerateThreadTitle}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
+              nowMinute={nowMinute}
               onSelectThread={props.onSelectThread}
               onSwipeableClose={handleSwipeableClose}
               onSwipeableWillOpen={handleSwipeableWillOpen}

--- a/apps/mobile/src/features/home/useThreadListActions.ts
+++ b/apps/mobile/src/features/home/useThreadListActions.ts
@@ -1,6 +1,10 @@
 import type { ThreadMoveDestination } from "../threads/threadOrder";
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import { canSnooze, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
+import {
+  canSnooze,
+  effectiveSnoozed,
+  isTitleRegenerationPending,
+} from "@t3tools/client-runtime/state/thread-settled";
 import * as Cause from "effect/Cause";
 import * as Haptics from "expo-haptics";
 import { useCallback, useRef } from "react";
@@ -437,7 +441,7 @@ export function useThreadListActions(): {
     async (thread: EnvironmentThreadShell) => {
       const key = scopedThreadKey(thread.environmentId, thread.id);
       if (
-        thread.titleRegeneration != null ||
+        isTitleRegenerationPending(thread, { now: new Date().toISOString() }) ||
         titleRegenerationInFlightThreadKeys.current.has(key)
       ) {
         return false;

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -1049,6 +1049,7 @@ function ThreadNavigationSidebarPane(
               onDeleteThread={confirmDeleteThread}
               onRegenerateThreadTitle={regenerateThreadTitle}
               titleRegenerationSupported={titleRegenerationEnvironmentIds.has(thread.environmentId)}
+              nowMinute={nowMinute}
               onSelectThread={handleSelectThread}
               onSwipeableClose={handleSwipeableClose}
               onSwipeableWillOpen={handleSwipeableWillOpen}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -4,6 +4,7 @@ import type {
   EnvironmentThreadShell,
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
+import { isTitleRegenerationPending } from "@t3tools/client-runtime/state/thread-settled";
 import type { EnvironmentMachineKind } from "@t3tools/contracts";
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "../../components/AppSymbol";
@@ -549,7 +550,10 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       THREAD_ROW_MENU_ACTIONS[0]!,
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
-        isRegenerating: thread.titleRegeneration != null,
+        isRegenerating: isTitleRegenerationPending(
+          { titleRegeneration: thread.titleRegeneration },
+          { now: new Date().toISOString() },
+        ),
       }),
       THREAD_ROW_MENU_ACTIONS[1]!,
     ],

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -458,6 +458,8 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   readonly onNewThreadOnBranch: (thread: EnvironmentThreadShell) => void;
   readonly onRegenerateThreadTitle: (thread: EnvironmentThreadShell) => void;
   readonly titleRegenerationSupported: boolean;
+  /** Minute-resolution clock so a stale title regeneration re-enables the menu entry. */
+  readonly nowMinute: string;
   readonly onSwipeableWillOpen: (methods: SwipeableMethods) => void;
   readonly onSwipeableClose: (methods: SwipeableMethods) => void;
   readonly simultaneousSwipeGesture?: ComponentProps<
@@ -550,14 +552,11 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
       THREAD_ROW_MENU_ACTIONS[0]!,
       ...buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
-        isRegenerating: isTitleRegenerationPending(
-          { titleRegeneration: thread.titleRegeneration },
-          { now: new Date().toISOString() },
-        ),
+        isRegenerating: isTitleRegenerationPending(thread, { now: `${props.nowMinute}:00.000Z` }),
       }),
       THREAD_ROW_MENU_ACTIONS[1]!,
     ],
-    [props.titleRegenerationSupported, thread.branch, thread.titleRegeneration],
+    [props.nowMinute, props.titleRegenerationSupported, thread],
   );
   const primaryAction = useMemo(
     () => ({

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -563,12 +563,11 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     () =>
       buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
-        isRegenerating: isTitleRegenerationPending(
-          { titleRegeneration: thread.titleRegeneration },
-          { now: new Date().toISOString() },
-        ),
+        isRegenerating: isTitleRegenerationPending(thread, {
+          now: `${props.snoozePresetMinute}:00.000Z`,
+        }),
       }),
-    [props.titleRegenerationSupported, thread.titleRegeneration],
+    [props.snoozePresetMinute, props.titleRegenerationSupported, thread],
   );
   const snoozableCardMenuActions = useMemo<MenuAction[]>(
     () => [

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -8,7 +8,11 @@ import type {
 } from "@t3tools/client-runtime/state/shell";
 import type { EnvironmentThreadSearchMatch } from "@t3tools/client-runtime/state/thread-search";
 import type { EnvironmentMachineKind } from "@t3tools/contracts";
-import { canSnooze, resolveSnoozePresets } from "@t3tools/client-runtime/state/thread-settled";
+import {
+  canSnooze,
+  isTitleRegenerationPending,
+  resolveSnoozePresets,
+} from "@t3tools/client-runtime/state/thread-settled";
 import { resolveSettledThreadTimestamp } from "@t3tools/client-runtime/state/thread-sort";
 import type { MenuAction } from "@react-native-menu/menu";
 import { memo, useCallback, useEffect, useMemo, useState, type ComponentProps } from "react";
@@ -559,7 +563,10 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
     () =>
       buildThreadTitleRegenerationMenuItems({
         supported: props.titleRegenerationSupported,
-        isRegenerating: thread.titleRegeneration != null,
+        isRegenerating: isTitleRegenerationPending(
+          { titleRegeneration: thread.titleRegeneration },
+          { now: new Date().toISOString() },
+        ),
       }),
     [props.titleRegenerationSupported, thread.titleRegeneration],
   );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   canSnooze,
   effectiveSnoozed,
+  isTitleRegenerationPending,
   threadWokeAt,
 } from "@t3tools/client-runtime/state/thread-settled";
 import { resolveSettledThreadTimestamp } from "@t3tools/client-runtime/state/thread-sort";
@@ -1035,7 +1036,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   );
   const threadKey = scopedThreadKey(threadRef);
   const { leaseLiveStatus, rowRef } = useSidebarRowSubscriptionLease(props.isActive);
-  const isRegeneratingTitle = thread.titleRegeneration != null;
+  const isRegeneratingTitle = isTitleRegenerationPending(thread, {
+    now: new Date().toISOString(),
+  });
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const openPrLink = useOpenPrLink();
@@ -3750,7 +3753,7 @@ export default function Sidebar() {
             .threadTitleRegeneration === true,
       );
       const regeneratableTitleThreads = titleRegenerationThreads.filter(
-        (thread) => thread.titleRegeneration == null,
+        (thread) => !isTitleRegenerationPending(thread, { now: selectionNow.toISOString() }),
       );
       const titleRegenerationMenuItem = buildBulkTitleRegenerationContextMenuItem({
         supportedCount: titleRegenerationThreads.length,
@@ -3993,7 +3996,9 @@ export default function Sidebar() {
         const supportsTitleRegeneration =
           serverConfigs.get(thread.environmentId)?.environment.capabilities
             .threadTitleRegeneration === true;
-        const isRegeneratingTitle = thread.titleRegeneration != null;
+        const isRegeneratingTitle = isTitleRegenerationPending(thread, {
+          now: new Date().toISOString(),
+        });
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
         const isPinned = thread.pinnedAt != null;

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -5,7 +5,11 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { canSnooze, effectiveSnoozed } from "@t3tools/client-runtime/state/thread-settled";
+import {
+  canSnooze,
+  effectiveSnoozed,
+  isTitleRegenerationPending,
+} from "@t3tools/client-runtime/state/thread-settled";
 import type { ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import { useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
@@ -135,7 +139,9 @@ export function useThreadActionMenu(input: {
           pinning: readEnvironmentSupportsPinning(threadRef.environmentId),
           titleRegeneration: readEnvironmentSupportsTitleRegeneration(threadRef.environmentId),
         };
-        const isRegeneratingTitle = thread.titleRegeneration != null;
+        const isRegeneratingTitle = isTitleRegenerationPending(thread, {
+          now: now.toISOString(),
+        });
         const snoozePresets = resolveSnoozePresets(now, timestampFormat);
         const items = buildThreadActionMenuItems({
           branch: thread.branch ?? null,

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -11,20 +11,25 @@ import type { OrchestrationThreadShell } from "@t3tools/contracts";
 export const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
 
 /**
- * A title regeneration request lives for at most this long: every text
- * generation provider bounds its own call at 180s, so a request still
- * pending after this window means the server's completion was never
- * dispatched or never reached this client. Without the bound the pending
- * flag is a one-way door — the menu entry reads "Regenerating…" and stays
- * disabled forever, so the retry that would clear it can never be sent.
+ * How long the UI keeps trusting a pending title regeneration. The server
+ * clears the flag when the request resolves, so this bound only decides
+ * what to show when that resolution does not arrive — without it the
+ * pending flag is a one-way door: the menu entry reads "Regenerating…"
+ * and stays disabled forever, so the retry that would clear it can never
+ * be sent.
+ *
+ * Sized for the bulk path. The server regenerates titles on a single
+ * serial worker, and one generation runs until its provider's own limit
+ * (180s for most, unbounded for OpenCode), so a batch legitimately leaves
+ * later threads pending for several minutes.
  */
-export const TITLE_REGENERATION_GRACE_MS = 5 * 60 * 1_000;
+export const TITLE_REGENERATION_GRACE_MS = 15 * 60 * 1_000;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 /**
  * Whether a title regeneration is still plausibly in flight. Server events
- * clear `titleRegeneration` on completion; this only decides how long the
- * UI keeps trusting a pending request that never completed.
+ * clear `titleRegeneration` when the request resolves; this only decides
+ * how long the UI keeps trusting one that has not resolved.
  */
 export function isTitleRegenerationPending(
   shell: Pick<OrchestrationThreadShell, "titleRegeneration">,

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -23,7 +23,7 @@ export const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
  * (180s for most, unbounded for OpenCode), so a batch legitimately leaves
  * later threads pending for several minutes.
  */
-export const TITLE_REGENERATION_GRACE_MS = 15 * 60 * 1_000;
+const TITLE_REGENERATION_GRACE_MS = 15 * 60 * 1_000;
 const DAY_MS = 24 * 60 * 60 * 1_000;
 
 /**

--- a/packages/client-runtime/src/state/threadSettled.ts
+++ b/packages/client-runtime/src/state/threadSettled.ts
@@ -9,7 +9,37 @@ import type { OrchestrationThreadShell } from "@t3tools/contracts";
  * such threads would be permanently unsettleable.
  */
 export const QUEUED_TURN_START_GRACE_MS = 2 * 60 * 1_000;
+
+/**
+ * A title regeneration request lives for at most this long: every text
+ * generation provider bounds its own call at 180s, so a request still
+ * pending after this window means the server's completion was never
+ * dispatched or never reached this client. Without the bound the pending
+ * flag is a one-way door — the menu entry reads "Regenerating…" and stays
+ * disabled forever, so the retry that would clear it can never be sent.
+ */
+export const TITLE_REGENERATION_GRACE_MS = 5 * 60 * 1_000;
 const DAY_MS = 24 * 60 * 60 * 1_000;
+
+/**
+ * Whether a title regeneration is still plausibly in flight. Server events
+ * clear `titleRegeneration` on completion; this only decides how long the
+ * UI keeps trusting a pending request that never completed.
+ */
+export function isTitleRegenerationPending(
+  shell: Pick<OrchestrationThreadShell, "titleRegeneration">,
+  options: { readonly now: string },
+): boolean {
+  const startedAt = shell.titleRegeneration?.startedAt;
+  if (startedAt == null) return false;
+  const startedAtMs = Date.parse(startedAt);
+  if (Number.isNaN(startedAtMs)) return false;
+  const nowMs = Date.parse(options.now);
+  if (Number.isNaN(nowMs)) return false;
+  // Bounded on both sides like hasQueuedTurnStart: startedAt is stamped by
+  // the environment's server, whose clock can run ahead of this device's.
+  return Math.abs(nowMs - startedAtMs) <= TITLE_REGENERATION_GRACE_MS;
+}
 
 /**
  * A user message no turn has picked up yet: the turn.start command was

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -1,5 +1,5 @@
 // @effect-diagnostics globalDate:off -- Tests exercise local calendar snooze boundaries.
-import { ThreadId } from "@t3tools/contracts";
+import { CommandId, ThreadId } from "@t3tools/contracts";
 import { TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -7,6 +7,7 @@ import {
   canSnooze,
   effectiveSnoozed,
   hasQueuedTurnStart,
+  isTitleRegenerationPending,
   resolveSnoozePresets,
   snoozeWakeLabel,
   threadRaisedHandWhileSnoozed,
@@ -369,5 +370,31 @@ describe("resolveSnoozePresets", () => {
     ]);
     const tomorrow = new Date(presets.find((preset) => preset.id === "tomorrow")!.snoozedUntil);
     expect(tomorrow.getDay()).toBe(1);
+  });
+});
+
+describe("isTitleRegenerationPending", () => {
+  const startedAt = "2026-04-10T11:58:00.000Z";
+
+  it("stays pending while the request is within the grace window", () => {
+    expect(
+      isTitleRegenerationPending(
+        { titleRegeneration: { requestId: CommandId.make("cmd-1"), startedAt } },
+        { now: NOW },
+      ),
+    ).toBe(true);
+  });
+
+  it("stops pending once the request outlives the grace window, so it can be retried", () => {
+    expect(
+      isTitleRegenerationPending(
+        { titleRegeneration: { requestId: CommandId.make("cmd-1"), startedAt } },
+        { now: "2026-04-10T12:10:00.000Z" },
+      ),
+    ).toBe(false);
+  });
+
+  it("is never pending without a request", () => {
+    expect(isTitleRegenerationPending({ titleRegeneration: null }, { now: NOW })).toBe(false);
   });
 });

--- a/packages/client-runtime/src/state/threadSnoozed.test.ts
+++ b/packages/client-runtime/src/state/threadSnoozed.test.ts
@@ -385,11 +385,20 @@ describe("isTitleRegenerationPending", () => {
     ).toBe(true);
   });
 
-  it("stops pending once the request outlives the grace window, so it can be retried", () => {
+  it("stays pending across a serial bulk run that outlasts a single generation", () => {
     expect(
       isTitleRegenerationPending(
         { titleRegeneration: { requestId: CommandId.make("cmd-1"), startedAt } },
         { now: "2026-04-10T12:10:00.000Z" },
+      ),
+    ).toBe(true);
+  });
+
+  it("stops pending once the request outlives the grace window, so it can be retried", () => {
+    expect(
+      isTitleRegenerationPending(
+        { titleRegeneration: { requestId: CommandId.make("cmd-1"), startedAt } },
+        { now: "2026-04-10T12:20:00.000Z" },
       ),
     ).toBe(false);
   });


### PR DESCRIPTION
The client only clears a thread's pending `titleRegeneration` when the server's completion event arrives, so any lost completion leaves the row dimmed and pins the menu entry at `Regenerating…` / disabled forever — and the guard `if (isRegeneratingTitle) return;` then swallows every later click with no toast and no retry, which is what makes the action look permanently dead.

This bounds the pending state instead of trusting it indefinitely: `isTitleRegenerationPending` treats a request older than 15 minutes as lost, so the row un-dims, the menu item becomes clickable again, and the retry re-issues the request — which the decider accepts and which replaces the stale `requestId`. The window is sized for the bulk path: the server regenerates on a single serial worker and one generation runs to its provider's own limit (180s for most, unbounded for OpenCode), so `Regenerate titles (N)` legitimately leaves later threads pending for several minutes. Same shape and clock-skew handling as the existing `QUEUED_TURN_START_GRACE_MS` bound next to it, which exists for the identical "permanently unsettleable" failure. Web and mobile both route through the shared helper. Web menus read the clock when they open; the mobile row menus are memoized, so they now take the minute clock the screens already keep as a dependency and the entry re-enables on the next tick after the window. Web row dimming stays as rendered until the next thread event, like the neighbouring snooze guard.

This is a client-side mitigation: it closes the one-way door so the user can retry, it does not change why a completion fails to arrive.

Scope note: I could not reproduce the reporter's follow-up claim that the server never dispatches the completion on remote environments, and I did not change server behaviour — the underlying leak is still open, hence `Refs` rather than `Fixes`. I did confirm the client applies `thread.meta-updated` correctly (`applyThreadDetailEvent` and the shell stream both carry `titleRegeneration` end to end, with no remote-vs-local branch), so the original "the client never consumes the completion" framing is not the defect.

Verified (all from the package dir with the workspace `vp`):
- `vp test run src/state/threadSnoozed.test.ts` (client-runtime) — 33 passed.
- `vp test run src/components/Sidebar.logic.test.ts src/components/threadActionMenu.logic.test.ts` (web) — 168 passed.
- `vp test run src/features/threads/thread-title-regeneration-menu.test.ts src/features/threads/threadListV2.test.ts` (mobile) — 74 passed.
- `vp run --filter @t3tools/client-runtime|@t3tools/web|@t3tools/mobile typecheck` — all pass.
- `vp lint` on the seven changed files — pass; warning counts match origin/main file for file, no new findings.

Refs #7328

UI evidence: unverified. The browser preview host was unavailable in this session, so the changed interaction was not exercised in a real client.

Done by Claude Opus 5 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread title-regeneration status handling by recognizing only active requests within the 15-minute grace period.
  - Prevented expired requests from incorrectly blocking retries or displaying pending states.
  - Applied consistent status checks across web and mobile thread rows, bulk actions, and context menus.
  - Updated thread menus to re-enable title regeneration automatically after the grace period expires.

- **Tests**
  - Added coverage for active, expired, missing, and longer-running title-regeneration requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
