### PR TITLE
fix(web): use selected endpoint for remote previews

### DIFF
--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -160,6 +160,30 @@ describe("browser target resolver", () => {
     ).toBe("http://192.168.1.25:3000/app");
   });
 
+  it("uses the selected advertised endpoint for remote local servers", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "localhost:5173/app?mode=test#results",
+        "http://192.168.1.25:3773",
+      ),
+    ).toBe("http://192.168.1.25:5173/app?mode=test#results");
+  });
+
+  it("keeps remote local servers on localhost when network access is disabled", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://192.168.1.25:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(
+        EnvironmentId.make("environment-1"),
+        "localhost:5173/app",
+        "http://localhost",
+      ),
+    ).toBe("http://localhost:5173/app");
+  });
+
   it("preserves localhost server-picker values when the prepared base is 127.0.0.1", async () => {
     readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
     const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -75,7 +75,11 @@ export function resolveBrowserNavigationTarget(
   return resolveEnvironmentPortTarget(environmentId, target, readEnvironmentUrl(environmentId));
 }
 
-export function resolveDiscoveredServerUrl(environmentId: EnvironmentId, rawUrl: string): string {
+export function resolveDiscoveredServerUrl(
+  environmentId: EnvironmentId,
+  rawUrl: string,
+  preferredBaseUrl?: string | null,
+): string {
   try {
     const normalizedUrl = normalizePreviewUrl(rawUrl);
     const parsed = new URL(normalizedUrl);
@@ -88,7 +92,7 @@ export function resolveDiscoveredServerUrl(environmentId: EnvironmentId, rawUrl:
         protocol: parsed.protocol === "https:" ? "https" : "http",
         path: `${parsed.pathname}${parsed.search}${parsed.hash}`,
       },
-      readEnvironmentUrl(environmentId),
+      preferredBaseUrl ? new URL(preferredBaseUrl) : readEnvironmentUrl(environmentId),
       rawUrl,
       parsed,
     ).resolvedUrl;

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -96,6 +96,7 @@ import {
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { useThreadDiscoveredPorts } from "../portDiscoveryState";
+import { useDesktopPreviewBaseUrl } from "../state/desktopPreviewBaseUrl";
 import { openDiscoveredPort } from "./preview/openDiscoveredPort";
 import { useAtomCommand } from "../state/use-atom-command";
 import { previewEnvironment } from "../state/preview";
@@ -416,6 +417,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
     environmentId: thread.environmentId,
     threadId: thread.id,
   });
+  const desktopPreviewBaseUrl = useDesktopPreviewBaseUrl(thread.environmentId);
   const openPreview = useAtomCommand(previewEnvironment.open, {
     reportFailure: false,
   });
@@ -445,7 +447,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
       event.stopPropagation();
       navigateToThread(threadRef);
       void (async () => {
-        const result = await openDiscoveredPort({ threadRef, port, openPreview });
+        const result = await openDiscoveredPort({
+          threadRef,
+          port,
+          openPreview,
+          preferredBaseUrl: desktopPreviewBaseUrl,
+        });
         if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
           return;
         }
@@ -460,7 +467,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         );
       })();
     },
-    [discoveredPorts, navigateToThread, openPreview, threadRef],
+    [desktopPreviewBaseUrl, discoveredPorts, navigateToThread, openPreview, threadRef],
   );
   const isThreadRunning =
     thread.session?.status === "running" && thread.session.activeTurnId != null;

