### PR TITLE
fix(server): advertise the tailnet editor target when Tailscale SSH serves without a local sshd

### DIFF
--- a/apps/server/src/environment/RemoteOpenTargets.test.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { describe, expect } from "vite-plus/test";
 
@@ -16,27 +17,34 @@ const TAILSCALE_STATUS_JSON = JSON.stringify({
   Self: { DNSName: "bb-1.tail1234.ts.net.", TailscaleIPs: ["100.64.1.2"] },
 });
 
-/** Spawner whose `tailscale status --json` exits with the given output. */
-const spawnerLayer = (input: { readonly exitCode: number; readonly stdout: string }) =>
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+}
+
+/** Spawner answering `tailscale status --json` and `tailscale debug prefs` separately. */
+const spawnerLayer = (input: { readonly status: CommandResult; readonly prefs?: CommandResult }) =>
   Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make(() =>
-      Effect.succeed(
+    ChildProcessSpawner.make((command) => {
+      const args = ChildProcess.isStandardCommand(command) ? command.args : [];
+      const result = args[0] === "debug" ? (input.prefs ?? TAILSCALE_PREFS_NO_SSH) : input.status;
+      return Effect.succeed(
         ChildProcessSpawner.makeHandle({
           pid: ChildProcessSpawner.ProcessId(1),
-          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(input.exitCode)),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.exitCode)),
           isRunning: Effect.succeed(false),
           kill: () => Effect.void,
           unref: Effect.succeed(Effect.void),
           stdin: Sink.drain,
-          stdout: Stream.make(encoder.encode(input.stdout)),
+          stdout: Stream.make(encoder.encode(result.stdout)),
           stderr: Stream.empty,
           all: Stream.empty,
           getInputFd: () => Sink.drain,
           getOutputFd: () => Stream.empty,
         }),
-      ),
-    ),
+      );
+    }),
   );
 
 const netLayer = (input: { readonly ipv4: boolean; readonly ipv6: boolean }) =>
