### PR TITLE
fix(editors): accept root paths and Windows servers in Zed remote links

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -93,10 +93,16 @@ describe("ElectronShell", () => {
       openExternalMock.mockResolvedValue(undefined);
 
       const electronShell = yield* ElectronShell.ElectronShell;
-      const result = yield* electronShell.openExternal("zed://ssh/example.com/home/user/project");
+      const results = yield* Effect.all([
+        electronShell.openExternal("zed://ssh/example.com/home/user/project"),
+        electronShell.openExternal("zed://ssh/example.com/"),
+      ]);
 
-      assert.equal(result, true);
-      assert.deepEqual(openExternalMock.mock.calls, [["zed://ssh/example.com/home/user/project"]]);
+      assert.deepEqual(results, [true, true]);
+      assert.deepEqual(openExternalMock.mock.calls, [
+        ["zed://ssh/example.com/home/user/project"],
+        ["zed://ssh/example.com/"],
+      ]);
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -36,7 +36,7 @@ const REMOTE_EDITOR_PROTOCOLS = new Set(
 );
 
 // Zed's host sits in the first path segment, so it needs its own userinfo ban.
-const ZED_SSH_PATHNAME = /^\/[^/@:]+\/.+$/;
+const ZED_SSH_PATHNAME = /^\/[^/@:]+\/.*$/;
 
 const isRemoteEditorUrl = (url: URL) =>
   REMOTE_EDITOR_PROTOCOLS.has(url.protocol) &&

--- a/apps/web/src/remoteOpen.test.ts
+++ b/apps/web/src/remoteOpen.test.ts
@@ -155,6 +155,9 @@ describe("buildRemoteOpenUrl", () => {
     expect(
       buildRemoteOpenUrl({ editor: "zed", host: "sol", absolutePath: "C:\\Users\\theo" }),
     ).toBe("zed://ssh/sol/Users/theo");
+    expect(buildRemoteOpenUrl({ editor: "zed", host: "sol", absolutePath: "/C:/project" })).toBe(
+      "zed://ssh/sol/C%3A/project",
+    );
   });
 
   it("returns undefined for editors without remote support", () => {

--- a/apps/web/src/remoteOpen.test.ts
+++ b/apps/web/src/remoteOpen.test.ts
@@ -151,6 +151,12 @@ describe("buildRemoteOpenUrl", () => {
     ).toBe("zed://ssh/sol.tail1234.ts.net/home/theo/code/my%20repo");
   });
 
+  it("drops the Windows drive letter for Zed", () => {
+    expect(
+      buildRemoteOpenUrl({ editor: "zed", host: "sol", absolutePath: "C:\\Users\\theo" }),
+    ).toBe("zed://ssh/sol/Users/theo");
+  });
+
   it("returns undefined for editors without remote support", () => {
     expect(buildRemoteOpenUrl({ editor: "idea", host: "sol", absolutePath: "/tmp/x" })).toBe(
       undefined,

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -122,8 +122,9 @@ export const buildRemoteOpenUrl = (input: {
   const encodedHost = encodeURIComponent(input.host);
   if (input.editor === "zed") {
     // Zed's remote server resolves a rooted path on the system drive, so a
-    // Windows `/C:/Users/x` must become `/Users/x` (verified in #8938).
-    const zedPath = rootedPath.replace(/^\/[A-Za-z]:(?=\/|$)/, "");
+    // Windows `/C:/Users/x` must become `/Users/x` (verified in #8938). Other
+    // drives are untested and kept as is rather than silently remapped.
+    const zedPath = rootedPath.replace(/^\/[Cc]:(?=\/|$)/, "");
     const encodedZedPath = zedPath.split("/").map(encodeURIComponent).join("/");
     return `${scheme}://ssh/${encodedHost}${encodedZedPath || "/"}`;
   }

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -91,7 +91,7 @@ export type LaunchEditorInput = typeof LaunchEditorInput.Type;
 
 const remoteSchemeOf = (editor: EditorDefinition): string | undefined => editor.remoteScheme;
 
-/** Editors that can open a remote workspace via `vscode-remote` deep links. */
+/** Editors that can open a remote workspace via an SSH deep link. */
 export const REMOTE_CAPABLE_EDITOR_IDS: ReadonlyArray<EditorId> = EDITORS.flatMap((editor) =>
   remoteSchemeOf(editor) !== undefined ? [editor.id] : [],
 );
@@ -119,11 +119,16 @@ export const buildRemoteOpenUrl = (input: {
   // Windows server paths (`C:\...`) appear as `/C:/...` in vscode-remote URIs.
   const posixPath = input.absolutePath.replaceAll("\\", "/");
   const rootedPath = posixPath.startsWith("/") ? posixPath : `/${posixPath}`;
-  const encodedPath = rootedPath.split("/").map(encodeURIComponent).join("/");
   const encodedHost = encodeURIComponent(input.host);
-  return input.editor === "zed"
-    ? `${scheme}://ssh/${encodedHost}${encodedPath}`
-    : `${scheme}://vscode-remote/ssh-remote+${encodedHost}${encodedPath}`;
+  if (input.editor === "zed") {
+    // Zed's remote server resolves a rooted path on the system drive, so a
+    // Windows `/C:/Users/x` must become `/Users/x` (verified in #8938).
+    const zedPath = rootedPath.replace(/^\/[A-Za-z]:(?=\/|$)/, "");
+    const encodedZedPath = zedPath.split("/").map(encodeURIComponent).join("/");
+    return `${scheme}://ssh/${encodedHost}${encodedZedPath || "/"}`;
+  }
+  const encodedPath = rootedPath.split("/").map(encodeURIComponent).join("/");
+  return `${scheme}://vscode-remote/ssh-remote+${encodedHost}${encodedPath}`;
 };
 
 /**

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -122,11 +122,12 @@ export const buildRemoteOpenUrl = (input: {
   const encodedHost = encodeURIComponent(input.host);
   if (input.editor === "zed") {
     // Zed's remote server resolves a rooted path on the system drive, so a
-    // Windows `/C:/Users/x` must become `/Users/x` (verified in #8938). Other
-    // drives are untested and kept as is rather than silently remapped.
-    const zedPath = rootedPath.replace(/^\/[Cc]:(?=\/|$)/, "");
+    // Windows `C:\Users\x` must become `/Users/x` (verified in #8938). Other
+    // drives are untested and kept as is rather than silently remapped, and a
+    // POSIX path that happens to start with `/C:` is left alone.
+    const zedPath = /^[Cc]:[\\/]/.test(input.absolutePath) ? rootedPath.slice(3) : rootedPath;
     const encodedZedPath = zedPath.split("/").map(encodeURIComponent).join("/");
-    return `${scheme}://ssh/${encodedHost}${encodedZedPath || "/"}`;
+    return `${scheme}://ssh/${encodedHost}${encodedZedPath}`;
   }
   const encodedPath = rootedPath.split("/").map(encodeURIComponent).join("/");
   return `${scheme}://vscode-remote/ssh-remote+${encodedHost}${encodedPath}`;


### PR DESCRIPTION
Follow-up to #11022. Two link shapes Zed accepts were still rejected or malformed.

The desktop allowlist required at least one path segment after the host, so `zed://ssh/<host>/` (the remote root) was refused. The regex now accepts an empty path.

For Windows servers the builder fed the vscode-remote form `/C:/Users/x` into the Zed branch. Zed's remote server resolves rooted paths on the system drive and rejects that form; the issue reporter verified end to end that `/Users/x` is what works. `buildRemoteOpenUrl` now drops the drive letter for Zed only. Other drives are untested, as the issue notes.

Verified with worktree-local vp: `ElectronShell.test.ts` 11 tests and `remoteOpen.test.ts` 13 tests pass, contracts typecheck clean. Both cases were added to the existing test files. Real Zed launch over SSH from the picker is unverified in this session.

Refs #8938

Done by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zed SSH deep links now support URLs without a project path.
  - Zed remote paths on Windows now correctly handle the supported drive-letter format, while preserving valid rooted paths.

- **Tests**
  - Expanded coverage for Zed SSH links with and without project paths.
  - Added validation for Windows remote path conversion, including removal of the supported drive-letter segment and preservation of rooted paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->