### PR TITLE
fix(server): raise the macOS service open-file limit above the launchd default

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -83,6 +83,14 @@ it("restarts the launch agent on the systemd cadence", () => {
   expect(plist).toContain("<key>ExitTimeOut</key>\n  <integer>90</integer>");
 });
 
+it("raises the launch agent's open-file limit above the 256 launchd default", () => {
+  const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
+
+  expect(plist).toContain(
+    "<key>SoftResourceLimits</key>\n  <dict>\n    <key>NumberOfFiles</key>\n    <integer>16384</integer>\n  </dict>",
+  );
+});
+
 it("appends both stdio streams to the boot service log", () => {
   const plist = BootService.renderBootServicePlist(macPlan, macRenderOptions);
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -98,6 +98,8 @@ function escapeXmlText(value: string): string {
   return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
+const BOOT_SERVICE_MAX_OPEN_FILES = 16_384;
+
 /** Pure renderer: launch agents cannot rely on the user's shell or PATH. */
 export function renderBootServicePlist(
   plan: BootServicePlan,
@@ -111,6 +113,8 @@ export function renderBootServicePlist(
   // system-defined default (5s on current macOS) would SIGKILL the launcher
   // (and, with it, the process group) mid-handoff.
   // ProcessType Interactive opts out of background-job resource throttling.
+  // launchd jobs inherit the 256 soft maxfiles default, which the server's
+  // user-data and workspace watchers exhaust (EMFILE) on a normal profile.
   // AbandonProcessGroup stays at its default (false): launchd reaps leftover
   // process-group members only when the launcher itself exits — the analog of
   // KillMode=mixed's final cgroup kill — and not when the launcher restarts its
@@ -148,6 +152,11 @@ export function renderBootServicePlist(
     `  <integer>90</integer>`,
     `  <key>ProcessType</key>`,
     `  <string>Interactive</string>`,
+    `  <key>SoftResourceLimits</key>`,
+    `  <dict>`,
+    `    <key>NumberOfFiles</key>`,
+    `    <integer>${BOOT_SERVICE_MAX_OPEN_FILES}</integer>`,
+    `  </dict>`,
     `  <key>StandardOutPath</key>`,
     `  <string>${escapeXmlText(plan.logPath)}</string>`,
     `  <key>StandardErrorPath</key>`,


### PR DESCRIPTION
The generated `com.t3tools.t3code.service` LaunchAgent sets no resource limits, so the server inherits launchd's 256 soft `maxfiles`. The user-data and workspace watchers can exhaust that on a normal profile, and startup logs `EMFILE: too many open files, watch` while the service keeps running with a watcher missing. `service update` recreates the plist, so a manual edit does not survive a repair.

The plist now carries `SoftResourceLimits.NumberOfFiles` of 16384. The hard limit stays at launchd's default (unlimited for user agents), so raising the soft limit needs no privilege. The systemd unit is unchanged: user units already get systemd's own file-descriptor defaults.

## Verification

- `bootService.test.ts` asserts the rendered plist carries the limit; `vp test run apps/server/src/cloud/bootService.test.ts`: 33 tests pass.
- Server typecheck and lint on the touched files are clean.

Fixes #11055. Implemented with Claude Code (Claude Fable 5.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the macOS launch agent’s soft open-file limit to 16,384, reducing the likelihood of file descriptor exhaustion during service operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->