### PR TITLE
fix(desktop): reopen the main window from the File menu

### DIFF
--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -129,6 +129,15 @@ export const make = Effect.gen(function* () {
   };
 
   const configure = Effect.gen(function* () {
+    const newWindowClick = () => {
+      runMenuEffect(
+        "new-window",
+        Effect.gen(function* () {
+          const desktopWindow = yield* DesktopWindow.DesktopWindow;
+          yield* desktopWindow.activate;
+        }),
+      );
+    };
     const checkForUpdatesClick = () => {
       runMenuEffect("check-for-updates", handleCheckForUpdatesMenuClick);
     };
@@ -171,6 +180,12 @@ export const make = Effect.gen(function* () {
       {
         label: "File",
         submenu: [
+          {
+            label: "New Window",
+            accelerator: "CmdOrCtrl+N",
+            click: newWindowClick,
+          },
+          { type: "separator" },
           ...(environment.platform === "darwin"
             ? []
             : [


### PR DESCRIPTION
## What Changed

Adds **File → New Window** with **⌘N** on macOS and **Ctrl+N** on Windows/Linux. Reuses the existing window activation behavior to reopen the main window, or restore and focus it when already open.

## Why

Addresses the macOS window-reopening problem reported in pingdotgg/t3code#435 (already closed).

After closing the main window with ⌘W on macOS, the File menu offers no way to reopen it. This adds the expected menu command and shortcut while preserving the existing single-window and backend-readiness behavior.

## Validation

- All 34 focused desktop menu/window tests passed; targeted lint, formatting, and desktop typecheck passed.
- Tested in an isolated macOS desktop instance: ⌘W followed by ⌘N, reopening through the File menu, repeated ⌘N without duplicate windows, and restoring a minimized window.
- Windows/Linux use Electron's platform-aware accelerator; interactive testing was on macOS only.

## UI Changes

| Before | After |
| --- | --- |
| ![File menu before: Close Window only](https://github.com/angusm73/t3code/releases/download/pr-11069-screenshots/before.png) | ![File menu after: New Window with Command-N](https://github.com/angusm73/t3code/releases/download/pr-11069-screenshots/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implemented with GPT-6 via Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **New Window** option to the desktop app’s **File** menu.
  - Added the `Cmd/Ctrl+N` keyboard shortcut to activate the main desktop window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