@@ -50,7 +58,7 @@ const netLayer = (input: { readonly ipv4: boolean; readonly ipv6: boolean }) =>
 
 const resolveTargets = (input: {
   readonly sshd: { readonly ipv4: boolean; readonly ipv6: boolean };
-  readonly tailscale: { readonly exitCode: number; readonly stdout: string };
+  readonly tailscale: { readonly status: CommandResult; readonly prefs?: CommandResult };
   readonly hostname: string;
 }) =>
   Effect.flatMap(RemoteOpenTargets.RemoteOpenTargets, (service) => service.resolveTargets()).pipe(
@@ -62,18 +70,20 @@ const resolveTargets = (input: {
     ),
   );
 
-const TAILSCALE_UP = { exitCode: 0, stdout: TAILSCALE_STATUS_JSON };
-const TAILSCALE_SSH = {
+// `tailscale debug prefs` as printed by tailscale 1.94 (trimmed); RunSSH is the SSH switch.
+const TAILSCALE_PREFS_NO_SSH = {
   exitCode: 0,
-  stdout: JSON.stringify({
-    Self: {
-      DNSName: "bb-1.tail1234.ts.net.",
-      TailscaleIPs: ["100.64.1.2"],
-      SSH_HostKeys: ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample"],
-    },
-  }),
+  stdout:
+    '{\n\t"ControlURL": "https://controlplane.tailscale.com",\n\t"RunSSH": false,\n\t"WantRunning": true\n}\n',
 };
-const TAILSCALE_DOWN = { exitCode: 1, stdout: "" };
+const TAILSCALE_PREFS_SSH = {
+  exitCode: 0,
+  stdout:
+    '{\n\t"ControlURL": "https://controlplane.tailscale.com",\n\t"RunSSH": true,\n\t"WantRunning": true\n}\n',
+};
+const TAILSCALE_UP = { status: { exitCode: 0, stdout: TAILSCALE_STATUS_JSON } };
+const TAILSCALE_SSH = { status: TAILSCALE_UP.status, prefs: TAILSCALE_PREFS_SSH };
+const TAILSCALE_DOWN = { status: { exitCode: 1, stdout: "" }, prefs: { exitCode: 1, stdout: "" } };
 
 describe("RemoteOpenTargets", () => {
   it.effect("advertises nothing when no sshd accepts on either loopback", () =>
@@ -95,6 +105,17 @@ describe("RemoteOpenTargets", () => {
         hostname: "bb-1",
       });
       expect(targets).toEqual([{ kind: "tailscale", host: "bb-1.tail1234.ts.net" }]);
+    }),
+  );
+
+  it.effect("ignores the SSH pref while tailscale is down", () =>
+    Effect.gen(function* () {
+      const targets = yield* resolveTargets({
+        sshd: { ipv4: false, ipv6: false },
+        tailscale: { status: TAILSCALE_DOWN.status, prefs: TAILSCALE_PREFS_SSH },
+        hostname: "bb-1",
+      });
+      expect(targets).toEqual([]);
     }),
   );
 

--- a/apps/server/src/environment/RemoteOpenTargets.test.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.test.ts
@@ -14,6 +14,12 @@ import * as RemoteOpenTargets from "./RemoteOpenTargets.ts";
 const encoder = new TextEncoder();
 
 const TAILSCALE_STATUS_JSON = JSON.stringify({
+  BackendState: "Running",
+  Self: { DNSName: "bb-1.tail1234.ts.net.", TailscaleIPs: ["100.64.1.2"] },
+});
+// `tailscale down` keeps the node name in the status output but nothing answers on it.
+const TAILSCALE_STOPPED_STATUS_JSON = JSON.stringify({
+  BackendState: "Stopped",
   Self: { DNSName: "bb-1.tail1234.ts.net.", TailscaleIPs: ["100.64.1.2"] },
 });
 
@@ -116,6 +122,26 @@ describe("RemoteOpenTargets", () => {
         hostname: "bb-1",
       });
       expect(targets).toEqual([]);
+    }),
+  );
+
+  it.effect("does not advertise a stopped daemon's name even with SSH enabled", () =>
+    Effect.gen(function* () {
+      const targets = yield* resolveTargets({
+        sshd: { ipv4: false, ipv6: false },
+        tailscale: {
+          status: { exitCode: 0, stdout: TAILSCALE_STOPPED_STATUS_JSON },
+          prefs: TAILSCALE_PREFS_SSH,
+        },
+        hostname: "bb-1",
+      });
+      expect(targets).toEqual([]);
+      const withSshd = yield* resolveTargets({
+        sshd: { ipv4: true, ipv6: false },
+        tailscale: { status: { exitCode: 0, stdout: TAILSCALE_STOPPED_STATUS_JSON } },
+        hostname: "bb-1",
+      });
+      expect(withSshd).toEqual([{ kind: "mdns", host: "bb-1.local" }]);
     }),
   );
 

--- a/apps/server/src/environment/RemoteOpenTargets.test.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.test.ts
@@ -63,6 +63,16 @@ const resolveTargets = (input: {
   );
 
 const TAILSCALE_UP = { exitCode: 0, stdout: TAILSCALE_STATUS_JSON };
+const TAILSCALE_SSH = {
+  exitCode: 0,
+  stdout: JSON.stringify({
+    Self: {
+      DNSName: "bb-1.tail1234.ts.net.",
+      TailscaleIPs: ["100.64.1.2"],
+      SSH_HostKeys: ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample"],
+    },
+  }),
+};
 const TAILSCALE_DOWN = { exitCode: 1, stdout: "" };
 
 describe("RemoteOpenTargets", () => {
@@ -74,6 +84,17 @@ describe("RemoteOpenTargets", () => {
         hostname: "bb-1",
       });
       expect(targets).toEqual([]);
+    }),
+  );
+
+  it.effect("advertises the tailnet name alone when only Tailscale SSH is serving", () =>
+    Effect.gen(function* () {
+      const targets = yield* resolveTargets({
+        sshd: { ipv4: false, ipv6: false },
+        tailscale: TAILSCALE_SSH,
+        hostname: "bb-1",
+      });
+      expect(targets).toEqual([{ kind: "tailscale", host: "bb-1.tail1234.ts.net" }]);
     }),
   );
 

