### PR TITLE
fix(web): keep a file-to-symlink type change from crashing the diff view

### DIFF
--- a/apps/web/src/components/diffs/DiffFileTree.test.tsx
+++ b/apps/web/src/components/diffs/DiffFileTree.test.tsx
@@ -5,7 +5,10 @@ import { act, type MouseEvent, type ReactNode } from "react";
 import { create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
+import type { FileDiffMetadata } from "@pierre/diffs";
+
 import { DiffFileTree, type DiffFileTreeEntry } from "./DiffFileTree";
+import { diffFileTreeEntries } from "./diffFileTree.logic";
 import { useCodeViewFileReveal } from "./useCodeViewFileReveal";
 
 vi.mock("../../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
@@ -110,6 +113,22 @@ describe("diff tree file activation", () => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it("mounts a file-to-symlink type change as one tree row", async () => {
+    // Git carries a type change as a deletion and an addition of the same path.
+    const typeChange = diffFileTreeEntries([
+      { type: "deleted", name: "b/AGENTS.md", prevName: "a/AGENTS.md" } as FileDiffMetadata,
+      { type: "new", name: "b/AGENTS.md", prevName: "a/AGENTS.md" } as FileDiffMetadata,
+      { type: "change", name: "b/CLAUDE.md", prevName: "a/CLAUDE.md" } as FileDiffMetadata,
+    ]);
+    await mount({ files: [...typeChange] });
+
+    const tree = model();
+    expect(tree.getItem("AGENTS.md")?.isDirectory()).toBe(false);
+    expect(tree.getItem("CLAUDE.md")?.isDirectory()).toBe(false);
+    await activate("AGENTS.md");
+    expect(targets).toEqual([{ type: "item", id: "AGENTS.md\u0000AGENTS.md", align: "start" }]);
   });
 
   it("reissues the reveal when the sole selected file is activated again", async () => {

--- a/apps/web/src/components/diffs/diffFileTree.logic.test.ts
+++ b/apps/web/src/components/diffs/diffFileTree.logic.test.ts
@@ -31,6 +31,23 @@ describe("diffFileTreeEntries", () => {
   });
 });
 
+describe("diffFileTreeEntries", () => {
+  it("folds a file-to-symlink type change into one modified entry", () => {
+    expect(
+      diffFileTreeEntries([
+        file("change", "CLAUDE.md"),
+        file("deleted", "AGENTS.md"),
+        file("new", "AGENTS.md"),
+        file("new", "docs/new.md"),
+      ]),
+    ).toEqual([
+      { path: "CLAUDE.md", status: "modified" },
+      { path: "AGENTS.md", status: "modified" },
+      { path: "docs/new.md", status: "added" },
+    ]);
+  });
+});
+
 describe("collectDirectoryPaths", () => {
   it("lists every ancestor once, parents first, with Pierre's trailing slash", () => {
     expect(collectDirectoryPaths(["apps/web/src/a.ts", "apps/web/b.ts", "README.md"])).toEqual([

--- a/apps/web/src/components/diffs/diffFileTree.logic.ts
+++ b/apps/web/src/components/diffs/diffFileTree.logic.ts
@@ -23,11 +23,22 @@ function toGitStatus(file: FileDiffMetadata): GitStatus {
   }
 }
 
-/** Maps parsed diff files to tree entries, keeping the diff's own order. */
+/**
+ * Maps parsed diff files to tree entries, keeping the diff's own order. A path
+ * appears once: a type change (regular file to symlink) is a deletion plus an
+ * addition of the same path, and the tree shows the surviving file as modified.
+ */
 export function diffFileTreeEntries(
   files: ReadonlyArray<FileDiffMetadata>,
 ): ReadonlyArray<DiffFileTreeEntry> {
-  return files.map((file) => ({ path: resolveFileDiffPath(file), status: toGitStatus(file) }));
+  const statusByPath = new Map<string, GitStatus>();
+  for (const file of files) {
+    const path = resolveFileDiffPath(file);
+    const status = toGitStatus(file);
+    const previous = statusByPath.get(path);
+    statusByPath.set(path, previous === undefined || previous === status ? status : "modified");
+  }
+  return [...statusByPath].map(([path, status]) => ({ path, status }));
 }
 
 /**

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -107,6 +107,33 @@ describe("diff file reconciliation", () => {
     expect(buildFileDiffRenderKey(file)).toBe(key);
   });
 
+  it("gives a type change its own identity per block", () => {
+    const patch = [
+      "diff --git a/AGENTS.md b/AGENTS.md",
+      "deleted file mode 100644",
+      "--- a/AGENTS.md",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-duplicated instructions",
+      "diff --git a/AGENTS.md b/AGENTS.md",
+      "new file mode 120000",
+      "--- /dev/null",
+      "+++ b/AGENTS.md",
+      "@@ -0,0 +1 @@",
+      "+CLAUDE.md",
+    ].join("\n");
+    const parsed = getRenderablePatch(patch, "type-change");
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+    const [deleted, added] = parsed.files;
+    expect(deleted?.type).toBe("deleted");
+    expect(added?.type).toBe("new");
+    if (!deleted || !added) return;
+
+    expect(buildFileDiffIdentityKey(deleted)).not.toBe(buildFileDiffIdentityKey(added));
+    expect(new Set(parsed.files.map(buildFileDiffIdentityKey)).size).toBe(parsed.files.length);
+  });
+
   it("keeps identities stable and versions local to the changed file", () => {
     const patch = (secondLine: string) =>
       [

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -163,8 +163,13 @@ export function resolveFileDiffPreviousPath(fileDiff: FileDiffMetadata): string 
   return raw;
 }
 
+/**
+ * Stable across re-renders of the same file, distinct for every block in a
+ * patch. A type change (regular file to symlink) arrives as a deletion and an
+ * addition of the same path, so the change type is part of the identity.
+ */
 export function buildFileDiffIdentityKey(fileDiff: FileDiffMetadata): string {
-  return `${resolveFileDiffPreviousPath(fileDiff)}\u0000${resolveFileDiffPath(fileDiff)}`;
+  return `${resolveFileDiffPreviousPath(fileDiff)}\u0000${resolveFileDiffPath(fileDiff)}\u0000${fileDiff.type}`;
 }
 
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {


### PR DESCRIPTION
A regular file that becomes a symlink (or the reverse) is a Git type change. With `--no-renames` the patch carries it as two blocks with the same path: a deletion of the regular file and an addition of the symlink. The diff panel keys each block by previous and current path only, so both blocks got the identity `AGENTS.md\0AGENTS.md`, CodeView threw `duplicate id`, and the whole thread view fell into the "Something went wrong" state.

The identity key now includes the block's change type, so the deleted and the new block of a type change get distinct ids while a file that is merely edited keeps its key across renders. The pull request tab keys by render key and was not affected.

The file tree next to the diff had the same failure one layer down: `diffFileTreeEntries` produced two entries for the path and `model.resetPaths` threw `Duplicate path`, which also crashed the thread and kept crashing on reload while the tree preference was on. Same-path blocks now fold into one tree entry shown as modified, while the diff itself keeps both blocks.

## Verification

- `diffRendering.test.ts` parses the exact two-block patch from #11074 and asserts the two identities differ and every file in the patch has a unique key; the existing stability test still passes.
- `diffFileTree.logic.test.ts` folds the deletion plus addition into one modified entry; `DiffFileTree.test.tsx` mounts the real tree model with a type change, which reproduced the `Duplicate path` throw before the fold, and activates the surviving row.
- `vp test run` for `apps/web/src/lib/diffRendering.test.ts` and `apps/web/src/components/diffs` (37 tests), web typecheck and lint on the touched files are clean.

Fixes #11074. Implemented with Claude Code (Claude Fable 5.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diff rendering for file type changes, such as a regular file becoming a symlink.
  - Entries sharing a path are now displayed as a single modified item when appropriate, preventing duplicate rows in the diff tree.
  - File changes now maintain distinct identities, avoiding collisions when deleted and newly added entries share the same path.
  - Activating affected entries reveals the correct file target once, improving navigation and preventing duplicate reveals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->