### PR TITLE
fix(mobile): restore Android composer skill pills

### DIFF
--- a/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
+++ b/apps/mobile/modules/t3-composer-editor/android/src/main/java/expo/modules/t3composereditor/T3ComposerEditorView.kt
@@ -18,6 +18,7 @@ import android.view.Gravity
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
+import androidx.core.graphics.PathParser
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
@@ -416,8 +417,25 @@ private class ComposerChipSpan(
 ) : ReplacementSpan() {
   private val horizontalPadding = 7f * density
   private val verticalPadding = 2f * density
-  private val cornerRadius = 6f * density
+  private val cornerRadius = 8f * density
   private val borderWidth = density
+  private val iconPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+    style = Paint.Style.STROKE
+    strokeWidth = 1.85f
+    strokeCap = Paint.Cap.ROUND
+    strokeJoin = Paint.Join.ROUND
+  }
+
+  private fun iconWidth(paint: Paint): Float =
+    if (skill) paint.textSize * (1.17f + 0.33f) else 0f
+
+  companion object {
+    // Same 24-unit cube path as the desktop composer skill chip.
+    private val skillIcon = requireNotNull(PathParser.createPathFromPathData(
+      "M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z " +
+        "M3.3 7l8.7 5 8.7-5 M12 22V12"
+    ))
+  }
 
   override fun getSize(
     paint: Paint,
@@ -434,7 +452,7 @@ private class ComposerChipSpan(
       it.descent = base.descent + extra
       it.bottom = base.bottom + extra
     }
-    return (paint.measureText(label) + horizontalPadding * 2).toInt()
+    return (paint.measureText(label) + iconWidth(paint) + horizontalPadding * 2).toInt()
   }
 
   override fun draw(
@@ -448,7 +466,8 @@ private class ComposerChipSpan(
     bottom: Int,
     paint: Paint
   ) {
-    val width = paint.measureText(label) + horizontalPadding * 2
+    val iconWidth = iconWidth(paint)
+    val width = paint.measureText(label) + iconWidth + horizontalPadding * 2
     val metrics = paint.fontMetrics
     val rect = RectF(
       x,
@@ -469,7 +488,17 @@ private class ComposerChipSpan(
     canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint)
     paint.color = if (skill) theme.skillText else theme.chipText
     paint.style = Paint.Style.FILL
-    canvas.drawText(label, x + horizontalPadding, y.toFloat(), paint)
+    if (skill) {
+      val iconSize = paint.textSize * 1.17f
+      iconPaint.color = theme.skillText
+      iconPaint.alpha = (Color.alpha(theme.skillText) * 0.85f).toInt()
+      val saveCount = canvas.save()
+      canvas.translate(x + horizontalPadding, rect.centerY() - iconSize / 2)
+      canvas.scale(iconSize / 24f, iconSize / 24f)
+      canvas.drawPath(skillIcon, iconPaint)
+      canvas.restoreToCount(saveCount)
+    }
+    canvas.drawText(label, x + horizontalPadding + iconWidth, y.toFloat(), paint)
 
     paint.color = originalColor
     paint.style = originalStyle

--- a/apps/mobile/src/native/T3ComposerEditor.native.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.native.tsx
@@ -10,8 +10,8 @@ import {
   useState,
   type Ref,
 } from "react";
-import type { NativeSyntheticEvent, ViewProps } from "react-native";
-import { Image, StyleSheet } from "react-native";
+import type { ColorValue, NativeSyntheticEvent, ViewProps } from "react-native";
+import { Image, Platform, processColor, StyleSheet } from "react-native";
 
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownFileIcon } from "@t3tools/mobile-markdown-text/links";
@@ -78,6 +78,15 @@ interface NativeComposerEditorProps extends ViewProps {
 }
 
 const NativeView = requireNativeView<NativeComposerEditorProps>(NATIVE_MODULE_NAME);
+
+// The native editor accepts CSS hex; processColor returns Android's AARRGGBB.
+function composerThemeColor(color: ColorValue): string {
+  if (Platform.OS !== "android") return String(color);
+  const processed = processColor(color);
+  return typeof processed === "number"
+    ? `#${(((processed << 8) | (processed >>> 24)) >>> 0).toString(16).padStart(8, "0")}`
+    : String(color);
+}
 
 function basename(path: string): string {
   const separator = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
@@ -215,15 +224,15 @@ export function ComposerEditor({
   const { systemColorsActive } = useAppearancePreferences();
   const themeJson = JSON.stringify({
     selection: systemColorsActive ? theme["--color-primary"] : null,
-    text: theme["--color-foreground"],
-    placeholder: theme["--color-placeholder"],
-    chipBackground: theme["--color-subtle"],
-    chipBorder: theme["--color-border"],
-    chipText: theme["--color-foreground"],
-    skillBackground: theme["--color-inline-skill-background"],
-    skillBorder: theme["--color-inline-skill-border"],
-    skillText: theme["--color-inline-skill-foreground"],
-    fileTint: theme["--color-icon-muted"],
+    text: composerThemeColor(theme["--color-foreground"]),
+    placeholder: composerThemeColor(theme["--color-placeholder"]),
+    chipBackground: composerThemeColor(theme["--color-subtle"]),
+    chipBorder: composerThemeColor(theme["--color-border"]),
+    chipText: composerThemeColor(theme["--color-foreground"]),
+    skillBackground: composerThemeColor(theme["--color-inline-skill-background"]),
+    skillBorder: composerThemeColor(theme["--color-inline-skill-border"]),
+    skillText: composerThemeColor(theme["--color-inline-skill-foreground"]),
+    fileTint: composerThemeColor(theme["--color-icon-muted"]),
   });
   const resolvedTextStyle = StyleSheet.flatten(textStyle) ?? {};
   const regularFontFamily = useFontFamily("regular");


### PR DESCRIPTION
## What Changed

**Android only.** Restore the intended theme colors and cube icon for inline composer skill pills, and increase the native composer chip corner radius from 6dp to 8dp. The iOS wrapper and Swift renderer are unchanged; web and desktop are unchanged.

Normalize CSS theme colors with React Native's `processColor` before sending them to the Android editor. Serialize them as `#RRGGBBAA`, matching the native parser introduced in #10691. Draw the existing desktop cube path beside skill labels and reserve its width in the text span.

## Why

Selecting a skill on Android can produce pale text on a pale fallback background, without the cube icon shown on desktop. The native color parser accepts hex but not the theme's `rgba(...)` strings, so the background and border silently fall back instead of using the selected theme.

Related: #7525 and the unmerged #7527 address the same color bug. This uses React Native's color processor instead of adding a CSS parser in Kotlin. #10397 changes contrast/popup styling, while #10368 replaces chip rendering as part of broader context support. This is a focused fix for the existing editor; it does not change the glass backgrounds fixed in #10998.

## UI Changes

Android phone screenshots supplied by the contributor, captured before rebasing onto current upstream. The captures use different provider/skill display labels; those differences are not introduced by this PR.

| Before | After |
| --- | --- |
| <img width="540" alt="Before: pale Android skill pill without a cube icon" src="https://github.com/user-attachments/assets/8c00294b-d706-4a62-a0a0-0971b758d608" /> | <img width="540" alt="After: purple Android skill pill with cube icon and rounder corners" src="https://github.com/user-attachments/assets/4e503754-bf94-4b9a-b9e4-276635e68dbe" /> |

## Validation

- Mobile typecheck, changed-file formatting, and `git diff --check` passed.
- Targeted TypeScript lint: no errors; nine existing React warnings also present in the upstream source.
- Disposable check using the installed React Native `processColor`: eight cases passed, covering translucent skill background/border, opaque colors, eight-digit hex, shorthand hex, named colors, and transparency, including native-parser byte order.
- No native rebuild or device run of the rebased head. Kotlin lint tools were unavailable locally. No iOS runtime verification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] No animation/interaction changes requiring a video

Implemented with GPT-5.6 Sol; prepared for upstream with GPT-6 in the Codex harness.
