### PR TITLE
fix(server): run the background service through a Homebrew Node path that survives upgrades

### DIFF
--- a/apps/server/src/cloud/bootService.test.ts
+++ b/apps/server/src/cloud/bootService.test.ts
@@ -181,13 +181,13 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       };
     }),
   });
-  const makeService = (environmentPath = installerPath) =>
+  const makeService = (environmentPath = installerPath, execPath = "/usr/bin/node") =>
     BootService.make({
       baseDir,
       logsDir: path.join(baseDir, "userdata", "logs"),
       cliVersion: "1.2.3",
       host: {
-        execPath: "/usr/bin/node",
+        execPath,
         ...(usePinnedLauncher ? {} : { launcherSourcePath: sourceLauncher }),
       },
     }).pipe(
@@ -207,7 +207,21 @@ const makeHarness = Effect.fn("test.make_boot_service_harness")(function* (
       ),
     );
   const service = yield* makeService();
-  return { service, makeService, fs, statePath, commands, timeouts, control, runtime };
+  return { service, makeService, fs, home, statePath, commands, timeouts, control, runtime };
+});
+
+it("maps a Homebrew Node keg to the formula's stable opt link", () => {
+  expect(BootService.durableHomebrewNodePath("/opt/homebrew/Cellar/node/26.8.1/bin/node")).toBe(
+    "/opt/homebrew/opt/node/bin/node",
+  );
+  expect(BootService.durableHomebrewNodePath("/opt/homebrew/Cellar/node@22/22.1.0/bin/node")).toBe(
+    "/opt/homebrew/opt/node@22/bin/node",
+  );
+  expect(
+    BootService.durableHomebrewNodePath("/home/linuxbrew/.linuxbrew/Cellar/node/26.8.1/bin/node"),
+  ).toBe("/home/linuxbrew/.linuxbrew/opt/node/bin/node");
+  expect(BootService.durableHomebrewNodePath("/usr/bin/node")).toBeNull();
+  expect(BootService.durableHomebrewNodePath("/opt/homebrew/bin/node")).toBeNull();
 });
 
 it.layer(NodeServices.layer)("boot service install", (it) => {
@@ -523,6 +537,29 @@ it.layer(NodeServices.layer)("boot service install", (it) => {
       const { service } = yield* makeHarness("win32");
       expect((yield* service.status).supported).toBe(false);
       expect((yield* service.install().pipe(Effect.flip))._tag).toBe("BootServiceUnsupportedError");
+    }),
+  );
+
+  it.effect("points the launch agent at the Homebrew opt link instead of the Node keg", () =>
+    Effect.gen(function* () {
+      const { makeService, fs, home } = yield* makeHarness("darwin");
+      const path = yield* Path.Path;
+      const kegNode = path.join(home, "brew", "Cellar", "node", "26.8.1", "bin", "node");
+      const optNode = path.join(home, "brew", "opt", "node", "bin", "node");
+      yield* fs.makeDirectory(path.dirname(kegNode), { recursive: true });
+      yield* fs.writeFileString(kegNode, "");
+
+      // Without the opt link the keg path is still the only known executable.
+      const kegOnly = yield* (yield* makeService(macInstallerPath, kegNode)).install();
+      expect(yield* fs.readFileString(kegOnly.unitPath)).toContain(`<string>${kegNode}</string>`);
+
+      yield* fs.makeDirectory(path.dirname(optNode), { recursive: true });
+      yield* fs.writeFileString(optNode, "");
+      const plan = yield* (yield* makeService(macInstallerPath, kegNode)).install();
+      expect(plan.nodePath).toBe(optNode);
+      const plist = yield* fs.readFileString(plan.unitPath);
+      expect(plist).toContain(`<string>${optNode}</string>`);
+      expect(plist).not.toContain("Cellar");
     }),
   );
 

--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -15,6 +15,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
 import * as ProcessRunner from "../processRunner.ts";
+import { homebrewOwnershipFromCommandPath } from "../provider/providerMaintenance.ts";
 import {
   ensurePinnedRuntimeInstalled,
   pinnedRuntimePaths,
@@ -497,6 +498,20 @@ export interface BootServiceHost {
   readonly launcherSourcePath?: string;
 }
 
+/**
+ * `process.execPath` is the realpath, so a Homebrew Node is its versioned keg
+ * (`/opt/homebrew/Cellar/node/26.8.1/bin/node`), which `brew upgrade` deletes.
+ * The formula's `opt` link follows the current keg and keeps the same absolute
+ * path across upgrades, which is what a service unit needs.
+ */
+export function durableHomebrewNodePath(execPath: string): string | null {
+  const keg = homebrewOwnershipFromCommandPath(execPath);
+  if (!keg || keg.kind !== "formula") {
+    return null;
+  }
+  return `${keg.prefix}/opt/${keg.name}/bin/node`;
+}
+
 export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   readonly baseDir: string;
   readonly logsDir: string;
@@ -512,6 +527,12 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const path = yield* Path.Path;
   const runner = yield* ProcessRunner.ProcessRunner;
   const host = input.host ?? { execPath: hostExecPath };
+  const durableNodePath = durableHomebrewNodePath(host.execPath);
+  const nodePath =
+    durableNodePath !== null &&
+    (yield* fs.exists(durableNodePath).pipe(Effect.orElseSucceed(() => false)))
+      ? durableNodePath
+      : host.execPath;
   const xmlSafeInstallerDirectories = installerPath.split(":").filter(
     (directory) =>
       directory.length > 0 &&
@@ -523,7 +544,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
   const environmentPath = Array.from(
     new Set([
       ...xmlSafeInstallerDirectories,
-      path.dirname(host.execPath),
+      path.dirname(nodePath),
       "/opt/homebrew/bin",
       "/usr/local/bin",
       "/usr/bin",
@@ -568,7 +589,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       }),
     ).pipe(Effect.mapError((cause) => new BootServiceInstallError({ cause })));
   const plan: BootServicePlan = {
-    nodePath: host.execPath,
+    nodePath,
     launcherPath,
     baseDir: input.baseDir,
     logPath,
@@ -711,7 +732,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
       validate: (runtime) =>
         runner
           .run({
-            command: host.execPath,
+            command: nodePath,
             args: [runtime.entryPath, "--version"],
             timeout: Duration.seconds(30),
           })

--- a/apps/server/src/serviceLauncher.test.ts
+++ b/apps/server/src/serviceLauncher.test.ts
@@ -4,7 +4,12 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 
-import { Launcher, readServiceState, writeServiceState } from "./serviceLauncher.ts";
+import {
+  Launcher,
+  launcherNodePath,
+  readServiceState,
+  writeServiceState,
+} from "./serviceLauncher.ts";
 import {
   compareExactServiceVersions,
   decodeServiceState,
@@ -289,4 +294,15 @@ if (context.update?.status === "pending") {
       assert.isFalse(yield* fs.exists(path.join(root, "runtime", "db-backup", updateId)));
     }),
   );
+});
+
+it("spawns runtimes through the Node path the service unit started, not its realpath", () => {
+  assert.equal(
+    launcherNodePath(
+      "/opt/homebrew/opt/node/bin/node",
+      "/opt/homebrew/Cellar/node/26.8.1/bin/node",
+    ),
+    "/opt/homebrew/opt/node/bin/node",
+  );
+  assert.equal(launcherNodePath("node", "/usr/bin/node"), "/usr/bin/node");
 });

--- a/apps/server/src/serviceLauncher.ts
+++ b/apps/server/src/serviceLauncher.ts
@@ -263,6 +263,19 @@ async function terminateChild(
 const stopMarkerPath = (baseDir: string) =>
   NodePath.join(baseDir, "runtime", SERVICE_STOP_MARKER_FILE);
 
+/**
+ * The service unit starts the launcher through a durable Node path (a Homebrew
+ * `opt` link, for example). `process.execPath` is the realpath behind it, which
+ * a Node upgrade can delete while the launcher keeps running, so runtimes spawn
+ * through the path the launcher was started with whenever that is absolute.
+ */
+export function launcherNodePath(
+  argv0: string = process.argv0,
+  execPath: string = process.execPath,
+): string {
+  return NodePath.isAbsolute(argv0) ? argv0 : execPath;
+}
+
 export class Launcher {
   readonly #baseDir: string;
   readonly #statePath: string;
@@ -402,7 +415,7 @@ export class Launcher {
       childVersion: version,
       ...(update === undefined ? {} : { update }),
     };
-    const child = NodeChildProcess.spawn(process.execPath, [paths.entryPath, "serve"], {
+    const child = NodeChildProcess.spawn(launcherNodePath(), [paths.entryPath, "serve"], {
       env: { ...process.env, [SERVICE_LAUNCHER_CONTEXT_ENV]: JSON.stringify(context) },
       stdio: ["inherit", "inherit", "inherit", "ipc"],
     });


### PR DESCRIPTION
`t3 service install` / `service update` record `process.execPath` as the service's Node. Node reports the realpath, so a Homebrew install becomes `/opt/homebrew/Cellar/node/<version>/bin/node`, a path that `brew upgrade node` deletes. The running service survives on the old inode, but the next launchd or systemd start fails even though `node` still works through the Homebrew prefix. The launcher also spawns managed runtimes through `process.execPath`, so a live handoff after a keg removal breaks the same way.

Following the triage on #11054:

- The service plan now prefers the formula's `opt` link (`<prefix>/opt/<formula>/bin/node`) whenever `execPath` sits in a Homebrew keg and that link exists. It stays absolute, follows the current keg across upgrades, and covers versioned formulae such as `node@22` and Linuxbrew prefixes. Any other `execPath` is used as before. The same path goes into the unit's `PATH` entry and into the runtime validation run.
- The launcher spawns runtimes through the Node path it was started with (`process.argv0`) when that is absolute, and falls back to `process.execPath` otherwise.

`homebrewOwnershipFromCommandPath` from provider maintenance already parses keg layouts, so the keg detection is shared.

## Verification

- `bootService.test.ts`: keg to opt-link mapping (plain, versioned and Linuxbrew formulae, non-keg paths), and a macOS install that writes the keg path while the opt link is missing and the opt link once it exists, with no `Cellar` left in the plist.
- `serviceLauncher.test.ts`: absolute `argv0` wins, a bare `node` falls back to `execPath`.
- `vp test run` on both files (43 tests), server typecheck and lint on the touched files are clean.

Fixes #11054. Implemented with Claude Code (Claude Fable 5.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service reliability after Node.js updates by using stable Homebrew Node paths.
  * Ensured launched runtimes continue using the configured service path instead of an outdated resolved path.
  * Improved macOS launch-agent setup when stable Node paths are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->