--- a/apps/server/src/environment/RemoteOpenTargets.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.ts
@@ -3,7 +3,8 @@
  * for remote open-in-editor deep links (`vscode://vscode-remote/ssh-remote+…`).
  *
  * The server can only check itself: sshd listening locally, tailscaled
- * reporting a MagicDNS name, and the machine hostname for mDNS. Whether a
+ * reporting a MagicDNS name and whether Tailscale SSH serves it, and the
+ * machine hostname for mDNS. Whether a
  * given name resolves from the viewer's machine is inherently client-side.
  * Targets are ordered most-reachable first (tailnet name works from anywhere
  * on the tailnet; `<hostname>.local` only on the same LAN).
@@ -32,36 +33,37 @@ export const make = Effect.gen(function* () {
   const net = yield* NetService.NetService;
 
   const resolveTargets = Effect.gen(function* () {
-    // No local sshd means no name can work; advertise nothing so clients
-    // render a clear "no SSH route" state instead of links that hang.
     // Check both loopback families: sshd can be bound IPv6-only.
     const sshdListening = yield* Effect.zipWith(
       net.hasListenerOnHost(SSH_PORT, "127.0.0.1"),
       net.hasListenerOnHost(SSH_PORT, "::1"),
       (ipv4, ipv6) => ipv4 || ipv6,
     );
-    if (!sshdListening) {
-      return [];
-    }
-
-    const targets: Array<RemoteOpenTarget> = [];
 
     // Tailscale absent or down is the common case, not an error.
-    const magicDnsName = yield* readTailscaleStatus.pipe(
-      Effect.map((status) => status.magicDnsName),
+    const tailscale = yield* readTailscaleStatus.pipe(
       Effect.orElseSucceed(() => null),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
-    if (magicDnsName !== null) {
-      targets.push({ kind: "tailscale", host: magicDnsName });
+
+    const targets: Array<RemoteOpenTarget> = [];
+
+    // Tailscale SSH answers on the tailnet name without any local sshd, so
+    // the tailnet target only needs one of the two to be serving.
+    if (tailscale?.magicDnsName && (sshdListening || tailscale.sshEnabled)) {
+      targets.push({ kind: "tailscale", host: tailscale.magicDnsName });
     }
 
+    // Without a local sshd no LAN name can work; advertise nothing there so
+    // clients render a clear "no SSH route" state instead of links that hang.
     // os.hostname() may already be an FQDN (macOS often reports
     // "Name.local"); mDNS names are always `<first-label>.local`.
-    const hostname = yield* HostProcessHostname;
-    const shortHostname = hostname.split(".")[0]?.trim();
-    if (shortHostname !== undefined && shortHostname.length > 0) {
-      targets.push({ kind: "mdns", host: `${shortHostname}.local` });
+    if (sshdListening) {
+      const hostname = yield* HostProcessHostname;
+      const shortHostname = hostname.split(".")[0]?.trim();
+      if (shortHostname !== undefined && shortHostname.length > 0) {
+        targets.push({ kind: "mdns", host: `${shortHostname}.local` });
+      }
     }
 
     return targets;

--- a/apps/server/src/environment/RemoteOpenTargets.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.ts
@@ -40,9 +40,10 @@ export const make = Effect.gen(function* () {
       (ipv4, ipv6) => ipv4 || ipv6,
     );
 
-    // Tailscale absent or down is the common case, not an error.
+    // Tailscale absent or down is the common case, not an error. A stopped
+    // daemon still reports its name, and nothing can reach it.
     const magicDnsName = yield* readTailscaleStatus.pipe(
-      Effect.map((status) => status.magicDnsName),
+      Effect.map((status) => (status.running ? status.magicDnsName : null)),
       Effect.orElseSucceed(() => null),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );

--- a/apps/server/src/environment/RemoteOpenTargets.ts
+++ b/apps/server/src/environment/RemoteOpenTargets.ts
@@ -3,8 +3,8 @@
  * for remote open-in-editor deep links (`vscode://vscode-remote/ssh-remote+…`).
  *
  * The server can only check itself: sshd listening locally, tailscaled
- * reporting a MagicDNS name and whether Tailscale SSH serves it, and the
- * machine hostname for mDNS. Whether a
+ * reporting a MagicDNS name, its prefs saying whether Tailscale SSH serves that
+ * name, and the machine hostname for mDNS. Whether a
  * given name resolves from the viewer's machine is inherently client-side.
  * Targets are ordered most-reachable first (tailnet name works from anywhere
  * on the tailnet; `<hostname>.local` only on the same LAN).
@@ -12,7 +12,7 @@
 import { type RemoteOpenTarget } from "@t3tools/contracts";
 import { HostProcessHostname } from "@t3tools/shared/hostProcess";
 import * as NetService from "@t3tools/shared/Net";
-import { readTailscaleStatus } from "@t3tools/tailscale";
+import { readTailscaleSshEnabled, readTailscaleStatus } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -41,17 +41,26 @@ export const make = Effect.gen(function* () {
     );
 
     // Tailscale absent or down is the common case, not an error.
-    const tailscale = yield* readTailscaleStatus.pipe(
+    const magicDnsName = yield* readTailscaleStatus.pipe(
+      Effect.map((status) => status.magicDnsName),
       Effect.orElseSucceed(() => null),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
+    // Tailscale SSH answers on the tailnet name without any local sshd, so
+    // the tailnet target only needs one of the two to be serving. A running
+    // tailscaled alone (`--tailscale-serve`) is not an SSH route.
+    const tailscaleSshServing =
+      magicDnsName !== null &&
+      !sshdListening &&
+      (yield* readTailscaleSshEnabled.pipe(
+        Effect.orElseSucceed(() => false),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      ));
 
     const targets: Array<RemoteOpenTarget> = [];
 
-    // Tailscale SSH answers on the tailnet name without any local sshd, so
-    // the tailnet target only needs one of the two to be serving.
-    if (tailscale?.magicDnsName && (sshdListening || tailscale.sshEnabled)) {
-      targets.push({ kind: "tailscale", host: tailscale.magicDnsName });
+    if (magicDnsName !== null && (sshdListening || tailscaleSshServing)) {
+      targets.push({ kind: "tailscale", host: magicDnsName });
     }
 
     // Without a local sshd no LAN name can work; advertise nothing there so

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -149,7 +149,14 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.100.100.100"],
+        sshEnabled: false,
       });
+      const sshStatus = yield* parseTailscaleStatus(
+        '{"Self":{"DNSName":"box.tail.ts.net.","SSH_HostKeys":["ssh-ed25519 AAAA"]}}',
+      );
+      assert.equal(sshStatus.sshEnabled, true);
+      const noKeys = yield* parseTailscaleStatus('{"Self":{"SSH_HostKeys":[]}}');
+      assert.equal(noKeys.sshEnabled, false);
     }),
   );
 
@@ -191,6 +198,7 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.90.1.2"],
+        sshEnabled: false,
       });
     });
   });

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -66,7 +66,7 @@ function assertCarriesNoSecret(error: object, secret: string): void {
 
   walk(error, "error");
 }
-const tailscaleStatusJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100","fd7a:115c:a1e0::1","192.168.1.20"]}}`;
+const tailscaleStatusJson = `{"BackendState":"Running","Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100","fd7a:115c:a1e0::1","192.168.1.20"]}}`;
 // Real `tailscale debug prefs` output (trimmed), as printed by tailscale 1.94 on a node
 // brought up with `tailscale up --ssh`.
 const tailscalePrefsWithSshJson = `{
@@ -89,7 +89,7 @@ const tailscalePrefsWithSshJson = `{
 }
 `;
 
-const tailscaleStatusWithSingleIpJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.90.1.2"]}}`;
+const tailscaleStatusWithSingleIpJson = `{"BackendState":"Running","Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.90.1.2"]}}`;
 
 function mockHandle(result: { stdout?: string; stderr?: string; code?: number }) {
   return ChildProcessSpawner.makeHandle({
@@ -173,7 +173,13 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.100.100.100"],
+        running: true,
       });
+      const stopped = yield* parseTailscaleStatus(
+        '{"BackendState":"Stopped","Self":{"DNSName":"desktop.tail.ts.net."}}',
+      );
+      assert.equal(stopped.running, false);
+      assert.equal(stopped.magicDnsName, "desktop.tail.ts.net");
     }),
   );
 
