### PR TITLE
feat(picker): create and navigate folders on remote environments

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -24,6 +24,7 @@ import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
   filterFilesystemBrowseEntries,
+  getBrowseCreateDirectoryTarget,
   getFilesystemBrowsePath,
 } from "@t3tools/client-runtime/state/filesystem";
 import {
@@ -779,16 +780,87 @@ function FolderBrowser(props: {
     () => filterFilesystemBrowseEntries(browseState.data?.entries ?? [], browseFilterQuery),
     [browseFilterQuery, browseState.data?.entries],
   );
+  // Only once the listing has loaded, so a folder that already exists is never
+  // offered as a new one.
+  const createDirectoryTarget =
+    browseState.data === null
+      ? null
+      : getBrowseCreateDirectoryTarget({
+          directoryPath: browsePath.directoryPath,
+          leafName: browseFilterQuery,
+          entries: browseState.data.entries,
+          caseSensitive: !isWindowsPlatform(props.environment.platform),
+        });
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isCreatingDirectory, setIsCreatingDirectory] = useState(false);
+  const createDirectory = useAtomCommand(filesystemEnvironment.createDirectory, {
+    reportFailure: false,
+  });
+  const reloadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
+    reportFailure: false,
+    reportDefect: false,
+    refresh: true,
+  });
+
+  const createBrowsedDirectory = async (target: {
+    readonly parentPath: string;
+    readonly name: string;
+  }) => {
+    if (isCreatingDirectory) return;
+    setCreateError(null);
+    setIsCreatingDirectory(true);
+    const result = await createDirectory({
+      environmentId: props.environment.environmentId,
+      input: { parentPath: target.parentPath, name: target.name },
+    });
+    if (AsyncResult.isFailure(result)) {
+      setCreateError(errorMessage(Cause.squash(result.cause)));
+      setIsCreatingDirectory(false);
+      return;
+    }
+    // Re-read the folder it was created in before stepping into it, so going
+    // back up shows the new folder instead of the cached listing.
+    await reloadBrowsePath({
+      environmentId: props.environment.environmentId,
+      input: { partialPath: target.parentPath },
+    });
+    await props.navigateToBrowsePath({
+      browseDirectoryPath: target.parentPath,
+      selectedDirectoryName: target.name,
+    });
+    setIsCreatingDirectory(false);
+  };
 
   return (
     <>
       <SectionTitle>Browse folders</SectionTitle>
       {browseState.error ? <ErrorBanner message={browseState.error} /> : null}
+      {createError ? <ErrorBanner message={createError} /> : null}
       <ListSection>
         {browseState.isPending && browseState.data === null ? (
           <View className="items-center py-5">
             <ActivityIndicator colorClassName={"accent-icon-muted"} />
           </View>
+        ) : null}
+        {createDirectoryTarget ? (
+          <ListRow
+            title={`New folder "${createDirectoryTarget.name}"`}
+            subtitle={`Create in ${createDirectoryTarget.parentPath}`}
+            disabled={isCreatingDirectory}
+            icon={
+              <SymbolView
+                name="folder.badge.plus"
+                size={17}
+                tintColorClassName={"accent-icon-muted"}
+                type="monochrome"
+              />
+            }
+            isFirst
+            right={null}
+            onPress={() => {
+              void createBrowsedDirectory(createDirectoryTarget);
+            }}
+          />
         ) : null}
         {browsePath.canBrowseUp ? (
           <ListRow
@@ -801,7 +873,7 @@ function FolderBrowser(props: {
                 type="monochrome"
               />
             }
-            isFirst
+            isFirst={createDirectoryTarget === null}
             right={null}
             onPress={() => {
               if (browsePath.parentPath) {
@@ -824,7 +896,7 @@ function FolderBrowser(props: {
                 type="monochrome"
               />
             }
-            isFirst={index === 0 && !browsePath.canBrowseUp}
+            isFirst={index === 0 && !browsePath.canBrowseUp && createDirectoryTarget === null}
             right={null}
             onPress={() => {
               void props.navigateToBrowsePath({

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -100,6 +100,9 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.projectsWriteFile]: AuthOrchestrationOperateScope,
   [WS_METHODS.shellOpenInEditor]: AuthOrchestrationOperateScope,
   [WS_METHODS.filesystemBrowse]: AuthOrchestrationReadScope,
+  // Creating a folder writes to the host filesystem, so it needs the same scope as every other
+  // operation that changes the machine rather than the read scope that lists directories.
+  [WS_METHODS.filesystemCreateDirectory]: AuthOrchestrationOperateScope,
   [WS_METHODS.agentSessionsScan]: AuthOrchestrationReadScope,
   [WS_METHODS.agentSessionsImport]: AuthOrchestrationOperateScope,
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -5279,6 +5279,53 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("creates and lists a picker folder through websocket rpc", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const parentDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-ws-create-folder-" });
+
+      yield* buildAppUnderTest();
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const results = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const created = yield* client[WS_METHODS.filesystemCreateDirectory]({
+              parentPath: parentDir,
+              name: "scratch",
+            });
+            const listing = yield* client[WS_METHODS.filesystemBrowse]({
+              partialPath: `${parentDir}/`,
+            });
+            const escaped = yield* client[WS_METHODS.filesystemCreateDirectory]({
+              parentPath: parentDir,
+              name: "../escape",
+            }).pipe(Effect.result);
+            return { created, listing, escaped };
+          }),
+        ),
+      );
+
+      assert.equal(results.created.path, path.join(parentDir, "scratch"));
+      assert.deepEqual(
+        results.listing.entries.map((entry) => entry.name),
+        ["scratch"],
+      );
+      if (
+        results.escaped._tag !== "Failure" ||
+        results.escaped.failure._tag !== "FilesystemCreateDirectoryError"
+      ) {
+        assert.fail("Expected a FilesystemCreateDirectoryError");
+      }
+      assert.equal(results.escaped.failure.failure, "invalid_directory_name");
+      assert.equal(
+        results.escaped.failure.message,
+        `Failed to create folder '../escape' in '${parentDir}'.`,
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("routes websocket rpc server.upsertKeybinding", () =>
     Effect.gen(function* () {
       const rule: KeybindingRule = {

--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -736,4 +736,96 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
   });
+
+  describe("createDirectory", () => {
+    it.effect("lists a folder created through createDirectory", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-" });
+
+        const created = yield* workspaceEntries.createDirectory({
+          parentPath: yield* appendSeparator(cwd),
+          name: "scratch",
+        });
+        const listing = yield* workspaceEntries.browse({
+          partialPath: yield* appendSeparator(cwd),
+        });
+
+        expect(created).toEqual({ path: path.join(cwd, "scratch") });
+        expect(listing.entries.map((entry) => entry.name)).toEqual(["scratch"]);
+      }),
+    );
+
+    it.effect("creates missing parents and accepts an existing folder", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-nested-" });
+        const parentPath = path.join(cwd, "deep", "nested");
+
+        const created = yield* workspaceEntries.createDirectory({ parentPath, name: "scratch" });
+        const again = yield* workspaceEntries.createDirectory({ parentPath, name: "scratch" });
+
+        expect(created).toEqual({ path: path.join(parentPath, "scratch") });
+        expect(again).toEqual(created);
+      }),
+    );
+
+    it.effect("creates relative folders against the current project", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-relative-" });
+
+        const created = yield* workspaceEntries.createDirectory({
+          cwd,
+          parentPath: "./packages/",
+          name: "shared",
+        });
+        const error = yield* workspaceEntries
+          .createDirectory({ parentPath: "./packages/", name: "shared" })
+          .pipe(Effect.flip);
+
+        expect(created).toEqual({ path: path.join(cwd, "packages", "shared") });
+        expect(error._tag).toBe("WorkspaceEntriesCurrentProjectRequiredError");
+      }),
+    );
+
+    it.effect("rejects names that would leave the browsed directory", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-invalid-" });
+        const parentPath = yield* appendSeparator(cwd);
+
+        for (const name of ["..", ".", "../escape", "nested/child"]) {
+          const error = yield* workspaceEntries
+            .createDirectory({ parentPath, name })
+            .pipe(Effect.flip);
+          expect(error._tag).toBe("WorkspaceEntriesInvalidDirectoryNameError");
+        }
+
+        const listing = yield* workspaceEntries.browse({ partialPath: parentPath });
+        expect(listing.entries).toEqual([]);
+      }),
+    );
+
+    it.effect("reports a failed directory creation with its resolved path", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-conflict-" });
+        yield* writeTextFile(cwd, "occupied", "not a directory");
+
+        const error = yield* workspaceEntries
+          .createDirectory({ parentPath: yield* appendSeparator(cwd), name: "occupied" })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("WorkspaceEntriesCreateDirectoryError");
+        expect(error.message).toBe(
+          `Failed to create workspace directory '${path.join(cwd, "occupied")}'.`,
+        );
+      }),
+    );
+  });
 });

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -11,6 +11,8 @@ import * as Schema from "effect/Schema";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  FilesystemCreateDirectoryInput,
+  FilesystemCreateDirectoryResult,
   ProjectListEntriesInput,
   ProjectListEntriesResult,
   ProjectSearchContentsInput,
