### PR TITLE
fix(providers): keep running threads alive when renaming providers

### DIFF
--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -94,9 +94,11 @@ export const deriveProviderInstanceConfigMap = (
       continue;
     }
 
+    const { enabled, ...config } = legacyConfig;
     merged[instanceId] = {
       driver: driver.driverKind,
-      config: legacyConfig,
+      enabled,
+      config,
     };
   }
 

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -30,6 +30,8 @@ import {
   type CursorSettings,
   type GrokSettings,
   type OpenCodeSettings,
+  DEFAULT_SERVER_SETTINGS,
+  type ProviderInstanceConfig,
   ProviderDriverKind,
   type ProviderInstanceConfigMap,
   ProviderInstanceId,
@@ -40,6 +42,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 
@@ -59,6 +62,7 @@ import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
 import * as CodexResetCredit from "./codexResetCredit.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "./ProviderEventLoggers.ts";
 import { makeProviderInstanceRegistry } from "./ProviderInstanceRegistryLive.ts";
+import { deriveProviderInstanceConfigMap } from "./ProviderInstanceRegistryHydration.ts";
 
 const TestHttpClientLive = Layer.succeed(
   HttpClient.HttpClient,
@@ -335,6 +339,102 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(instance!.enabled).toBe(false);
       const snapshot = yield* instance!.snapshot.getSnapshot;
       expect(snapshot.enabled).toBe(false);
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.live(
+    "keeps live resources through presentation edits and closes them for runtime changes",
+    () =>
+      Effect.gen(function* () {
+        const instanceId = ProviderInstanceId.make("codex_personal");
+        let closed = 0;
+        const driver = {
+          ...CodexDriver,
+          create: (...args: Parameters<typeof CodexDriver.create>) =>
+            CodexDriver.create(...args).pipe(
+              Effect.tap(() => Effect.addFinalizer(() => Effect.sync(() => closed++))),
+            ),
+        };
+        let entry: ProviderInstanceConfig = {
+          driver: driver.driverKind,
+          displayName: "Personal",
+          accentColor: "#123456",
+          enabled: false,
+          environment: [{ name: "TEST_ACCOUNT", value: "personal", sensitive: false }],
+          config: makeCodexConfig({}),
+        };
+        const { registry, mutator } = yield* makeProviderInstanceRegistry({
+          drivers: [driver],
+          configMap: { [instanceId]: entry },
+        });
+        const original = (yield* registry.getInstance(instanceId))!;
+        const changes = yield* registry.subscribeChanges;
+
+        for (const presentation of [
+          { displayName: "Work", accentColor: "#123456" },
+          { displayName: "Work", accentColor: "#654321" },
+          { displayName: undefined, accentColor: undefined },
+        ]) {
+          entry = { ...structuredClone(entry), ...presentation };
+          yield* mutator.reconcile({ [instanceId]: entry });
+          expect(closed).toBe(0);
+          const current = (yield* registry.getInstance(instanceId))!;
+          expect(current).toBe(original);
+          expect(current.adapter).toBe(original.adapter);
+          expect(current).toMatchObject(presentation);
+          for (const snapshot of yield* Effect.all([
+            current.snapshot.getSnapshot,
+            current.snapshot.refresh,
+            current.snapshotForCwd!(process.cwd()),
+          ])) {
+            expect(snapshot.displayName).toBe(presentation.displayName);
+            expect(snapshot.accentColor).toBe(presentation.accentColor);
+            expect(Object.values(snapshot)).not.toContain(undefined);
+          }
+          yield* PubSub.take(changes);
+        }
+
+        yield* mutator.reconcile({ [instanceId]: structuredClone(entry) });
+        expect(closed).toBe(0);
+        expect(yield* registry.getInstance(instanceId)).toBe(original);
+
+        entry = {
+          ...entry,
+          environment: [{ name: "TEST_ACCOUNT", value: "work", sensitive: false }],
+        };
+        yield* mutator.reconcile({ [instanceId]: entry });
+        expect(closed).toBe(1);
+        expect((yield* registry.getInstance(instanceId))!.adapter).not.toBe(original.adapter);
+
+        yield* mutator.reconcile({});
+        expect(closed).toBe(2);
+        expect(yield* registry.listInstances).toEqual([]);
+      }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.live("keeps a legacy default instance alive on its first display name edit", () =>
+    Effect.gen(function* () {
+      const instanceId = ProviderInstanceId.make("codex");
+      const config = makeCodexConfig({});
+      const { registry, mutator } = yield* makeProviderInstanceRegistry({
+        drivers: [CodexDriver],
+        configMap: deriveProviderInstanceConfigMap({
+          ...DEFAULT_SERVER_SETTINGS,
+          providers: { ...DEFAULT_SERVER_SETTINGS.providers, codex: config },
+        }),
+      });
+      const original = yield* registry.getInstance(instanceId);
+      const { enabled, ...configWithoutEnabled } = config;
+      yield* mutator.reconcile({
+        [instanceId]: {
+          driver: CodexDriver.driverKind,
+          enabled,
+          config: configWithoutEnabled,
+          displayName: "Personal",
+        },
+      });
+      expect(yield* registry.getInstance(instanceId)).toBe(original);
+      expect(original?.displayName).toBe("Personal");
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -34,6 +34,7 @@
  */
 import {
   providerInstanceConfigEnabledFlag,
+  providerInstanceRuntimeConfigEqual,
   ProviderInstanceId,
   type ProviderInstanceConfig,
   type ProviderInstanceConfigMap,
@@ -64,13 +65,13 @@ import type { AnyProviderDriver, ProviderInstance } from "../ProviderDriver.ts";
 
 /**
  * Live registry entry: the materialized `ProviderInstance` + the fresh
- * child scope its `create` effect ran in + the original `entry` envelope
+ * child scope its `create` effect ran in + the current `entry` envelope
  * so `reconcile` can cheaply detect "no-op" updates.
  */
 interface LiveEntry {
   readonly instance: ProviderInstance;
   readonly scope: Scope.Closeable;
-  readonly entry: ProviderInstanceConfig;
+  entry: ProviderInstanceConfig;
 }
 
 /**
@@ -82,16 +83,6 @@ interface RegistryState {
   readonly unavailable: Ref.Ref<ReadonlyMap<ProviderInstanceId, ServerProvider>>;
   readonly changes: PubSub.PubSub<void>;
 }
-
-/**
- * Structural equality on `ProviderInstanceConfig` envelopes. Used by
- * `reconcile` to skip rebuilds when settings arrive unchanged. Config
- * payloads are opaque `unknown` at the envelope layer; `Equal.equals`
- * falls back to structural equality for plain records, which matches how
- * the schema decode output is constructed.
- */
-const entryEqual = (a: ProviderInstanceConfig, b: ProviderInstanceConfig): boolean =>
-  Equal.equals(a, b);
 
 /**
  * Resolve an entry's enabled state. An explicit false on either the
@@ -202,14 +193,43 @@ const buildEntry = <R>(input: {
       };
     }
 
-    return {
-      kind: "live" as const,
-      live: {
-        instance: createResult.success,
-        scope: childScope,
-        entry,
+    const instance = createResult.success;
+    const { snapshotForCwd } = instance;
+    // Read presentation from the current envelope, including on later probe emissions.
+    const withPresentation = (snapshot: ServerProvider): ServerProvider => {
+      const { displayName: _displayName, accentColor: _accentColor, ...rest } = snapshot;
+      return {
+        ...rest,
+        ...(live.entry.displayName ? { displayName: live.entry.displayName } : {}),
+        ...(live.entry.accentColor ? { accentColor: live.entry.accentColor } : {}),
+      };
+    };
+    const live: LiveEntry = {
+      scope: childScope,
+      entry,
+      instance: {
+        ...instance,
+        get displayName() {
+          return live.entry.displayName;
+        },
+        get accentColor() {
+          return live.entry.accentColor;
+        },
+        snapshot: {
+          ...instance.snapshot,
+          getSnapshot: instance.snapshot.getSnapshot.pipe(Effect.map(withPresentation)),
+          refresh: instance.snapshot.refresh.pipe(Effect.map(withPresentation)),
+          streamChanges: instance.snapshot.streamChanges.pipe(Stream.map(withPresentation)),
+        },
+        ...(snapshotForCwd
+          ? {
+              snapshotForCwd: (cwd: string) =>
+                snapshotForCwd(cwd).pipe(Effect.map(withPresentation)),
+            }
+          : {}),
       },
     };
+    return { kind: "live" as const, live };
   });
 
 /**
@@ -242,7 +262,7 @@ const makeReconcile = <R>(input: {
           continue;
         }
         const nextEntry = configMap[instanceId];
-        if (nextEntry !== undefined && !entryEqual(live.entry, nextEntry)) {
+        if (nextEntry !== undefined && !providerInstanceRuntimeConfigEqual(live.entry, nextEntry)) {
           replacedIds.add(instanceId);
         }
       }
@@ -258,6 +278,7 @@ const makeReconcile = <R>(input: {
       const builtEntries = new Map<ProviderInstanceId, LiveEntry>();
       const builtUnavailable = new Map<ProviderInstanceId, ServerProvider>();
       let orderChanged = false;
+      let presentationChanged = false;
       const previousOrder = [...previousEntries.keys()];
       const nextOrder: Array<ProviderInstanceId> = [];
 
@@ -267,7 +288,9 @@ const makeReconcile = <R>(input: {
 
         const existing = previousEntries.get(instanceId);
         if (existing !== undefined && !replacedIds.has(instanceId)) {
-          // No-op update: keep the existing live entry and scope.
+          presentationChanged ||= !Equal.equals(existing.entry, entry);
+          existing.entry = entry;
+          // Presentation edits keep the adapter, subscriptions, and scope alive.
           builtEntries.set(instanceId, existing);
           continue;
         }
@@ -298,6 +321,7 @@ const makeReconcile = <R>(input: {
       }
 
       const entriesChanged =
+        presentationChanged ||
         orderChanged ||
         removedIds.length > 0 ||
         replacedIds.size > 0 ||

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -677,10 +677,11 @@ export const ProviderRegistryLive = Layer.effect(
         // Snapshot current state without starting a probe. Managed providers
         // launch their startup refresh independently, so this closes the
         // subscription race without putting external work on the registry
-        // or HTTP server construction path.
+        // or HTTP server construction path. Include retained instances so
+        // presentation edits reach clients without replacing subscriptions.
         yield* Effect.forEach(
-          newlyAdded,
-          ([, instance]) =>
+          instances,
+          (instance) =>
             Effect.gen(function* () {
               const source = buildSnapshotSource(instance);
               const provider = yield* source.getSnapshot;

--- a/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.environment.test.tsx
@@ -20,8 +20,13 @@ const atoms = vi.hoisted(() => ({
 }));
 
 const commands = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
   refresh: vi.fn(),
   updateProvider: vi.fn(),
+}));
+
+vi.mock("../../localApi", () => ({
+  ensureLocalApi: () => ({ dialogs: { confirm: commands.confirm } }),
 }));
 
 const settingsState = vi.hoisted(() => ({
@@ -63,7 +68,11 @@ vi.mock("react/compiler-runtime", async () => {
 });
 
 vi.mock("@effect/atom-react", () => ({
-  useAtomValue: () => atoms.providers,
+  useAtomValue: (atom: symbol) => (atom === atoms.providersAtom ? atoms.providers : []),
+}));
+
+vi.mock("../../state/threads", () => ({
+  environmentThreadShells: { environmentThreadsAtom: () => Symbol.for("threads") },
 }));
 
 vi.mock("../../state/server", () => ({
@@ -301,7 +310,7 @@ describe("EnvironmentProviderSettings routing", () => {
     ).not.toBeNull();
   });
 
-  it("deletes and resets provider configuration without erasing shared preferences", () => {
+  it("deletes and resets provider configuration without erasing shared preferences", async () => {
     settingsState.value = {
       ...DEFAULT_UNIFIED_SETTINGS,
       providerInstances: {
@@ -331,7 +340,10 @@ describe("EnvironmentProviderSettings routing", () => {
       (element) => element.props.instanceId === customId && element.props.mode === "editor",
     );
     expect(customCard).not.toBeNull();
-    (customCard?.props.onDelete as (() => void) | undefined)?.();
+    commands.confirm.mockResolvedValueOnce(false);
+    await (customCard?.props.onDelete as (() => Promise<void>) | undefined)?.();
+    expect(settingsState.updateSettings).not.toHaveBeenCalled();
+    await (customCard?.props.onDelete as (() => Promise<void>) | undefined)?.();
 
     expect(settingsState.updateSettings).toHaveBeenLastCalledWith({
       providerInstances: {
@@ -356,7 +368,7 @@ describe("EnvironmentProviderSettings routing", () => {
       (element) => typeof element.props.onClick === "function",
     );
     expect(resetButton).not.toBeNull();
-    (resetButton?.props.onClick as (() => void) | undefined)?.();
+    await (resetButton?.props.onClick as (() => Promise<void>) | undefined)?.();
 
     const resetPatch = settingsState.updateSettings.mock.lastCall?.[0] as
       | Record<string, unknown>

--- a/apps/web/src/components/settings/ProviderSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsPanel.tsx
@@ -11,6 +11,7 @@ import {
   type EnvironmentId,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
+  providerInstanceRuntimeConfigEqual,
   type ProviderInstanceConfig,
   type ProviderInstanceId,
   resolveEnvironmentMachineKind,
@@ -34,6 +35,7 @@ import { usePrimarySessionState } from "../../environments/primary";
 import { useEnvironmentSettings, useUpdateEnvironmentSettings } from "../../hooks/useSettings";
 import { EnvironmentMachineIcon } from "../EnvironmentMachineIcon";
 import { cn } from "../../lib/utils";
+import { ensureLocalApi } from "../../localApi";
 import { resolveAppModelSelectionState } from "../../modelSelection";
 import {
   useEnvironments,
@@ -42,6 +44,7 @@ import {
 } from "../../state/environments";
 import { EMPTY_SERVER_PROVIDERS, serverEnvironment } from "../../state/server";
 import { useEnvironmentSessionState } from "../../state/session";
+import { environmentThreadShells } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { getRelativeTimeState } from "../../timestampFormat";
 import {
@@ -559,6 +562,7 @@ export function EnvironmentProviderSettings({
   readonly readOnly?: boolean;
 }) {
   const settings = useEnvironmentSettings(environmentId);
+  const threads = useAtomValue(environmentThreadShells.environmentThreadsAtom(environmentId));
   const updateSettings = useUpdateEnvironmentSettings(environmentId);
   const serverProviders =
     useAtomValue(serverEnvironment.providersValueAtom(environmentId)) ?? EMPTY_SERVER_PROVIDERS;
@@ -778,7 +782,17 @@ export function EnvironmentProviderSettings({
     rows.find((row) => row.instanceId === selectedInstanceId) ??
     (targetInstanceMissing ? null : (rows[0] ?? null));
 
-  const updateProviderInstance = (
+  const confirmStoppingThreads = (instanceId: ProviderInstanceId) =>
+    !threads.some(
+      (thread) =>
+        (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId) === instanceId &&
+        (thread.session?.status === "running" || thread.session?.status === "starting"),
+    ) ||
+    ensureLocalApi().dialogs.confirm(
+      `Change this provider on ${environmentLabel}? This stops its running threads. Thread history is kept.`,
+    );
+
+  const updateProviderInstance = async (
     row: InstanceRow,
     next: ProviderInstanceConfig,
     options?: {
@@ -787,6 +801,11 @@ export function EnvironmentProviderSettings({
       >[0]["textGenerationModelSelection"];
     },
   ) => {
+    if (
+      !providerInstanceRuntimeConfigEqual(row.instance, next) &&
+      !(await confirmStoppingThreads(row.instanceId))
+    )
+      return;
     updateSettings(
       buildProviderInstanceUpdatePatch({
         settings,
@@ -799,7 +818,13 @@ export function EnvironmentProviderSettings({
     );
   };
 
-  const deleteProviderInstance = (id: ProviderInstanceId) => {
+  const deleteProviderInstance = async (id: ProviderInstanceId) => {
+    if (
+      !(await ensureLocalApi().dialogs.confirm(
+        `Delete this provider from ${environmentLabel}? This stops its running threads. Thread history is kept.`,
+      ))
+    )
+      return;
     updateSettings({
       providerInstances: withoutProviderInstanceKey(settings.providerInstances, id),
     });
@@ -849,7 +874,7 @@ export function EnvironmentProviderSettings({
     });
   };
 
-  const resetDefaultInstance = (driverKind: ProviderDriverKind) => {
+  const resetDefaultInstance = async (driverKind: ProviderDriverKind) => {
     type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
     const defaultLegacyProviders = DEFAULT_UNIFIED_SETTINGS.providers as Record<
       string,
@@ -858,6 +883,7 @@ export function EnvironmentProviderSettings({
     const defaultInstanceId = defaultInstanceIdForDriver(driverKind);
     const defaultLegacyProvider = defaultLegacyProviders[driverKind];
     if (defaultLegacyProvider === undefined) return;
+    if (!(await confirmStoppingThreads(defaultInstanceId))) return;
     updateSettings({
       providers: {
         ...settings.providers,

--- a/packages/contracts/src/providerInstance.ts
+++ b/packages/contracts/src/providerInstance.ts
@@ -34,6 +34,7 @@
  * @module providerInstance
  */
 import * as Effect from "effect/Effect";
+import * as Equal from "effect/Equal";
 import * as Schema from "effect/Schema";
 import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 
@@ -130,6 +131,15 @@ export const ProviderInstanceConfig = Schema.Struct({
   config: Schema.optionalKey(Schema.Unknown),
 });
 export type ProviderInstanceConfig = typeof ProviderInstanceConfig.Type;
+
+export const providerInstanceRuntimeConfigEqual = (
+  a: ProviderInstanceConfig,
+  b: ProviderInstanceConfig,
+): boolean =>
+  a.driver === b.driver &&
+  a.enabled === b.enabled &&
+  Equal.equals(a.environment, b.environment) &&
+  Equal.equals(a.config, b.config);
 
 /**
  * Map shape for `ServerSettings.providerInstances`. Keyed by


### PR DESCRIPTION
## What Changed

Renaming or recoloring a provider keeps its live instance and sessions, while refreshed snapshots publish the new presentation. Runtime edits, disabling, and resetting warn when that instance has running threads. Deletion always asks for confirmation.

## Why

The registry compared the whole settings envelope and closed the instance scope for cosmetic edits. Compare runtime fields separately and update presentation in place. Normalize the legacy enabled flag during hydration so a default provider's first rename preserves its instance too.

Fixes #11043. No existing PR found through issue references, the issue timeline, or related provider searches.

Validation: 65 focused registry and settings tests passed, including the regression that failed before the fix. Server, contracts, and web typechecks pass; scoped lint passes with one existing warning. In an isolated web client, two Codex mock subprocess turns survived rename and color changes and then completed through normal provider events. Canceling runtime edits or deletion preserved the provider; confirmed deletion removed it. Native desktop/mobile and real provider binaries were not exercised.

## UI Changes

Before: Delete immediately removes the provider. After: confirmation explains the effect on running threads.

| Before | After |
| --- | --- |
| ![Immediate deletion](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11043/delete-before.png) | ![Deletion confirmation](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11043/delete-after.png) |

[Before recording](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11043/delete-before.webm) · [Rename, color, and cancellation recording](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11043/rename-and-warnings-after.webm)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Provider display changes, such as names and accent colors, now update without interrupting active provider instances or their resources.
  - Provider updates, deletions, and resets now request confirmation when related threads are running or starting.
  - Declining a confirmation safely cancels the requested change while preserving thread history.

- **Bug Fixes**
  - Provider configuration updates now correctly distinguish runtime settings from enabled status, improving consistency for legacy provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->