### PR TITLE
feat(mobile): show final answers in completion notifications

### DIFF
--- a/apps/mobile/modules/t3-agent-notifications/android/src/main/java/expo/modules/t3agentnotifications/AgentNotifications.kt
+++ b/apps/mobile/modules/t3-agent-notifications/android/src/main/java/expo/modules/t3agentnotifications/AgentNotifications.kt
@@ -141,8 +141,8 @@ object AgentNotifications {
       // so a delivery retry cannot surface them after the app backgrounds.
       if (!ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
         val title = data["alert_title"].orEmpty().take(120)
-        // Grouped alerts list up to five 120-character thread titles.
-        val body = data["alert_body"].orEmpty().take(608)
+        // The relay fits the full response to FCM's 4 KB payload budget.
+        val body = data["alert_body"].orEmpty().take(4096)
         val id = alertId.hashCode()
         val notification = base(context, ALERT_CHANNEL)
           .setContentTitle(title).setContentText(body)

--- a/apps/mobile/modules/t3-agent-notifications/android/src/test/java/expo/modules/t3agentnotifications/AgentNotificationsTest.kt
+++ b/apps/mobile/modules/t3-agent-notifications/android/src/test/java/expo/modules/t3agentnotifications/AgentNotificationsTest.kt
@@ -143,6 +143,19 @@ class AgentNotificationsTest {
   }
 
   @Test
+  fun completionAlertDisplaysLongFinalAnswer() {
+    val answer = "The change is complete.\n\n" + "Tests pass. ".repeat(120)
+    AgentNotifications.receive(context, update("long-answer", false) + ("alert_body" to answer))
+
+    val alert = manager.activeNotifications.single()
+    assertEquals(answer, alert.notification.extras.getString(Notification.EXTRA_BIG_TEXT))
+    assertEquals(
+      "t3code-dev://threads/environment/thread",
+      shadowOf(alert.notification.contentIntent).savedIntent.dataString
+    )
+  }
+
+  @Test
   fun groupedAlertDisplaysEveryThreadAndRetriesStaySilent() {
     val titles = (1..5).map { "Thread $it " + "x".repeat(111) }.joinToString(", ")
     val grouped = update("group-completion", false) + mapOf(

--- a/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
@@ -76,6 +76,7 @@ describe("CheckpointDiffQuery.layer", () => {
         Layer.provideMerge(
           Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
             getUserInputActivity: () => Effect.die("unused"),
+            getThreadCompletionResponse: () => Effect.die("unused"),
             getCommandReadModel: () =>
               Effect.die("CheckpointDiffQuery should not request the command read model"),
             getSnapshot: () =>
@@ -190,6 +191,7 @@ describe("CheckpointDiffQuery.layer", () => {
         Layer.provideMerge(
           Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
             getUserInputActivity: () => Effect.die("unused"),
+            getThreadCompletionResponse: () => Effect.die("unused"),
             getCommandReadModel: () =>
               Effect.die("CheckpointDiffQuery should not request the command read model"),
             getSnapshot: () =>
@@ -279,6 +281,7 @@ describe("CheckpointDiffQuery.layer", () => {
         Layer.provideMerge(
           Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
             getUserInputActivity: () => Effect.die("unused"),
+            getThreadCompletionResponse: () => Effect.die("unused"),
             getCommandReadModel: () =>
               Effect.die("CheckpointDiffQuery should not request the command read model"),
             getSnapshot: () =>
@@ -353,6 +356,7 @@ describe("CheckpointDiffQuery.layer", () => {
         Layer.provideMerge(
           Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
             getUserInputActivity: () => Effect.die("unused"),
+            getThreadCompletionResponse: () => Effect.die("unused"),
             getCommandReadModel: () =>
               Effect.die("CheckpointDiffQuery should not request the command read model"),
             getSnapshot: () =>
@@ -412,6 +416,7 @@ describe("CheckpointDiffQuery.layer", () => {
         Layer.provideMerge(
           Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
             getUserInputActivity: () => Effect.die("unused"),
+            getThreadCompletionResponse: () => Effect.die("unused"),
             getCommandReadModel: () =>
               Effect.die("CheckpointDiffQuery should not request the command read model"),
             getSnapshot: () =>

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -404,6 +404,7 @@ describe("OrchestrationEngine", () => {
       Layer.provide(
         Layer.succeed(ProjectionSnapshotQuery, {
           getUserInputActivity: () => Effect.die("unused"),
+          getThreadCompletionResponse: () => Effect.die("unused"),
           getCommandReadModel: () => Effect.succeed(commandReadModel),
           getSnapshot: () =>
             Effect.sync(() => {

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -52,6 +52,41 @@ const projectionSnapshotLayer = it.layer(
 );
 
 projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
+  it.effect("reads only the latest turn's final answer and bounds large responses", () =>
+    Effect.gen(function* () {
+      const query = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+      const threadId = ThreadId.make("completion-response-test");
+      yield* sql`INSERT INTO projection_turns
+        (thread_id, turn_id, assistant_message_id, state, requested_at, checkpoint_files_json)
+        VALUES (${threadId}, 'response-turn', 'response-message', 'completed',
+          '2026-09-10T00:00:00.000Z', '[]')`;
+      yield* sql`INSERT INTO projection_thread_messages
+        (thread_id, turn_id, message_id, role, text, is_streaming, created_at, updated_at)
+        VALUES (${threadId}, 'response-turn', 'response-message', 'assistant', 'Final answer.',
+          0, '2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z')`;
+      assert.deepEqual(
+        yield* query.getThreadCompletionResponse(threadId),
+        Option.some("Final answer."),
+      );
+      yield* sql`UPDATE projection_thread_messages SET is_streaming = 1
+        WHERE message_id = 'response-message'`;
+      assert.deepEqual(yield* query.getThreadCompletionResponse(threadId), Option.none());
+      yield* sql`UPDATE projection_thread_messages SET is_streaming = 0, text = ${"🤖".repeat(16001)}
+        WHERE message_id = 'response-message'`;
+      assert.deepEqual(
+        yield* query.getThreadCompletionResponse(threadId),
+        Option.some("🤖".repeat(16000) + "…"),
+      );
+      yield* sql`INSERT INTO projection_turns
+        (thread_id, turn_id, state, requested_at, checkpoint_files_json)
+        VALUES (${threadId}, 'newer-turn', 'completed', '2026-09-10T00:01:00.000Z', '[]')`;
+      assert.deepEqual(yield* query.getThreadCompletionResponse(threadId), Option.none());
+      yield* sql`DELETE FROM projection_turns WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_thread_messages WHERE thread_id = ${threadId}`;
+    }),
+  );
+
   it.effect("hydrates read model from projection tables and computes snapshot sequence", () =>
     Effect.gen(function* () {
       const snapshotQuery = yield* ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1136,6 +1136,44 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       ),
   });
 
+  // ponytail: cap raw Markdown at 16K characters before signing; render here
+  // if very large markup must produce a small notification.
+  const getThreadCompletionResponseRow = SqlSchema.findOneOption({
+    Request: ThreadIdLookupInput,
+    Result: Schema.Struct({ text: Schema.String }),
+    execute: ({ threadId }) => sql`
+      SELECT substr(messages.text, 1, 16000) ||
+        CASE WHEN length(messages.text) > 16000 THEN '…' ELSE '' END AS text
+      FROM projection_turns AS turns
+      JOIN projection_thread_messages AS messages
+        ON messages.thread_id = turns.thread_id
+        AND messages.message_id = turns.assistant_message_id
+        AND messages.turn_id = turns.turn_id
+      WHERE turns.rowid = (
+        SELECT rowid FROM projection_turns
+        WHERE thread_id = ${threadId}
+        ORDER BY COALESCE(started_at, requested_at) DESC, rowid DESC
+        LIMIT 1
+      )
+        AND turns.state = 'completed'
+        AND messages.role = 'assistant'
+        AND messages.is_streaming = 0
+    `,
+  });
+
+  const getThreadCompletionResponse: ProjectionSnapshotQueryShape["getThreadCompletionResponse"] = (
+    threadId,
+  ) =>
+    getThreadCompletionResponseRow({ threadId }).pipe(
+      Effect.map(Option.map((row) => row.text)),
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionSnapshotQuery.getThreadCompletionResponse:query",
+          "ProjectionSnapshotQuery.getThreadCompletionResponse:decodeRow",
+        ),
+      ),
+    );
+
   const getTurnStartMessageRow = SqlSchema.findOneOption({
     Request: TurnStartMessageLookupInput,
     Result: ProjectionTurnStartMessageDbRowSchema,
@@ -3397,6 +3435,7 @@ pending_approval_requests AS (
       );
 
   return {
+    getThreadCompletionResponse,
     getCommandReadModel,
     getUserInputActivity,
     getSnapshot,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -385,6 +385,8 @@ describe("ProviderRuntimeIngestion", () => {
       engine,
       dispatch,
       readModel: () => testRuntime.runPromise(snapshotQuery.getSnapshot()),
+      readCompletionResponse: () =>
+        testRuntime.runPromise(snapshotQuery.getThreadCompletionResponse(asThreadId("thread-1"))),
       readThreadShell: () =>
         testRuntime.runPromise(
           snapshotQuery
@@ -2316,6 +2318,47 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread?.proposedPlans).toEqual([
       expect.objectContaining({ planMarkdown: "# Replacement plan", createdAt: replacementTime }),
     ]);
+  });
+
+  it("saves the final answer before publishing the terminal session", async () => {
+    const harness = await createHarness();
+    const base = {
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: "2026-09-10T00:00:00.000Z",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("notification-turn"),
+    };
+    await harness.emitAndDrain([
+      { ...base, type: "turn.started", eventId: asEventId("notification-start") },
+      {
+        ...base,
+        type: "content.delta",
+        eventId: asEventId("notification-delta"),
+        itemId: asItemId("notification-answer"),
+        payload: { streamKind: "assistant_text", delta: "Final answer.\n\nTests pass." },
+      },
+      {
+        ...base,
+        type: "turn.completed",
+        eventId: asEventId("notification-end"),
+        payload: { state: "completed" },
+      },
+    ]);
+    expect(await harness.readCompletionResponse()).toEqual(
+      Option.some("Final answer.\n\nTests pass."),
+    );
+    const events = await Effect.runPromise(Stream.runCollect(harness.engine.readEvents(0)));
+    const answer = events.find(
+      (event) =>
+        event.type === "thread.message-sent" &&
+        event.payload.role === "assistant" &&
+        !event.payload.streaming,
+    );
+    const completed = events.findLast(
+      (event) => event.type === "thread.session-set" && event.payload.session.status === "ready",
+    );
+    expect(answer?.sequence).toBeDefined();
+    expect(completed?.sequence).toBeGreaterThan(answer!.sequence);
   });
 
   it("buffers assistant deltas with one lifecycle query per event until completion", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1487,6 +1487,7 @@ const make = Effect.gen(function* () {
       const eventTurnId = toTurnId(event.turnId);
       const activeTurnId = thread.session?.activeTurnId ?? null;
       const isTerminalTurn = event.type === "turn.completed" || event.type === "turn.aborted";
+      let terminalSessionUpdate: ReturnType<typeof orchestrationEngine.dispatch> | undefined;
       const isCompactedThreadState =
         event.type === "thread.state.changed" && event.payload.state === "compacted";
       const pendingTurnStart =
@@ -1627,7 +1628,7 @@ const make = Effect.gen(function* () {
             );
           }
 
-          yield* orchestrationEngine.dispatch({
+          const updateSession = orchestrationEngine.dispatch({
             type: "thread.session.set",
             commandId: yield* providerCommandId(event, "thread-session-set"),
             threadId: thread.id,
@@ -1645,6 +1646,10 @@ const make = Effect.gen(function* () {
             },
             createdAt: now,
           });
+          // Completion consumers must see the saved final answer, including
+          // buffered deltas, before they see the session leave running.
+          if (isTerminalTurn) terminalSessionUpdate = updateSession;
+          else yield* updateSession;
         }
       }
 
@@ -1909,6 +1914,8 @@ const make = Effect.gen(function* () {
           });
         }
       }
+
+      if (terminalSessionUpdate) yield* terminalSessionUpdate;
 
       if (event.type === "session.exited") {
         yield* clearTurnStateForSession(thread.id);

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -77,6 +77,11 @@ export interface ProjectionThreadDetailQuery {
  * ProjectionSnapshotQueryShape - Service API for read-model snapshots.
  */
 export interface ProjectionSnapshotQueryShape {
+  /** Read only the latest turn's final answer for completion notifications. */
+  readonly getThreadCompletionResponse: (
+    threadId: ThreadId,
+  ) => Effect.Effect<Option.Option<string>, ProjectionRepositoryError>;
+
   /** Read the latest request or resolution without loading the thread history. */
   readonly getUserInputActivity: (input: {
     readonly threadId: ThreadId;

--- a/apps/server/src/project/AgentSessionScanner.test.ts
+++ b/apps/server/src/project/AgentSessionScanner.test.ts
@@ -38,6 +38,7 @@ const makeProjectionSnapshotQueryLayer = (importedWorkspaceRoots: ReadonlyArray<
   Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
     getCommandReadModel: () => Effect.die("unused"),
     getUserInputActivity: () => Effect.die("unused"),
+    getThreadCompletionResponse: () => Effect.die("unused"),
     getSnapshot: () => Effect.die("unused"),
     getShellSnapshot: () =>
       Effect.succeed({

--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -28,6 +28,7 @@ const makeProject = (scripts: OrchestrationProject["scripts"]): OrchestrationPro
 const makeProjectionSnapshotQueryLayer = (project: OrchestrationProject) =>
   Layer.succeed(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
     getUserInputActivity: () => Effect.die("unused"),
+    getThreadCompletionResponse: () => Effect.die("unused"),
     getCommandReadModel: () => Effect.die("unused"),
     getSnapshot: () => Effect.die("unused"),
     getShellSnapshot: () => Effect.die("unused"),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -4822,6 +4822,7 @@ describe("agent browser access", () => {
         getTurnStartMessage: () => Effect.die("unused"),
         getImportedAgentSessionSources: () => Effect.die("unused"),
         getUserInputActivity: () => Effect.die("unused"),
+        getThreadCompletionResponse: () => Effect.die("unused"),
         getCommandReadModel: () => Effect.die("unused"),
         getSnapshot: () => Effect.die("unused"),
         getShellSnapshot: () => Effect.die("unused"),

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -233,6 +233,7 @@ describe("ProviderSessionReaper", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getUserInputActivity: () => Effect.die("unused"),
+          getThreadCompletionResponse: () => Effect.die("unused"),
           getCommandReadModel: () => Effect.die("unused"),
           getSnapshot: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),

--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -154,6 +154,14 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
       AgentAwarenessRelay.shouldPublishAgentAwarenessEvent({
         ...base,
         type: "thread.message-sent",
+        payload: { threadId: "thread-1", role: "assistant", streaming: false },
+      } as unknown as OrchestrationEvent),
+    ).toBe(true);
+
+    expect(
+      AgentAwarenessRelay.shouldPublishAgentAwarenessEvent({
+        ...base,
+        type: "thread.message-sent",
         payload: {
           threadId: "thread-1" as ThreadId,
           streaming: true,
@@ -406,7 +414,7 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
         exp: 200,
         environmentId: state.environmentId,
         threadId: state.threadId,
-        state,
+        state: { ...state, phase: "completed", completionResponse: "Final answer.\n\nTests pass." },
       } satisfies RelayAgentActivityPublishProofPayload;
       const proof = yield* AgentAwarenessRelay.signRelayAgentActivityPublishProof({
         privateKey: keyPair.privateKey,
@@ -422,7 +430,7 @@ describe.sequential("signRelayAgentActivityPublishProof", () => {
           nowEpochSeconds: 150,
         });
 
-      expect(yield* verify(proof)).toMatchObject({ jti: "nonce-1", state });
+      expect(yield* verify(proof)).toMatchObject({ jti: "nonce-1", state: payload.state });
 
       const [header, body, signature = ""] = proof.split(".");
       const corruptedSignature = `${signature.startsWith("a") ? "b" : "a"}${signature.slice(1)}`;

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -72,6 +72,7 @@ export function shouldPublishAgentAwarenessEvent(event: OrchestrationEvent): boo
   }
   switch (event.type) {
     case "thread.message-sent":
+      return event.payload.role === "assistant" && !event.payload.streaming;
     case "thread.turn-start-requested":
       // These events express intent to start work, but the shell still contains
       // the previous turn's terminal state until the provider acknowledges the
@@ -409,12 +410,21 @@ export const make = Effect.gen(function* () {
     const project = Option.isSome(thread)
       ? yield* snapshotQuery.getProjectShellById(thread.value.projectId)
       : Option.none<OrchestrationProjectShell>();
-    const snapshot = resolveAgentAwarenessRelayPublishSnapshot({
+    let snapshot = resolveAgentAwarenessRelayPublishSnapshot({
       environmentId,
       threadId,
       thread,
       project,
     });
+    if (snapshot.state?.phase === "completed") {
+      const response = yield* snapshotQuery.getThreadCompletionResponse(threadId);
+      if (Option.isSome(response) && response.value.trim()) {
+        snapshot = {
+          ...snapshot,
+          state: { ...snapshot.state, completionResponse: response.value.trim() },
+        };
+      }
+    }
     const publishIdentity = agentAwarenessPublishIdentity(snapshot.state);
     const publishedStateByThread = yield* Ref.get(publishedStateByThreadRef);
     if (publishedStateByThread.get(threadId) === publishIdentity) {

--- a/apps/server/src/serverRuntimeStartup.test.ts
+++ b/apps/server/src/serverRuntimeStartup.test.ts
@@ -142,6 +142,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets returns existing project and threa
       } as never),
       Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
         getUserInputActivity: () => Effect.die("unused"),
+        getThreadCompletionResponse: () => Effect.die("unused"),
         getCommandReadModel: () => Effect.die("unused"),
         getSnapshot: () => Effect.die("unused"),
         getShellSnapshot: () => Effect.die("unused"),
@@ -230,6 +231,7 @@ it.effect.each([
       } as never),
       Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
         getUserInputActivity: () => Effect.die("unused"),
+        getThreadCompletionResponse: () => Effect.die("unused"),
         getCommandReadModel: () => Effect.die("unused"),
         getSnapshot: () => Effect.die("unused"),
         getShellSnapshot: () => Effect.die("unused"),
@@ -313,6 +315,7 @@ it.effect(
         } as never),
         Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
           getUserInputActivity: () => Effect.die("unused"),
+          getThreadCompletionResponse: () => Effect.die("unused"),
           getCommandReadModel: () => Effect.die("unused"),
           getSnapshot: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
@@ -375,6 +378,7 @@ it.effect("resolveAutoBootstrapWelcomeTargets preserves typed UUID generation fa
       } as never),
       Effect.provideService(ProjectionSnapshotQuery.ProjectionSnapshotQuery, {
         getUserInputActivity: () => Effect.die("unused"),
+        getThreadCompletionResponse: () => Effect.die("unused"),
         getCommandReadModel: () => Effect.die("unused"),
         getSnapshot: () => Effect.die("unused"),
         getShellSnapshot: () => Effect.die("unused"),

--- a/infra/relay/src/agentActivity/ApnsClient.test.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.test.ts
@@ -18,9 +18,11 @@ import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import type { ApnsCredentials } from "../Config.ts";
 import * as ApnsClient from "./ApnsClient.ts";
 import * as ApnsProviderTokens from "./ApnsProviderTokens.ts";
+import { fitNotificationText, jsonByteLength } from "./notificationText.ts";
 
 const isApnsJwtSigningError = Schema.is(ApnsClient.ApnsJwtSigningError);
 const isApnsHttpRequestError = Schema.is(ApnsClient.ApnsHttpRequestError);
+const encodeJson = Schema.encodeEffect(Schema.fromJsonString(Schema.Unknown));
 
 const TestLayer = ApnsClient.layer.pipe(
   Layer.provide(ApnsProviderTokens.layer),
@@ -33,6 +35,19 @@ const TestLayer = ApnsClient.layer.pipe(
 );
 
 describe("ApnsClient", () => {
+  it("preserves full text when it fits and truncates at a sentence or Unicode boundary", () => {
+    const fits = (text: string) => jsonByteLength({ body: text }) <= 70;
+    expect(fitNotificationText("Full answer.\n\nSecond paragraph.", fits)).toBe(
+      "Full answer.\n\nSecond paragraph.",
+    );
+    expect(fitNotificationText("First sentence. " + "🤖".repeat(100), fits)).toBe(
+      "First sentence.…",
+    );
+    const excerpt = fitNotificationText("🤖".repeat(100), fits);
+    expect(fits(excerpt)).toBe(true);
+    expect(excerpt).toMatch(/^🤖+…$/u);
+  });
+
   const now = DateTime.makeUnsafe(0);
   const state: RelayAgentActivityAggregateState = {
     title: "T3 Code",
@@ -53,6 +68,51 @@ describe("ApnsClient", () => {
       },
     ],
   };
+
+  it.effect("fits final answers to APNs without duplicating them in widget props", () =>
+    Effect.gen(function* () {
+      const apns = yield* ApnsClient.ApnsClient;
+      const body = 'Checked "quotes", \\ paths and 🤖. '.repeat(300);
+      const notification = {
+        title: "Thread",
+        body,
+        environmentId: EnvironmentId.make("env"),
+        threadId: ThreadId.make("thread"),
+        deepLink: "/threads/env/thread",
+      };
+      const push = apns.makePushNotificationRequest({ token: "token", notification });
+      expect(jsonByteLength(push.payload)).toBeLessThanOrEqual(4096);
+      expect(push.payload).toMatchObject({ deepLink: notification.deepLink });
+      expect(
+        apns.makePushNotificationRequest({
+          token: "token",
+          notification: { ...notification, body: "Ready.\n\nTests pass." },
+        }).payload,
+      ).toMatchObject({ aps: { alert: { body: "Ready.\n\nTests pass." } } });
+      for (const event of ["update", "end"] as const) {
+        const request = apns.makeLiveActivityRequest({
+          token: "token",
+          event,
+          nowEpochSeconds: 0,
+          nowIso: DateTime.formatIso(now),
+          state: {
+            ...state,
+            activities: Array.from({ length: 5 }, (_, index) => ({
+              ...state.activities[0]!,
+              threadId: ThreadId.make(`thread-${index}`),
+              threadTitle: "🤖".repeat(60),
+              projectTitle: "漢".repeat(120),
+              completionBody: body,
+            })),
+          },
+          alert: { title: "Thread", body },
+        });
+        expect(jsonByteLength(request.payload)).toBeLessThanOrEqual(4096);
+        expect(yield* encodeJson(request.payload)).not.toContain("completionBody");
+        expect(request.payload).toMatchObject({ aps: { alert: { sound: "default" } } });
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
 
   it.effect("requests an update push token when remotely starting a Live Activity", () =>
     Effect.gen(function* () {

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -11,6 +11,7 @@ import { ApnsEnvironment as ApnsEnvironmentSchema, type ApnsCredentials } from "
 import type { ApnsLiveActivityAlert, ApnsNotificationPayload } from "./apnsDeliveryJobs.ts";
 import { ApnsJwtEncodingError, ApnsJwtSigningError } from "./apnsJwt.ts";
 import * as ApnsProviderTokens from "./ApnsProviderTokens.ts";
+import { fitNotificationText, jsonByteLength } from "./notificationText.ts";
 
 export { ApnsJwtEncodingError, ApnsJwtSigningError } from "./apnsJwt.ts";
 
@@ -86,9 +87,34 @@ const decodeApnsErrorResponseJson = Schema.decodeUnknownOption(
   ),
 );
 function contentState(state: RelayAgentActivityAggregateState) {
-  return {
+  // Responses belong in the alert only, not in the widget's serialized props.
+  const activities = state.activities.map(({ completionBody: _body, ...row }) => row);
+  const content = () => ({
     name: LIVE_ACTIVITY_NAME,
-    props: JSON.stringify(state),
+    props: JSON.stringify({ ...state, activities }),
+  });
+  // Leave room for the APNs envelope and alert when several rows contain
+  // long Unicode titles. The aggregate count still includes hidden rows.
+  while (activities.length > 1 && jsonByteLength(content()) > 3000) activities.pop();
+  return content();
+}
+
+function fitApnsPayload<T extends { aps: { alert?: { title: string; body: string } } }>(
+  payload: T,
+): T {
+  const alert = payload.aps.alert;
+  if (!alert) return payload;
+  const body = fitNotificationText(
+    alert.body,
+    (candidate) =>
+      jsonByteLength({
+        ...payload,
+        aps: { ...payload.aps, alert: { ...alert, body: candidate } },
+      }) <= 4096,
+  );
+  return {
+    ...payload,
+    aps: { ...payload.aps, alert: { ...alert, body } },
   };
 }
 
@@ -130,7 +156,7 @@ function makeLiveActivityRequest(input: MakeLiveActivityRequestInput): ApnsLiveA
       token: input.token,
       event: input.event,
       priority: "10",
-      payload: {
+      payload: fitApnsPayload({
         aps: {
           timestamp,
           event: "end",
@@ -139,7 +165,7 @@ function makeLiveActivityRequest(input: MakeLiveActivityRequestInput): ApnsLiveA
           "dismissal-date":
             timestamp + (input.state ? DISMISS_AFTER_SECONDS : CONTENTLESS_DISMISS_AFTER_SECONDS),
         },
-      },
+      }),
     };
   }
 
@@ -150,7 +176,7 @@ function makeLiveActivityRequest(input: MakeLiveActivityRequestInput): ApnsLiveA
     // Alerting updates must land immediately; routine redraws stay at the
     // budget-friendly low priority.
     priority: input.event === "update" && !input.alert ? "5" : "10",
-    payload: {
+    payload: fitApnsPayload({
       aps: {
         timestamp,
         event: input.event,
@@ -169,7 +195,7 @@ function makeLiveActivityRequest(input: MakeLiveActivityRequestInput): ApnsLiveA
         "content-state": contentState(state),
         "stale-date": timestamp + STALE_AFTER_SECONDS,
       },
-    },
+    }),
   };
 }
 
@@ -180,7 +206,7 @@ function makePushNotificationRequest(input: {
   return {
     token: input.token,
     priority: "10",
-    payload: {
+    payload: fitApnsPayload({
       aps: {
         alert: {
           title: input.notification.title,
@@ -191,7 +217,7 @@ function makePushNotificationRequest(input: {
       environmentId: input.notification.environmentId,
       threadId: input.notification.threadId,
       deepLink: input.notification.deepLink,
-    },
+    }),
   };
 }
 

--- a/infra/relay/src/agentActivity/FcmDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/FcmDeliveries.test.ts
@@ -480,9 +480,13 @@ describe("Android delivery routing", () => {
     },
   );
 
-  it.effect("keeps completion alerts working with ongoing activity disabled", () => {
+  it.effect("sends the final answer with ongoing activity disabled", () => {
     const h = harness();
-    h.current.state = { ...state, phase: "completed" };
+    h.current.state = {
+      ...state,
+      phase: "completed",
+      completionResponse: "**Fixed.**\n\nTests pass.",
+    };
     h.current.target.preferences_json = encodeJson({
       ...preferences,
       liveActivitiesEnabled: false,
@@ -493,7 +497,7 @@ describe("Android delivery routing", () => {
       expect(h.sent[0]?.data).toMatchObject({
         active: "false",
         alert_title: "Fix notifications",
-        alert_body: "Done: Project",
+        alert_body: "Fixed.\n\nTests pass.",
       });
       expect(h.sent[0]?.data.user_id).toBe("user");
     }).pipe(Effect.provide(h.layer));
@@ -631,6 +635,21 @@ describe("Android delivery routing", () => {
     expect(androidActivityData(aggregateFor([state])).activity_expires_at).toBe(
       String(2 * 60 * 60 * 1000),
     );
+  });
+
+  it("keeps full answers that fit and shortens large answers at a sentence boundary", () => {
+    const base = {
+      t3_kind: "agent_activity",
+      alert_title: "Thread",
+      alert_path: "/threads/env/thread",
+      alert_id: "completion",
+    };
+    const full = "Ready.\n\n" + "Tests pass. ".repeat(120);
+    expect(fitFcmData({ ...base, alert_body: full }).alert_body).toBe(full);
+    const data = fitFcmData({ ...base, alert_body: "Ready. " + "🤖".repeat(2000) });
+    expect(data.alert_body).toBe("Ready.…");
+    expect(data.alert_path).toBe(base.alert_path);
+    expect(new TextEncoder().encode(JSON.stringify(data)).length).toBeLessThanOrEqual(3800);
   });
 
   it("fits five Unicode rows and a grouped alert in the FCM budget without corrupting text or routes", () => {

--- a/infra/relay/src/agentActivity/agentActivityAggregate.ts
+++ b/infra/relay/src/agentActivity/agentActivityAggregate.ts
@@ -9,6 +9,7 @@ import {
   isTerminalPhase,
   MAX_ACTIVITY_ROWS,
   sanitizeAgentActivityAggregateState,
+  completionBodyForResponse,
 } from "./agentActivityPayloads.ts";
 
 export function statusForPhase(phase: RelayAgentActivityState["phase"]): string {
@@ -33,6 +34,8 @@ export function statusForPhase(phase: RelayAgentActivityState["phase"]): string 
 }
 
 function aggregateRowForState(state: RelayAgentActivityState) {
+  const completionBody =
+    state.phase === "completed" ? completionBodyForResponse(state.completionResponse) : "";
   return {
     environmentId: state.environmentId,
     threadId: state.threadId,
@@ -41,6 +44,7 @@ function aggregateRowForState(state: RelayAgentActivityState) {
     modelTitle: state.modelTitle,
     phase: state.phase,
     status: statusForPhase(state.phase),
+    ...(completionBody ? { completionBody } : {}),
     updatedAt: state.updatedAt,
     deepLink: state.deepLink,
   };

--- a/infra/relay/src/agentActivity/agentActivityAlerts.ts
+++ b/infra/relay/src/agentActivity/agentActivityAlerts.ts
@@ -5,6 +5,7 @@ import type {
 } from "@t3tools/contracts/relay";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
+import { notificationForActivity } from "./agentActivityPayloads.ts";
 
 export interface AgentActivityAlert {
   readonly title: string;
@@ -110,7 +111,8 @@ export function alertForActivityRows(
   const first = rows[0];
   if (!first) return null;
   if (rows.length === 1) {
-    return { title: first.threadTitle, body: `${first.status}: ${first.projectTitle}` };
+    const { title, body } = notificationForActivity(first);
+    return { title, body };
   }
   return {
     title: `${rows.length} agents ${isAttentionPhase(first.phase) ? "need attention" : "finished"}`,

--- a/infra/relay/src/agentActivity/agentActivityPayloads.ts
+++ b/infra/relay/src/agentActivity/agentActivityPayloads.ts
@@ -3,10 +3,12 @@ import type {
   RelayAgentActivityAggregateState,
   RelayAgentActivityState,
 } from "@t3tools/contracts/relay";
+import { markdownPlainText } from "@t3tools/client-runtime/markdown-plain-text";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 
 import type { ApnsNotificationPayload } from "./apnsDeliveryJobs.ts";
+import { fitNotificationText, jsonByteLength } from "./notificationText.ts";
 
 export function isTerminalPhase(state: RelayAgentActivityState): boolean {
   return state.phase === "completed" || state.phase === "failed";
@@ -102,18 +104,31 @@ export function sanitizeApnsNotificationPayload(
   return {
     ...notification,
     title: truncateText(notification.title, MAX_SUMMARY_TEXT_LENGTH),
-    body: truncateText(notification.body, MAX_SUMMARY_TEXT_LENGTH),
+    body: notification.body.trim(),
     deepLink: sanitizeDeepLink(notification.deepLink),
   };
 }
 
+export function completionBodyForResponse(response: string | undefined): string {
+  // Bound each stored aggregate row as well as the eventual push payload.
+  // Several raw answers in one delivery job can exceed the queue's size limit.
+  return fitNotificationText(
+    markdownPlainText(response ?? ""),
+    (body) => jsonByteLength(body) <= 4096,
+  );
+}
+
 export function notificationForActivity(
-  row: RelayAgentActivityAggregateRow,
+  row: RelayAgentActivityAggregateRow & Pick<RelayAgentActivityState, "completionResponse">,
 ): ApnsNotificationPayload {
   const activity = sanitizeAgentActivityAggregateRow(row);
   return sanitizeApnsNotificationPayload({
     title: activity.threadTitle,
-    body: `${activity.status}: ${activity.projectTitle}`,
+    body:
+      (activity.phase === "completed"
+        ? activity.completionBody?.trim() || completionBodyForResponse(row.completionResponse)
+        : "") ||
+      truncateText(`${activity.status}: ${activity.projectTitle}`, MAX_SUMMARY_TEXT_LENGTH),
     environmentId: activity.environmentId,
     threadId: activity.threadId,
     deepLink: activity.deepLink,

--- a/infra/relay/src/agentActivity/agentActivityPolicy.test.ts
+++ b/infra/relay/src/agentActivity/agentActivityPolicy.test.ts
@@ -6,7 +6,10 @@ import {
   attentionTransitionRows,
   terminalTransitionRows,
   shouldAlertForActivity,
+  alertForActivityRows,
 } from "./agentActivityAlerts.ts";
+import { notificationForActivity } from "./agentActivityPayloads.ts";
+import { jsonByteLength } from "./notificationText.ts";
 
 const state: RelayAgentActivityState = {
   environmentId: EnvironmentId.make("env"),
@@ -31,6 +34,55 @@ const aggregate = (states: RelayAgentActivityState[]) =>
   makeAggregateState({ activeStates: states, terminalState: null, nowMs: 0 })!;
 
 describe("shared agent activity policy", () => {
+  it("uses the final answer for a single completion and thread titles for a group", () => {
+    const row = aggregate([
+      {
+        ...state,
+        phase: "completed",
+        completionResponse: "**Fixed.**\n\n- Tests pass\n- Ready to review",
+      },
+    ]).activities[0]!;
+    const expected = { title: "Thread", body: "Fixed.\n\n• Tests pass\n• Ready to review" };
+    expect(notificationForActivity(row)).toMatchObject({
+      ...expected,
+      deepLink: state.deepLink,
+    });
+    expect(alertForActivityRows([row])).toEqual(expected);
+    expect(alertForActivityRows([row, { ...row, threadTitle: "Second" }])).toEqual({
+      title: "2 agents finished",
+      body: "Thread, Second",
+    });
+    for (const completionResponse of [undefined, "  ", "<!-- empty -->"]) {
+      expect(
+        notificationForActivity({ ...row, completionBody: undefined, completionResponse }).body,
+      ).toBe("Done: Project");
+    }
+    expect(notificationForActivity({ ...row, phase: "failed", status: "Failed" }).body).toBe(
+      "Failed: Project",
+    );
+  });
+
+  it("keeps several long answers within the delivery queue budget", () => {
+    const next = aggregate(
+      Array.from({ length: 5 }, (_, index) => ({
+        ...state,
+        threadId: ThreadId.make(`thread-${index}`),
+        phase: "completed",
+        completionResponse: "🤖".repeat(16000),
+      })),
+    );
+    expect(jsonByteLength(next)).toBeLessThan(25000);
+    expect(next.activities).toHaveLength(5);
+    const literal = aggregate([
+      {
+        ...state,
+        phase: "completed",
+        completionResponse: "Keep `**literal**`.",
+      },
+    ]).activities[0]!;
+    expect(notificationForActivity(literal).body).toBe("Keep **literal**.");
+  });
+
   it.each(["waiting_for_approval", "waiting_for_input"] as const)(
     "keeps an older %s ahead of five running rows",
     (phase) => {

--- a/infra/relay/src/agentActivity/fcmPayloads.ts
+++ b/infra/relay/src/agentActivity/fcmPayloads.ts
@@ -4,6 +4,7 @@ import {
   TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS,
 } from "./agentActivityAggregate.ts";
 import { agentActivityExpiresAt } from "./agentActivityPayloads.ts";
+import { fitNotificationText } from "./notificationText.ts";
 
 export function androidActivityHero(aggregate: RelayAgentActivityAggregateState) {
   return [...aggregate.activities].sort(
@@ -59,10 +60,21 @@ export function fitFcmData(input: Readonly<Record<string, string>>): Record<stri
     (key) => key.endsWith("_body") || key.endsWith("_title") || key.startsWith("activity_line_"),
   );
   while (encoder.encode(JSON.stringify(data)).length > 3800) {
-    const key = textKeys.sort(
-      (a, b) => encoder.encode(data[b]!).length - encoder.encode(data[a]!).length,
-    )[0];
+    const key = textKeys
+      .filter(
+        (key) =>
+          key !== "alert_body" ||
+          encoder.encode(JSON.stringify({ ...data, alert_body: "…" })).length <= 3800,
+      )
+      .sort((a, b) => encoder.encode(data[b]!).length - encoder.encode(data[a]!).length)[0];
     if (!key) break;
+    if (key === "alert_body") {
+      data[key] = fitNotificationText(
+        data[key]!,
+        (body) => encoder.encode(JSON.stringify({ ...data, alert_body: body })).length <= 3800,
+      );
+      continue;
+    }
     if (data[key]!.length <= 8) {
       textKeys.splice(textKeys.indexOf(key), 1);
       continue;

--- a/infra/relay/src/agentActivity/notificationText.ts
+++ b/infra/relay/src/agentActivity/notificationText.ts
@@ -1,0 +1,25 @@
+const encoder = new TextEncoder();
+export const jsonByteLength = (value: unknown): number =>
+  encoder.encode(JSON.stringify(value)).length;
+
+/** Fit the actual encoded payload; prefer a complete sentence over a cut word. */
+export function fitNotificationText(text: string, fits: (text: string) => boolean): string {
+  if (fits(text)) return text;
+  const characters = Array.from(text);
+  let low = 0;
+  let high = characters.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (fits(characters.slice(0, middle).join("").trimEnd() + "…")) low = middle;
+    else high = middle - 1;
+  }
+  const prefix = characters.slice(0, low).join("").trimEnd();
+  let sentenceEnd = 0;
+  for (const part of new Intl.Segmenter(undefined, { granularity: "sentence" }).segment(text)) {
+    const end = part.index + part.segment.trimEnd().length;
+    if (end > prefix.length) break;
+    sentenceEnd = end;
+  }
+  const excerpt = sentenceEnd > 0 ? text.slice(0, sentenceEnd) : prefix;
+  return fits(excerpt + "…") ? excerpt + "…" : "";
+}

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./markdown-plain-text": {
+      "types": "./src/markdownPlainText.ts",
+      "default": "./src/markdownPlainText.ts"
+    },
     "./load-balancing": {
       "types": "./src/load-balancing.ts",
       "default": "./src/load-balancing.ts"

--- a/packages/client-runtime/src/markdownPlainText.test.ts
+++ b/packages/client-runtime/src/markdownPlainText.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from "vite-plus/test";
+import { markdownPlainText } from "./markdownPlainText.ts";
+
+it("keeps paragraphs, lists, links and code readable without Markdown syntax", () => {
+  expect(
+    markdownPlainText(`# Complete
+
+Fixed **notifications** and [tests](https://example.test).
+
+- Uses \`finalAnswer\`
+- Keeps paragraphs
+
+3. Review
+4. Ship
+
+> Ready &amp; checked.
+
+\`\`\`ts
+const done = true;
+\`\`\`
+
+![Screenshot](image.png)
+`),
+  ).toBe(`Complete
+
+Fixed notifications and tests.
+
+• Uses finalAnswer
+• Keeps paragraphs
+
+3. Review
+4. Ship
+
+Ready & checked.
+
+const done = true;
+
+Screenshot`);
+  expect(markdownPlainText("<!-- no answer -->\n\n---")).toBe("");
+});

--- a/packages/client-runtime/src/markdownPlainText.ts
+++ b/packages/client-runtime/src/markdownPlainText.ts
@@ -1,0 +1,45 @@
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+
+interface MarkdownNode {
+  type: string;
+  value?: string | undefined;
+  alt?: string | null | undefined;
+  ordered?: boolean | null | undefined;
+  start?: number | null | undefined;
+  children?: MarkdownNode[] | undefined;
+}
+
+const parser = unified().use(remarkParse);
+
+/** Render message text without Markdown syntax, keeping paragraphs and lists. */
+export function markdownPlainText(markdown: string): string {
+  function render(node: MarkdownNode): string {
+    const children = node.children ?? [];
+    switch (node.type) {
+      case "html":
+      case "definition":
+      case "thematicBreak":
+        return "";
+      case "image":
+      case "imageReference":
+        return node.alt ?? "";
+      case "break":
+        return "\n";
+      case "list":
+        return children
+          .map(
+            (child, index) =>
+              `${node.ordered ? `${(node.start ?? 1) + index}.` : "•"} ${render(child)}`,
+          )
+          .join("\n");
+      case "root":
+      case "blockquote":
+      case "listItem":
+        return children.map(render).filter(Boolean).join("\n\n");
+      default:
+        return node.value ?? children.map(render).join("");
+    }
+  }
+  return render(parser.parse(markdown)).trim();
+}

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -127,6 +127,7 @@ export const RelayAgentActivityState = Schema.Struct({
   phase: RelayAgentAwarenessPhase,
   headline: TrimmedNonEmptyString,
   detail: Schema.optional(TrimmedNonEmptyString),
+  completionResponse: Schema.optional(TrimmedNonEmptyString),
   modelTitle: TrimmedNonEmptyString,
   updatedAt: TrimmedNonEmptyString,
   deepLink: TrimmedNonEmptyString,
@@ -141,6 +142,7 @@ export const RelayAgentActivityAggregateRow = Schema.Struct({
   modelTitle: TrimmedNonEmptyString,
   phase: RelayAgentAwarenessPhase,
   status: TrimmedNonEmptyString,
+  completionBody: Schema.optional(TrimmedNonEmptyString),
   updatedAt: TrimmedNonEmptyString,
   deepLink: TrimmedNonEmptyString,
 });


### PR DESCRIPTION
## What Changed

When one agent finishes, the mobile completion alert shows the turn's final answer as plain text. The thread title stays in the notification title. Paragraphs, lists, links and code remain readable. For example, `Done: Project` becomes `Fixed the save error. Tests pass.`

This covers ordinary iOS push notifications, alerts sent with iOS Live Activity updates, and Android notifications. Long bodies are shortened at a sentence boundary when possible, with an ellipsis. Empty answers use the existing status body. Grouped alerts keep their list of thread titles. Tapping an alert opens the thread.

## Why

The status body tells the user that a turn ended, but gives no result. The final answer lets the user read the result from the notification.

The server saves buffered assistant output before it publishes the terminal session. A narrow query reads the latest turn's final answer. Optional relay fields carry the response and the bounded plain text body. Push bodies are checked against their encoded byte limits. Widget content omits the answer to keep the payload small.

## Validation

- 449 tests passed across 15 focused test files with Node 24.13.1.
- Type checks passed for the server, relay, client runtime and contracts.
- Lint and formatting checks passed for the changed TypeScript and JSON files.
- Tests cover final-answer selection, buffered output order, Markdown conversion, grouped alerts, fallback text, Unicode, routing, and payload limits.
- Added an Android test for an expanded notification with a long answer. It was not run here because the Android SDK and JDK 21 are not installed.

The server caps source Markdown at 16,000 characters before sending it to the relay. Push limits can require a shorter excerpt. The full answer remains in the thread.

## UI Changes

Before-and-after screenshots still need to be captured on a mobile client.

A relay and server update is required. Android needs a new native build to display bodies longer than the previous 608-character limit.

## Checklist

- [x] This PR has one scope.
- [x] I explained what changed and why.
- [x] Focused TypeScript tests and checks pass.
- [ ] Run the Android native test with JDK 21 and the Android SDK.
- [ ] Add before-and-after notification screenshots.
- [ ] Check the notification-to-thread tap on a mobile client.

Implemented with Codex, model GPT-6.