@@ -66,12 +68,49 @@ export class WorkspaceEntriesReadDirectoryError extends Schema.TaggedError<Works
   }
 }
 
+export class WorkspaceEntriesInvalidDirectoryNameError extends Schema.TaggedError<WorkspaceEntriesInvalidDirectoryNameError>()(
+  "WorkspaceEntriesInvalidDirectoryNameError",
+  {
+    parentPath: Schema.String,
+    name: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `'${this.name}' is not a valid folder name for '${this.parentPath}'.`;
+  }
+}
+
+export class WorkspaceEntriesCreateDirectoryError extends Schema.TaggedError<WorkspaceEntriesCreateDirectoryError>()(
+  "WorkspaceEntriesCreateDirectoryError",
+  {
+    cwd: Schema.optional(Schema.String),
+    parentPath: Schema.String,
+    name: Schema.String,
+    resolvedPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const cwd = this.cwd ? ` from '${this.cwd}'` : "";
+    return `Failed to create workspace directory '${this.resolvedPath}'${cwd}.`;
+  }
+}
+
 export const WorkspaceEntriesBrowseError = Schema.Union([
   WorkspaceEntriesWindowsPathUnsupportedError,
   WorkspaceEntriesCurrentProjectRequiredError,
   WorkspaceEntriesReadDirectoryError,
 ]);
 export type WorkspaceEntriesBrowseError = typeof WorkspaceEntriesBrowseError.Type;