@@ -215,6 +221,7 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.90.1.2"],
+        running: true,
       });
     });
   });

--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -16,7 +16,9 @@ import {
   ensureTailscaleServe,
   isTailscaleIpv4Address,
   parseTailscaleMagicDnsName,
+  parseTailscaleSshEnabled,
   parseTailscaleStatus,
+  readTailscaleSshEnabled,
   readTailscaleStatus,
   TAILSCALE_STATUS_TIMEOUT,
   TailscaleCommandExitError,
@@ -65,6 +67,28 @@ function assertCarriesNoSecret(error: object, secret: string): void {
   walk(error, "error");
 }
 const tailscaleStatusJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100","fd7a:115c:a1e0::1","192.168.1.20"]}}`;
+// Real `tailscale debug prefs` output (trimmed), as printed by tailscale 1.94 on a node
+// brought up with `tailscale up --ssh`.
+const tailscalePrefsWithSshJson = `{
+	"ControlURL": "https://controlplane.tailscale.com",
+	"RouteAll": true,
+	"ExitNodeID": "",
+	"CorpDNS": true,
+	"RunSSH": true,
+	"RunWebClient": false,
+	"WantRunning": true,
+	"LoggedOut": false,
+	"ShieldsUp": false,
+	"Hostname": "",
+	"NoSNAT": false,
+	"NetfilterMode": 0,
+	"AutoUpdate": {
+		"Check": true,
+		"Apply": true
+	}
+}
+`;
+
 const tailscaleStatusWithSingleIpJson = `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.90.1.2"]}}`;
 
 function mockHandle(result: { stdout?: string; stderr?: string; code?: number }) {
@@ -149,14 +173,7 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.100.100.100"],
-        sshEnabled: false,
       });
