### PR TITLE
fix(server): pin background service to a stable Node path

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -108,6 +108,8 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
   platform: NodeJS.Platform = "linux",
   usePinnedLauncher = false,
   installerPath = macInstallerPath,
+  execPath = "/usr/bin/node",
+  argv0?: string,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -187,7 +189,8 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       logsDir: path.join(baseDir, "userdata", "logs"),
       cliVersion: "1.2.3",
       host: {
-        execPath: "/usr/bin/node",
+        execPath,
+        ...(argv0 === undefined ? {} : { argv0 }),
         ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
       },
     }).pipe(
@@ -196,8 +199,8 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
         Layer.mergeAll(
           Layer.succeed(HostProcessPlatform, platform),
           Layer.succeed(HostProcessUserId, 501),
-          Layer.succeed(HostProcessExecutablePath, "/usr/bin/node"),
-          Layer.succeed(HostProcessArguments, ["/usr/bin/node", path.join(home, "bin.mjs")]),
+          Layer.succeed(HostProcessExecutablePath, execPath),
+          Layer.succeed(HostProcessArguments, [execPath, path.join(home, "bin.mjs")]),
           ConfigProvider.layer(
             ConfigProvider.fromEnv({
               env: { HOME: home, ...(environmentPath === "" ? {} : { PATH: environmentPath }) },
@@ -628,6 +631,61 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
         "    <key>PATH</key>\n    <string>/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin:/usr/sbin:/sbin</string>",
       );
       expect(plist).not.toContain("\u0001");
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("writes a Homebrew prefix shim instead of a Cellar keg on macOS", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness(
+        "darwin",
+        false,
+        macInstallerPath,
+        "/opt/homebrew/Cellar/node/26.8.1/bin/node",
+      );
+      const plan = yield* service.install();
+      const plist = yield* fs.readFileString(plan.unitPath);
+
+      expect(plan.nodePath).toBe("/opt/homebrew/bin/node");
+      expect(plist).toContain("<string>/opt/homebrew/bin/node</string>");
+      expect(plist).not.toContain("Cellar");
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("writes a linuxbrew prefix shim instead of a Cellar keg", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness(
+        "linux",
+        false,
+        "/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin",
+        "/home/linuxbrew/.linuxbrew/Cellar/node/24.4.0/bin/node",
+      );
+      const plan = yield* service.install();
+      const unit = yield* fs.readFileString(plan.unitPath);
+
+      expect(plan.nodePath).toBe("/home/linuxbrew/.linuxbrew/bin/node");
+      expect(unit).toContain("ExecStart=/home/linuxbrew/.linuxbrew/bin/node ");
+      expect(unit).not.toContain("Cellar");
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
+  it.effect("keeps a non-keg argv0 when Homebrew Node was invoked through opt", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness(
+        "darwin",
+        false,
+        macInstallerPath,
+        "/opt/homebrew/Cellar/node@22/22.14.0/bin/node",
+        "/opt/homebrew/opt/node@22/bin/node",
+      );
+      const plan = yield* service.install();
+      const plist = yield* fs.readFileString(plan.unitPath);
+
+      expect(plan.nodePath).toBe("/opt/homebrew/opt/node@22/bin/node");
+      expect(plist).toContain("<string>/opt/homebrew/opt/node@22/bin/node</string>");
+      expect(plist).not.toContain("Cellar");
       expect((yield* service.status).current).toBe(true);
     }),
   );

--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -690,6 +690,26 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
     }),
   );
 
+  it.effect("writes a keg-only node@ Cellar path to Homebrew opt when argv0 is bare node", () =>
+    Effect.gen(function* () {
+      const { service, fs } = yield* makeHarness(
+        "darwin",
+        false,
+        macInstallerPath,
+        "/opt/homebrew/Cellar/node@22/22.14.0/bin/node",
+        "node",
+      );
+      const plan = yield* service.install();
+      const plist = yield* fs.readFileString(plan.unitPath);
+
+      expect(plan.nodePath).toBe("/opt/homebrew/opt/node@22/bin/node");
+      expect(plist).toContain("<string>/opt/homebrew/opt/node@22/bin/node</string>");
+      expect(plist).not.toContain("/opt/homebrew/bin/node");
+      expect(plist).not.toContain("Cellar");
+      expect((yield* service.status).current).toBe(true);
+    }),
+  );
+
   it.effect("ignores a bootout for an agent that is not loaded", () =>
     Effect.gen(function* () {
       const { service, control } = yield* makeHarness("darwin");

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -495,7 +495,7 @@ export class BootService extends Context.Service<
 
 export interface BootServiceHost {
   readonly execPath: string;
-  /** Original invocation path (`process.argv0`) when Node was started through a symlink. */
+  /** Original invocation path (`process.argv0`); kept only when it resolves to execPath. */
   readonly argv0?: string;
   readonly launcherSourcePath?: string;
 }

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -15,6 +15,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import * as ProcessRunner from "../processRunner.ts";
+import { stableNodeExecutablePath } from "../stableNodeExecutablePath.ts";
 import {
   ensurePinnedRuntimeInstalled,
   pinnedRuntimePaths,
@@ -494,6 +495,8 @@ export class BootService extends Context.Service<
 
 export interface BootServiceHost {
   readonly execPath: string;
+  /** Original invocation path (`process.argv0`) when Node was started through a symlink. */
+  readonly argv0?: string;
   readonly launcherSourcePath?: string;
 }
 
@@ -511,7 +514,8 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
-  const host = input.host ?? { execPath: hostExecPath };
+  const host = input.host ?? { execPath: hostExecPath, argv0: process.argv0 };
+  const nodePath = stableNodeExecutablePath(host.execPath, host.argv0);
   const xmlSafeInstallerDirectories = installerPath.split(":").filter(
     (directory) =>
       directory.length > 0 &&
@@ -523,7 +527,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const environmentPath = Array.from(
     new Set([
       ...xmlSafeInstallerDirectories,
-      path.dirname(host.execPath),
+      path.dirname(nodePath),
       "/opt/homebrew/bin",
       "/usr/local/bin",
       "/usr/bin",
@@ -568,7 +572,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       }),
     ).pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
   const plan: BootServicePlan = {
-    nodePath: host.execPath,
+    nodePath,
     launcherPath,
     baseDir: input.baseDir,
     logPath,

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -27,6 +27,7 @@ import {
   SERVICE_STOP_MARKER_FILE,
 } from "./cloud/serviceProtocol.ts";
 import { isEntrypoint } from "./entrypoint.ts";
+import { stableNodeExecutablePath } from "./stableNodeExecutablePath.ts";
 
 const HANDOFF_DELAY_MS = 2_000;
 const PREPARED_TIMEOUT_MS = 120_000;
@@ -402,10 +403,15 @@ export class Launcher {
       childVersion: version,
       ...(update === undefined ? {} : { update }),
     };
-    const child = NodeChildProcess.spawn(process.execPath, [paths.entryPath, "serve"], {
-      env: { ...process.env, [SERVICE_LAUNCHER_CONTEXT_ENV]: JSON.stringify(context) },
-      stdio: ["inherit", "inherit", "inherit", "ipc"],
-    });
+    // launchd following a symlink leaves process.execPath on the keg realpath.
+    const child = NodeChildProcess.spawn(
+      stableNodeExecutablePath(process.execPath, process.argv0),
+      [paths.entryPath, "serve"],
+      {
+        env: { ...process.env, [SERVICE_LAUNCHER_CONTEXT_ENV]: JSON.stringify(context) },
+        stdio: ["inherit", "inherit", "inherit", "ipc"],
+      },
+    );
     await new Promise<void>((resolve, reject) => {
       const onError = (error: Error) => reject(error);
       child.once("error", onError);

--- a/apps/server/src/stableNodeExecutablePath.test.ts
+++ b/apps/server/src/stableNodeExecutablePath.test.ts
@@ -1,4 +1,7 @@
 import { expect, it } from "@effect/vitest";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
 
 import { stableNodeExecutablePath } from "./stableNodeExecutablePath.ts";
 
@@ -14,24 +17,24 @@ it("rewrites a Homebrew Cellar keg to the prefix shim", () => {
   );
 });
 
+it("rewrites a keg-only node@ formula to the Homebrew opt path", () => {
+  expect(stableNodeExecutablePath("/opt/homebrew/Cellar/node@22/22.14.0/bin/node", "node")).toBe(
+    "/opt/homebrew/opt/node@22/bin/node",
+  );
+});
+
+it("keeps an unversioned Cellar rewrite when argv0 is bare node", () => {
+  expect(stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node", "node")).toBe(
+    "/opt/homebrew/bin/node",
+  );
+});
+
 it("keeps an already durable absolute path", () => {
   expect(stableNodeExecutablePath("/opt/homebrew/bin/node")).toBe("/opt/homebrew/bin/node");
   expect(stableNodeExecutablePath("/usr/bin/node")).toBe("/usr/bin/node");
   expect(stableNodeExecutablePath("/Users/theo/.nvm/versions/node/v22.16.0/bin/node")).toBe(
     "/Users/theo/.nvm/versions/node/v22.16.0/bin/node",
   );
-});
-
-it("prefers argv0 when it is already a non-keg absolute", () => {
-  expect(
-    stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node", "/opt/homebrew/bin/node"),
-  ).toBe("/opt/homebrew/bin/node");
-  expect(
-    stableNodeExecutablePath(
-      "/opt/homebrew/Cellar/node@22/22.14.0/bin/node",
-      "/opt/homebrew/opt/node@22/bin/node",
-    ),
-  ).toBe("/opt/homebrew/opt/node@22/bin/node");
 });
 
 it("ignores a relative or keg argv0 and still rewrites a Cellar execPath", () => {
@@ -44,4 +47,29 @@ it("ignores a relative or keg argv0 and still rewrites a Cellar execPath", () =>
       "/opt/homebrew/Cellar/node/26.8.1/bin/node",
     ),
   ).toBe("/opt/homebrew/bin/node");
+});
+
+it("ignores an absolute argv0 that does not resolve to execPath", () => {
+  expect(
+    stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node", "/tmp/not-node"),
+  ).toBe("/opt/homebrew/bin/node");
+});
+
+it("prefers argv0 when it is a non-keg absolute that resolves to execPath", () => {
+  const root = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-stable-node-"));
+  try {
+    const cellar = NodePath.join(root, "Cellar", "node", "26.8.1", "bin", "node");
+    const shim = NodePath.join(root, "bin", "node");
+    NodeFS.mkdirSync(NodePath.dirname(cellar), { recursive: true });
+    NodeFS.mkdirSync(NodePath.dirname(shim), { recursive: true });
+    NodeFS.writeFileSync(cellar, "");
+    NodeFS.chmodSync(cellar, 0o755);
+    NodeFS.symlinkSync(cellar, shim);
+
+    expect(stableNodeExecutablePath(cellar, shim)).toBe(shim);
+    expect(stableNodeExecutablePath(cellar, "/tmp/not-node")).toBe(shim);
+    expect(stableNodeExecutablePath(cellar, "/bin/sh")).toBe(shim);
+  } finally {
+    NodeFS.rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/apps/server/src/stableNodeExecutablePath.test.ts
+++ b/apps/server/src/stableNodeExecutablePath.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from "@effect/vitest";
+
+import { stableNodeExecutablePath } from "./stableNodeExecutablePath.ts";
+
+it("rewrites a Homebrew Cellar keg to the prefix shim", () => {
+  expect(stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node")).toBe(
+    "/opt/homebrew/bin/node",
+  );
+  expect(stableNodeExecutablePath("/usr/local/Cellar/node/22.14.0/bin/node")).toBe(
+    "/usr/local/bin/node",
+  );
+  expect(stableNodeExecutablePath("/home/linuxbrew/.linuxbrew/Cellar/node/24.4.0/bin/node")).toBe(
+    "/home/linuxbrew/.linuxbrew/bin/node",
+  );
+});
+
+it("keeps an already durable absolute path", () => {
+  expect(stableNodeExecutablePath("/opt/homebrew/bin/node")).toBe("/opt/homebrew/bin/node");
+  expect(stableNodeExecutablePath("/usr/bin/node")).toBe("/usr/bin/node");
+  expect(stableNodeExecutablePath("/Users/theo/.nvm/versions/node/v22.16.0/bin/node")).toBe(
+    "/Users/theo/.nvm/versions/node/v22.16.0/bin/node",
+  );
+});
+
+it("prefers argv0 when it is already a non-keg absolute", () => {
+  expect(
+    stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node", "/opt/homebrew/bin/node"),
+  ).toBe("/opt/homebrew/bin/node");
+  expect(
+    stableNodeExecutablePath(
+      "/opt/homebrew/Cellar/node@22/22.14.0/bin/node",
+      "/opt/homebrew/opt/node@22/bin/node",
+    ),
+  ).toBe("/opt/homebrew/opt/node@22/bin/node");
+});
+
+it("ignores a relative or keg argv0 and still rewrites a Cellar execPath", () => {
+  expect(stableNodeExecutablePath("/opt/homebrew/Cellar/node/26.8.1/bin/node", "node")).toBe(
+    "/opt/homebrew/bin/node",
+  );
+  expect(
+    stableNodeExecutablePath(
+      "/opt/homebrew/Cellar/node/26.8.1/bin/node",
+      "/opt/homebrew/Cellar/node/26.8.1/bin/node",
+    ),
+  ).toBe("/opt/homebrew/bin/node");
+});

--- a/apps/server/src/stableNodeExecutablePath.ts
+++ b/apps/server/src/stableNodeExecutablePath.ts
@@ -1,0 +1,32 @@
+/**
+ * Absolute Node to persist in a service unit or to spawn a managed runtime.
+ *
+ * launchd and systemd cannot search PATH, so the path must be absolute.
+ * `process.execPath` is the wrong absolute: Node realpaths Homebrew's prefix
+ * symlink into a Cellar keg (`/opt/homebrew/Cellar/node/<ver>/bin/node`) whose
+ * lifetime is one `brew upgrade`. Prefer the original invocation path when it
+ * is already a non-keg absolute (`process.argv0`, e.g. `/opt/homebrew/bin/node`
+ * or `/opt/homebrew/opt/node@22/bin/node`), otherwise rewrite a keg execPath to
+ * `$prefix/bin/<name>`.
+ */
+export function stableNodeExecutablePath(execPath: string, argv0?: string): string {
+  if (argv0 !== undefined && isDurableAbsoluteNodePath(argv0)) {
+    return argv0;
+  }
+  return homebrewPrefixBinPath(execPath) ?? execPath;
+}
+
+function isDurableAbsoluteNodePath(filePath: string): boolean {
+  return filePath.startsWith("/") && homebrewPrefixBinPath(filePath) === undefined;
+}
+
+/** `$prefix/Cellar|$Caskroom/$name/$version/bin/$exe` → `$prefix/bin/$exe`. */
+function homebrewPrefixBinPath(filePath: string): string | undefined {
+  const match = /^(.*)\/(?:cellar|caskroom)\/[^/]+\/[^/]+\/bin\/([^/]+)$/i.exec(
+    filePath.replaceAll("\\", "/"),
+  );
+  if (match === null) {
+    return undefined;
+  }
+  return `${match[1]}/bin/${match[2]}`;
+}

--- a/apps/server/src/stableNodeExecutablePath.ts
+++ b/apps/server/src/stableNodeExecutablePath.ts
@@ -1,32 +1,61 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+
 /**
  * Absolute Node to persist in a service unit or to spawn a managed runtime.
  *
  * launchd and systemd cannot search PATH, so the path must be absolute.
  * `process.execPath` is the wrong absolute: Node realpaths Homebrew's prefix
  * symlink into a Cellar keg (`/opt/homebrew/Cellar/node/<ver>/bin/node`) whose
- * lifetime is one `brew upgrade`. Prefer the original invocation path when it
- * is already a non-keg absolute (`process.argv0`, e.g. `/opt/homebrew/bin/node`
- * or `/opt/homebrew/opt/node@22/bin/node`), otherwise rewrite a keg execPath to
- * `$prefix/bin/<name>`.
+ * lifetime is one `brew upgrade`. Prefer `process.argv0` only when it is an
+ * absolute non-keg path that resolves to the same executable as execPath
+ * (`exec -a` can otherwise plant a nonexistent path in the unit). Otherwise
+ * rewrite a keg execPath: unversioned formulas to `$prefix/bin/<name>`,
+ * keg-only `node@*` to `$prefix/opt/<formula>/bin/<name>`.
  */
 export function stableNodeExecutablePath(execPath: string, argv0?: string): string {
-  if (argv0 !== undefined && isDurableAbsoluteNodePath(argv0)) {
+  if (argv0 !== undefined && isVerifiedDurableArgv0(argv0, execPath)) {
     return argv0;
   }
-  return homebrewPrefixBinPath(execPath) ?? execPath;
+  return homebrewStableBinPath(execPath) ?? execPath;
 }
 
-function isDurableAbsoluteNodePath(filePath: string): boolean {
-  return filePath.startsWith("/") && homebrewPrefixBinPath(filePath) === undefined;
+function isVerifiedDurableArgv0(argv0: string, execPath: string): boolean {
+  if (!argv0.startsWith("/") || homebrewStableBinPath(argv0) !== undefined) {
+    return false;
+  }
+  return argv0RefersToExecPath(argv0, execPath);
 }
 
-/** `$prefix/Cellar|$Caskroom/$name/$version/bin/$exe` → `$prefix/bin/$exe`. */
-function homebrewPrefixBinPath(filePath: string): string | undefined {
-  const match = /^(.*)\/(?:cellar|caskroom)\/[^/]+\/[^/]+\/bin\/([^/]+)$/i.exec(
+function argv0RefersToExecPath(argv0: string, execPath: string): boolean {
+  try {
+    const argvStat = NodeFS.statSync(argv0);
+    if (!argvStat.isFile() || (argvStat.mode & 0o111) === 0) {
+      return false;
+    }
+    const execStat = NodeFS.statSync(execPath);
+    if (argvStat.dev === execStat.dev && argvStat.ino === execStat.ino) {
+      return true;
+    }
+    return NodeFS.realpathSync(argv0) === NodeFS.realpathSync(execPath);
+  } catch {
+    return false;
+  }
+}
+
+/** `$prefix/Cellar|$Caskroom/$formula/$version/bin/$exe` → a prefix path that survives upgrades. */
+function homebrewStableBinPath(filePath: string): string | undefined {
+  const match = /^(.*)\/(?:cellar|caskroom)\/([^/]+)\/[^/]+\/bin\/([^/]+)$/i.exec(
     filePath.replaceAll("\\", "/"),
   );
   if (match === null) {
     return undefined;
   }
-  return `${match[1]}/bin/${match[2]}`;
+  const prefix = match[1]!;
+  const formula = match[2]!;
+  const executable = match[3]!;
+  if (/^node@/i.test(formula)) {
+    return `${prefix}/opt/${formula}/bin/${executable}`;
+  }
+  return `${prefix}/bin/${executable}`;
 }


### PR DESCRIPTION
## What Changed

`t3 service install` / `update` now persist a durable absolute Node path in launchd and systemd units instead of Homebrew's versioned Cellar realpath. The service launcher uses the same path when handing off managed runtimes, so a later `brew upgrade node` does not leave `ProgramArguments[0]` / `ExecStart` pointing at a deleted keg.

## Why

Homebrew's `/opt/homebrew/bin/node` is a symlink. Node realpaths `process.execPath` to `/opt/homebrew/Cellar/node/<version>/bin/node`. That keg disappears on upgrade even though the prefix shim still works. The renderer already requires an absolute Node (no `PATH` lookup); the bug was pinning the keg realpath.

When `process.argv0` is already a non-keg absolute (for example `/opt/homebrew/bin/node` or `/opt/homebrew/opt/node@22/bin/node`), that path is kept. Otherwise a Cellar/Caskroom execPath is rewritten to `$prefix/bin/<name>`. Distro and nvm paths are unchanged.

Fixes #11054

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service startup reliability for Node.js installations managed by Homebrew or Linuxbrew.
  - Preserved stable executable paths for keg-only and alternate Node.js installations.
  - Improved handling of symlinked Node.js launches and custom invocation paths.
  - Service-managed child processes now use the most reliable available Node.js executable path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->