### PR TITLE
fix(desktop): stop opening a project from creating it twice

### DIFF
--- a/apps/web/src/desktopAppActivation.test.ts
+++ b/apps/web/src/desktopAppActivation.test.ts
@@ -75,6 +75,50 @@ describe("desktop app activation", () => {
     expect(response).toMatchObject({ ok: true, projectId: createdProjectId });
   });
 
+  it("creates one project when two activations race for the same workspace root", async () => {
+    let release = () => {};
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const deps = dependencies({
+      findProject: () => null,
+      createProject: vi.fn(async () => {
+        await pending;
+        return createdProjectId;
+      }),
+    });
+
+    const first = handleDesktopAppActivationRequest(request, deps);
+    const second = handleDesktopAppActivationRequest({ ...request, requestId: "request-2" }, deps);
+    release();
+    const responses = await Promise.all([first, second]);
+
+    expect(deps.createProject).toHaveBeenCalledTimes(1);
+    expect(responses).toMatchObject([
+      { ok: true, projectId: createdProjectId },
+      { ok: true, projectId: createdProjectId },
+    ]);
+  });
+
+  it("reuses a project that appeared while the duplicate create was rejected", async () => {
+    let created = false;
+    const deps = dependencies({
+      findProject: () =>
+        created
+          ? { id: existingProjectId, environmentId, workspaceRoot: request.workspaceRoot }
+          : null,
+      createProject: vi.fn(async () => {
+        created = true;
+        throw new Error("Active project 'project-existing' already exists for workspace root.");
+      }),
+    });
+
+    const response = await handleDesktopAppActivationRequest(request, deps);
+
+    expect(response).toMatchObject({ ok: true, projectId: existingProjectId });
+    expect(deps.openThread).toHaveBeenCalledWith({ environmentId, projectId: existingProjectId });
+  });
+
   it("rejects a Windows path when the primary environment is WSL", async () => {
     const response = await handleDesktopAppActivationRequest(
       { ...request, platform: "win32" },

--- a/apps/web/src/desktopAppActivation.ts
+++ b/apps/web/src/desktopAppActivation.ts
@@ -8,6 +8,7 @@ import type {
   ScopedProjectRef,
   ThreadId,
 } from "@t3tools/contracts";
+import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 
 export interface DesktopAppActivationProject {
   readonly id: ProjectId;
@@ -54,6 +55,30 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message.trim().length > 0 ? error.message : fallback;
 }
 
+/**
+ * Activation requests can overlap: the broker re-dispatches after a renderer
+ * blip and the coordinator's queue restarts with the component, so two requests
+ * for one workspace root can reach here before the projection shows the first
+ * create. Sharing the in-flight create keeps the server from rejecting the
+ * second one with its "already exists" invariant.
+ */
+const inFlightCreates = new Map<string, Promise<ProjectId>>();
+
+function createProjectOnce(
+  dependencies: DesktopAppActivationDependencies,
+  environmentId: EnvironmentId,
+  workspaceRoot: string,
+): Promise<ProjectId> {
+  const key = JSON.stringify([environmentId, normalizeProjectPathForComparison(workspaceRoot)]);
+  const inFlight = inFlightCreates.get(key);
+  if (inFlight !== undefined) return inFlight;
+  const created = dependencies
+    .createProject(environmentId, workspaceRoot)
+    .finally(() => inFlightCreates.delete(key));
+  inFlightCreates.set(key, created);
+  return created;
+}
+
 export async function handleDesktopAppActivationRequest(
   request: DesktopAppActivationRequest,
   dependencies: DesktopAppActivationDependencies,
@@ -79,14 +104,24 @@ export async function handleDesktopAppActivationRequest(
   let projectId = dependencies.findProject(target.environmentId, request.workspaceRoot)?.id ?? null;
   if (projectId === null) {
     try {
-      projectId = await dependencies.createProject(target.environmentId, request.workspaceRoot);
+      projectId = await createProjectOnce(
+        dependencies,
+        target.environmentId,
+        request.workspaceRoot,
+      );
       await dependencies.waitForProject({ environmentId: target.environmentId, projectId });
     } catch (error) {
-      return failure(
-        request.requestId,
-        "project-create-failed",
-        errorMessage(error, "T3 Code could not add the project."),
-      );
+      // An earlier activation for this root may have created the project already.
+      const existing =
+        dependencies.findProject(target.environmentId, request.workspaceRoot)?.id ?? null;
+      if (existing === null) {
+        return failure(
+          request.requestId,
+          "project-create-failed",
+          errorMessage(error, "T3 Code could not add the project."),
+        );
+      }
+      projectId = existing;
     }
   }
 


### PR DESCRIPTION
Opening a project from the desktop app could dispatch `project.create` twice for the same workspace root: two activation requests can reach `handleDesktopAppActivationRequest` before the client projection shows the first create (the broker re-dispatches after a renderer blip, and the coordinator's serializing queue lives in a `useRef` that resets when the component remounts), so the second create is rejected by the server's `Active project '...' already exists for workspace root '...'` invariant and the open fails.

Racing activations now share a single in-flight create keyed by environment plus normalized workspace root, and a rejected create falls back to whatever project has since appeared for that root instead of failing the request outright. Other create call sites (command palette, welcome wizard, mobile add-project) are single user-initiated dispatches, not this race, so they are out of scope.

Verified: `vp test run src/desktopAppActivation.test.ts` in `apps/web` passes 6/6, and both new cases fail on `origin/main`. `vp run --filter @t3tools/web typecheck` exits 0 (only pre-existing suggestion diagnostics in unrelated files). `vp lint apps/web/src/desktopAppActivation.ts apps/web/src/desktopAppActivation.test.ts` exits 0.

Fixes #5958

UI evidence: pending (parent will attach)

Done by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate project creation when multiple activations occur simultaneously for the same workspace.
  - Improved recovery when project creation reports a failure but the project becomes available through another activation.
  - Ensured existing projects are reopened and shared activation requests receive consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->