-      const sshStatus = yield* parseTailscaleStatus(
-        '{"Self":{"DNSName":"box.tail.ts.net.","SSH_HostKeys":["ssh-ed25519 AAAA"]}}',
-      );
-      assert.equal(sshStatus.sshEnabled, true);
-      const noKeys = yield* parseTailscaleStatus('{"Self":{"SSH_HostKeys":[]}}');
-      assert.equal(noKeys.sshEnabled, false);
     }),
   );
 
@@ -198,8 +215,23 @@ describe("tailscale", () => {
       assert.deepEqual(status, {
         magicDnsName: "desktop.tail.ts.net",
         tailnetIpv4Addresses: ["100.90.1.2"],
-        sshEnabled: false,
       });
+    });
+  });
+
+  it.effect("reads SSH enablement from the local prefs", () => {
+    const layer = mockSpawnerLayer((command, args) => {
+      assert.equal(command, "tailscale");
+      assert.deepEqual(args, ["debug", "prefs"]);
+      return { stdout: tailscalePrefsWithSshJson };
+    });
+
+    return Effect.gen(function* () {
+      assert.equal(yield* readTailscaleSshEnabled.pipe(Effect.provide(layer)), true);
+      assert.equal(yield* parseTailscaleSshEnabled('{"RunSSH":false,"WantRunning":true}'), false);
+      assert.equal(yield* parseTailscaleSshEnabled("{}"), false);
+      const error = yield* parseTailscaleSshEnabled("{not-json").pipe(Effect.flip);
+      assert.instanceOf(error, TailscaleStatusParseError);
     });
   });
 

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -131,6 +131,7 @@ export class TailscaleStatusParseError extends Schema.TaggedError<TailscaleStatu
 const TailscaleStatusSelf = Schema.Struct({
   DNSName: Schema.optional(Schema.Unknown),
   TailscaleIPs: Schema.optional(Schema.Unknown),
+  SSH_HostKeys: Schema.optional(Schema.Unknown),
 });
 
 const TailscaleStatusJson = Schema.Struct({
@@ -142,6 +143,8 @@ export type TailscaleStatusJson = typeof TailscaleStatusJson.Type;
 export interface TailscaleStatus {
   readonly magicDnsName: string | null;
   readonly tailnetIpv4Addresses: readonly string[];
+  /** Tailscale SSH is serving on this node: it advertises SSH host keys. */
+  readonly sshEnabled: boolean;
 }
 
 const collectStdout = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -209,9 +212,14 @@ export const parseTailscaleStatus = (
         }
       }
 
+      const rawHostKeys = parsed.Self?.SSH_HostKeys;
+      const sshEnabled =
+        Array.isArray(rawHostKeys) && rawHostKeys.some((key) => typeof key === "string" && key);
+
       return {
         magicDnsName: normalizeMagicDnsName(parsed),
         tailnetIpv4Addresses,
+        sshEnabled,
       };
     }),
   );

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -19,7 +19,7 @@ const tailscaleCommandForPlatform = (platform: NodeJS.Platform): "tailscale" | "
 
 const TailscaleCommandContext = {
   executable: Schema.Literals(["tailscale", "tailscale.exe"]),
-  subcommand: Schema.Literals(["status", "serve"]),
+  subcommand: Schema.Literals(["status", "serve", "debug"]),
   argumentCount: Schema.Number,
 };
 