--- a/apps/web/src/components/preview/PreviewEmptyState.tsx
+++ b/apps/web/src/components/preview/PreviewEmptyState.tsx
@@ -12,6 +12,7 @@ interface Props {
   threadRef: ScopedThreadRef;
   environmentId: EnvironmentId;
   configuredUrls?: ReadonlyArray<string> | undefined;
+  preferredBaseUrl?: string | null;
   recentEntries: ReadonlyArray<BrowserHistoryEntry>;
   onRemoveRecent: (url: string) => void;
   onOpenUrl: (url: string) => void;
@@ -21,6 +22,7 @@ export function PreviewEmptyState({
   threadRef,
   environmentId,
   configuredUrls,
+  preferredBaseUrl,
   recentEntries,
   onRemoveRecent,
   onOpenUrl,
@@ -28,6 +30,7 @@ export function PreviewEmptyState({
   const servers = useDiscoveredLocalServers({
     environmentId,
     configuredUrls,
+    preferredBaseUrl,
   });
   const recents = recentEntries.filter((entry) => URL.canParse(entry.url)).slice(0, 8);
 

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -32,6 +32,7 @@ import {
 } from "~/previewStateStore";
 import { resolveDiscoveredServerUrl } from "~/browser/browserTargetResolver";
 import { useEnvironmentHttpBaseUrl } from "~/state/environments";
+import { useDesktopPreviewBaseUrl } from "~/state/desktopPreviewBaseUrl";
 import { previewEnvironment } from "~/state/preview";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { selectThreadPreviewMiniPlayer, usePreviewMiniPlayerStore } from "~/previewMiniPlayerStore";
@@ -120,6 +121,7 @@ export function PreviewView({
   const addPreviewAnnotation = useComposerDraftStore((store) => store.addPreviewAnnotation);
   const addImage = useComposerDraftStore((store) => store.addImage);
   const environmentHttpBaseUrl = useEnvironmentHttpBaseUrl(threadRef.environmentId);
+  const desktopPreviewBaseUrl = useDesktopPreviewBaseUrl(threadRef.environmentId);
   const environmentHostname = environmentHttpBaseUrl
     ? new URL(environmentHttpBaseUrl).hostname
     : null;
@@ -222,7 +224,11 @@ export function PreviewView({
   const handleOpenServerUrl = useCallback(
     async (next: string) => {
       try {
-        const resolved = resolveDiscoveredServerUrl(threadRef.environmentId, next);
+        const resolved = resolveDiscoveredServerUrl(
+          threadRef.environmentId,
+          next,
+          desktopPreviewBaseUrl,
+        );
         if (await navigateToResolvedUrl(resolved)) {
           recordVisitForThread(threadRef, next);
         }
@@ -230,7 +236,7 @@ export function PreviewView({
         // Server-side `failed` event renders the unreachable view.
       }
     },
-    [navigateToResolvedUrl, threadRef],
+    [desktopPreviewBaseUrl, navigateToResolvedUrl, threadRef],
   );
 
   const handleRefresh = useCallback(() => {
@@ -786,6 +792,7 @@ export function PreviewView({
             threadRef={threadRef}
             environmentId={threadRef.environmentId}
             configuredUrls={configuredUrls}
+            preferredBaseUrl={desktopPreviewBaseUrl}
             recentEntries={recentHistoryEntries}
             onRemoveRecent={(url) => removeUrlForThread(threadRef, url)}
             onOpenUrl={(next) => void handleOpenServerUrl(next)}

--- a/apps/web/src/components/preview/openDiscoveredPort.ts
+++ b/apps/web/src/components/preview/openDiscoveredPort.ts
@@ -14,8 +14,13 @@ export async function openDiscoveredPort<E>(input: {
   readonly threadRef: ScopedThreadRef;
   readonly port: DiscoveredLocalServer;
   readonly openPreview: OpenPreviewMutation<E>;
+  readonly preferredBaseUrl?: string | null;
 }): Promise<AtomCommandResult<void, E | BrowserSettingsReadError>> {
-  const resolvedUrl = resolveDiscoveredServerUrl(input.threadRef.environmentId, input.port.url);
+  const resolvedUrl = resolveDiscoveredServerUrl(
+    input.threadRef.environmentId,
+    input.port.url,
+    input.preferredBaseUrl,
+  );
   const result = await openPreviewSession({
     openPreview: input.openPreview,
     threadRef: input.threadRef,

--- a/apps/web/src/components/preview/useDiscoveredLocalServers.ts
+++ b/apps/web/src/components/preview/useDiscoveredLocalServers.ts
@@ -18,6 +18,7 @@ export interface PreviewableServer extends DiscoveredLocalServer {
 interface UseDiscoveredLocalServersInput {
   environmentId: EnvironmentId;
   configuredUrls?: ReadonlyArray<string> | undefined;
+  preferredBaseUrl?: string | null;
 }
 
 /**
@@ -32,15 +33,22 @@ export function useDiscoveredLocalServers(
   return useMemo(
     () =>
       mergeServers({
-        scanner: scannerState.servers.map((server) => ({
-          ...server,
-          url: resolveDiscoveredServerUrl(input.environmentId, server.url),
-          requestedUrl: server.url,
-        })),
+        scanner: scannerState.servers.map((server) => {
+          const url = resolveDiscoveredServerUrl(
+            input.environmentId,
+            server.url,
+            input.preferredBaseUrl,
+          );
+          try {
+            return { ...server, url, host: new URL(url).hostname, requestedUrl: server.url };
+          } catch {
+            return { ...server, url, requestedUrl: server.url };
+          }
+        }),
         configuredUrls: input.configuredUrls ?? [],
         configuredUrlProbing: scannerState.configuredUrlProbing,
       }),
-    [input.environmentId, scannerState, input.configuredUrls],
+    [input.environmentId, input.preferredBaseUrl, scannerState, input.configuredUrls],
   );
 }
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -47,6 +47,10 @@ import { cn } from "../../lib/utils";
 import { formatElapsedDurationLabel, formatExpiresInLabel } from "../../timestampFormat";
 import { resolveDesktopPairingUrl, resolveHostedPairingUrl } from "./pairingUrls";
 import {
+  endpointDefaultPreferenceKey,
+  selectDefaultAdvertisedEndpoint,
+} from "~/state/desktopNetworkAccess";
+import {
   applyWslEnableSelection,
   isQrShareableEndpoint,
   isWslSettingsRowVisible,
@@ -452,53 +456,8 @@ function toDesktopClientSessionRecord(clientSession: AuthClientSession): ServerC
   };
 }
 
-function selectPairingEndpoint(
-  endpoints: ReadonlyArray<AdvertisedEndpoint>,
-  defaultEndpointKey?: string | null,
-): AdvertisedEndpoint | null {
-  const availableEndpoints = endpoints.filter((endpoint) => endpoint.status !== "unavailable");
-  if (defaultEndpointKey) {
-    const selectedEndpoint = availableEndpoints.find(
-      (endpoint) => endpointDefaultPreferenceKey(endpoint) === defaultEndpointKey,
-    );
-    if (selectedEndpoint) {
-      return selectedEndpoint;
-    }
-  }
-  return (
-    availableEndpoints.find((endpoint) => endpoint.isDefault) ??
-    availableEndpoints.find((endpoint) => endpoint.reachability !== "loopback") ??
-    availableEndpoints.find((endpoint) => endpoint.compatibility.hostedHttpsApp === "compatible") ??
-    null
-  );
-}
-
 function isTailscaleHttpsEndpoint(endpoint: AdvertisedEndpoint): boolean {
   return endpoint.id.startsWith("tailscale-magicdns:");
-}
-
-function endpointDefaultPreferenceKey(endpoint: AdvertisedEndpoint): string {
-  if (endpoint.id.startsWith("desktop-loopback:")) {
-    return "desktop-core:loopback:http";
-  }
-  if (endpoint.id.startsWith("desktop-lan:")) {
-    return "desktop-core:lan:http";
-  }
-  if (endpoint.id.startsWith("tailscale-ip:")) {
-    return "tailscale:ip:http";
-  }
-  if (isTailscaleHttpsEndpoint(endpoint)) {
-    return "tailscale:magicdns:https";
-  }
-
-  let scheme = "unknown";
-  try {
-    scheme = new URL(endpoint.httpBaseUrl).protocol.replace(/:$/u, "");
-  } catch {
-    // Keep the stored preference stable even if a custom endpoint is malformed.
-  }
-
-  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}`;
 }
 
 function resolveAdvertisedEndpointPairingUrl(
@@ -589,7 +548,7 @@ const PairingLinkListRow = memo(function PairingLinkListRow({
     [endpointUrl, credential],
   );
   const endpointPairingUrl = useMemo(() => {
-    const endpoint = selectPairingEndpoint(endpoints, defaultEndpointKey);
+    const endpoint = selectDefaultAdvertisedEndpoint(endpoints, defaultEndpointKey);
     return endpoint && credential
       ? resolveAdvertisedEndpointPairingUrl(endpoint, credential)
       : null;
@@ -708,7 +667,7 @@ const PairingLinkListRow = memo(function PairingLinkListRow({
     defaultEndpointKey,
   );
   const qrPairingUrl = selectedQrOption?.url ?? shareablePairingUrl;
-  // With no endpoint list the fallback is never loopback: selectPairingEndpoint
+  // With no endpoint list the fallback is never loopback: selectDefaultAdvertisedEndpoint
   // skips loopback and the current-origin fallback is guarded by
   // isLoopbackHostname, so only an explicit loopback selection hides the QR.
   const canRenderQrForSelection = selectedQrOption?.qrShareable ?? true;
@@ -2432,13 +2391,16 @@ export function ConnectionsSettings() {
     isLocalBackendNetworkAccessible || tailscaleHttpsEndpoint?.status === "available";
   const defaultDesktopNetworkAdvertisedEndpoint = useMemo(
     () =>
-      selectPairingEndpoint(visibleDesktopNetworkAdvertisedEndpoints, defaultAdvertisedEndpointKey),
+      selectDefaultAdvertisedEndpoint(
+        visibleDesktopNetworkAdvertisedEndpoints,
+        defaultAdvertisedEndpointKey,
+      ),
     [defaultAdvertisedEndpointKey, visibleDesktopNetworkAdvertisedEndpoints],
   );
   const defaultDesktopAdvertisedEndpoint = useMemo(
     () =>
       defaultDesktopNetworkAdvertisedEndpoint ??
-      selectPairingEndpoint(
+      selectDefaultAdvertisedEndpoint(
         tailscaleHttpsEndpoint ? [tailscaleHttpsEndpoint] : [],
         defaultAdvertisedEndpointKey,
       ),

--- a/apps/web/src/state/desktopNetworkAccess.ts
+++ b/apps/web/src/state/desktopNetworkAccess.ts
@@ -93,6 +93,40 @@ export const desktopNetworkAccessStateAtom = createDesktopNetworkAccessStateAtom
   getDesktopNetworkAccessBridge,
 );
 
+export function endpointDefaultPreferenceKey(endpoint: AdvertisedEndpoint): string {
+  if (endpoint.id.startsWith("desktop-loopback:")) return "desktop-core:loopback:http";
+  if (endpoint.id.startsWith("desktop-lan:")) return "desktop-core:lan:http";
+  if (endpoint.id.startsWith("tailscale-ip:")) return "tailscale:ip:http";
+  if (endpoint.id.startsWith("tailscale-magicdns:")) return "tailscale:magicdns:https";
+
+  let scheme = "unknown";
+  try {
+    scheme = new URL(endpoint.httpBaseUrl).protocol.replace(/:$/u, "");
+  } catch {
+    // Keep the stored preference stable even if a custom endpoint is malformed.
+  }
+  return `${endpoint.provider.id}:${endpoint.reachability}:${scheme}:${endpoint.label}`;
+}
+
+export function selectDefaultAdvertisedEndpoint(
+  endpoints: ReadonlyArray<AdvertisedEndpoint>,
+  defaultEndpointKey?: string | null,
+): AdvertisedEndpoint | null {
+  const availableEndpoints = endpoints.filter((endpoint) => endpoint.status !== "unavailable");
+  if (defaultEndpointKey) {
+    const selected = availableEndpoints.find(
+      (endpoint) => endpointDefaultPreferenceKey(endpoint) === defaultEndpointKey,
+    );
+    if (selected) return selected;
+  }
+  return (
+    availableEndpoints.find((endpoint) => endpoint.isDefault) ??
+    availableEndpoints.find((endpoint) => endpoint.reachability !== "loopback") ??
+    availableEndpoints.find((endpoint) => endpoint.compatibility.hostedHttpsApp === "compatible") ??
+    null
+  );
+}
+
 export function refreshDesktopNetworkAccessState(): void {
   appAtomRegistry.refresh(desktopNetworkAccessStateAtom);
 }

--- a/apps/web/src/state/desktopPreviewBaseUrl.ts
+++ b/apps/web/src/state/desktopPreviewBaseUrl.ts
@@ -1,0 +1,35 @@
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId } from "@t3tools/contracts";
+
+import { useUiStateStore } from "~/uiStateStore";
+import { usePrimaryEnvironmentId } from "./environments";
+
+import {
+  desktopNetworkAccessStateAtom,
+  selectDefaultAdvertisedEndpoint,
+} from "./desktopNetworkAccess";
+
+/** Base URL that a desktop-hosted browser can use to reach exposed local servers. */
+export function useDesktopPreviewBaseUrl(environmentId: EnvironmentId | null): string | null {
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const defaultEndpointKey = useUiStateStore((state) => state.defaultAdvertisedEndpointKey);
+  const networkAccess = useAtomValue(desktopNetworkAccessStateAtom);
+  if (
+    typeof window === "undefined" ||
+    window.desktopBridge === undefined ||
+    environmentId === null ||
+    environmentId === primaryEnvironmentId
+  ) {
+    return null;
+  }
+  if (
+    networkAccess._tag !== "Success" ||
+    networkAccess.value.serverExposureState.mode !== "network-accessible"
+  ) {
+    return "http://localhost";
+  }
+  return (
+    selectDefaultAdvertisedEndpoint(networkAccess.value.advertisedEndpoints, defaultEndpointKey)
+      ?.httpBaseUrl ?? null
+  );
+}


### PR DESCRIPTION
## Summary

Make discovered local-server previews for remote threads use the default advertised base URL selected in Connections when desktop network access is enabled. When network access is disabled, remote previews stay on `localhost`.

## Changes

- Reuse Connections' advertised-endpoint preference and selection rules for browser previews.
- Resolve discovered local server URLs and their displayed host through the selected endpoint for remote desktop threads.
- Preserve `localhost` for remote threads when network access is unavailable or disabled, and preserve existing behavior for primary/local and hosted-web environments.
- Apply the same resolution to the legacy sidebar quick-open action.
- Keep browser history keyed to the original local URL while navigating to the reachable URL.
- Add resolver coverage for enabled-network and disabled-network behavior.

## Test Plan

- `git diff --check`
- Attempted `vp test run apps/web/src/browser/browserTargetResolver.test.ts apps/web/src/components/preview/useDiscoveredLocalServers.test.ts apps/web/src/state/desktopNetworkAccess.test.ts`. The worktree has no dependency installation; the normal install/dev flow is blocked by an unavailable private package at `pkg.ing/alchemy/078ff00`. A compatible cached dependency tree was not usable with current upstream exports, so the focused suite could not execute.

## Risks

- The selected advertised endpoint must be reachable from the desktop browser. If it is not, preview navigation will fail in the same way as any unavailable endpoint.

## Rollback

- Revert commit `8a412c19d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local server previews now use the appropriate desktop network endpoint when available.
  - Discovered server links preserve their paths, queries, and fragments while adapting to the selected endpoint.
  - Desktop endpoint selection now consistently respects saved preferences and availability across connection-related displays.

- **Bug Fixes**
  - Localhost-based preview links remain on localhost when appropriate, preventing incorrect environment-host substitutions.
  - Preview handling now gracefully tolerates invalid discovered URLs without breaking the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->