### PR TITLE
fix(server): follow Claude worktree changes in thread metadata

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -310,6 +310,16 @@ describe("CheckpointReactor", () => {
     const cwd = createGitRepository();
     if (options?.initializeGit === false) {
       NodeFS.rmSync(NodePath.join(cwd, ".git"), { recursive: true });
+    } else if (
+      options?.providerSessionCwd === undefined &&
+      options?.localStatusRefName !== undefined
+    ) {
+      runGit(
+        cwd,
+        options.localStatusRefName === null
+          ? ["checkout", "--detach"]
+          : ["checkout", "-B", options.localStatusRefName],
+      );
     }
     tempDirs.push(cwd);
     const provider = createProviderServiceHarness(
@@ -1070,20 +1080,26 @@ describe("CheckpointReactor", () => {
     },
   );
 
-  effectIt.effect.each(["main", "feature"])(
-    "rejects a queued drift update from %s after the provider session moves again",
-    (originalBranch) =>
+  effectIt.effect.each([
+    { originalBranch: "main", change: "cwd" },
+    { originalBranch: "feature", change: "cwd" },
+    { originalBranch: "main", change: "branch" },
+    { originalBranch: "main", change: "detach" },
+  ])(
+    "rejects a queued drift update from $originalBranch after a $change change",
+    ({ originalBranch, change }) =>
       Effect.gen(function* () {
         const repository = createGitRepository();
         tempDirs.push(repository);
         const worktree = NodePath.join(repository, ".claude/worktrees/feature");
         runGit(repository, ["worktree", "add", "-b", "feature", worktree]);
+        const threadWorktreePath = change === "cwd" ? null : worktree;
         const pullRequestRefreshCalls: string[] = [];
         const harness = yield* Effect.promise(() =>
           createHarness({
             seedFilesystemCheckpoints: false,
             projectWorkspaceRoot: repository,
-            threadWorktreePath: null,
+            threadWorktreePath,
             providerSessionCwd: worktree,
             threadBranch: originalBranch,
             localStatusRefName: "feature",
@@ -1114,7 +1130,14 @@ describe("CheckpointReactor", () => {
             payload: { state: "completed" },
           });
           yield* Deferred.await(dispatchReached);
-          harness.provider.setSessionCwd(repository);
+          if (change === "cwd") {
+            harness.provider.setSessionCwd(repository);
+          } else {
+            runGit(
+              worktree,
+              change === "detach" ? ["checkout", "--detach"] : ["checkout", "-b", "next"],
+            );
+          }
         }).pipe(Effect.ensuring(Deferred.succeed(releaseDispatch, undefined)));
         yield* Effect.promise(harness.drain).pipe(
           Effect.ensuring(Effect.sync(() => spy.mockRestore())),
@@ -1123,7 +1146,7 @@ describe("CheckpointReactor", () => {
           (entry) => entry.id === ThreadId.make("thread-1"),
         );
         expect(thread?.branch).toBe(originalBranch);
-        expect(thread?.worktreePath).toBe(null);
+        expect(thread?.worktreePath).toBe(threadWorktreePath);
         expect(pullRequestRefreshCalls).toEqual([]);
       }),
   );

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -436,7 +436,8 @@ describe("CheckpointReactor", () => {
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "approval-required",
           branch: options?.threadBranch ?? null,
-          worktreePath: options?.threadWorktreePath ?? cwd,
+          worktreePath:
+            options?.threadWorktreePath !== undefined ? options.threadWorktreePath : cwd,
           createdAt,
         })
         .pipe(
@@ -970,6 +971,101 @@ describe("CheckpointReactor", () => {
 
     expect(pullRequestRefreshCalls).toEqual([]);
   });
+
+  it.each([
+    "dedicated",
+    "shared",
+    "shared-alias",
+    "detached",
+    "temporary",
+    "return",
+    "unrelated",
+  ] as const)(
+    "follows the provider into a %s checkout without retaining the old branch",
+    async (destination) => {
+      const repository = createGitRepository();
+      tempDirs.push(repository);
+      const worktree = NodePath.join(repository, ".claude/worktrees/feature");
+      runGit(repository, ["worktree", "add", "-b", "feature", worktree]);
+      runGit(repository, ["checkout", "-b", "original"]);
+      runGit(worktree, ["checkout", "main"]);
+      if (destination === "detached") runGit(worktree, ["checkout", "--detach"]);
+      if (destination === "temporary") runGit(worktree, ["checkout", "-b", "t3code/0a1b2c3d"]);
+      const unrelated = destination === "unrelated" ? createGitRepository() : null;
+      if (unrelated) tempDirs.push(unrelated);
+      const cwd = unrelated ?? (destination === "return" ? repository : worktree);
+      const harness = await createHarness({
+        seedFilesystemCheckpoints: false,
+        projectWorkspaceRoot: repository,
+        threadWorktreePath: destination === "return" ? worktree : null,
+        providerSessionCwd: cwd,
+        threadBranch: "original",
+        localStatusRefName:
+          destination === "detached"
+            ? null
+            : destination === "temporary"
+              ? "t3code/0a1b2c3d"
+              : destination === "return"
+                ? "original"
+                : "main",
+      });
+      const shared = destination === "shared" || destination === "shared-alias";
+      const siblingPath =
+        destination === "shared-alias" ? NodePath.join(repository, "alias") : worktree;
+      if (destination === "shared-alias") NodeFS.symlinkSync(worktree, siblingPath, "junction");
+      if (shared) {
+        await Effect.runPromise(
+          harness.engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make("create-worktree-owner"),
+            threadId: ThreadId.make("thread-2"),
+            projectId: asProjectId("project-1"),
+            title: "Worktree owner",
+            modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5-codex" },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            branch: "feature",
+            worktreePath: siblingPath,
+            createdAt: "2026-01-01T00:00:00.000Z",
+          }),
+        );
+      }
+      harness.provider.emit({
+        type: "turn.completed",
+        eventId: EventId.make("evt-turn-completed-cwd-change"),
+        provider: ProviderDriverKind.make("claudeAgent"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        threadId: ThreadId.make("thread-1"),
+        turnId: asTurnId("turn-cwd-change"),
+        payload: { state: "completed" },
+      });
+      await harness.drain();
+      const snapshot = await harness.readModel();
+      const thread = snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      expect(thread?.worktreePath).toBe(destination === "return" || unrelated ? null : worktree);
+      expect(thread?.branch).toBe(
+        destination === "dedicated" ? "main" : unrelated ? "original" : null,
+      );
+      if (shared) {
+        expect(
+          snapshot.threads.find((entry) => entry.id === ThreadId.make("thread-2"))?.branch,
+        ).toBe("feature");
+        harness.provider.emit({
+          type: "turn.completed",
+          eventId: EventId.make("evt-turn-completed-still-shared"),
+          provider: ProviderDriverKind.make("claudeAgent"),
+          createdAt: "2026-01-01T00:00:01.000Z",
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-still-shared"),
+          payload: { state: "completed" },
+        });
+        await harness.drain();
+        expect(
+          (await harness.readModel()).threads.find((entry) => entry.id === thread?.id)?.branch,
+        ).toBe(null);
+      }
+    },
+  );
 
   it("adopts a drifted checkout as the thread branch on a dedicated worktree", async () => {
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -149,6 +149,9 @@ function createProviderServiceHarness(
 
   return {
     service,
+    setSessionCwd: (nextCwd: string) => {
+      sessionCwd = nextCwd;
+    },
     assertConversationRollbackSupported,
     rollbackConversation,
     emit,
@@ -1065,6 +1068,64 @@ describe("CheckpointReactor", () => {
         ).toBe(null);
       }
     },
+  );
+
+  effectIt.effect.each(["main", "feature"])(
+    "rejects a queued drift update from %s after the provider session moves again",
+    (originalBranch) =>
+      Effect.gen(function* () {
+        const repository = createGitRepository();
+        tempDirs.push(repository);
+        const worktree = NodePath.join(repository, ".claude/worktrees/feature");
+        runGit(repository, ["worktree", "add", "-b", "feature", worktree]);
+        const pullRequestRefreshCalls: string[] = [];
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            seedFilesystemCheckpoints: false,
+            projectWorkspaceRoot: repository,
+            threadWorktreePath: null,
+            providerSessionCwd: worktree,
+            threadBranch: originalBranch,
+            localStatusRefName: "feature",
+            pullRequestRefreshCalls,
+          }),
+        );
+        const dispatchReached = yield* Deferred.make<void>();
+        const releaseDispatch = yield* Deferred.make<void>();
+        const dispatch = harness.engine.dispatch;
+        const spy = vi
+          .spyOn(harness.engine, "dispatch")
+          .mockImplementation((command, options) =>
+            command.type === "thread.meta.update"
+              ? Deferred.succeed(dispatchReached, undefined).pipe(
+                  Effect.andThen(Deferred.await(releaseDispatch)),
+                  Effect.andThen(dispatch(command, options)),
+                )
+              : dispatch(command, options),
+          );
+        yield* Effect.gen(function* () {
+          harness.provider.emit({
+            type: "turn.completed",
+            eventId: EventId.make("evt-stale-cwd-refresh"),
+            provider: ProviderDriverKind.make("claudeAgent"),
+            createdAt: "2026-01-01T00:00:00.000Z",
+            threadId: ThreadId.make("thread-1"),
+            turnId: asTurnId("turn-stale-cwd"),
+            payload: { state: "completed" },
+          });
+          yield* Deferred.await(dispatchReached);
+          harness.provider.setSessionCwd(repository);
+        }).pipe(Effect.ensuring(Deferred.succeed(releaseDispatch, undefined)));
+        yield* Effect.promise(harness.drain).pipe(
+          Effect.ensuring(Effect.sync(() => spy.mockRestore())),
+        );
+        const thread = (yield* Effect.promise(harness.readModel)).threads.find(
+          (entry) => entry.id === ThreadId.make("thread-1"),
+        );
+        expect(thread?.branch).toBe(originalBranch);
+        expect(thread?.worktreePath).toBe(null);
+        expect(pullRequestRefreshCalls).toEqual([]);
+      }),
   );
 
   it("adopts a drifted checkout as the thread branch on a dedicated worktree", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -605,6 +605,7 @@ const make = Effect.gen(function* () {
       if (!locationChanged && worktreeIsShared) return;
       const branch =
         worktreePath !== null && !worktreeIsShared && adoptableBranch ? checkedOutBranch : null;
+      const { driver } = yield* vcs.resolve({ cwd: input.cwd });
 
       // Reject stale reads if a user changed the branch or worktree meanwhile.
       yield* orchestrationEngine.dispatch(
@@ -619,11 +620,31 @@ const make = Effect.gen(function* () {
         },
         {
           validateBeforeCommit: Effect.gen(function* () {
+            const currentBranch = yield* driver
+              .execute({
+                operation: "CheckpointReactor.validateWorktreeBranch",
+                cwd: input.cwd,
+                args: ["branch", "--show-current"],
+              })
+              .pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new OrchestrationCommandInvariantError({
+                      commandType: "thread.meta.update",
+                      detail: "Could not verify the provider checkout branch.",
+                      cause,
+                    }),
+                ),
+              );
             const sessionRuntime = yield* resolveSessionRuntimeForThread(input.threadId);
-            if (Option.isNone(sessionRuntime) || sessionRuntime.value.cwd !== input.cwd) {
+            if (
+              Option.isNone(sessionRuntime) ||
+              sessionRuntime.value.cwd !== input.cwd ||
+              (currentBranch.stdout.trim() || null) !== checkedOutBranch
+            ) {
               return yield* new OrchestrationCommandInvariantError({
                 commandType: "thread.meta.update",
-                detail: "Provider session cwd changed during worktree status refresh.",
+                detail: "Provider checkout changed during worktree status refresh.",
               });
             }
           }),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -37,6 +37,7 @@ import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts"
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
+import { OrchestrationCommandInvariantError } from "../Errors.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { VcsDriverRegistry } from "../../vcs/VcsDriverRegistry.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
@@ -530,6 +531,8 @@ const make = Effect.gen(function* () {
       .pipe(Effect.map(Option.getOrUndefined));
     if (!thread || thread.branch !== checkedOutBranch) return;
     if (thread.session?.activeTurnId && !sameId(thread.session.activeTurnId, input.turnId)) return;
+    const sessionRuntime = yield* resolveSessionRuntimeForThread(input.threadId);
+    if (Option.isNone(sessionRuntime) || sessionRuntime.value.cwd !== input.cwd) return;
     yield* vcsStatusBroadcaster.refreshPullRequestStatus(input.cwd).pipe(
       Effect.catch((error) =>
         Effect.logWarning("failed to refresh pull request status after turn completion", {
@@ -604,15 +607,28 @@ const make = Effect.gen(function* () {
         worktreePath !== null && !worktreeIsShared && adoptableBranch ? checkedOutBranch : null;
 
       // Reject stale reads if a user changed the branch or worktree meanwhile.
-      yield* orchestrationEngine.dispatch({
-        type: "thread.meta.update",
-        commandId: yield* serverCommandId("worktree-branch-drift"),
-        threadId: thread.id,
-        branch,
-        expectedBranch: thread.branch,
-        expectedWorktreePath: thread.worktreePath,
-        ...(locationChanged ? { worktreePath } : {}),
-      });
+      yield* orchestrationEngine.dispatch(
+        {
+          type: "thread.meta.update",
+          commandId: yield* serverCommandId("worktree-branch-drift"),
+          threadId: thread.id,
+          branch,
+          expectedBranch: thread.branch,
+          expectedWorktreePath: thread.worktreePath,
+          ...(locationChanged ? { worktreePath } : {}),
+        },
+        {
+          validateBeforeCommit: Effect.gen(function* () {
+            const sessionRuntime = yield* resolveSessionRuntimeForThread(input.threadId);
+            if (Option.isNone(sessionRuntime) || sessionRuntime.value.cwd !== input.cwd) {
+              return yield* new OrchestrationCommandInvariantError({
+                commandType: "thread.meta.update",
+                detail: "Provider session cwd changed during worktree status refresh.",
+              });
+            }
+          }),
+        },
+      );
       yield* Effect.logInfo("thread branch followed worktree checkout", {
         threadId: thread.id,
         previousBranch: thread.branch,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -14,8 +14,10 @@ import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Path from "effect/Path";
 import type * as PlatformError from "effect/PlatformError";
 import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
@@ -36,6 +38,7 @@ import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import type { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import type { OrchestrationDispatchError } from "../Errors.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
+import { VcsDriverRegistry } from "../../vcs/VcsDriverRegistry.ts";
 import * as WorkspaceEntries from "../../workspace/WorkspaceEntries.ts";
 import * as PullRequestService from "../../pullRequest/PullRequestService.ts";
 
@@ -89,6 +92,9 @@ const make = Effect.gen(function* () {
   const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
   const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
   const pullRequests = yield* PullRequestService.PullRequestService;
+  const vcs = yield* VcsDriverRegistry;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
   const startedTurns = new Map<ThreadId, TurnId>();
   const pending = new Set<ThreadId>();
 
@@ -535,61 +541,82 @@ const make = Effect.gen(function* () {
     );
   });
 
-  // A `git checkout` run inside a thread's dedicated worktree (by an agent or
-  // the user) bypasses T3's commands, so the thread's recorded branch goes
-  // stale. Since #4460 the client only attributes PR state to a thread when
-  // the checked-out branch equals the recorded one, so stale metadata silently
-  // orphans the thread's PR. Follow the drift here: adopt the checked-out
-  // branch as the thread's branch, but only when the worktree belongs to
-  // exactly this thread — for shared cwds the strict matching is the point.
+  // Follow provider cwd moves and external checkouts. Only a dedicated worktree
+  // owns its HEAD; moving elsewhere clears the old branch's attribution.
   const followWorktreeBranchDrift = Effect.fn("followWorktreeBranchDrift")(function* (input: {
     readonly threadId: ThreadId;
     readonly cwd: string;
     readonly local: VcsStatusLocalResult;
   }) {
-    // Detached HEAD has no branch to adopt; a temporary placeholder checkout
-    // means the first-turn auto-rename is still in flight — don't race it.
     const checkedOutBranch = input.local.refName;
-    if (checkedOutBranch === null || isTemporaryWorktreeBranch(checkedOutBranch)) {
-      return;
-    }
+    const adoptableBranch =
+      checkedOutBranch !== null && !isTemporaryWorktreeBranch(checkedOutBranch);
 
     yield* Effect.gen(function* () {
       const thread = yield* projectionSnapshotQuery
         .getThreadShellById(input.threadId)
         .pipe(Effect.map(Option.getOrUndefined));
-      if (
-        !thread ||
-        thread.branch === null ||
-        thread.branch === checkedOutBranch ||
-        thread.worktreePath === null ||
-        thread.worktreePath !== input.cwd
-      ) {
+      if (!thread) return;
+
+      const project = yield* projectionSnapshotQuery
+        .getProjectShellById(thread.projectId)
+        .pipe(Effect.map(Option.getOrUndefined));
+      if (!project) return;
+      const recordedCwd = thread.worktreePath ?? project.workspaceRoot;
+      const locationChanged =
+        recordedCwd !== input.cwd &&
+        (yield* fileSystem.realPath(recordedCwd).pipe(Effect.orElseSucceed(() => recordedCwd))) !==
+          (yield* fileSystem.realPath(input.cwd));
+      let worktreePath = thread.worktreePath;
+      if (locationChanged) {
+        const current = yield* vcs.detect({ cwd: input.cwd });
+        const original = yield* vcs.detect({ cwd: project.workspaceRoot });
+        if (!current?.repository.metadataPath || !original?.repository.metadataPath) return;
+        const currentMetadata = yield* fileSystem.realPath(
+          path.resolve(input.cwd, current.repository.metadataPath),
+        );
+        const originalMetadata = yield* fileSystem.realPath(
+          path.resolve(project.workspaceRoot, original.repository.metadataPath),
+        );
+        // Only follow checkouts belonging to this project's repository.
+        if (currentMetadata !== originalMetadata) return;
+        worktreePath =
+          current.repository.rootPath === original.repository.rootPath
+            ? null
+            : current.repository.rootPath;
+      } else if (!adoptableBranch || worktreePath === null || thread.branch === checkedOutBranch) {
         return;
       }
 
       const shell = yield* projectionSnapshotQuery.getShellSnapshot();
-      const worktreeIsShared = shell.threads.some(
-        (other) => other.id !== thread.id && other.worktreePath === thread.worktreePath,
-      );
-      if (worktreeIsShared) {
-        return;
-      }
+      const projectRoots = new Map(shell.projects.map((entry) => [entry.id, entry.workspaceRoot]));
+      const targetPath = worktreePath === null ? null : yield* fileSystem.realPath(worktreePath);
+      const worktreeIsShared = yield* Effect.findFirst(shell.threads, (other) => {
+        const otherCwd = other.worktreePath ?? projectRoots.get(other.projectId);
+        if (other.id === thread.id || !otherCwd) return Effect.succeed(false);
+        return fileSystem.realPath(otherCwd).pipe(
+          Effect.map((otherPath) => otherPath === targetPath),
+          Effect.orElseSucceed(() => false),
+        );
+      }).pipe(Effect.map(Option.isSome));
+      if (!locationChanged && worktreeIsShared) return;
+      const branch =
+        worktreePath !== null && !worktreeIsShared && adoptableBranch ? checkedOutBranch : null;
 
-      // expectedBranch makes this a compare-and-swap in the decider: if the
-      // recorded branch moved between our read and the dispatch (rename,
-      // concurrent drift-follow), the stale update is dropped.
+      // Reject stale reads if a user changed the branch or worktree meanwhile.
       yield* orchestrationEngine.dispatch({
         type: "thread.meta.update",
         commandId: yield* serverCommandId("worktree-branch-drift"),
         threadId: thread.id,
-        branch: checkedOutBranch,
+        branch,
         expectedBranch: thread.branch,
+        expectedWorktreePath: thread.worktreePath,
+        ...(locationChanged ? { worktreePath } : {}),
       });
       yield* Effect.logInfo("thread branch followed worktree checkout", {
         threadId: thread.id,
         previousBranch: thread.branch,
-        branch: checkedOutBranch,
+        branch,
       });
     }).pipe(
       Effect.catchCause((cause) => {

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -20,6 +20,8 @@ import {
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Metric from "effect/Metric";
@@ -54,6 +56,7 @@ import {
 } from "../Services/ProjectionPipeline.ts";
 import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import { ServerConfig } from "../../config.ts";
+import { OrchestrationCommandInvariantError } from "../Errors.ts";
 
 const asProjectId = (value: string): ProjectId => ProjectId.make(value);
 const asMessageId = (value: string): MessageId => MessageId.make(value);
@@ -130,6 +133,66 @@ const hasMetricSnapshot = (
   );
 
 describe("OrchestrationEngine", () => {
+  effectIt.effect("validates queued commands before committing their events", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngineService;
+      const blocked = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const projectId = asProjectId("guarded-project");
+      let cwd = "/tmp/checkout-a";
+      const create = yield* engine
+        .dispatch(
+          {
+            type: "project.create",
+            commandId: CommandId.make("guarded-create"),
+            projectId,
+            title: "Original",
+            workspaceRoot: cwd,
+            createdAt: now(),
+          },
+          {
+            validateBeforeCommit: Deferred.succeed(blocked, undefined).pipe(
+              Effect.andThen(Deferred.await(release)),
+            ),
+          },
+        )
+        .pipe(Effect.forkChild({ startImmediately: true }));
+      yield* Deferred.await(blocked);
+      const update = yield* engine
+        .dispatch(
+          {
+            type: "project.meta.update",
+            commandId: CommandId.make("guarded-update"),
+            projectId,
+            title: "Stale",
+          },
+          {
+            validateBeforeCommit: Effect.suspend(() =>
+              cwd === "/tmp/checkout-a"
+                ? Effect.void
+                : Effect.fail(
+                    new OrchestrationCommandInvariantError({
+                      commandType: "project.meta.update",
+                      detail: "cwd changed",
+                    }),
+                  ),
+            ),
+          },
+        )
+        .pipe(Effect.result, Effect.forkChild({ startImmediately: true }));
+      cwd = "/tmp/checkout-b";
+      yield* Deferred.succeed(release, undefined);
+      const created = yield* Fiber.join(create);
+      expect(yield* Fiber.join(update)).toMatchObject({
+        _tag: "Failure",
+        failure: { _tag: "OrchestrationCommandInvariantError", detail: "cwd changed" },
+      });
+      expect(yield* engine.latestSequence).toBe(created.sequence);
+      const snapshots = yield* ProjectionSnapshotQuery;
+      expect((yield* snapshots.getSnapshot()).projects[0]?.title).toBe("Original");
+    }).pipe(Effect.provide(makeOrchestrationLayer())),
+  );
+
   it.each(["running", "stopped"] as const)(
     "sends async answers with a %s session and rejects old duplicate replies",
     async (status) => {

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -1019,6 +1019,24 @@ describe("OrchestrationEngine", () => {
 
     const snapshot = await system.readModel();
     expect(snapshot.threads[0]?.branch).toBe("t3code/generated-branch-name");
+    for (const expected of [
+      { expectedBranch: "stale", expectedWorktreePath: "/tmp/project-branch-race-worktree" },
+      { expectedBranch: "t3code/generated-branch-name", expectedWorktreePath: null },
+    ]) {
+      await system.run(
+        engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make(`stale-location-${expected.expectedBranch}`),
+          threadId: ThreadId.make("thread-branch-race"),
+          branch: "another-branch",
+          worktreePath: "/tmp/another-worktree",
+          ...expected,
+        }),
+      );
+      const current = (await system.readModel()).threads[0];
+      expect(current?.branch).toBe("t3code/generated-branch-name");
+      expect(current?.worktreePath).toBe("/tmp/project-branch-race-worktree");
+    }
     await system.dispose();
   });
 

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -57,6 +57,7 @@ const isOrchestrationCommandIdConflictError = Schema.is(OrchestrationCommandIdCo
 interface CommandEnvelope {
   command: OrchestrationCommand;
   origin: OrchestrationClientOrigin | undefined;
+  validateBeforeCommit: Effect.Effect<void, OrchestrationDispatchError> | undefined;
   result: Deferred.Deferred<{ sequence: number }, OrchestrationDispatchError>;
   startedAtMs: number;
 }
@@ -273,6 +274,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         const committedCommand = yield* sql
           .withTransaction(
             Effect.gen(function* () {
+              if (envelope.validateBeforeCommit) yield* envelope.validateBeforeCommit;
               const committedEvents: OrchestrationEvent[] = [];
               const attachmentCleanups: Effect.Effect<void>[] = [];
               let nextCommandReadModel = commandReadModel;
@@ -441,6 +443,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       yield* Queue.offer(commandQueue, {
         command,
         origin: options?.origin,
+        validateBeforeCommit: options?.validateBeforeCommit,
         result,
         startedAtMs: yield* Clock.currentTimeMillis,
       });

--- a/apps/server/src/orchestration/Services/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationEngine.ts
@@ -72,7 +72,11 @@ export interface OrchestrationEngineShape {
    */
   readonly dispatch: (
     command: OrchestrationCommand,
-    options?: { readonly origin?: OrchestrationClientOrigin },
+    options?: {
+      readonly origin?: OrchestrationClientOrigin;
+      // Runs inside the command transaction; must not dispatch other commands.
+      readonly validateBeforeCommit?: Effect.Effect<void, OrchestrationDispatchError>;
+    },
   ) => Effect.Effect<{ sequence: number }, OrchestrationDispatchError, never>;
 
   /**

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -965,12 +965,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           ],
         });
       }
-      const branch =
-        command.branch !== undefined &&
-        command.expectedBranch !== undefined &&
-        thread.branch !== command.expectedBranch
-          ? thread.branch
-          : command.branch;
+      const staleCheckout =
+        (command.expectedBranch !== undefined && thread.branch !== command.expectedBranch) ||
+        (command.expectedWorktreePath !== undefined &&
+          thread.worktreePath !== command.expectedWorktreePath);
+      const branch = staleCheckout ? thread.branch : command.branch;
+      const worktreePath = staleCheckout ? thread.worktreePath : command.worktreePath;
       const occurredAt = yield* nowIso;
       return {
         ...(yield* withEventBase({
@@ -1000,7 +1000,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             ? { modelSelection: command.modelSelection }
             : {}),
           ...(branch !== undefined ? { branch } : {}),
-          ...(command.worktreePath !== undefined ? { worktreePath: command.worktreePath } : {}),
+          ...(worktreePath !== undefined ? { worktreePath } : {}),
           ...(command.linkedPullRequest !== undefined
             ? { linkedPullRequest: command.linkedPullRequest }
             : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -378,6 +378,51 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("follows the session cwd when Claude enters and leaves a worktree", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const cwd = "/tmp/claude-adapter-test";
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        cwd,
+      });
+      const hook = harness.getLastCreateQueryInput()?.options.hooks?.PostToolUse?.[0]?.hooks[0];
+      for (const [toolName, nextCwd, agentId] of [
+        ["EnterWorktree", `${cwd}/.claude/worktrees/feature`, undefined],
+        ["EnterWorktree", `${cwd}/.claude/worktrees/subagent`, "agent-1"],
+        ["ExitWorktree", cwd, undefined],
+      ] as const) {
+        const previousCwd = (yield* adapter.listSessions())[0]?.cwd;
+        if (hook) {
+          yield* Effect.promise(() =>
+            hook(
+              {
+                hook_event_name: "PostToolUse",
+                session_id: "sdk-session",
+                transcript_path: "/tmp/transcript.jsonl",
+                cwd: nextCwd,
+                tool_name: toolName,
+                tool_use_id: "tool-worktree",
+                tool_input: {},
+                tool_response: {},
+                ...(agentId ? { agent_id: agentId } : {}),
+              },
+              undefined,
+              { signal: new AbortController().signal },
+            ),
+          );
+        }
+        assert.equal((yield* adapter.listSessions())[0]?.cwd, agentId ? previousCwd : nextCwd);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("derives bypass permission mode from full-access runtime policy", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4693,6 +4693,33 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
+        hooks: {
+          PostToolUse: [
+            {
+              matcher: "^(EnterWorktree|ExitWorktree)$",
+              hooks: [
+                (hookInput) =>
+                  runPromise(
+                    Effect.gen(function* () {
+                      const context = yield* Ref.get(contextRef);
+                      if (
+                        context &&
+                        hookInput.hook_event_name === "PostToolUse" &&
+                        !hookInput.agent_id
+                      ) {
+                        context.session = {
+                          ...context.session,
+                          cwd: hookInput.cwd,
+                          updatedAt: yield* nowIso,
+                        };
+                      }
+                      return {};
+                    }),
+                  ),
+              ],
+            },
+          ],
+        },
         canUseTool,
         onUserDialog,
         supportedDialogKinds: ["resume_return"],

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1133,6 +1133,7 @@ const ThreadMetaUpdateCommand = Schema.Struct({
   modelSelection: Schema.optional(ModelSelection),
   branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   expectedBranch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  expectedWorktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   worktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   linkedPullRequest: Schema.optional(Schema.NullOr(ThreadLinkedPullRequest)),
 }).check(


### PR DESCRIPTION
Claude's EnterWorktree could move a local thread into another worktree while T3 kept the original cwd and branch. The sidebar and automatic MR badge continued pointing at the old checkout.

Read the cwd from successful top-level EnterWorktree and ExitWorktree hooks, then reuse the existing turn-end drift sync to persist the checkout. Dedicated worktrees follow HEAD. Moving to a shared, detached, temporary, or main checkout clears the old branch association, letting existing PR discovery clear its automatic badge. Manual PR links retain their existing semantics. Repository identity, shared-path aliases, and concurrent branch/worktree changes are guarded.

Validation: reproduced six failing checks before the fix; 208 focused tests now pass. A real Claude Code 2.1.267 session entered an existing worktree, checked out main, and exited, confirming both hooks report the actual cwd. Scoped server typecheck and targeted lint pass. Browser rendering was not tested.

Fixes #11078

Implemented with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worktree tracking when sessions move between dedicated, shared, detached, temporary, or unrelated checkouts.
  - Prevented stale branch or worktree updates from overwriting current session state.
  - Kept branch attribution accurate when a session leaves its dedicated worktree.
  - Rejected outdated queued updates when a session’s working directory changes.
  - Claude sessions now track working-directory changes after entering or exiting worktrees, while preserving the main session directory during subagent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->