@@ -131,7 +131,6 @@ export class TailscaleStatusParseError extends Schema.TaggedError<TailscaleStatu
 const TailscaleStatusSelf = Schema.Struct({
   DNSName: Schema.optional(Schema.Unknown),
   TailscaleIPs: Schema.optional(Schema.Unknown),
-  SSH_HostKeys: Schema.optional(Schema.Unknown),
 });
 
 const TailscaleStatusJson = Schema.Struct({
@@ -143,8 +142,6 @@ export type TailscaleStatusJson = typeof TailscaleStatusJson.Type;
 export interface TailscaleStatus {
   readonly magicDnsName: string | null;
   readonly tailnetIpv4Addresses: readonly string[];
-  /** Tailscale SSH is serving on this node: it advertises SSH host keys. */
-  readonly sshEnabled: boolean;
 }
 
 const collectStdout = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -212,75 +209,97 @@ export const parseTailscaleStatus = (
         }
       }
 
-      const rawHostKeys = parsed.Self?.SSH_HostKeys;
-      const sshEnabled =
-        Array.isArray(rawHostKeys) && rawHostKeys.some((key) => typeof key === "string" && key);
-
       return {
         magicDnsName: normalizeMagicDnsName(parsed),
         tailnetIpv4Addresses,
-        sshEnabled,
       };
     }),
   );
 