+
+export const WorkspaceEntriesCreateDirectoryFailure = Schema.Union([
+  WorkspaceEntriesWindowsPathUnsupportedError,
+  WorkspaceEntriesCurrentProjectRequiredError,
+  WorkspaceEntriesInvalidDirectoryNameError,
+  WorkspaceEntriesCreateDirectoryError,
+]);
+export type WorkspaceEntriesCreateDirectoryFailure =
+  typeof WorkspaceEntriesCreateDirectoryFailure.Type;
 
 export const WorkspaceEntriesError = Schema.Union([
   WorkspacePaths.WorkspaceRootNotExistsError,
@@ -90,6 +129,9 @@ export class WorkspaceEntries extends Context.Service<
     readonly browse: (
       input: FilesystemBrowseInput,
     ) => Effect.Effect<FilesystemBrowseResult, WorkspaceEntriesBrowseError>;
+    readonly createDirectory: (
+      input: FilesystemCreateDirectoryInput,
+    ) => Effect.Effect<FilesystemCreateDirectoryResult, WorkspaceEntriesCreateDirectoryFailure>;
     readonly list: (
       input: ProjectListEntriesInput,
     ) => Effect.Effect<ProjectListEntriesResult, WorkspaceEntriesError>;
@@ -103,10 +145,17 @@ export class WorkspaceEntries extends Context.Service<
   }
 >()("t3/workspace/WorkspaceEntries") {}
 
+/**
+ * Resolves a browse-style path (`~/...`, absolute, or project-relative) that
+ * both listing and folder creation start from.
+ */
 const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(function* (
-  input: FilesystemBrowseInput,
+  input: { readonly partialPath: string; readonly cwd?: string | undefined },
   path: Path.Path,
-): Effect.fn.Return<string, WorkspaceEntriesBrowseError> {
+): Effect.fn.Return<
+  string,
+  WorkspaceEntriesWindowsPathUnsupportedError | WorkspaceEntriesCurrentProjectRequiredError
+> {
   const platform = yield* HostProcessPlatform;
   if (platform !== "win32" && isWindowsAbsolutePath(input.partialPath)) {
     return yield* new WorkspaceEntriesWindowsPathUnsupportedError({
@@ -228,6 +277,42 @@ export const make = Effect.gen(function* () {
     },
   );
 
+  const createDirectory: WorkspaceEntries["Service"]["createDirectory"] = Effect.fn(
+    "WorkspaceEntries.createDirectory",
+  )(function* (input) {
+    const parentPath = yield* resolveBrowseTarget(
+      { partialPath: input.parentPath, ...(input.cwd ? { cwd: input.cwd } : {}) },
+      path,
+    );
+    const name = input.name.trim();
+    // The picker only ever adds a child of the directory it is showing, so a
+    // name carrying separators or dot segments is rejected instead of being
+    // resolved somewhere else on the host.
+    if (name.length === 0 || name === "." || name === ".." || /[\\/]/.test(name)) {
+      return yield* new WorkspaceEntriesInvalidDirectoryNameError({
+        parentPath: input.parentPath,
+        name: input.name,
+      });
+    }
+
+    const resolvedPath = path.join(parentPath, name);
+    yield* Effect.tryPromise({
+      // Recursive so naming a folder inside a path the user typed but has not
+      // created yet works, and so a folder that already exists is a no-op.
+      try: () => NodeFSP.mkdir(resolvedPath, { recursive: true }),
+      catch: (cause) =>
+        new WorkspaceEntriesCreateDirectoryError({
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          parentPath: input.parentPath,
+          name,
+          resolvedPath,
+          cause,
+        }),
+    });
+
+    return { path: resolvedPath };
+  });
+
   const search: WorkspaceEntries["Service"]["search"] = Effect.fn("WorkspaceEntries.search")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
@@ -279,7 +364,7 @@ export const make = Effect.gen(function* () {
     },
   );
 
-  return WorkspaceEntries.of({ browse, list, refresh, search, searchContents });
+  return WorkspaceEntries.of({ browse, createDirectory, list, refresh, search, searchContents });
 });
 
 export const layer = Layer.effect(WorkspaceEntries, make).pipe(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -61,6 +61,8 @@ import {
   type ServerLifecycleStreamEvent,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
+  type FilesystemCreateDirectoryFailure,
+  FilesystemCreateDirectoryError,
   AssetWorkspaceContextNotFoundError,
   AssetWorkspaceContextResolutionError,
   RpcClientId,
@@ -258,6 +260,27 @@ function filesystemBrowseFailureContext(error: WorkspaceEntries.WorkspaceEntries
       return { failure: "current_project_required" };
     case "WorkspaceEntriesReadDirectoryError":
       return { failure: "read_directory_failed", parentPath: error.parentPath };
+    default:
+      return unexpectedCompatibilityError(error);
+  }
+}
+
+function filesystemCreateDirectoryFailureContext(
+  error: WorkspaceEntries.WorkspaceEntriesCreateDirectoryFailure,
+): {
+  readonly failure: FilesystemCreateDirectoryFailure;
+  readonly resolvedPath?: string;
+  readonly platform?: string;
+} {
+  switch (error._tag) {
+    case "WorkspaceEntriesWindowsPathUnsupportedError":
+      return { failure: "windows_path_unsupported", platform: error.platform };
+    case "WorkspaceEntriesCurrentProjectRequiredError":
+      return { failure: "current_project_required" };
+    case "WorkspaceEntriesInvalidDirectoryNameError":
+      return { failure: "invalid_directory_name" };
+    case "WorkspaceEntriesCreateDirectoryError":
+      return { failure: "create_directory_failed", resolvedPath: error.resolvedPath };
     default:
       return unexpectedCompatibilityError(error);
   }
@@ -2346,6 +2369,21 @@ const makeWsRpcLayer = (
                   new FilesystemBrowseError({
                     ...input,
                     ...filesystemBrowseFailureContext(cause),
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.filesystemCreateDirectory]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.filesystemCreateDirectory,
+            workspaceEntries.createDirectory(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new FilesystemCreateDirectoryError({
+                    ...input,
+                    ...filesystemCreateDirectoryFailureContext(cause),
                     cause,
                   }),
               ),

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -9,6 +9,7 @@ import {
   filterPinnedBrowseEntries,
   filterCommandPaletteGroups,
   reduceCommandPaletteUiState,
+  resolveBrowseCompletionTarget,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -469,6 +470,105 @@ describe("buildBrowseGroups", () => {
     finishNavigation?.();
     await action;
     expect(actionSettled).toBe(true);
+  });
+});
+
+describe("browse folder creation item", () => {
+  const entries = [{ name: "Downloads", fullPath: "/Users/test/Downloads" }];
+
+  it("leads the listing with the folder to create and runs it once activated", async () => {
+    const run = vi.fn(() => Promise.resolve());
+    const groups = buildBrowseGroups({
+      browseEntries: entries,
+      browseQuery: "~/scratch",
+      canBrowseUp: true,
+      upIcon: null,
+      directoryIcon: null,
+      browseUp: vi.fn(),
+      browseTo: vi.fn(),
+      createDirectory: { name: "scratch", directoryPath: "~/", icon: null, run },
+    });
+    const items = groups[0]?.items ?? [];
+    const createItem = items[0];
+    if (!createItem || createItem.kind !== "action") {
+      throw new Error("Expected a create-folder action");
+    }
+
+    expect(createItem.value).toBe("browse:create-directory");
+    expect(createItem.title).toBe('New folder "scratch"');
+    expect(createItem.description).toBe("Create in ~/");
+    expect(createItem.keepOpen).toBe(true);
+    expect(items.map((item) => item.value)).toEqual([
+      "browse:create-directory",
+      "browse:up",
+      "browse:/Users/test/Downloads",
+    ]);
+
+    await createItem.run();
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("omits the item when there is nothing to create", () => {
+    const groups = buildBrowseGroups({
+      browseEntries: entries,
+      browseQuery: "~/",
+      canBrowseUp: false,
+      upIcon: null,
+      directoryIcon: null,
+      browseUp: vi.fn(),
+      browseTo: vi.fn(),
+      createDirectory: null,
+    });
+
+    expect(groups[0]?.items.map((item) => item.value)).toEqual(["browse:/Users/test/Downloads"]);
+  });
+});
+
+describe("resolveBrowseCompletionTarget", () => {
+  const entries = [
+    { name: "code", fullPath: "/Users/test/code" },
+    { name: "codex", fullPath: "/Users/test/codex" },
+  ];
+
+  it("prefers the highlighted folder, then the typed one, then the only match", () => {
+    expect(
+      resolveBrowseCompletionTarget({
+        browseEntries: entries,
+        exactEntry: entries[0] ?? null,
+        highlightedItemValue: "browse:/Users/test/codex",
+      }),
+    ).toEqual(entries[1]);
+    expect(
+      resolveBrowseCompletionTarget({
+        browseEntries: entries,
+        exactEntry: entries[0] ?? null,
+        highlightedItemValue: "browse:up",
+      }),
+    ).toEqual(entries[0]);
+    expect(
+      resolveBrowseCompletionTarget({
+        browseEntries: entries.slice(1),
+        exactEntry: null,
+        highlightedItemValue: null,
+      }),
+    ).toEqual(entries[1]);
+  });
+
+  it("stays out of the way when the folder is ambiguous", () => {
+    expect(
+      resolveBrowseCompletionTarget({
+        browseEntries: entries,
+        exactEntry: null,
+        highlightedItemValue: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveBrowseCompletionTarget({
+        browseEntries: [],
+        exactEntry: null,
+        highlightedItemValue: null,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -383,6 +383,15 @@ export function filterCommandPaletteGroups(input: {
   });
 }
 
+export interface BrowseCreateDirectoryAction {
+  /** The folder name the user typed but that the listing does not contain. */
+  readonly name: string;
+  /** The browsed directory the folder is created in, shown as the item description. */
+  readonly directoryPath: string;
+  readonly icon: ReactNode;
+  readonly run: () => void | Promise<void>;
+}
+
 export function buildBrowseGroups(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
   browseQuery: string;
@@ -391,8 +400,31 @@ export function buildBrowseGroups(input: {
   directoryIcon: ReactNode;
   browseUp: () => void | Promise<void>;
   browseTo: (name: string) => void | Promise<void>;
+  createDirectory?: BrowseCreateDirectoryAction | null;
 }): CommandPaletteGroup[] {
   const items: CommandPaletteActionItem[] = [];
+
+  const createDirectory = input.createDirectory;
+  if (createDirectory) {
+    items.push({
+      kind: "action",
+      value: "browse:create-directory",
+      searchTerms: [
+        input.browseQuery,
+        createDirectory.name,
+        "new folder",
+        "create folder",
+        "mkdir",
+      ],
+      title: `New folder "${createDirectory.name}"`,
+      description: `Create in ${createDirectory.directoryPath}`,
+      icon: createDirectory.icon,
+      keepOpen: true,
+      run: async () => {
+        await createDirectory.run();
+      },
+    });
+  }
 
   if (input.canBrowseUp) {
     items.push({
@@ -423,6 +455,27 @@ export function buildBrowseGroups(input: {
   }
 
   return [{ value: "directories", label: "Directories", items }];
+}
+
+/**
+ * The folder Tab completion should open: whatever the user highlighted, the
+ * folder they typed in full, or the only remaining match. Anything more
+ * ambiguous than that is left alone so Tab never guesses.
+ */
+export function resolveBrowseCompletionTarget(input: {
+  readonly browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
+  readonly exactEntry: FilesystemBrowseEntry | null;
+  readonly highlightedItemValue: string | null;
+}): FilesystemBrowseEntry | null {
+  const highlighted =
+    input.highlightedItemValue === null
+      ? null
+      : (input.browseEntries.find(
+          (entry) => `browse:${entry.fullPath}` === input.highlightedItemValue,
+        ) ?? null);
+  if (highlighted) return highlighted;
+  if (input.exactEntry) return input.exactEntry;
+  return input.browseEntries.length === 1 ? (input.browseEntries[0] ?? null) : null;
 }
 
 export function filterPinnedBrowseEntries(input: {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
   filterFilesystemBrowseEntries,
+  getBrowseCreateDirectoryTarget,
   getFilesystemBrowsePath,
 } from "@t3tools/client-runtime/state/filesystem";
 import {
@@ -88,6 +89,7 @@ import {
   ensureBrowseDirectoryPath,
   findProjectByPath,
   getBrowseDirectoryPath,
+  getBrowsePathSegments,
   hasTrailingPathSeparator,
   inferProjectTitleFromPath,
   isExplicitRelativeProjectPath,
@@ -135,6 +137,7 @@ import {
   filterPinnedBrowseEntries,
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
+  resolveBrowseCompletionTarget,
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
   reduceCommandPaletteUiState,
@@ -142,6 +145,7 @@ import {
 } from "./CommandPalette.logic";
 import { orderItemsByPreferredIds, sortLogicalProjectsForSidebar } from "./Sidebar.logic";
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
+import { CommandPaletteBrowseBreadcrumb } from "./CommandPaletteBrowseBreadcrumb";
 import { CommandPaletteContent } from "./CommandPaletteContent";
 import { CommandPaletteResults } from "./CommandPaletteResults";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
@@ -176,6 +180,7 @@ import {
 import type { Project } from "../types";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
+const EMPTY_BREADCRUMB_SEGMENTS: ReturnType<typeof getBrowsePathSegments> = [];
 
 function projectFavicon(project: Project) {
   return <ProjectFavicon project={project} className="size-4" />;
@@ -584,6 +589,16 @@ function OpenCommandPaletteDialog(props: {
     reportFailure: false,
     reportDefect: false,
   });
+  // A folder created from the picker has to invalidate the listing it was
+  // created in, so the same query is also run with `refresh` after a mkdir.
+  const reloadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
+    reportFailure: false,
+    reportDefect: false,
+    refresh: true,
+  });
+  const createBrowseDirectoryCommand = useAtomCommand(filesystemEnvironment.createDirectory, {
+    reportFailure: false,
+  });
   const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
     reportFailure: false,
   });
@@ -974,6 +989,17 @@ function OpenCommandPaletteDialog(props: {
         : filterFilesystemBrowseEntries(browseEntries, browsePath.filterQuery),
     [browseEntries, browseEnvironmentPlatform, browsePath.filterQuery, pinnedCloneDirectoryName],
   );
+
+  // The clone destination keeps the repository folder appended to the browsed
+  // path, so that leaf is the pending clone target rather than a name the user
+  // is typing to filter or create.
+  const browseLeafName =
+    pinnedCloneDirectoryName.length > 0 &&
+    (isWindowsPlatform(browseEnvironmentPlatform)
+      ? pinnedCloneDirectoryName.toLowerCase() === browsePath.filterQuery.toLowerCase()
+      : pinnedCloneDirectoryName === browsePath.filterQuery)
+      ? ""
+      : browsePath.filterQuery;
 
   const prefetchBrowsePath = useCallback(
     async (
@@ -2101,22 +2127,27 @@ function OpenCommandPaletteDialog(props: {
     ],
   );
 
+  const browseToDirectory = useCallback(
+    async (directoryPath: string): Promise<void> => {
+      const nextQuery = getCloneDestinationPath(directoryPath, pinnedCloneDirectoryName);
+      await browseNavigation.run(
+        () => prefetchBrowsePath(directoryPath),
+        () => {
+          setHighlightedItemValue(null);
+          setQuery(nextQuery);
+          setBrowseGeneration((generation) => generation + 1);
+        },
+      );
+    },
+    [browseNavigation, pinnedCloneDirectoryName, prefetchBrowsePath],
+  );
+
   const browseUp = useCallback(async (): Promise<void> => {
-    const parentPath = browsePath.parentPath;
-    if (parentPath === null) {
+    if (browsePath.parentPath === null) {
       return;
     }
-
-    const nextQuery = getCloneDestinationPath(parentPath, pinnedCloneDirectoryName);
-    await browseNavigation.run(
-      () => prefetchBrowsePath(parentPath),
-      () => {
-        setHighlightedItemValue(null);
-        setQuery(nextQuery);
-        setBrowseGeneration((generation) => generation + 1);
-      },
-    );
-  }, [browseNavigation, browsePath.parentPath, pinnedCloneDirectoryName, prefetchBrowsePath]);
+    await browseToDirectory(browsePath.parentPath);
+  }, [browsePath.parentPath, browseToDirectory]);
 
   // Resolve the add-project path from browse data when available. When the
   // query has a trailing separator (e.g. "~/projects/foo/"), parentPath is the
@@ -2128,6 +2159,58 @@ function OpenCommandPaletteDialog(props: {
 
   const canBrowseUp = !relativePathNeedsActiveProject && browsePath.canBrowseUp;
 
+  // Only offer to create the typed name once the listing it would join has
+  // loaded, and never the repository folder the clone destination pins on --
+  // the clone creates that one itself.
+  const createDirectoryTarget =
+    !browseResult || relativePathNeedsActiveProject
+      ? null
+      : getBrowseCreateDirectoryTarget({
+          directoryPath: browsePath.directoryPath,
+          leafName: browseLeafName,
+          entries: browseEntries,
+          caseSensitive: !isWindowsPlatform(browseEnvironmentPlatform),
+        });
+
+  async function createBrowseDirectory(target: {
+    readonly parentPath: string;
+    readonly name: string;
+  }): Promise<void> {
+    if (browseEnvironmentId === null) {
+      return;
+    }
+    const browseCwd = currentProjectCwdForBrowse;
+    const result = await createBrowseDirectoryCommand({
+      environmentId: browseEnvironmentId,
+      input: {
+        parentPath: target.parentPath,
+        name: target.name,
+        ...(browseCwd ? { cwd: browseCwd } : {}),
+      },
+    });
+    if (result._tag === "Failure") {
+      if (!isAtomCommandInterrupted(result)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Could not create folder",
+            description: errorMessage(squashAtomCommandFailure(result)),
+          }),
+        );
+      }
+      return;
+    }
+
+    await reloadBrowsePath({
+      environmentId: browseEnvironmentId,
+      input: {
+        partialPath: target.parentPath,
+        ...(browseCwd ? { cwd: browseCwd } : {}),
+      },
+    });
+    await browseTo(target.name);
+  }
+
   const browseGroups = buildBrowseGroups({
     browseEntries: visibleBrowseEntries,
     browseQuery: query,
@@ -2136,6 +2219,15 @@ function OpenCommandPaletteDialog(props: {
     directoryIcon: <FolderIcon className={ITEM_ICON_CLASS} />,
     browseUp,
     browseTo,
+    createDirectory:
+      createDirectoryTarget === null
+        ? null
+        : {
+            name: createDirectoryTarget.name,
+            directoryPath: createDirectoryTarget.parentPath,
+            icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
+            run: () => createBrowseDirectory(createDirectoryTarget),
+          },
   });
   const cloneDestinationBrowseGroups = useMemo(
     () =>
@@ -2273,6 +2365,29 @@ function OpenCommandPaletteDialog(props: {
       event.preventDefault();
       void submitAddProjectCloneFlow();
       return;
+    }
+
+    if (
+      isBrowsing &&
+      event.key === "ArrowUp" &&
+      (isPrimaryModifierPressed(event) || event.altKey)
+    ) {
+      event.preventDefault();
+      void browseUp();
+      return;
+    }
+
+    if (isBrowsing && event.key === "Tab" && !event.shiftKey) {
+      const completionTarget = resolveBrowseCompletionTarget({
+        browseEntries: visibleBrowseEntries,
+        exactEntry: exactBrowseEntry,
+        highlightedItemValue,
+      });
+      if (completionTarget) {
+        event.preventDefault();
+        void browseTo(completionTarget.name);
+        return;
+      }
     }
 
     const shouldSubmitBrowsePath =
@@ -2432,79 +2547,82 @@ function OpenCommandPaletteDialog(props: {
     primaryEnvironmentId,
   ]);
 
+  // Both accessory buttons already show their label and shortcut, so they carry
+  // no tooltip: a popup repeating the label rendered over the dialog header and
+  // read as a second, broken button.
   const inputAccessory =
     addProjectCloneFlow?.step === "repository" ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="outline"
-              size="xs"
-              tabIndex={-1}
-              className="absolute inset-e-2.5 top-1/2 gap-1.5 pe-1 ps-2 -translate-y-1/2"
-              aria-label={`${remoteProjectButtonLabel ?? "Continue"} (Enter)`}
-              disabled={!canSubmitRemoteProjectFlow}
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={() => {
-                void submitAddProjectCloneFlow();
-              }}
-            />
-          }
-        >
-          <span>{isRemoteProjectPending ? "Working" : remoteProjectButtonLabel}</span>
-          <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
-            <Kbd>Enter</Kbd>
-          </KbdGroup>
-        </TooltipTrigger>
-        <TooltipPopup side="top">{remoteProjectButtonLabel ?? "Continue"} (Enter)</TooltipPopup>
-      </Tooltip>
+      <Button
+        variant="outline"
+        size="xs"
+        tabIndex={-1}
+        className="absolute inset-e-2.5 top-1/2 gap-1.5 pe-1 ps-2 -translate-y-1/2"
+        aria-label={`${remoteProjectButtonLabel ?? "Continue"} (Enter)`}
+        disabled={!canSubmitRemoteProjectFlow}
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
+        onClick={() => {
+          void submitAddProjectCloneFlow();
+        }}
+      >
+        <span>{isRemoteProjectPending ? "Working" : remoteProjectButtonLabel}</span>
+        <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
+          <Kbd>Enter</Kbd>
+        </KbdGroup>
+      </Button>
     ) : isBrowsing ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button
-              variant="outline"
-              size="xs"
-              tabIndex={-1}
-              className={cn(
-                "absolute inset-e-2.5 top-1/2 pe-1 ps-2 -translate-y-1/2",
-                hasHighlightedBrowseItem ? "gap-1" : "gap-1.5",
-              )}
-              aria-label={`${submitActionLabel} (${addShortcutLabel})`}
-              disabled={
-                !canCreateProjectInEnvironment(browseEnvironment?.connection.phase) ||
-                relativePathNeedsActiveProject ||
-                (isCloneDestinationStep && isRemoteProjectPending)
-              }
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={() => {
-                if (relativePathNeedsActiveProject) {
-                  return;
-                }
-                if (isCloneDestinationStep) {
-                  void submitAddProjectCloneFlow(resolvedAddProjectPath);
-                } else {
-                  void handleAddProject(resolvedAddProjectPath);
-                }
-              }}
-            />
+      <Button
+        variant="outline"
+        size="xs"
+        tabIndex={-1}
+        className={cn(
+          "absolute inset-e-2.5 top-1/2 pe-1 ps-2 -translate-y-1/2",
+          hasHighlightedBrowseItem ? "gap-1" : "gap-1.5",
+        )}
+        aria-label={`${submitActionLabel} (${addShortcutLabel})`}
+        disabled={
+          !canCreateProjectInEnvironment(browseEnvironment?.connection.phase) ||
+          relativePathNeedsActiveProject ||
+          (isCloneDestinationStep && isRemoteProjectPending)
+        }
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
+        onClick={() => {
+          if (relativePathNeedsActiveProject) {
+            return;
           }
-        >
-          <span>
-            {isCloneDestinationStep && isRemoteProjectPending ? "Cloning" : submitActionLabel}
-          </span>
-          <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
-            <Kbd>{hasHighlightedBrowseItem ? `${submitModifierLabel} Enter` : "Enter"}</Kbd>
-          </KbdGroup>
-        </TooltipTrigger>
-        <TooltipPopup side="top">
-          {submitActionLabel} ({addShortcutLabel})
-        </TooltipPopup>
-      </Tooltip>
+          if (isCloneDestinationStep) {
+            void submitAddProjectCloneFlow(resolvedAddProjectPath);
+          } else {
+            void handleAddProject(resolvedAddProjectPath);
+          }
+        }}
+      >
+        <span>
+          {isCloneDestinationStep && isRemoteProjectPending ? "Cloning" : submitActionLabel}
+        </span>
+        <KbdGroup className="pointer-events-none -me-0.5 items-center gap-1">
+          <Kbd>{hasHighlightedBrowseItem ? `${submitModifierLabel} Enter` : "Enter"}</Kbd>
+        </KbdGroup>
+      </Button>
+    ) : null;
+
+  const browseBreadcrumbSegments = useMemo(
+    () =>
+      isBrowsing && !relativePathNeedsActiveProject
+        ? getBrowsePathSegments(browseDirectoryPath)
+        : EMPTY_BREADCRUMB_SEGMENTS,
+    [browseDirectoryPath, isBrowsing, relativePathNeedsActiveProject],
+  );
+
+  const footerHints =
+    isBrowsing && !relativePathNeedsActiveProject ? (
+      <KbdGroup className="items-center gap-1.5">
+        <Kbd>Tab</Kbd>
+        <span>Open folder</span>
+      </KbdGroup>
     ) : null;
 
   const footerActionLabel =
@@ -2531,6 +2649,7 @@ function OpenCommandPaletteDialog(props: {
       aria-label="Command palette"
       autoHighlight={isBrowsing || isRemoteProjectCloneFlow ? false : "always"}
       footerActionLabel={footerActionLabel}
+      footerHints={footerHints}
       footerTrailing={footerTrailing}
       inputAccessory={inputAccessory}
       inputProps={{
@@ -2589,6 +2708,14 @@ function OpenCommandPaletteDialog(props: {
             </span>
           </div>
         </div>
+      ) : null}
+      {browseBreadcrumbSegments.length > 0 ? (
+        <CommandPaletteBrowseBreadcrumb
+          onNavigate={(path) => {
+            void browseToDirectory(path);
+          }}
+          segments={browseBreadcrumbSegments}
+        />
       ) : null}
       <CommandPaletteResults
         groups={displayedGroups}

--- a/apps/web/src/components/CommandPaletteBrowseBreadcrumb.tsx
+++ b/apps/web/src/components/CommandPaletteBrowseBreadcrumb.tsx
@@ -1,0 +1,62 @@
+import type { BrowsePathSegment } from "@t3tools/client-runtime/state/projects";
+
+import { cn } from "../lib/utils";
+
+/**
+ * The directory the picker is listing, one selectable crumb per level. The
+ * typed path can point deeper than the listing (a partial folder name, or the
+ * repository folder pinned onto a clone destination), so the crumbs are the
+ * only place that always says which directory the rows below belong to.
+ */
+export function CommandPaletteBrowseBreadcrumb(props: {
+  readonly segments: ReadonlyArray<BrowsePathSegment>;
+  readonly onNavigate: (path: string) => void;
+}) {
+  if (props.segments.length === 0) {
+    return null;
+  }
+
+  // Windows crumbs join with a backslash, and a root that is already a bare
+  // separator ("/") must not gain another one before the first folder.
+  const separator = props.segments[0]?.path.includes("\\") ? "\\" : "/";
+
+  return (
+    <nav
+      aria-label="Folder path"
+      className="flex flex-wrap items-center gap-0.5 px-3 pt-2 text-xs"
+      data-testid="command-palette-browse-breadcrumb"
+    >
+      {props.segments.map((segment, index) => {
+        const isCurrent = index === props.segments.length - 1;
+        const previousLabel = index === 0 ? null : (props.segments[index - 1]?.label ?? null);
+        return (
+          <span className="flex items-center gap-0.5" key={segment.path}>
+            {previousLabel !== null && !previousLabel.endsWith(separator) ? (
+              <span className="text-muted-foreground/60">{separator}</span>
+            ) : null}
+            <button
+              aria-current={isCurrent ? "location" : undefined}
+              className={cn(
+                "max-w-40 truncate rounded-sm px-1 py-0.5 text-start",
+                isCurrent
+                  ? "font-medium text-foreground"
+                  : "cursor-pointer text-muted-foreground hover:bg-accent hover:text-foreground",
+              )}
+              onMouseDown={(event) => {
+                event.preventDefault();
+              }}
+              onClick={() => {
+                if (!isCurrent) {
+                  props.onNavigate(segment.path);
+                }
+              }}
+              type="button"
+            >
+              {segment.label}
+            </button>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/CommandPaletteContent.tsx
+++ b/apps/web/src/components/CommandPaletteContent.tsx
@@ -8,6 +8,8 @@ type CommandPaletteContentProps = Omit<ComponentProps<typeof Command>, "children
   readonly children: ReactNode;
   readonly escapeLabel?: ReactNode;
   readonly footerActionLabel?: ReactNode;
+  /** Mode-specific keyboard hints shown after the primary action hint. */
+  readonly footerHints?: ReactNode;
   readonly footerTrailing?: ReactNode;
   readonly inputAccessory?: ReactNode;
   readonly inputProps: ComponentProps<typeof CommandInput>;
@@ -25,6 +27,7 @@ export function CommandPaletteContent({
   children,
   escapeLabel = "Close",
   footerActionLabel,
+  footerHints,
   footerTrailing,
   inputAccessory,
   inputProps,
@@ -51,7 +54,7 @@ export function CommandPaletteContent({
         </div>
         <CommandPanel className={panelClassName}>{children}</CommandPanel>
         <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <KbdGroup className="items-center gap-1.5">
               <Kbd>
                 <ArrowUpIcon />
@@ -67,6 +70,7 @@ export function CommandPaletteContent({
                 <span>{footerActionLabel}</span>
               </KbdGroup>
             ) : null}
+            {footerHints}
             {showBackHint ? (
               <KbdGroup className="items-center gap-1.5">
                 <Kbd>Backspace</Kbd>

--- a/apps/web/src/lib/projectPaths.test.ts
+++ b/apps/web/src/lib/projectPaths.test.ts
@@ -7,6 +7,7 @@ import {
   findProjectByPath,
   getBrowseLeafPathSegment,
   getBrowseParentPath,
+  getBrowsePathSegments,
   hasTrailingPathSeparator,
   inferProjectTitleFromPath,
   isExplicitRelativeProjectPath,
@@ -94,6 +95,33 @@ describe("projectPaths", () => {
     expect(getBrowseParentPath("\\\\server\\share\\repo\\")).toBe("\\\\server\\share\\");
     expect(getBrowseParentPath("C:\\")).toBeNull();
     expect(getBrowseParentPath("/home/user\\project/docs/")).toBe("/home/user\\project/");
+  });
+
+  it("breaks a browsed directory into navigable breadcrumb segments", () => {
+    expect(getBrowsePathSegments("~/projects/t3")).toEqual([
+      { label: "~", path: "~/" },
+      { label: "projects", path: "~/projects/" },
+    ]);
+    expect(getBrowsePathSegments("/home/user/code/")).toEqual([
+      { label: "/", path: "/" },
+      { label: "home", path: "/home/" },
+      { label: "user", path: "/home/user/" },
+      { label: "code", path: "/home/user/code/" },
+    ]);
+    expect(getBrowsePathSegments("C:\\Work\\Repo\\")).toEqual([
+      { label: "C:", path: "C:\\" },
+      { label: "Work", path: "C:\\Work\\" },
+      { label: "Repo", path: "C:\\Work\\Repo\\" },
+    ]);
+    expect(getBrowsePathSegments("\\\\server\\share\\repo\\")).toEqual([
+      { label: "\\\\server\\share", path: "\\\\server\\share\\" },
+      { label: "repo", path: "\\\\server\\share\\repo\\" },
+    ]);
+    expect(getBrowsePathSegments("../sibling/")).toEqual([
+      { label: "..", path: "../" },
+      { label: "sibling", path: "../sibling/" },
+    ]);
+    expect(getBrowsePathSegments("  ")).toEqual([]);
   });
 
   it("detects browse path boundaries", () => {

--- a/apps/web/src/lib/projectPaths.ts
+++ b/apps/web/src/lib/projectPaths.ts
@@ -6,6 +6,7 @@ export {
   getBrowseDirectoryPath,
   getBrowseLeafPathSegment,
   getBrowseParentPath,
+  getBrowsePathSegments,
   hasTrailingPathSeparator,
   inferProjectTitleFromPath,
   isExplicitRelativeProjectPath,

--- a/packages/client-runtime/src/state/filesystem.test.ts
+++ b/packages/client-runtime/src/state/filesystem.test.ts
@@ -4,6 +4,7 @@ import {
   canPreloadBrowsePath,
   createBrowseNavigationCoordinator,
   filterFilesystemBrowseEntries,
+  getBrowseCreateDirectoryTarget,
   getFilesystemBrowsePath,
 } from "./filesystem.ts";
 
@@ -34,6 +35,48 @@ describe("filesystem browse model", () => {
     expect(filterFilesystemBrowseEntries(entries, "").visibleEntries).toEqual(entries.slice(1));
     expect(filterFilesystemBrowseEntries(entries, ".").visibleEntries).toEqual(entries.slice(0, 1));
     expect(filterFilesystemBrowseEntries(entries, "Code").exactEntry).toEqual(entries[1]);
+  });
+});
+
+describe("browse folder creation", () => {
+  const entries = [
+    { name: "Code", fullPath: "/Users/test/Code" },
+    { name: "notes", fullPath: "/Users/test/notes" },
+  ];
+  const target = (leafName: string, caseSensitive = true) =>
+    getBrowseCreateDirectoryTarget({
+      directoryPath: "~/",
+      leafName,
+      entries,
+      caseSensitive,
+    });
+
+  it("offers the typed name as a new child of the browsed directory", () => {
+    expect(target("scratch")).toEqual({ parentPath: "~/", name: "scratch" });
+    expect(target("  scratch  ")).toEqual({ parentPath: "~/", name: "scratch" });
+  });
+
+  it("does not offer a folder the listing already has", () => {
+    expect(target("Code")).toBeNull();
+    expect(target("code")).toEqual({ parentPath: "~/", name: "code" });
+    expect(target("code", false)).toBeNull();
+  });
+
+  it("ignores names that are not a single new folder", () => {
+    for (const name of ["", "   ", ".", "..", "a/b", "a\\b"]) {
+      expect(target(name)).toBeNull();
+    }
+  });
+
+  it("needs a browsed directory to create the folder in", () => {
+    expect(
+      getBrowseCreateDirectoryTarget({
+        directoryPath: "",
+        leafName: "scratch",
+        entries: [],
+        caseSensitive: true,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/client-runtime/src/state/filesystem.ts
+++ b/packages/client-runtime/src/state/filesystem.ts
@@ -11,7 +11,7 @@ import {
   hasTrailingPathSeparator,
   isFilesystemBrowseQuery,
 } from "./projects.ts";
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import { createEnvironmentRpcCommand, createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
 
 export function getFilesystemBrowsePath(query: string, platform = "", enabled = true) {
   const isBrowsing = enabled && isFilesystemBrowseQuery(query, platform);
@@ -46,6 +46,40 @@ export function filterFilesystemBrowseEntries(
   return { visibleEntries, exactEntry };
 }
 
+/**
+ * A folder the picker may create: one new child of the directory it is showing.
+ * Names carrying separators or dot segments belong to a path the user is still
+ * typing, not to a folder we should offer to create.
+ */
+function isCreatableDirectoryName(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed.length > 0 && trimmed !== "." && trimmed !== ".." && !/[\\/]/.test(trimmed);
+}
+
+/**
+ * The create-folder target for a browse query, or null when there is nothing to
+ * create: no name typed, an unusable name, or a folder of that name already in
+ * the listing. `entries` must be the loaded listing for `directoryPath`, so a
+ * pending listing never offers to create a folder that already exists.
+ */
+export function getBrowseCreateDirectoryTarget(input: {
+  readonly directoryPath: string;
+  readonly leafName: string;
+  readonly entries: ReadonlyArray<FilesystemBrowseEntry>;
+  readonly caseSensitive: boolean;
+}): { readonly parentPath: string; readonly name: string } | null {
+  const name = input.leafName.trim();
+  if (input.directoryPath.length === 0 || !isCreatableDirectoryName(name)) {
+    return null;
+  }
+
+  const lowerName = name.toLowerCase();
+  const exists = input.entries.some((entry) =>
+    input.caseSensitive ? entry.name === name : entry.name.toLowerCase() === lowerName,
+  );
+  return exists ? null : { parentPath: input.directoryPath, name };
+}
+
 export function createBrowseNavigationCoordinator() {
   let generation = 0;
 
@@ -78,6 +112,10 @@ export function createFilesystemEnvironmentAtoms<R, E>(
     browse: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:filesystem:browse",
       tag: WS_METHODS.filesystemBrowse,
+    }),
+    createDirectory: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:filesystem:create-directory",
+      tag: WS_METHODS.filesystemCreateDirectory,
     }),
   };
 }

--- a/packages/client-runtime/src/state/projects.ts
+++ b/packages/client-runtime/src/state/projects.ts
@@ -77,6 +77,21 @@ function splitAbsolutePath(value: string): {
   return null;
 }
 
+function trimTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, "");
+}
+
+// Home- and project-relative paths keep their leading token (`~`, `.`, `..`) as
+// the first crumb, since that is the anchor every deeper crumb resolves from.
+function leadingBrowseSegment(
+  directoryPath: string,
+  separator: "/" | "\\",
+): [BrowsePathSegment | null, string[]] {
+  const [head, ...rest] = splitPathSegments(directoryPath, separator);
+  if (head === undefined) return [null, []];
+  return [{ label: head, path: `${head}${separator}` }, rest];
+}
+
 export function isFilesystemBrowseQuery(value: string, platform = ""): boolean {
   const allowWindowsPaths = isWindowsPlatform(platform);
   return (
@@ -188,6 +203,44 @@ export function getBrowseParentPath(currentPath: string): string | null {
     return `${trimmed.slice(0, 2)}${separator}`;
   }
   return trimmed.slice(0, lastSeparatorIndex + 1);
+}
+
+export interface BrowsePathSegment {
+  /** The segment as it is shown in a breadcrumb (`~`, `/`, `C:`, or a folder name). */
+  readonly label: string;
+  /** The browse path this segment stands for, always ending in a separator. */
+  readonly path: string;
+}
+
+/**
+ * Breadcrumb segments for the directory a picker is listing. Every `path` is
+ * itself a browse path, so selecting a segment navigates to that ancestor.
+ * Returns an empty list for anything that is not a directory path yet.
+ */
+export function getBrowsePathSegments(currentPath: string): BrowsePathSegment[] {
+  const directoryPath = getBrowseDirectoryPath(currentPath.trim());
+  if (directoryPath.length === 0) return [];
+
+  const absolutePath = splitAbsolutePath(directoryPath);
+  const separator = absolutePath?.separator ?? preferredPathSeparator(directoryPath);
+  const [root, segments] = absolutePath
+    ? [
+        {
+          label: absolutePath.root === "/" ? "/" : trimTrailingSeparators(absolutePath.root),
+          path: absolutePath.root,
+        },
+        absolutePath.segments,
+      ]
+    : leadingBrowseSegment(directoryPath, separator);
+  if (root === null) return [];
+
+  const crumbs: BrowsePathSegment[] = [root];
+  let crumbPath = root.path;
+  for (const segment of segments) {
+    crumbPath = `${crumbPath}${segment}${separator}`;
+    crumbs.push({ label: segment, path: crumbPath });
+  }
+  return crumbs;
 }
 
 export function canNavigateUp(currentPath: string): boolean {

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 const FILESYSTEM_PATH_MAX_LENGTH = 512;
+const FILESYSTEM_DIRECTORY_NAME_MAX_LENGTH = 255;
 
 export const FilesystemBrowseInput = Schema.Struct({
   partialPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
@@ -28,7 +29,7 @@ export const FilesystemBrowseFailure = Schema.Literals([
 ]);
 export type FilesystemBrowseFailure = typeof FilesystemBrowseFailure.Type;
 
-function decodedFilesystemBrowseErrorMessage(props: object): string | undefined {
+function decodedFilesystemErrorMessage(props: object): string | undefined {
   if (!("message" in props)) return undefined;
   return typeof props.message === "string" ? props.message : undefined;
 }
@@ -60,8 +61,70 @@ export class FilesystemBrowseError extends Schema.TaggedError<FilesystemBrowseEr
     super({
       ...props,
       message:
-        decodedFilesystemBrowseErrorMessage(props) ??
+        decodedFilesystemErrorMessage(props) ??
         `Failed to browse filesystem path '${props.partialPath}'${cwd}.`,
+    } as any);
+  }
+}
+
+/**
+ * Creates one directory inside an already browsed directory. `name` is a single
+ * path segment so the picker can only ever add a child of what it is showing;
+ * `parentPath` accepts the same forms as a browse path (`~/`, absolute, or
+ * project-relative with `cwd`).
+ */
+export const FilesystemCreateDirectoryInput = Schema.Struct({
+  parentPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_DIRECTORY_NAME_MAX_LENGTH)),
+  cwd: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH))),
+});
+export type FilesystemCreateDirectoryInput = typeof FilesystemCreateDirectoryInput.Type;
+
+export const FilesystemCreateDirectoryResult = Schema.Struct({
+  path: TrimmedNonEmptyString,
+});
+export type FilesystemCreateDirectoryResult = typeof FilesystemCreateDirectoryResult.Type;
+
+export const FilesystemCreateDirectoryFailure = Schema.Literals([
+  "windows_path_unsupported",
+  "current_project_required",
+  "invalid_directory_name",
+  "create_directory_failed",
+]);
+export type FilesystemCreateDirectoryFailure = typeof FilesystemCreateDirectoryFailure.Type;
+
+export class FilesystemCreateDirectoryError extends Schema.TaggedError<FilesystemCreateDirectoryError>()(
+  "FilesystemCreateDirectoryError",
+  {
+    parentPath: Schema.optional(TrimmedNonEmptyString),
+    name: Schema.optional(TrimmedNonEmptyString),
+    cwd: Schema.optional(TrimmedNonEmptyString),
+    failure: Schema.optional(FilesystemCreateDirectoryFailure),
+    resolvedPath: Schema.optional(TrimmedNonEmptyString),
+    platform: Schema.optional(TrimmedNonEmptyString),
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  // Structured diagnostics stay optional so a client can still decode this
+  // error from a server that only sends a message, exactly like its browse
+  // sibling above.
+  // @effect-diagnostics-next-line overriddenSchemaConstructor:off
+  constructor(props: {
+    readonly parentPath: string;
+    readonly name: string;
+    readonly cwd?: string | undefined;
+    readonly failure: FilesystemCreateDirectoryFailure;
+    readonly resolvedPath?: string;
+    readonly platform?: string;
+    readonly cause?: unknown;
+  }) {
+    const cwd = props.cwd === undefined ? "" : ` from '${props.cwd}'`;
+    super({
+      ...props,
+      message:
+        decodedFilesystemErrorMessage(props) ??
+        `Failed to create folder '${props.name}' in '${props.parentPath}'${cwd}.`,
     } as any);
   }
 }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -27,6 +27,9 @@ import {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   FilesystemBrowseError,
+  FilesystemCreateDirectoryInput,
+  FilesystemCreateDirectoryResult,
+  FilesystemCreateDirectoryError,
 } from "./filesystem.ts";
 import {
   AgentSessionImportInput,
@@ -251,6 +254,7 @@ export const WS_METHODS = {
 
   // Filesystem methods
   filesystemBrowse: "filesystem.browse",
+  filesystemCreateDirectory: "filesystem.createDirectory",
   agentSessionsScan: "agentSessions.scan",
   agentSessionsImport: "agentSessions.import",
   assetsCreateUrl: "assets.createUrl",
@@ -822,6 +826,12 @@ const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
   error: Schema.Union([FilesystemBrowseError, EnvironmentAuthorizationError]),
 });
 
+const WsFilesystemCreateDirectoryRpc = Rpc.make(WS_METHODS.filesystemCreateDirectory, {
+  payload: FilesystemCreateDirectoryInput,
+  success: FilesystemCreateDirectoryResult,
+  error: Schema.Union([FilesystemCreateDirectoryError, EnvironmentAuthorizationError]),
+});
+
 const WsAgentSessionsScanRpc = Rpc.make(WS_METHODS.agentSessionsScan, {
   payload: AgentSessionScanInput,
   success: AgentSessionScanResult,
@@ -1249,6 +1259,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
+  WsFilesystemCreateDirectoryRpc,
   WsAgentSessionsScanRpc,
   WsAgentSessionsImportRpc,
   WsAssetsCreateUrlRpc,


### PR DESCRIPTION
## The problem

Picking a directory on a remote environment is harder than it should be. The picker lists folders and nothing else: creating one means typing a path that does not exist yet and committing to adding a project there, and moving around is arrow keys plus Backspace. On a clone destination it also lies about where you are — the input reads `…/picker-demo/t3code` while the rows below are the contents of `…/picker-demo`, with nothing on screen naming the listed directory. The Clone button's tooltip repeats the label the button already shows and renders outside the dialog, on top of the header, which reads as a second broken button.

## What changed

- **New folder.** When the loaded listing does not contain the name you typed, the picker offers it as `New folder "<name>"` with the directory it will be created in. Activating it creates the folder on the browsed environment through a new `filesystem.createDirectory` RPC and steps into it. The RPC takes a single path segment, rejects separators and dot segments so it can only ever add a child of the directory being shown, and requires the same operate scope as every other write.
- **Breadcrumb.** A crumb row names the directory the rows actually belong to and jumps to any ancestor in one click — the part that was missing when the path input pointed somewhere deeper than the listing.
- **Keyboard.** `Tab` opens the highlighted folder, the folder you typed in full, or the only remaining match; `⌘/Ctrl+↑` (or `Alt+↑`) leaves the current one. The footer advertises `Tab`.
- **The duplicate button.** Both input accessory buttons dropped the tooltip that only repeated their own label and shortcut; the accessible name keeps it.
- **Mobile** gets the same create-folder row in its folder browser.

Creating a folder invalidates the listing it was created in, so stepping back up shows it instead of a cached listing.

## Before / after

Typing a folder that does not exist — before, the only way forward is `Create & Add`, which also adds a project:

![before](https://raw.githubusercontent.com/lewismarshall/t3code/pr-assets/remote-dir-picker/before-create-folder.png)

![after](https://raw.githubusercontent.com/lewismarshall/t3code/pr-assets/remote-dir-picker/after-create-folder.png)

A clone destination — before, the tooltip duplicates the button over the dialog header and nothing says the rows are the contents of `picker-demo`:

![before](https://raw.githubusercontent.com/lewismarshall/t3code/pr-assets/remote-dir-picker/before-clone-destination.png)

![after](https://raw.githubusercontent.com/lewismarshall/t3code/pr-assets/remote-dir-picker/after-clone-destination.png)

## Testing

- `WorkspaceEntries` unit tests for creation, missing parents, an existing folder, relative parents with and without a current project, rejected names, and a failed mkdir.
- A websocket round-trip in `server.test.ts` that creates a folder, lists it, and checks the structured `invalid_directory_name` failure.
- Unit tests for the create-folder target, the breadcrumb segments (POSIX, Windows, UNC, `~`, relative), the palette's create item ordering, and `Tab` completion targets.
- Verified by hand in the web client against a dev server: create from the row and from the keyboard, the folder appearing on disk and in the parent listing after navigating back up, `Tab` completion, `Ctrl+↑`, and breadcrumb jumps.

Model: Claude Opus 5 (1M context) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5DrFpWZdCWRQk2NSBzcWc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create new folders directly from project browse pickers on web and mobile.
  - Navigate directories using clickable breadcrumbs.
  - Use improved keyboard controls and contextual hints for folder completion, navigation, and browse actions.
  - Browse and clone destinations now provide clearer inline controls.

- **Bug Fixes**
  - Added validation and clearer error handling for invalid names, duplicate folders, unavailable paths, and path traversal attempts.
  - Folder listings refresh automatically after creating a directory.
  - Prevented duplicate folder-creation requests and navigation to stale listings after refresh failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->