### PR TITLE
fix(web): fit provider update text inside sidebar notices

### DIFF
--- a/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUpdatePill.tsx
@@ -126,7 +126,7 @@ export function SidebarProviderUpdatePill() {
 
   return (
     <div
-      className={`group/provider-update relative flex h-7 w-full items-center overflow-hidden rounded-lg text-xs font-medium transform-gpu transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform ${
+      className={`group/provider-update relative flex min-h-7 w-full shrink-0 items-center overflow-hidden rounded-lg text-[11px] leading-4 font-medium transform-gpu transition-all duration-180 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-transform ${
         PROVIDER_UPDATE_PILL_STYLES[displayedView.tone]
       } ${
         exitingKey === displayedView.key
@@ -170,19 +170,19 @@ export function SidebarProviderUpdatePill() {
             <button
               type="button"
               aria-label={displayedView.description}
-              className="provider-update-main relative z-[1] flex h-full flex-1 items-center gap-2 px-2 text-left"
+              className="provider-update-main relative z-[1] flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left"
               onClick={openProviderSettings}
             >
               {displayedView.tone === "loading" ? (
-                <Spinner className="size-3.5" />
+                <Spinner className="size-3.5 shrink-0" />
               ) : displayedView.tone === "success" ? (
-                <CircleCheckIcon className="size-3.5" />
+                <CircleCheckIcon className="size-3.5 shrink-0" />
               ) : displayedView.tone === "error" ? (
-                <TriangleAlertIcon className="size-3.5" />
+                <TriangleAlertIcon className="size-3.5 shrink-0" />
               ) : (
-                <DownloadIcon className="size-3.5" />
+                <DownloadIcon className="size-3.5 shrink-0" />
               )}
-              <span>{displayedView.title}</span>
+              <span className="min-w-0 wrap-break-word">{displayedView.title}</span>
             </button>
           }
         />
@@ -199,7 +199,7 @@ export function SidebarProviderUpdatePill() {
                 className="relative z-[1] mr-1 [--control-icon-color:currentColor] rounded-md text-inherit opacity-70 hover:bg-transparent hover:opacity-100"
                 onClick={() => startExit(displayedView.key, null, displayedView.key)}
               >
-                <XIcon className="size-3.5" />
+                <XIcon className="size-3.5 shrink-0" />
               </Button>
             }
           />


### PR DESCRIPTION
## What Changed

Use 11px text with a 16px line height in the shared provider update sidebar notice. Let the notice grow when its title wraps, and keep its icon and dismiss control from being squeezed by the text. This applies to every provider and every notice state.

## Why

Titles such as "OpenCode still needs an update" wrapped to 32px inside a fixed 28px pill and were clipped. The smaller text fits at the default sidebar width, while natural height keeps longer messages readable at narrower widths.

## UI Changes

Before and after in the running web app, using an unchanged-update fixture. Screenshots are cropped to the sidebar footer.

| Before | After |
| --- | --- |
| ![Before: wrapped title clips inside the pill](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-notice-sizing/before.png) | ![After: title fits inside the pill](https://github.com/MatthewFeroz/t3code/releases/download/pr-evidence-provider-notice-sizing/after.png) |

Verified OpenCode and Antigravity at the default width, plus a 180px notice where the title wraps inside a 44px pill without overlapping the dismiss control. Web and desktop share this component. Native mobile has no equivalent notice. Settings, keybindings, provider adapters, contracts, and connection behavior are unaffected; this is local layout only. No documentation changes are needed.

Validation: 43 provider-update logic tests passed; web typecheck, targeted lint, formatting, and diff checks passed. Lint reports two existing set-state-in-effect warnings in unchanged code. No animation or interaction changes, so no video is needed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes, not applicable

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the provider update sidebar pill’s layout, spacing, typography, and text wrapping.
  - Enhanced sizing behavior for the pill’s content and controls to improve display across different text lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->