-export const readTailscaleStatus = Effect.gen(function* () {
-  const args = ["status", "--json"];
-  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const hostPlatform = yield* HostProcessPlatform;
-  const executable = tailscaleCommandForPlatform(hostPlatform);
-  const commandContext = {
-    executable,
-    subcommand: "status" as const,
-    argumentCount: args.length,
-  };
-  return yield* Effect.gen(function* () {
-    const child = yield* spawner.spawn(ChildProcess.make(executable, args)).pipe(
-      Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
-      // Spawning can also fail as a defect rather than a typed error - a
-      // non-directory entry on PATH makes node throw ENOTDIR synchronously.
-      // `mapError` never sees that, so it would escape as an uncaught error.
-      Effect.catchDefect((cause) =>
-        Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
-      ),
-    );
-    const [stdout, stderr, exitCode] = yield* Effect.all(
-      [
-        collectStdout(child.stdout),
-        collectStderr(child.stderr),
-        child.exitCode.pipe(Effect.map(Number)),
-      ],
-      { concurrency: "unbounded" },
-    ).pipe(
-      Effect.mapError((cause) => new TailscaleCommandOutputError({ ...commandContext, cause })),
-    );
-    if (exitCode !== 0) {
-      return yield* new TailscaleCommandExitError({
-        ...commandContext,
-        exitCode,
-        stdoutLength: stdout.length,
-        stderrLength: stderr.length,
-        ...(stderrDiagnosticOf(stderr) !== undefined
-          ? { stderrDiagnostic: stderrDiagnosticOf(stderr) }
-          : {}),
-      });
-    }
-    return yield* parseTailscaleStatus(stdout);
-  }).pipe(
-    Effect.scoped,
-    Effect.timeout(TAILSCALE_STATUS_TIMEOUT),
-    Effect.catchTags({
-      TimeoutError: (cause) =>
-        Effect.fail(
-          new TailscaleCommandTimeoutError({
-            ...commandContext,
-            timeoutMs: Duration.toMillis(TAILSCALE_STATUS_TIMEOUT),
-            cause,
-          }),
+const readTailscaleCommandOutput = (subcommand: "status" | "debug", args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const hostPlatform = yield* HostProcessPlatform;
+    const executable = tailscaleCommandForPlatform(hostPlatform);
+    const commandContext = {
+      executable,
+      subcommand,
+      argumentCount: args.length,
+    };
+    return yield* Effect.gen(function* () {
+      const child = yield* spawner.spawn(ChildProcess.make(executable, [...args])).pipe(
+        Effect.mapError((cause) => new TailscaleCommandSpawnError({ ...commandContext, cause })),
+        // Spawning can also fail as a defect rather than a typed error - a
+        // non-directory entry on PATH makes node throw ENOTDIR synchronously.
+        // `mapError` never sees that, so it would escape as an uncaught error.
+        Effect.catchDefect((cause) =>
+          Effect.fail(new TailscaleCommandSpawnError({ ...commandContext, cause })),
         ),
-    }),
-  );
+      );
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          collectStdout(child.stdout),
+          collectStderr(child.stderr),
+          child.exitCode.pipe(Effect.map(Number)),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(
+        Effect.mapError((cause) => new TailscaleCommandOutputError({ ...commandContext, cause })),
+      );
+      if (exitCode !== 0) {
+        return yield* new TailscaleCommandExitError({
+          ...commandContext,
+          exitCode,
+          stdoutLength: stdout.length,
+          stderrLength: stderr.length,
+          ...(stderrDiagnosticOf(stderr) !== undefined
+            ? { stderrDiagnostic: stderrDiagnosticOf(stderr) }
+            : {}),
+        });
+      }
+      return stdout;
+    }).pipe(
+      Effect.scoped,
+      Effect.timeout(TAILSCALE_STATUS_TIMEOUT),
+      Effect.catchTags({
+        TimeoutError: (cause) =>
+          Effect.fail(
+            new TailscaleCommandTimeoutError({
+              ...commandContext,
+              timeoutMs: Duration.toMillis(TAILSCALE_STATUS_TIMEOUT),
+              cause,
+            }),
+          ),
+      }),
+    );
+  });
+
+export const readTailscaleStatus = readTailscaleCommandOutput("status", ["status", "--json"]).pipe(
+  Effect.flatMap(parseTailscaleStatus),
+);
+
+const TailscalePrefsJson = Schema.Struct({
+  RunSSH: Schema.optional(Schema.Unknown),
 });
+
+const decodeTailscalePrefsJson = Schema.decodeEffect(Schema.fromJsonString(TailscalePrefsJson));
+
+/** Whether the local node serves Tailscale SSH (`tailscale up --ssh`), from its prefs. */
+export const parseTailscaleSshEnabled = (
+  rawPrefsJson: string,
+): Effect.Effect<boolean, TailscaleStatusParseError> =>
+  decodeTailscalePrefsJson(rawPrefsJson).pipe(
+    Effect.mapError((cause) => new TailscaleStatusParseError({ cause })),
+    Effect.map((parsed) => parsed.RunSSH === true),
+  );
+
+/**
+ * `tailscale status --json` does not report the local node's own SSH host
+ * keys, so SSH enablement comes from the local prefs instead.
+ */
+export const readTailscaleSshEnabled = readTailscaleCommandOutput("debug", ["debug", "prefs"]).pipe(
+  Effect.flatMap(parseTailscaleSshEnabled),
+);
 
 export function buildTailscaleHttpsBaseUrl(input: {
   readonly magicDnsName: string;

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -134,6 +134,7 @@ const TailscaleStatusSelf = Schema.Struct({
 });
 
 const TailscaleStatusJson = Schema.Struct({
+  BackendState: Schema.optional(Schema.Unknown),
   Self: Schema.optional(TailscaleStatusSelf),
 });
 
@@ -142,6 +143,8 @@ export type TailscaleStatusJson = typeof TailscaleStatusJson.Type;
 export interface TailscaleStatus {
   readonly magicDnsName: string | null;
   readonly tailnetIpv4Addresses: readonly string[];
+  /** The daemon is up and connected; `tailscale down` keeps the name but reports Stopped. */
+  readonly running: boolean;
 }
 
 const collectStdout = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
@@ -212,6 +215,7 @@ export const parseTailscaleStatus = (
       return {
         magicDnsName: normalizeMagicDnsName(parsed),
         tailnetIpv4Addresses,
+        running: parsed.BackendState === "Running",
       };
     }),
   );


### PR DESCRIPTION
"Open in editor" advertises the SSH hosts the environment can be reached on, but the server bails out with an empty list when nothing listens on localhost port 22. A host that runs Tailscale SSH has no local sshd at all, so the menu shows "No SSH route" even though `ssh <tailnet-name>` works from the viewer's machine.

This follows the split-gate direction from the triage on #11052. `tailscale status --json` does not report the local node's own SSH host keys (the `Self` entry never carries `sshHostKeys`), so enablement comes from the local prefs: `tailscale debug prefs` reports `RunSSH`, the switch `tailscale up --ssh` flips. `@t3tools/tailscale` gains `readTailscaleSshEnabled` on the same command runner as `readTailscaleStatus`, and `RemoteOpenTargets` consults it only when no loopback sshd answers. The tailnet name is advertised when either a local sshd or Tailscale SSH is serving; a running tailscaled alone (`--tailscale-serve`) still advertises nothing. The mDNS name still requires a local sshd, since Tailscale SSH only answers on the tailnet address. `readTailscaleStatus` also reports `running` from `BackendState`, and the tailnet name is only advertised while the daemon is Running: after `tailscale down` the status still carries the node name but nothing answers on it. The existing test that expects `[]` with Tailscale up but no SSH anywhere is unchanged.

## Verification

- `RemoteOpenTargets.test.ts`: the spawner now answers `status --json` and `debug prefs` separately. No loopback sshd plus `RunSSH: true` yields the tailnet target alone; `RunSSH: true` with tailscale down or with `BackendState: "Stopped"` yields nothing (a stopped daemon plus a local sshd still yields the mDNS name only); the existing no-sshd and ordering cases are unchanged. The prefs fixtures are the real `tailscale debug prefs` shape (trimmed) from tailscale 1.94.
- `tailscale.test.ts`: `readTailscaleSshEnabled` runs `tailscale debug prefs` and decodes `RunSSH`; missing or false reads as disabled, malformed JSON is a parse error.
- `vp test run` on both files (23 tests), plus typecheck and lint for `packages/tailscale`, `apps/server` and `apps/desktop` (the other `readTailscaleStatus` consumers).

Fixes #11052. Implemented with Claude Code (Claude Fable 5.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote target discovery when local SSH, Tailscale SSH, or mDNS availability changes.
  - Tailscale targets are now advertised only when the daemon is running, a MagicDNS name is available, and an appropriate SSH service is enabled.
  - Prevented stopped Tailscale devices from appearing as available targets.
  - mDNS targets are now shown only when the local SSH service is listening.
  - Improved handling of Tailscale SSH settings and daemon status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->