### PR TITLE
feat(web): add bindable right-panel tab cycling commands

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -170,6 +170,7 @@ import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import {
   pullRequestSurface,
+  selectAdjacentRightPanelSurface,
   selectActiveRightPanel,
   selectActiveRightPanelSurface,
   selectThreadRightPanelState,
@@ -6145,6 +6146,18 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
 
+      if (command === "rightPanel.nextTab" || command === "rightPanel.previousTab") {
+        event.preventDefault();
+        event.stopPropagation();
+        const surface = selectAdjacentRightPanelSurface(
+          useRightPanelStore.getState().byThreadKey,
+          activeThreadRef,
+          command === "rightPanel.nextTab" ? "next" : "previous",
+        );
+        if (surface) activateRightPanelSurface(surface);
+        return;
+      }
+
       if (command === "rightPanel.toggleMaximized") {
         event.preventDefault();
         event.stopPropagation();
@@ -6254,6 +6267,7 @@ export default function ChatView(props: ChatViewProps) {
     activeProject,
     activeRightPanelSurface,
     activeProjectScripts,
+    activateRightPanelSurface,
     addTerminalSurface,
     activeThreadRef,
     activeThreadPinned,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6147,14 +6147,15 @@ export default function ChatView(props: ChatViewProps) {
       }
 
       if (command === "rightPanel.nextTab" || command === "rightPanel.previousTab") {
-        event.preventDefault();
-        event.stopPropagation();
         const surface = selectAdjacentRightPanelSurface(
           useRightPanelStore.getState().byThreadKey,
           activeThreadRef,
           command === "rightPanel.nextTab" ? "next" : "previous",
         );
-        if (surface) activateRightPanelSurface(surface);
+        if (!surface) return;
+        event.preventDefault();
+        event.stopPropagation();
+        activateRightPanelSurface(surface);
         return;
       }
 

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -205,6 +205,8 @@ describe("KeybindingsSettings.logic", () => {
       expect.arrayContaining([
         "chat.new",
         "rightPanel.toggleMaximized",
+        "rightPanel.nextTab",
+        "rightPanel.previousTab",
         "thread.stop",
         "script.setup-db.run",
       ]),
@@ -212,6 +214,11 @@ describe("KeybindingsSettings.logic", () => {
     expect(DEFAULT_RESOLVED_KEYBINDINGS.some((binding) => binding.command === "thread.stop")).toBe(
       false,
     );
+    for (const command of ["rightPanel.nextTab", "rightPanel.previousTab"]) {
+      expect(DEFAULT_RESOLVED_KEYBINDINGS.some((binding) => binding.command === command)).toBe(
+        false,
+      );
+    }
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -819,6 +819,25 @@ describe("resolveShortcutCommand", () => {
     );
   });
 
+  it.each([false, true])("resolves custom panel cycling with terminalFocus=%s", (terminalFocus) => {
+    const keybindings = compile([
+      { shortcut: modShortcut("arrowright"), command: "rightPanel.nextTab" },
+      { shortcut: modShortcut("arrowleft"), command: "rightPanel.previousTab" },
+    ]);
+    for (const [key, command] of [
+      ["ArrowRight", "rightPanel.nextTab"],
+      ["ArrowLeft", "rightPanel.previousTab"],
+    ] as const) {
+      assert.strictEqual(
+        resolveShortcutCommand(event({ key, metaKey: true }), keybindings, {
+          platform: "MacIntel",
+          context: { terminalFocus },
+        }),
+        command,
+      );
+    }
+  });
+
   it("matches bracket shortcuts using the physical key code", () => {
     assert.strictEqual(
       resolveShortcutCommand(

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -7,6 +7,7 @@ import {
   pullRequestSurface,
   pullRequestSurfaceId,
   selectActiveRightPanel,
+  selectAdjacentRightPanelSurface,
   selectActiveRightPanelSurface,
   selectSelectedRightPanelSurface,
   selectThreadRightPanelState,
@@ -21,6 +22,80 @@ beforeEach(() => {
 });
 
 describe("rightPanelStore", () => {
+  it.each(["next", "previous"] as const)(
+    "cycles %s in displayed order and preserves surfaces",
+    (direction) => {
+      const store = useRightPanelStore.getState();
+      store.openFile(refA, "src/app.ts", 42);
+      store.openBrowser(refA, "tab-a");
+      store.openTerminal(refA, "term-a");
+      store.splitTerminal(refA, "terminal:term-a", "term-b", "vertical");
+      store.open(refA, "diff");
+      const initial = selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA);
+      const expected =
+        direction === "next"
+          ? ["file:src/app.ts", "browser:tab-a", "terminal:term-a", "diff"]
+          : ["terminal:term-a", "browser:tab-a", "file:src/app.ts", "diff"];
+      const revision = store.getUserActionRevision(refA);
+      for (const id of expected) {
+        const next = selectAdjacentRightPanelSurface(
+          useRightPanelStore.getState().byThreadKey,
+          refA,
+          direction,
+        );
+        expect(next?.id).toBe(id);
+        store.activateSurface(refA, next!.id);
+        const current = selectThreadRightPanelState(
+          useRightPanelStore.getState().byThreadKey,
+          refA,
+        );
+        expect(current.activeSurfaceId).toBe(id);
+        expect(current.surfaces).toBe(initial.surfaces);
+      }
+      expect(store.openProactive(refA, { id: "diff", kind: "diff" }, revision)).toBe(false);
+    },
+  );
+
+  it.each(["next", "previous"] as const)(
+    "safely ignores missing, empty, single and hidden panels for %s",
+    (direction) => {
+      const store = useRightPanelStore.getState();
+      const select = () =>
+        selectAdjacentRightPanelSurface(useRightPanelStore.getState().byThreadKey, refA, direction);
+      expect(select()).toBeNull();
+      store.show(refA);
+      expect(select()).toBeNull();
+      store.open(refA, "diff");
+      expect(select()).toBeNull();
+      store.open(refA, "files");
+      store.close(refA);
+      const state = useRightPanelStore.getState();
+      expect(select()).toBeNull();
+      expect(useRightPanelStore.getState()).toBe(state);
+      expect(selectAdjacentRightPanelSurface(state.byThreadKey, null, direction)).toBeNull();
+    },
+  );
+
+  it("isolates cycling by thread and environment", () => {
+    const otherEnvironment = scopeThreadRef("env-2" as EnvironmentId, refA.threadId);
+    const store = useRightPanelStore.getState();
+    for (const ref of [refA, refB, otherEnvironment]) {
+      store.open(ref, "files");
+      store.openBrowser(ref, "tab-a");
+    }
+    const before = useRightPanelStore.getState().byThreadKey;
+    const next = selectAdjacentRightPanelSurface(before, refA, "next");
+    store.activateSurface(refA, next!.id);
+    const after = useRightPanelStore.getState().byThreadKey;
+    expect(selectThreadRightPanelState(after, refA).activeSurfaceId).toBe("files");
+    for (const ref of [refB, otherEnvironment]) {
+      expect(selectThreadRightPanelState(after, ref)).toBe(
+        selectThreadRightPanelState(before, ref),
+      );
+      expect(selectThreadRightPanelState(after, ref).activeSurfaceId).toBe("browser:tab-a");
+    }
+  });
+
   const completedDiff = { id: "diff", kind: "diff" } as const;
   const linkedPullRequest = pullRequestSurface({
     projectId: "project-a",

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -785,6 +785,24 @@ export function selectThreadRightPanelState(
   return byThreadKey[scopedThreadKey(ref)] ?? EMPTY_THREAD_STATE;
 }
 
+/** Selects a neighbor in tab-strip order without changing any surface's resource state. */
+export function selectAdjacentRightPanelSurface(
+  byThreadKey: Record<string, ThreadRightPanelState>,
+  ref: ScopedThreadRef | null | undefined,
+  direction: "next" | "previous",
+): RightPanelSurface | null {
+  const state = selectThreadRightPanelState(byThreadKey, ref);
+  if (!state.isOpen || state.surfaces.length < 2) return null;
+  const index = state.surfaces.findIndex((surface) => surface.id === state.activeSurfaceId);
+  const nextIndex =
+    index < 0
+      ? direction === "next"
+        ? 0
+        : state.surfaces.length - 1
+      : (index + (direction === "next" ? 1 : -1) + state.surfaces.length) % state.surfaces.length;
+  return state.surfaces[nextIndex] ?? null;
+}
+
 export function selectActiveRightPanel(
   byThreadKey: Record<string, ThreadRightPanelState>,
   ref: ScopedThreadRef | null | undefined,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -53,6 +53,14 @@ a shortcut.
 
 ## Commands with special behavior
 
+`rightPanel.nextTab` and `rightPanel.previousTab` cycle the current thread's open
+right-panel tabs in displayed order, wrapping at either end. Both are unbound by
+default; assign them in **Settings → Keybindings**. They do nothing when the panel
+is hidden or has fewer than two tabs. Bindings work while a terminal is focused
+unless restricted by a `when` condition. Focused embedded browser pages own their
+keyboard input; focus the app outside the page to use these commands. Browser or
+operating-system reserved shortcuts may also take precedence.
+
 `thread.stop` interrupts the running turn in the focused thread. It has no default
 shortcut; assign one in **Settings → Keybindings**.
 

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -41,6 +41,10 @@ it.effect("parses keybinding rules", () =>
       command: "rightPanel.toggle",
     });
     assert.strictEqual(parsedRightPanelToggle.command, "rightPanel.toggle");
+    for (const command of ["rightPanel.nextTab", "rightPanel.previousTab"] as const) {
+      const parsed = yield* decode(KeybindingRule, { key: "alt+arrowright", command });
+      assert.strictEqual(parsed.command, command);
+    }
 
     const parsedRightPanelToggleMaximized = yield* decode(KeybindingRule, {
       key: "mod+shift+m",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -61,6 +61,8 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "rightPanel.toggle",
   "rightPanel.toggleMaximized",
   "rightPanel.close",
+  "rightPanel.nextTab",
+  "rightPanel.previousTab",
   "diff.toggle",
   "preview.toggle",
   "preview.refresh",


### PR DESCRIPTION
## What changed

Add bindable `rightPanel.nextTab` and `rightPanel.previousTab` commands, unbound by default. They cycle the current thread's tabs in displayed order with wraparound, using the same activation behavior as clicking a tab. Hidden panels and fewer than two tabs leave the key event alone.

## Why

Implements the next/previous navigation requested in pingdotgg/t3code#7470. Custom shortcuts can navigate open surfaces without changing default bindings or thread navigation. Focused embedded browser pages continue to own their keyboard input.

## UI changes

Before and after invoking previous-tab, followed by a short web interaction recording:

![Before cycling](https://github.com/user-attachments/assets/291ea158-be48-4c67-b0ea-8554b239eb87)
![After previous tab](https://github.com/user-attachments/assets/d79d7d1a-9304-4a57-b70e-4eac95eff96c)

[Tab cycling recording](https://github.com/user-attachments/assets/0515c2d6-d9ec-4dd0-a27a-548a1c94d12d)

The recording uses page-dispatched keyboard events. Native Ctrl+Tab and Ctrl+Shift+Tab were also verified in Electron, and the tester confirmed web and desktop behavior. Test bindings are personal configuration and are excluded from this change.

<details><summary>Validation</summary>

- 138 tests passed across right-panel store, shortcut resolution, settings command options, and command contracts.
- Targeted lint and web/contracts typechecks passed with existing warnings; desktop build passed.
- Fable 5.1 review completed. Its no-target event-consumption finding was fixed and locally verified afterward.

</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with GPT-6 via Codex; reviewed with Claude Fable 5.1 via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for cycling through right-panel surfaces in next or previous order.
  * Supports wraparound navigation and custom keybindings, including when terminal focus is active.
  * Added safeguards for closed, hidden, or single-surface panels.

* **Documentation**
  * Documented the new commands, behavior, and shortcut considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->