### PR TITLE
feat(usage): mark the even-pace point on pooled limit bars

### DIFF
--- a/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsPooled.tsx
@@ -1,12 +1,14 @@
 import { useAtomValue } from "@effect/atom-react";
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, type ServerProviderUsageWindow } from "@t3tools/contracts";
 import {
   collectLimitAccounts,
   collectLimitNotices,
   collectLimitPools,
+  evenPacePercent,
   formatDuration,
   formatResetsIn,
+  paceGapLabel,
   remainingPercent,
   type LimitAccount,
   type LimitPoolWindow,
@@ -66,6 +68,38 @@ function AccountSegment({
   );
 }
 
+/**
+ * Where even spending would have left the fill, as a tick above and below the
+ * segment rather than a line across it: the segment clips its own fill, and a
+ * mark outside the bar reads without competing with the position number. The
+ * provider colour ties it to the fill it is measured against. Drawn only when
+ * the window reports a length and a reset; without both there is no timeframe
+ * to compare against.
+ *
+ * The tick is shorter than the room its wrapper reserves, and the difference is
+ * the gap that keeps it reading as a tick. Flush against the bar, the two run
+ * together into one line.
+ */
+function EvenPaceTicks({
+  window,
+  now,
+  color,
+}: {
+  readonly window: ServerProviderUsageWindow;
+  readonly now: number;
+  readonly color: string;
+}) {
+  const evenPace = evenPacePercent(window, now);
+  if (evenPace === null) return null;
+  const tick = { left: `${evenPace}%`, width: 1, height: 6, backgroundColor: color } as const;
+  return (
+    <View pointerEvents="none" className="absolute inset-0">
+      <View className="absolute top-0" style={tick} />
+      <View className="absolute bottom-0" style={tick} />
+    </View>
+  );
+}
+
 function PoolWindowCard({
   pool,
   color,
@@ -118,26 +152,31 @@ function PoolWindowCard({
       <View className="flex-row gap-1">
         {pool.columns.map(({ account, window }, index) => {
           if (!window) return <View key={account.key} className="h-7 min-w-0 flex-1" />;
+          const paceGap = paceGapLabel(window, now);
           return (
-            <Pressable
-              key={account.key}
-              accessibilityRole="button"
-              accessibilityLabel={`Segment ${index + 1}, ${accountName(account)}, ${remainingPercent(window)}% left`}
-              accessibilityHint="Show account details"
-              onPress={() => openAccount(account)}
-              className="h-7 min-w-0 flex-1 overflow-hidden rounded-md bg-subtle"
-            >
-              <AccountSegment
-                remaining={remainingPercent(window)}
-                color={color}
-                pending={Boolean(window.resetsAt)}
-              />
-              <View pointerEvents="none" className="absolute inset-0 items-center justify-center">
-                <Text className="text-xs font-t3-medium tabular-nums text-foreground">
-                  {index + 1}
-                </Text>
-              </View>
-            </Pressable>
+            // The wrapper reserves the ticks' room; the segment clips its fill, so they sit
+            // outside it. Centring keeps both gaps equal when the row stretches the wrapper.
+            <View key={account.key} className="relative min-w-0 flex-1 justify-center py-2.5">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Segment ${index + 1}, ${accountName(account)}, ${remainingPercent(window)}% left${paceGap ? `, ${paceGap}` : ""}`}
+                accessibilityHint="Show account details"
+                onPress={() => openAccount(account)}
+                className="h-7 overflow-hidden rounded-md bg-subtle"
+              >
+                <AccountSegment
+                  remaining={remainingPercent(window)}
+                  color={color}
+                  pending={Boolean(window.resetsAt)}
+                />
+                <View pointerEvents="none" className="absolute inset-0 items-center justify-center">
+                  <Text className="text-xs font-t3-medium tabular-nums text-foreground">
+                    {index + 1}
+                  </Text>
+                </View>
+              </Pressable>
+              <EvenPaceTicks window={window} now={now} color={color} />
+            </View>
           );
         })}
       </View>
@@ -336,6 +375,11 @@ export function UsageLimitAccountScreen({ route }: AccountScreenProps) {
                     dateStyle: "medium",
                     timeStyle: "short",
                   })}
+                </Text>
+              ) : null}
+              {evenPacePercent(window, now) !== null ? (
+                <Text className="text-sm text-foreground-muted">
+                  {evenPacePercent(window, now)}% at even pace · {paceGapLabel(window, now)}
                 </Text>
               ) : null}
               {reset && reset.restoresPercent > 0 ? (

--- a/apps/mobile/src/features/usage/UsageLimitsSection.tsx
+++ b/apps/mobile/src/features/usage/UsageLimitsSection.tsx
@@ -9,7 +9,7 @@ import type {
   UsageProviderKind,
 } from "@t3tools/contracts";
 import {
-  elapsedShare,
+  evenPacePercent,
   formatDuration,
   formatResetsIn,
   limitsNotice,
@@ -51,8 +51,7 @@ function WindowRow(props: {
 }) {
   const { window, now } = props;
   const remaining = remainingPercent(window);
-  const elapsed = elapsedShare(window, now);
-  const timeLeft = elapsed === null ? null : Math.round((1 - elapsed) * 100);
+  const timeLeft = evenPacePercent(window, now);
   const pace = paceOf(window, now);
   const resetsIn = formatResetsIn(window, now);
   return (

--- a/apps/web/src/components/usage/UsageLimits.tsx
+++ b/apps/web/src/components/usage/UsageLimits.tsx
@@ -9,7 +9,7 @@ import {
 } from "@t3tools/contracts";
 import { useAtomValue } from "@effect/atom-react";
 import {
-  elapsedShare,
+  evenPacePercent,
   formatDuration,
   formatResetsIn,
   type LimitPace,
@@ -89,9 +89,8 @@ function WindowBar({
 }) {
   const timestampFormat = usePrimarySettings((settings) => settings.timestampFormat);
   const remaining = remainingPercent(window);
-  const elapsed = elapsedShare(window, now);
   // The fill is quota left, so the even-spending mark is the time left.
-  const timeLeft = elapsed === null ? null : Math.round((1 - elapsed) * 100);
+  const timeLeft = evenPacePercent(window, now);
   const resetsIn = formatResetsIn(window, now);
   const resetsAt = window.resetsAt
     ? formatUpcomingTimestamp(window.resetsAt, timestampFormat, now)

--- a/apps/web/src/components/usage/UsageLimitsPooled.tsx
+++ b/apps/web/src/components/usage/UsageLimitsPooled.tsx
@@ -2,12 +2,14 @@ import {
   collectLimitAccounts,
   collectLimitNotices,
   collectLimitPools,
+  evenPacePercent,
   formatDuration,
   formatResetsIn,
   type LimitAccount,
   type LimitPool,
   type LimitPoolMember,
   type LimitPoolWindow,
+  paceGapLabel,
   remainingPercent,
 } from "@t3tools/shared/usageLimits";
 import { TicketIcon } from "lucide-react";
@@ -147,6 +149,7 @@ function SegmentPopover({
 }) {
   const timestampFormat = usePrimarySettings((settings) => settings.timestampFormat);
   const remaining = remainingPercent(window);
+  const evenPace = evenPacePercent(window, now);
   const resetsIn = formatResetsIn(window, now);
   const where =
     account.environments.length > 0
@@ -181,6 +184,11 @@ function SegmentPopover({
       </div>
       <div className="flex flex-col gap-1 border-t border-border/60 pt-2.5">
         <Row label="Left">{remaining}%</Row>
+        {evenPace !== null ? (
+          <Row label="Even pace">
+            {evenPace}% <span className="text-muted-foreground">· {paceGapLabel(window, now)}</span>
+          </Row>
+        ) : null}
         {window.resetsAt ? (
           <Row label="Resets">
             {formatUpcomingTimestamp(window.resetsAt, timestampFormat, now)}
@@ -212,6 +220,26 @@ function SegmentPopover({
 }
 
 /**
+ * Where even spending would have left the fill, as a tick above and below the
+ * segment rather than a line across it: the segment's own label runs the full
+ * width, and a mark outside the bar reads at a glance without competing with it.
+ * The provider colour ties it to the fill it is measured against.
+ *
+ * The tick is shorter than the room its wrapper reserves, and the difference is
+ * the gap that keeps it reading as a tick. Flush against the bar, the two run
+ * together into one line.
+ */
+function EvenPaceTicks({ at, color }: { readonly at: number; readonly color: string }) {
+  const tick = "absolute w-px -translate-x-1/2 h-1.5 @2xl/pool:h-2";
+  return (
+    <span aria-hidden className="pointer-events-none">
+      <span className={cn(tick, "top-0")} style={{ left: `${at}%`, backgroundColor: color }} />
+      <span className={cn(tick, "bottom-0")} style={{ left: `${at}%`, backgroundColor: color }} />
+    </span>
+  );
+}
+
+/**
  * One account's share of one pooled window: the segment, its popover, and the
  * reset confirm. The confirm is a sibling of the popover, not a child: dialogs
  * stack under popovers, and the popover closes as the confirm opens.
@@ -234,66 +262,81 @@ function PoolSegment({
 }) {
   const [open, setOpen] = useState(false);
   const remaining = remainingPercent(window);
+  const evenPace = evenPacePercent(window, now);
   const resetsIn = formatResetsIn(window, now);
   const credits = account.limits.resetCredits?.availableCount ?? 0;
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        openOnHover
-        render={
-          <button
-            type="button"
-            style={{ gridColumn: index, gridRow: 1 }}
-            aria-label={`${account.displayName ?? (account.email ? accountInitials(account.email) : account.driver)}: ${remaining}% left${resetsIn ? `, ${resetsIn}` : ""}${credits ? `, ${credits} reset ${credits === 1 ? "credit" : "credits"} banked` : ""}`}
-            className="relative h-5 min-w-0 cursor-pointer overflow-hidden rounded-md bg-muted text-start outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[popup-open]:ring-1 data-[popup-open]:ring-border @2xl/pool:h-8"
-          />
-        }
+      {/* The wrapper reserves the ticks' room and their gap; the segment clips its fill, so they
+          cannot live inside it. Centring the segment keeps both gaps equal whatever height the
+          grid row takes, and makes the button a flex item, which drops the baseline space an
+          inline-level button would otherwise add under it. */}
+      <div
+        className="relative flex min-w-0 flex-col justify-center py-2.5 @2xl/pool:py-3"
+        style={{ gridColumn: index, gridRow: 1 }}
       >
-        {/* Translucent so the label reads over the fill for any provider colour and theme. */}
-        <div
-          aria-hidden
-          className="absolute inset-y-0 left-0 rounded-md opacity-35"
-          style={{ width: `${remaining}%`, backgroundColor: color }}
-        />
-        {/* The spent share is hatched, not blank: it is what the countdown restores. */}
-        {remaining < 100 && reset ? (
+        <PopoverTrigger
+          openOnHover
+          render={
+            <button
+              type="button"
+              aria-label={`${account.displayName ?? (account.email ? accountInitials(account.email) : account.driver)}: ${remaining}% left${evenPace === null ? "" : `, ${evenPace}% at even pace`}${resetsIn ? `, ${resetsIn}` : ""}${credits ? `, ${credits} reset ${credits === 1 ? "credit" : "credits"} banked` : ""}`}
+              className="relative h-5 w-full min-w-0 shrink-0 cursor-pointer overflow-hidden rounded-md bg-muted text-start outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[popup-open]:ring-1 data-[popup-open]:ring-border @2xl/pool:h-8"
+            />
+          }
+        >
+          {/* Translucent so the label reads over the fill for any provider colour and theme. */}
           <div
             aria-hidden
-            className="absolute inset-y-0 right-0 opacity-20"
-            style={{
-              width: `${100 - remaining}%`,
-              backgroundImage: `repeating-linear-gradient(135deg, ${color} 0 1px, transparent 1px 5px)`,
-            }}
+            className="absolute inset-y-0 left-0 rounded-md opacity-35"
+            style={{ width: `${remaining}%`, backgroundColor: color }}
           />
-        ) : null}
-        <span
-          aria-hidden
-          className="absolute inset-0 flex items-center justify-center text-[10px] leading-none font-semibold text-foreground/80 tabular-nums @2xl/pool:hidden"
-        >
-          {index}
-        </span>
-        <div className="relative hidden h-full min-w-0 items-center gap-1.5 px-2 text-xs @2xl/pool:flex">
-          <AccountName account={account} className="min-w-0 truncate font-medium text-foreground" />
-          <span className="shrink-0 font-semibold text-foreground tabular-nums">{remaining}%</span>
-          {/* Countdown and badge get their own plate: fill and hatching run under them otherwise. */}
-          <span className="ms-auto flex shrink-0 items-center gap-1.5 rounded-sm bg-background/85 px-1.5 py-0.5 text-[11px] text-foreground tabular-nums">
-            {resetsIn?.replace("resets in ", "↻ ") ?? ""}
-            {credits ? (
-              <>
-                {resetsIn ? (
-                  <span aria-hidden className="text-muted-foreground">
-                    ·
-                  </span>
-                ) : null}
-                <span aria-hidden className="inline-flex items-center gap-0.5 font-semibold">
-                  <TicketIcon className="size-3" aria-hidden />
-                  {credits}
-                </span>
-              </>
-            ) : null}
+          {/* The spent share is hatched, not blank: it is what the countdown restores. */}
+          {remaining < 100 && reset ? (
+            <div
+              aria-hidden
+              className="absolute inset-y-0 right-0 opacity-20"
+              style={{
+                width: `${100 - remaining}%`,
+                backgroundImage: `repeating-linear-gradient(135deg, ${color} 0 1px, transparent 1px 5px)`,
+              }}
+            />
+          ) : null}
+          <span
+            aria-hidden
+            className="absolute inset-0 flex items-center justify-center text-[10px] leading-none font-semibold text-foreground/80 tabular-nums @2xl/pool:hidden"
+          >
+            {index}
           </span>
-        </div>
-      </PopoverTrigger>
+          <div className="relative hidden h-full min-w-0 items-center gap-1.5 px-2 text-xs @2xl/pool:flex">
+            <AccountName
+              account={account}
+              className="min-w-0 truncate font-medium text-foreground"
+            />
+            <span className="shrink-0 font-semibold text-foreground tabular-nums">
+              {remaining}%
+            </span>
+            {/* Countdown and badge get their own plate: fill and hatching run under them otherwise. */}
+            <span className="ms-auto flex shrink-0 items-center gap-1.5 rounded-sm bg-background/85 px-1.5 py-0.5 text-[11px] text-foreground tabular-nums">
+              {resetsIn?.replace("resets in ", "↻ ") ?? ""}
+              {credits ? (
+                <>
+                  {resetsIn ? (
+                    <span aria-hidden className="text-muted-foreground">
+                      ·
+                    </span>
+                  ) : null}
+                  <span aria-hidden className="inline-flex items-center gap-0.5 font-semibold">
+                    <TicketIcon className="size-3" aria-hidden />
+                    {credits}
+                  </span>
+                </>
+              ) : null}
+            </span>
+          </div>
+        </PopoverTrigger>
+        {evenPace !== null ? <EvenPaceTicks at={evenPace} color={color} /> : null}
+      </div>
       <LegendRow account={account} window={window} color={color} now={now} index={index} />
       {account.redeem ? (
         <RedeemableSegmentPopup

--- a/packages/shared/src/usageLimits.test.ts
+++ b/packages/shared/src/usageLimits.test.ts
@@ -20,8 +20,10 @@ import {
   collectLimitSources,
   collectLimitsGroups,
   elapsedShare,
+  evenPacePercent,
   formatResetsIn,
   limitsNotice,
+  paceGapLabel,
   paceOf,
   providersWithLimits,
   remainingPercent,
@@ -63,9 +65,18 @@ describe("pace", () => {
     expect(paceOf({ ...window, usedPercent: 80 }, now)).toBe("ahead");
   });
 
+  it("marks where even spending would have left the quota and how far off it is", () => {
+    expect(evenPacePercent(window, now)).toBe(40);
+    expect(paceGapLabel(window, now)).toBe("20 pts of headroom");
+    expect(paceGapLabel({ ...window, usedPercent: 60 }, now)).toBe("exactly on pace");
+    expect(paceGapLabel({ ...window, usedPercent: 85 }, now)).toBe("25 pts ahead of pace");
+  });
+
   it("has no pace without a reset or a duration", () => {
     expect(paceOf({ ...window, resetsAt: undefined }, now)).toBeNull();
     expect(paceOf({ ...window, windowDurationMins: undefined }, now)).toBeNull();
+    expect(evenPacePercent({ ...window, resetsAt: undefined }, now)).toBeNull();
+    expect(paceGapLabel({ ...window, windowDurationMins: undefined }, now)).toBeNull();
     expect(formatResetsIn({ ...window, resetsAt: undefined }, now)).toBeNull();
   });
 

--- a/packages/shared/src/usageLimits.ts
+++ b/packages/shared/src/usageLimits.ts
@@ -519,6 +519,30 @@ export function elapsedShare(window: ServerProviderUsageWindow, now: number): nu
   return Math.max(0, Math.min(1, (length - (resetsAt - now)) / length));
 }
 
+/**
+ * Where even spending would have left the bar: the share of quota still open
+ * when the window is drawn down in step with its clock, 0..100. Null when the
+ * window has no known length or reset: there is no timeframe to compare
+ * against, so there is nothing to mark.
+ */
+export function evenPacePercent(window: ServerProviderUsageWindow, now: number): number | null {
+  const elapsed = elapsedShare(window, now);
+  return elapsed === null ? null : Math.round((1 - elapsed) * 100);
+}
+
+/**
+ * Quota left against what even spending would have left, in points:
+ * `9 pts of headroom`, `4 pts ahead of pace`. Null when the window has no
+ * timeframe.
+ */
+export function paceGapLabel(window: ServerProviderUsageWindow, now: number): string | null {
+  const evenPace = evenPacePercent(window, now);
+  if (evenPace === null) return null;
+  const gap = remainingPercent(window) - evenPace;
+  if (gap === 0) return "exactly on pace";
+  return gap > 0 ? `${gap} pts of headroom` : `${-gap} pts ahead of pace`;
+}
+
 export type LimitPace = "ahead" | "on" | "under";
 
 /**


### PR DESCRIPTION
Discussion: pingdotgg/t3code#11120 — filed after this PR, per CONTRIBUTING. Treat this branch as the reference implementation for that idea; happy to close it if the direction is not wanted.

## The problem

Usage → Limits tells you how much quota is left, but not whether that is a lot or a little for the time still to run. A weekly window at 40% left is comfortable on day six and alarming on day two, and the bar reads the same either way. You have to know the reset time, do the division in your head, and compare.

## The change

Each account segment now carries a tick above and below it at the point even spending would have reached. The distance between the tick and the fill edge is the headroom. The tick is drawn in the provider colour that fills the bar, and only when the window reports both a duration and a reset — without a timeframe there is nothing to compare against and nothing is drawn.

In the screenshots below, Claude's weekly window (40% left, 39% at even pace) sits right on the line, while Fable's (65% left, same clock) has a visible margin. Same numbers, different stories, and now you can see which is which without reading the countdown.

The segment popover carries the exact figures: `Even pace 39% · 1 pts of headroom`.

### Before

![before](https://raw.githubusercontent.com/badmike/t3code/pr-assets/usage-even-pace/before.png)

### After

![after](https://raw.githubusercontent.com/badmike/t3code/pr-assets/usage-even-pace/after.png)

### Narrow variant

The compact numbered strip gets the same treatment, scaled to the shorter bar.

![after, narrow](https://raw.githubusercontent.com/badmike/t3code/pr-assets/usage-even-pace/after-narrow.png)

## Notes

`evenPacePercent` and `paceGapLabel` live in `packages/shared/src/usageLimits.ts` so web and mobile agree on the maths, and the two views that already drew this marker inline now call them instead of repeating the arithmetic. Mobile gets the same ticks on its pool segments and the figures on the account detail screen.

No new dependencies, no contract changes, no docs change — the tick is a reading aid on an existing view, not a new feature to explain.

Verified with `vp test run packages/shared/src/usageLimits.test.ts apps/web/src/components/usage` (99 pass, four new cases cover the maths and the no-timeframe case), plus typecheck and lint on web, mobile, and shared.

Written by Claude Opus 5 driving T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Closes discussions

- https://github.com/pingdotgg/t3code/discussions/11120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added even-pace indicators to usage-limit bars and pooled usage segments across web and mobile.
  * Usage details now show the expected even-pace percentage and whether usage has headroom, is on pace, or is ahead of pace.
  * Pooled usage details include an “Even pace” breakdown and clearer segment accessibility labels.
* **Bug Fixes**
  * Standardized even-pace positioning across usage-limit displays for more consistent progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

