### PR TITLE
feat(web): thread.cycleRecent switches to the last viewed thread on Ctrl+Tab

### DIFF
--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -3573,6 +3573,12 @@ export default function LegacySidebar() {
   }, [shouldShowThreadJumpHintsNow, updateThreadJumpHintsVisibility]);
 
   const cycleRecentThread = useRecentThreadCycling(routeThreadKey);
+  // sidebarThreadByKey still holds archived threads; only rendered rows are
+  // valid cycle targets.
+  const orderedSidebarThreadKeySet = useMemo(
+    () => new Set(orderedSidebarThreadKeys),
+    [orderedSidebarThreadKeys],
+  );
   useEffect(() => {
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
       const shortcutContext = getCurrentSidebarShortcutContext();
@@ -3594,7 +3600,7 @@ export default function LegacySidebar() {
                 currentThreadId: routeThreadKey,
                 direction: traversalDirection,
               })
-            : cycleRecentThread((threadKey) => sidebarThreadByKey.has(threadKey));
+            : cycleRecentThread((threadKey) => orderedSidebarThreadKeySet.has(threadKey));
         if (!targetThreadKey) {
           return;
         }
@@ -3639,6 +3645,7 @@ export default function LegacySidebar() {
     keybindings,
     navigateToThread,
     orderedSidebarThreadKeys,
+    orderedSidebarThreadKeySet,
     platform,
     routeThreadKey,
     sidebarThreadByKey,

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -113,6 +113,7 @@ import {
   threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { isModelPickerOpen } from "../modelPickerVisibility";
+import { useRecentThreadCycling } from "../hooks/useRecentThreadCycling";
 import { useShortcutModifierState } from "../shortcutModifierState";
 import { ensureLocalApi, readLocalApi } from "../localApi";
 import { useComposerDraftStore } from "../composerDraftStore";
@@ -3571,6 +3572,7 @@ export default function LegacySidebar() {
     updateThreadJumpHintsVisibility(shouldShowThreadJumpHintsNow);
   }, [shouldShowThreadJumpHintsNow, updateThreadJumpHintsVisibility]);
 
+  const cycleRecentThread = useRecentThreadCycling(routeThreadKey);
   useEffect(() => {
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
       const shortcutContext = getCurrentSidebarShortcutContext();
@@ -3584,12 +3586,15 @@ export default function LegacySidebar() {
         context: shortcutContext,
       });
       const traversalDirection = threadTraversalDirectionFromCommand(command);
-      if (traversalDirection !== null) {
-        const targetThreadKey = resolveAdjacentThreadId({
-          threadIds: orderedSidebarThreadKeys,
-          currentThreadId: routeThreadKey,
-          direction: traversalDirection,
-        });
+      if (traversalDirection !== null || command === "thread.cycleRecent") {
+        const targetThreadKey =
+          traversalDirection !== null
+            ? resolveAdjacentThreadId({
+                threadIds: orderedSidebarThreadKeys,
+                currentThreadId: routeThreadKey,
+                direction: traversalDirection,
+              })
+            : cycleRecentThread((threadKey) => sidebarThreadByKey.has(threadKey));
         if (!targetThreadKey) {
           return;
         }
@@ -3629,6 +3634,7 @@ export default function LegacySidebar() {
       window.removeEventListener("keydown", onWindowKeyDown);
     };
   }, [
+    cycleRecentThread,
     getCurrentSidebarShortcutContext,
     keybindings,
     navigateToThread,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -93,6 +93,7 @@ import {
   threadTraversalDirectionFromCommand,
 } from "../keybindings";
 import { useShortcutModifierState } from "../shortcutModifierState";
+import { useRecentThreadCycling } from "../hooks/useRecentThreadCycling";
 import { useTerminalFocus } from "../hooks/useTerminalFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isModelPickerOpen } from "../modelPickerVisibility";
@@ -4216,6 +4217,7 @@ export default function Sidebar() {
       ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, routeThreadRef).terminalOpen
       : false,
   );
+  const cycleRecentThread = useRecentThreadCycling(routeThreadKey);
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || event.repeat || isCommandPaletteOpen() || isModelPickerOpen()) {
@@ -4238,6 +4240,10 @@ export default function Sidebar() {
         navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
         return true;
       };
+      if (command === "thread.cycleRecent") {
+        navigateToThreadKey(cycleRecentThread((threadKey) => threadByKey.has(threadKey)));
+        return;
+      }
       const traversalDirection = threadTraversalDirectionFromCommand(command);
       if (traversalDirection !== null) {
         navigateToThreadKey(
@@ -4256,6 +4262,7 @@ export default function Sidebar() {
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
   }, [
+    cycleRecentThread,
     keybindings,
     navigateToThread,
     orderedThreadKeys,

--- a/apps/web/src/hooks/useRecentThreadCycling.ts
+++ b/apps/web/src/hooks/useRecentThreadCycling.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import {
+  cycleRecentThread,
+  EMPTY_THREAD_RECENCY_STATE,
+  endThreadRecencyWalk,
+  isModifierKeyName,
+  recordThreadVisit,
+} from "../threadRecency";
+
+/**
+ * Backs `thread.cycleRecent`. Records the routed thread as visited and ends an
+ * in-progress walk when a modifier key is released or the window blurs, so a
+ * held Ctrl+Tab, Ctrl+Tab steps two threads back while Ctrl+Tab, release,
+ * Ctrl+Tab flips between the two newest.
+ */
+export function useRecentThreadCycling(routeThreadKey: string | null) {
+  const stateRef = useRef(EMPTY_THREAD_RECENCY_STATE);
+  const routeThreadKeyRef = useRef(routeThreadKey);
+
+  useEffect(() => {
+    routeThreadKeyRef.current = routeThreadKey;
+    stateRef.current = recordThreadVisit(stateRef.current, routeThreadKey);
+  }, [routeThreadKey]);
+
+  useEffect(() => {
+    const endWalk = () => {
+      stateRef.current = endThreadRecencyWalk(stateRef.current, routeThreadKeyRef.current);
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (isModifierKeyName(event.key)) endWalk();
+    };
+    window.addEventListener("keyup", onKeyUp, true);
+    window.addEventListener("blur", endWalk);
+    return () => {
+      window.removeEventListener("keyup", onKeyUp, true);
+      window.removeEventListener("blur", endWalk);
+    };
+  }, []);
+
+  return useCallback((isKnownThread: (threadKey: string) => boolean): string | null => {
+    const result = cycleRecentThread(stateRef.current, {
+      currentThreadKey: routeThreadKeyRef.current,
+      isKnownThread,
+    });
+    stateRef.current = result.state;
+    return result.target;
+  }, []);
+}

--- a/apps/web/src/hooks/useRecentThreadCycling.ts
+++ b/apps/web/src/hooks/useRecentThreadCycling.ts
@@ -8,6 +8,27 @@ import {
   recordThreadVisit,
 } from "../threadRecency";
 
+// Session-scoped on purpose: the thread sidebar unmounts on settings routes,
+// and Settings then back must not forget which threads were visited.
+let recencyState = EMPTY_THREAD_RECENCY_STATE;
+let walkEndListenersAttached = false;
+
+function attachWalkEndListeners(): void {
+  if (walkEndListenersAttached || typeof window === "undefined") return;
+  walkEndListenersAttached = true;
+  const endWalk = () => {
+    recencyState = endThreadRecencyWalk(recencyState);
+  };
+  window.addEventListener(
+    "keyup",
+    (event) => {
+      if (isModifierKeyName(event.key)) endWalk();
+    },
+    true,
+  );
+  window.addEventListener("blur", endWalk);
+}
+
 /**
  * Backs `thread.cycleRecent`. Records the routed thread as visited and ends an
  * in-progress walk when a modifier key is released or the window blurs, so a
@@ -15,35 +36,21 @@ import {
  * Ctrl+Tab flips between the two newest.
  */
 export function useRecentThreadCycling(routeThreadKey: string | null) {
-  const stateRef = useRef(EMPTY_THREAD_RECENCY_STATE);
   const routeThreadKeyRef = useRef(routeThreadKey);
 
   useEffect(() => {
     routeThreadKeyRef.current = routeThreadKey;
-    stateRef.current = recordThreadVisit(stateRef.current, routeThreadKey);
+    recencyState = recordThreadVisit(recencyState, routeThreadKey);
   }, [routeThreadKey]);
 
-  useEffect(() => {
-    const endWalk = () => {
-      stateRef.current = endThreadRecencyWalk(stateRef.current, routeThreadKeyRef.current);
-    };
-    const onKeyUp = (event: KeyboardEvent) => {
-      if (isModifierKeyName(event.key)) endWalk();
-    };
-    window.addEventListener("keyup", onKeyUp, true);
-    window.addEventListener("blur", endWalk);
-    return () => {
-      window.removeEventListener("keyup", onKeyUp, true);
-      window.removeEventListener("blur", endWalk);
-    };
-  }, []);
+  useEffect(attachWalkEndListeners, []);
 
   return useCallback((isKnownThread: (threadKey: string) => boolean): string | null => {
-    const result = cycleRecentThread(stateRef.current, {
+    const result = cycleRecentThread(recencyState, {
       currentThreadKey: routeThreadKeyRef.current,
       isKnownThread,
     });
-    stateRef.current = result.state;
+    recencyState = result.state;
     return result.target;
   }, []);
 }

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -145,6 +145,10 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("[", { shiftKey: true }), command: "thread.previous" },
   { shortcut: modShortcut("]", { shiftKey: true }), command: "thread.next" },
   {
+    shortcut: { ...modShortcut("tab"), modKey: false, ctrlKey: true },
+    command: "thread.cycleRecent",
+  },
+  {
     shortcut: modShortcut("c", { shiftKey: true }),
     command: "thread.copyReference",
     whenAst: whenNot(whenIdentifier("terminalFocus")),

--- a/apps/web/src/threadRecency.test.ts
+++ b/apps/web/src/threadRecency.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  cycleRecentThread,
+  EMPTY_THREAD_RECENCY_STATE,
+  endThreadRecencyWalk,
+  recordThreadVisit,
+  type ThreadRecencyState,
+} from "./threadRecency";
+
+const known = new Set(["a", "b", "c"]);
+const isKnownThread = (key: string) => known.has(key);
+
+function visit(...keys: Array<string | null>): ThreadRecencyState {
+  return keys.reduce(recordThreadVisit, EMPTY_THREAD_RECENCY_STATE);
+}
+
+describe("threadRecency", () => {
+  it("orders visits most recent first without duplicates", () => {
+    expect(visit("a", "b", "a", "c", null).history).toEqual(["c", "a", "b"]);
+  });
+
+  it("a single press jumps to the previously visited thread", () => {
+    const { target } = cycleRecentThread(visit("a", "b"), {
+      currentThreadKey: "b",
+      isKnownThread,
+    });
+    expect(target).toBe("a");
+  });
+
+  it("pressing again after release flips back", () => {
+    let state = visit("a", "b");
+    const first = cycleRecentThread(state, { currentThreadKey: "b", isKnownThread });
+    state = recordThreadVisit(first.state, first.target);
+    state = endThreadRecencyWalk(state, first.target);
+    const second = cycleRecentThread(state, { currentThreadKey: "a", isKnownThread });
+    expect(second.target).toBe("b");
+  });
+
+  it("holding the modifier walks further back and wraps", () => {
+    let state = visit("a", "b", "c");
+    const steps: Array<string | null> = [];
+    for (let index = 0; index < 4; index += 1) {
+      const step = cycleRecentThread(state, {
+        currentThreadKey: steps.at(-1) ?? "c",
+        isKnownThread,
+      });
+      // Route changes during the walk must not reorder the list.
+      state = recordThreadVisit(step.state, step.target);
+      steps.push(step.target);
+    }
+    expect(steps).toEqual(["b", "a", "c", "b"]);
+  });
+
+  it("releasing the modifier promotes the landed thread", () => {
+    let state = visit("a", "b", "c");
+    const step = cycleRecentThread(state, { currentThreadKey: "c", isKnownThread });
+    state = cycleRecentThread(step.state, { currentThreadKey: step.target, isKnownThread }).state;
+    state = endThreadRecencyWalk(state, "a");
+    expect(state.walkIndex).toBeNull();
+    expect(state.history).toEqual(["a", "c", "b"]);
+  });
+
+  it("skips threads that no longer exist", () => {
+    const { target, state } = cycleRecentThread(visit("gone", "a", "b"), {
+      currentThreadKey: "b",
+      isKnownThread,
+    });
+    expect(target).toBe("a");
+    expect(state.history).toEqual(["b", "a"]);
+  });
+
+  it("does nothing with fewer than two threads", () => {
+    expect(
+      cycleRecentThread(visit("a"), { currentThreadKey: "a", isKnownThread }).target,
+    ).toBeNull();
+    expect(
+      cycleRecentThread(EMPTY_THREAD_RECENCY_STATE, { currentThreadKey: null, isKnownThread })
+        .target,
+    ).toBeNull();
+  });
+
+  it("starts the walk from the current thread even if it was not recorded", () => {
+    const { target } = cycleRecentThread(visit("a", "b"), {
+      currentThreadKey: "c",
+      isKnownThread,
+    });
+    expect(target).toBe("b");
+  });
+});

--- a/apps/web/src/threadRecency.test.ts
+++ b/apps/web/src/threadRecency.test.ts
@@ -8,7 +8,7 @@ import {
   type ThreadRecencyState,
 } from "./threadRecency";
 
-const known = new Set(["a", "b", "c"]);
+const known = new Set(["a", "b", "c", "d"]);
 const isKnownThread = (key: string) => known.has(key);
 
 function visit(...keys: Array<string | null>): ThreadRecencyState {
@@ -29,11 +29,9 @@ describe("threadRecency", () => {
   });
 
   it("pressing again after release flips back", () => {
-    let state = visit("a", "b");
-    const first = cycleRecentThread(state, { currentThreadKey: "b", isKnownThread });
-    state = recordThreadVisit(first.state, first.target);
-    state = endThreadRecencyWalk(state, first.target);
-    const second = cycleRecentThread(state, { currentThreadKey: "a", isKnownThread });
+    const first = cycleRecentThread(visit("a", "b"), { currentThreadKey: "b", isKnownThread });
+    const released = recordThreadVisit(endThreadRecencyWalk(first.state), first.target);
+    const second = cycleRecentThread(released, { currentThreadKey: "a", isKnownThread });
     expect(second.target).toBe("b");
   });
 
@@ -41,10 +39,7 @@ describe("threadRecency", () => {
     let state = visit("a", "b", "c");
     const steps: Array<string | null> = [];
     for (let index = 0; index < 4; index += 1) {
-      const step = cycleRecentThread(state, {
-        currentThreadKey: steps.at(-1) ?? "c",
-        isKnownThread,
-      });
+      const step = cycleRecentThread(state, { currentThreadKey: "c", isKnownThread });
       // Route changes during the walk must not reorder the list.
       state = recordThreadVisit(step.state, step.target);
       steps.push(step.target);
@@ -52,13 +47,26 @@ describe("threadRecency", () => {
     expect(steps).toEqual(["b", "a", "c", "b"]);
   });
 
-  it("releasing the modifier promotes the landed thread", () => {
+  it("ending the walk promotes the landed thread even if the route has not caught up", () => {
     let state = visit("a", "b", "c");
-    const step = cycleRecentThread(state, { currentThreadKey: "c", isKnownThread });
-    state = cycleRecentThread(step.state, { currentThreadKey: step.target, isKnownThread }).state;
-    state = endThreadRecencyWalk(state, "a");
-    expect(state.walkIndex).toBeNull();
+    state = cycleRecentThread(state, { currentThreadKey: "c", isKnownThread }).state;
+    state = cycleRecentThread(state, { currentThreadKey: "c", isKnownThread }).state;
+    state = endThreadRecencyWalk(state);
+    expect(state.walkKey).toBeNull();
     expect(state.history).toEqual(["a", "c", "b"]);
+    // The route effect firing afterwards with the same thread is a no-op.
+    expect(recordThreadVisit(state, "a")).toBe(state);
+  });
+
+  it("keeps its place when an earlier entry disappears mid-walk", () => {
+    let state = visit("a", "b", "c", "d");
+    state = cycleRecentThread(state, { currentThreadKey: "d", isKnownThread }).state;
+    expect(state.walkKey).toBe("c");
+    const next = cycleRecentThread(state, {
+      currentThreadKey: "c",
+      isKnownThread: (key) => key !== "d" && isKnownThread(key),
+    });
+    expect(next.target).toBe("b");
   });
 
   it("skips threads that no longer exist", () => {

--- a/apps/web/src/threadRecency.ts
+++ b/apps/web/src/threadRecency.ts
@@ -1,0 +1,80 @@
+/**
+ * Most-recently-used thread order for `thread.cycleRecent`, the Ctrl+Tab
+ * switcher. Visits are recorded from the route; the list is session-only and
+ * never persisted. Pressing the shortcut steps one thread further back in
+ * visit order. While the walk is in progress the order is frozen, so holding
+ * the modifier and pressing again keeps moving back instead of bouncing
+ * between the two newest threads. Releasing the modifier ends the walk and
+ * the thread landed on becomes the most recent.
+ */
+
+const THREAD_RECENCY_LIMIT = 50;
+
+export interface ThreadRecencyState {
+  /** Scoped thread keys, most recent first. */
+  readonly history: readonly string[];
+  /** Index into `history` of the thread landed on mid-walk; null when idle. */
+  readonly walkIndex: number | null;
+}
+
+export const EMPTY_THREAD_RECENCY_STATE: ThreadRecencyState = { history: [], walkIndex: null };
+
+function moveToFront(history: readonly string[], threadKey: string): readonly string[] {
+  if (history[0] === threadKey) return history;
+  return [threadKey, ...history.filter((key) => key !== threadKey)].slice(0, THREAD_RECENCY_LIMIT);
+}
+
+export function recordThreadVisit(
+  state: ThreadRecencyState,
+  threadKey: string | null,
+): ThreadRecencyState {
+  if (threadKey === null || state.walkIndex !== null) return state;
+  const history = moveToFront(state.history, threadKey);
+  return history === state.history ? state : { history, walkIndex: null };
+}
+
+export function cycleRecentThread(
+  state: ThreadRecencyState,
+  input: {
+    currentThreadKey: string | null;
+    isKnownThread: (threadKey: string) => boolean;
+  },
+): { state: ThreadRecencyState; target: string | null } {
+  const { currentThreadKey, isKnownThread } = input;
+  const walking = state.walkIndex !== null;
+  let history: readonly string[] = state.history.filter(
+    (key) => key === currentThreadKey || isKnownThread(key),
+  );
+  if (!walking && currentThreadKey !== null) {
+    history = moveToFront(history, currentThreadKey);
+  }
+  if (history.length < 2) {
+    return { state: { history, walkIndex: null }, target: null };
+  }
+  const fromIndex = walking ? Math.min(state.walkIndex ?? 0, history.length - 1) : 0;
+  const walkIndex = (fromIndex + 1) % history.length;
+  return { state: { history, walkIndex }, target: history[walkIndex] ?? null };
+}
+
+export function endThreadRecencyWalk(
+  state: ThreadRecencyState,
+  currentThreadKey: string | null,
+): ThreadRecencyState {
+  if (state.walkIndex === null) return state;
+  return recordThreadVisit({ history: state.history, walkIndex: null }, currentThreadKey);
+}
+
+export function isModifierKeyName(key: string): boolean {
+  switch (key) {
+    case "Control":
+    case "Meta":
+    case "OS":
+    case "Command":
+    case "Alt":
+    case "Option":
+    case "Shift":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/apps/web/src/threadRecency.ts
+++ b/apps/web/src/threadRecency.ts
@@ -2,10 +2,11 @@
  * Most-recently-used thread order for `thread.cycleRecent`, the Ctrl+Tab
  * switcher. Visits are recorded from the route; the list is session-only and
  * never persisted. Pressing the shortcut steps one thread further back in
- * visit order. While the walk is in progress the order is frozen, so holding
- * the modifier and pressing again keeps moving back instead of bouncing
- * between the two newest threads. Releasing the modifier ends the walk and
- * the thread landed on becomes the most recent.
+ * visit order. While a walk is in progress the order is frozen and the thread
+ * landed on is remembered by key, so holding the modifier and pressing again
+ * keeps moving back instead of bouncing between the two newest threads, and a
+ * thread vanishing mid-walk cannot shift the position. Ending the walk
+ * promotes the landed thread to most recent.
  */
 
 const THREAD_RECENCY_LIMIT = 50;
@@ -13,11 +14,11 @@ const THREAD_RECENCY_LIMIT = 50;
 export interface ThreadRecencyState {
   /** Scoped thread keys, most recent first. */
   readonly history: readonly string[];
-  /** Index into `history` of the thread landed on mid-walk; null when idle. */
-  readonly walkIndex: number | null;
+  /** Thread landed on mid-walk; null when idle. */
+  readonly walkKey: string | null;
 }
 
-export const EMPTY_THREAD_RECENCY_STATE: ThreadRecencyState = { history: [], walkIndex: null };
+export const EMPTY_THREAD_RECENCY_STATE: ThreadRecencyState = { history: [], walkKey: null };
 
 function moveToFront(history: readonly string[], threadKey: string): readonly string[] {
   if (history[0] === threadKey) return history;
@@ -28,9 +29,9 @@ export function recordThreadVisit(
   state: ThreadRecencyState,
   threadKey: string | null,
 ): ThreadRecencyState {
-  if (threadKey === null || state.walkIndex !== null) return state;
+  if (threadKey === null || state.walkKey !== null) return state;
   const history = moveToFront(state.history, threadKey);
-  return history === state.history ? state : { history, walkIndex: null };
+  return history === state.history ? state : { history, walkKey: null };
 }
 
 export function cycleRecentThread(
@@ -41,27 +42,23 @@ export function cycleRecentThread(
   },
 ): { state: ThreadRecencyState; target: string | null } {
   const { currentThreadKey, isKnownThread } = input;
-  const walking = state.walkIndex !== null;
   let history: readonly string[] = state.history.filter(
     (key) => key === currentThreadKey || isKnownThread(key),
   );
-  if (!walking && currentThreadKey !== null) {
+  if (state.walkKey === null && currentThreadKey !== null) {
     history = moveToFront(history, currentThreadKey);
   }
   if (history.length < 2) {
-    return { state: { history, walkIndex: null }, target: null };
+    return { state: { history, walkKey: null }, target: null };
   }
-  const fromIndex = walking ? Math.min(state.walkIndex ?? 0, history.length - 1) : 0;
-  const walkIndex = (fromIndex + 1) % history.length;
-  return { state: { history, walkIndex }, target: history[walkIndex] ?? null };
+  const fromIndex = state.walkKey === null ? 0 : Math.max(history.indexOf(state.walkKey), 0);
+  const target = history[(fromIndex + 1) % history.length] ?? null;
+  return { state: { history, walkKey: target }, target };
 }
 
-export function endThreadRecencyWalk(
-  state: ThreadRecencyState,
-  currentThreadKey: string | null,
-): ThreadRecencyState {
-  if (state.walkIndex === null) return state;
-  return recordThreadVisit({ history: state.history, walkIndex: null }, currentThreadKey);
+export function endThreadRecencyWalk(state: ThreadRecencyState): ThreadRecencyState {
+  if (state.walkKey === null) return state;
+  return { history: moveToFront(state.history, state.walkKey), walkKey: null };
 }
 
 export function isModifierKeyName(key: string): boolean {

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -56,6 +56,12 @@ a shortcut.
 `thread.stop` interrupts the running turn in the focused thread. It has no default
 shortcut; assign one in **Settings → Keybindings**.
 
+`thread.cycleRecent` (`ctrl+tab` by default) switches to the thread you viewed
+before this one, in most-recently-used order. Hold the modifier and press again to
+step further back; release it to stay. `thread.previous` and `thread.next` walk
+the sidebar in its displayed order instead. Browsers reserve `ctrl+tab` for their
+own tabs, so on the web app rebind this command to an available shortcut.
+
 `chat.new` may ask you to choose a project when there is more than one.
 `chat.newLocal` skips that chooser. Both use your
 [new-thread defaults](./thread-sidebar.md#start-a-thread).

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -108,6 +108,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedThreadPrevious.command, "thread.previous");
 
+    const parsedThreadCycleRecent = yield* decode(KeybindingRule, {
+      key: "ctrl+tab",
+      command: "thread.cycleRecent",
+    });
+    assert.strictEqual(parsedThreadCycleRecent.command, "thread.cycleRecent");
+
     const parsedThreadSettle = yield* decode(KeybindingRule, {
       key: "mod+shift+s",
       command: "thread.settle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -38,6 +38,7 @@ const THREAD_KEYBINDING_COMMANDS = [
   "thread.stop",
   "thread.previous",
   "thread.next",
+  "thread.cycleRecent",
   "thread.copyReference",
   "thread.settle",
   "thread.pin",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -47,6 +47,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "ctrl+tab", command: "thread.cycleRecent" },
   { key: "mod+shift+c", command: "thread.copyReference", when: "!terminalFocus" },
   { key: "mod+shift+s", command: "thread.settle", when: "!terminalFocus" },
   { key: "mod+shift+p", command: "thread.pin", when: "!terminalFocus" },


### PR DESCRIPTION
## What Changed

Adds one keybinding command, `thread.cycleRecent`, bound to `ctrl+tab` by default.

- One press jumps to the thread you viewed before this one.
- Holding the modifier and pressing again steps further back through recently viewed threads; releasing it commits, the way Arc, Dia, and Chrome cycle tabs.
- The list is per session, in memory, capped at 50, and drops threads that leave the sidebar. Nothing is persisted and nothing crosses the wire.

`thread.previous` and `thread.next` are untouched and still walk the sidebar in display order.

Files: the pure ordering logic lives in `apps/web/src/threadRecency.ts` with unit tests. A small hook records the routed thread and listens for modifier keyup. Both `Sidebar.tsx` and `LegacySidebar.tsx` dispatch the command next to the existing traversal, so v1 and v2 sidebars behave the same. Contracts, shared defaults, and the keybindings user doc gain one line each.

## Why

`thread.previous` walks the sidebar list, so "previous" is rarely the thread you were just in. When two threads sit far apart it takes several presses to flip between them. #6966 (Ctrl+Tab for traversal) explicitly deferred most-recently-used order as a follow-up, and discussion #9751 asks for that follow-up. This is the smallest version of it: no overlay, no persistence, no new settings.

Web browsers reserve `ctrl+tab`, so the default only fires in the desktop app and the doc says to rebind on the web app. That matches how #6966 scoped the original request.

## UI Changes

None. No new visible surface; navigation only.

## Verification

`vp test run` on the touched web, contracts, and server keybinding tests (268 passing), `tsc --noEmit` clean for web, contracts, and shared. Lint on the new files is clean; the pre-existing ref warnings in `Sidebar.tsx` are unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (none: no UI change)
- [ ] I included a video for animation/interaction changes (no animation; happy to record one if wanted)

Written by Claude Fable 5.1 in Claude Code via T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Ctrl+Tab switching through recently viewed threads.
  - Hold Ctrl+Tab to move further back through recent threads; release to commit the selected thread.
  - Navigation now skips unavailable or non-rendered threads and handles threads removed during cycling.

- **Documentation**
  - Documented the shortcut and noted that browsers may reserve Ctrl+Tab, allowing users to rebind it.

- **Tests**
  - Added coverage for recent-thread ordering, cycling, wrapping, unavailable threads, and keybinding parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->