### PR TITLE
fix(server): open a new OpenCode turn after the provider goes idle

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1627,6 +1627,269 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("opens a new turn when the follow-up arrives before the idle event is processed", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-stale-active-turn");
+      const sessionID = "http://127.0.0.1:9999/session";
+      let nativeIdle = false;
+      const busyEvent = promiseWithResolvers<unknown>();
+      const retryEvent = promiseWithResolvers<unknown>();
+      const heldIdleEvent = promiseWithResolvers<unknown>();
+      const retryAfterIdle = promiseWithResolvers<unknown>();
+      runtimeMock.state.subscribedEvents = [
+        busyEvent.promise,
+        retryEvent.promise,
+        heldIdleEvent.promise,
+        retryAfterIdle.promise,
+      ];
+      runtimeMock.state.sessionStatusImplementation = async () => ({
+        data: nativeIdle ? {} : { [sessionID]: { type: "busy" as const } },
+      });
+
+      // `streamEvents` is a shared queue, so subscribers compete for events. Take
+      // one phase at a time; anything emitted between phases waits in the queue.
+      const startedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.started" || event.type === "runtime.warning"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First task",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-busy",
+        type: "session.status",
+        properties: { sessionID, status: { type: "busy" } },
+      });
+      // The retry event sits behind the busy event in the same queue, so observing
+      // its warning proves the busy status was already applied to the turn.
+      retryEvent.resolve({
+        id: "evt-retry",
+        type: "session.status",
+        properties: { sessionID, status: { type: "retry", attempt: 1, message: "transient" } },
+      });
+      const started = yield* Fiber.join(startedFiber).pipe(Effect.timeout("5 seconds"));
+      NodeAssert.deepEqual(
+        started.map((event) => event.type),
+        ["turn.started", "runtime.warning"],
+      );
+
+      const followUpFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.started" || event.type === "turn.completed"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      // OpenCode has finished the turn, but its idle event is still queued behind
+      // the pump, so `activeTurnId` still names the finished turn.
+      nativeIdle = true;
+      const secondTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "Second task",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      // OpenCode picks the follow-up up and runs again.
+      nativeIdle = false;
+
+      NodeAssert.notEqual(String(secondTurn.turnId), String(firstTurn.turnId));
+      const followUp = yield* Fiber.join(followUpFiber).pipe(Effect.timeout("5 seconds"));
+      NodeAssert.deepEqual(
+        followUp.map((event) => [event.type, String(event.turnId)]),
+        [
+          ["turn.completed", String(firstTurn.turnId)],
+          ["turn.started", String(secondTurn.turnId)],
+        ],
+      );
+
+      // Draining the now-stale idle must not retire the turn it raced. The retry
+      // behind it warns only after the idle was handled, so a completion for the
+      // second turn would have to arrive first.
+      const drainedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.completed" || event.type === "runtime.warning"),
+        ),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      heldIdleEvent.resolve({
+        id: "evt-idle-held",
+        type: "session.status",
+        properties: { sessionID, status: { type: "idle" } },
+      });
+      retryAfterIdle.resolve({
+        id: "evt-retry-after-idle",
+        type: "session.status",
+        properties: { sessionID, status: { type: "retry", attempt: 2, message: "transient" } },
+      });
+      const drained = Option.getOrUndefined(
+        yield* Fiber.join(drainedFiber).pipe(Effect.timeout("5 seconds")),
+      );
+      NodeAssert.equal(drained?.type, "runtime.warning");
+
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(session?.status, "running");
+      NodeAssert.equal(String(session?.activeTurnId), String(secondTurn.turnId));
+
+      // The second turn is intentionally left running; stop the session so its
+      // admission recovery loop cannot poll status into the next test.
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("opens a new turn when the idle event lands during the status preflight", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-idle-during-preflight");
+      const sessionID = "http://127.0.0.1:9999/session";
+      const busyEvent = promiseWithResolvers<unknown>();
+      const retryEvent = promiseWithResolvers<unknown>();
+      const idleEvent = promiseWithResolvers<unknown>();
+      const openEvent = promiseWithResolvers<unknown>();
+      const statusStarted = promiseWithResolvers<void>();
+      const statusRelease = promiseWithResolvers<void>();
+      let statusPhase: "busy" | "preflight" | "done" = "busy";
+      runtimeMock.state.subscribedEvents = [
+        busyEvent.promise,
+        retryEvent.promise,
+        idleEvent.promise,
+        // Never resolves; keeps the native event stream open until stopSession.
+        openEvent.promise,
+      ];
+      // Exactly one status call, the follow-up's preflight, is suspended and
+      // answers idle. Every other call reports the session busy.
+      runtimeMock.state.sessionStatusImplementation = async () => {
+        if (statusPhase !== "preflight") {
+          return { data: { [sessionID]: { type: "busy" as const } } };
+        }
+        statusPhase = "done";
+        statusStarted.resolve(undefined);
+        await statusRelease.promise;
+        return { data: {} };
+      };
+
+      // `streamEvents` is a shared queue, so subscribers compete for events. Take
+      // one phase at a time; anything emitted between phases waits in the queue.
+      const startedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "turn.started" || event.type === "runtime.warning"),
+        ),
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const firstTurn = yield* adapter.sendTurn({
+        threadId,
+        input: "First task",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      busyEvent.resolve({
+        id: "evt-busy",
+        type: "session.status",
+        properties: { sessionID, status: { type: "busy" } },
+      });
+      // The retry event sits behind the busy event in the same queue, so observing
+      // its warning proves the busy status was already applied to the turn.
+      retryEvent.resolve({
+        id: "evt-retry",
+        type: "session.status",
+        properties: { sessionID, status: { type: "retry", attempt: 1, message: "transient" } },
+      });
+      const started = yield* Fiber.join(startedFiber).pipe(Effect.timeout("5 seconds"));
+      NodeAssert.deepEqual(
+        started.map((event) => event.type),
+        ["turn.started", "runtime.warning"],
+      );
+
+      // Suspend the follow-up inside its preflight, then let the real idle event
+      // retire the first turn while that status request is still in flight.
+      const completedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.completed"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      statusPhase = "preflight";
+      const followUpFiber = yield* adapter
+        .sendTurn({
+          threadId,
+          input: "Second task",
+          modelSelection: createModelSelection(
+            ProviderInstanceId.make("opencode"),
+            "opencode/kimi-k3",
+          ),
+        })
+        .pipe(Effect.forkChild);
+      yield* Effect.promise(() => statusStarted.promise);
+      idleEvent.resolve({
+        id: "evt-idle-during-preflight",
+        type: "session.status",
+        properties: { sessionID, status: { type: "idle" } },
+      });
+      const completed = Option.getOrUndefined(
+        yield* Fiber.join(completedFiber).pipe(Effect.timeout("5 seconds")),
+      );
+      NodeAssert.equal(String(completed?.turnId), String(firstTurn.turnId));
+
+      // The turn the follow-up captured before the preflight is gone, so resuming
+      // it must open a new one rather than steer into the finished turn.
+      const secondStartedFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "turn.started"),
+        Stream.runHead,
+        Effect.forkChild,
+      );
+      statusRelease.resolve(undefined);
+      const secondTurn = yield* Fiber.join(followUpFiber).pipe(Effect.timeout("5 seconds"));
+      NodeAssert.notEqual(String(secondTurn.turnId), String(firstTurn.turnId));
+      const secondStarted = Option.getOrUndefined(
+        yield* Fiber.join(secondStartedFiber).pipe(Effect.timeout("5 seconds")),
+      );
+      NodeAssert.equal(String(secondStarted?.turnId), String(secondTurn.turnId));
+
+      const sessions = yield* adapter.listSessions();
+      const session = sessions.find((candidate) => candidate.threadId === threadId);
+      NodeAssert.equal(String(session?.activeTurnId), String(secondTurn.turnId));
+
+      // The second turn is intentionally left running; stop the session so its
+      // admission recovery loop cannot poll status into the next test.
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("waits for steer admission before accepting the only idle event", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -358,6 +358,11 @@ interface OpenCodeSessionContext {
   interruptedTurnId: TurnId | undefined;
   reconcileIdleStatus: boolean;
   awaitingBusyAfterInterruption: boolean;
+  /**
+   * True once OpenCode has natively reported this turn busy. Only then is a later
+   * idle reading trustworthy enough to treat a cached `activeTurnId` as stale.
+   */
+  nativeBusyObservedForActiveTurn: boolean;
   pendingIdleReconciliation: OpenCodeIdleReconciliation | undefined;
   pendingRequestRecovery: OpenCodePendingRequestRecovery | undefined;
   promptGeneration: number;
@@ -1130,6 +1135,7 @@ export function makeOpenCodeAdapter(
       }
       const tokenUsage = takeOpenCodeTurnTokenUsage(context, true);
       context.activeTurnId = undefined;
+      context.nativeBusyObservedForActiveTurn = false;
       context.activeAgent = undefined;
       context.activeVariant = undefined;
       context.interruptedTurnId = undefined;
@@ -1299,6 +1305,7 @@ export function makeOpenCodeAdapter(
       const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
       context.promptAdmission = undefined;
       context.activeTurnId = undefined;
+      context.nativeBusyObservedForActiveTurn = false;
       context.activeAgent = undefined;
       context.activeVariant = undefined;
       context.awaitingBusyAfterInterruption = false;
@@ -1505,6 +1512,7 @@ export function makeOpenCodeAdapter(
       if (context.activeTurnId === turnId) {
         tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
         context.activeTurnId = undefined;
+        context.nativeBusyObservedForActiveTurn = false;
         context.activeAgent = undefined;
         context.activeVariant = undefined;
         yield* updateProviderSession(
@@ -2570,6 +2578,7 @@ export function makeOpenCodeAdapter(
             }
             yield* cancelIdleReconciliation(context);
             context.awaitingBusyAfterInterruption = false;
+            context.nativeBusyObservedForActiveTurn = true;
             if (context.promptAdmission?.turnId === turnId) {
               context.promptAdmission.busyObserved = true;
               yield* schedulePromptAdmissionRecovery(context, event);
@@ -2650,6 +2659,7 @@ export function makeOpenCodeAdapter(
           }
           const tokenUsage = activeTurnId ? takeOpenCodeTurnTokenUsage(context, false) : undefined;
           context.activeTurnId = undefined;
+          context.nativeBusyObservedForActiveTurn = false;
           context.activeAgent = undefined;
           context.activeVariant = undefined;
           context.reconcileIdleStatus = false;
@@ -2998,6 +3008,7 @@ export function makeOpenCodeAdapter(
           cancellation: undefined,
           interruptedTurnId: undefined,
           reconcileIdleStatus: false,
+          nativeBusyObservedForActiveTurn: false,
           awaitingBusyAfterInterruption: false,
           pendingIdleReconciliation: undefined,
           pendingRequestRecovery: undefined,
@@ -3129,7 +3140,59 @@ export function makeOpenCodeAdapter(
           }
           // A sendTurn while a turn is active is a steer. OpenCode queues the
           // prompt into the running session, so the active turn id is reused.
-          const steeringTurnId = context.activeTurnId;
+          //
+          // `activeTurnId` is cleared asynchronously by the event pump, so it can
+          // still name a turn OpenCode has already finished, and the follow-up is
+          // then folded into that turn. Reusing it therefore needs the native status
+          // confirmed — but only where an idle reading is authoritative for this
+          // turn. It is not authoritative while idle evidence is deliberately
+          // withheld: admission, post-interruption, and reconciliation all mean a
+          // known-stale idle is in flight and the prompt is a genuine mid-turn
+          // steer. Nor is it authoritative before OpenCode has reported this turn
+          // busy, since it then describes the state before the turn started rather
+          // than after it ended.
+          let steeringTurnId = context.activeTurnId;
+          const idleEvidenceWithheld =
+            context.promptAdmission !== undefined ||
+            context.pendingIdleReconciliation !== undefined ||
+            context.reconcileIdleStatus ||
+            context.awaitingBusyAfterInterruption;
+          if (
+            steeringTurnId !== undefined &&
+            !idleEvidenceWithheld &&
+            context.nativeBusyObservedForActiveTurn
+          ) {
+            const preflight = yield* runOpenCodeSdk("session.status", (signal) =>
+              context.client.session.status(undefined, { signal }),
+            ).pipe(Effect.timeout("1 second"), Effect.option);
+            if (sessions.get(input.threadId) !== context || (yield* Ref.get(context.stopped))) {
+              return yield* Effect.interrupt;
+            }
+            // An unavailable or undecodable status keeps the current behavior:
+            // never guess idle.
+            const preflightStatus = Option.isSome(preflight)
+              ? Option.getOrUndefined(decodeOpenCodeSessionStatusMap(preflight.value.data))
+              : undefined;
+            if (preflightStatus !== undefined && context.activeTurnId === steeringTurnId) {
+              const nativeStatus = preflightStatus[context.openCodeSessionId];
+              if (nativeStatus === undefined || nativeStatus.type === "idle") {
+                yield* completeOpenCodeTurn(context, steeringTurnId, context.promptGeneration, {
+                  type: "session.status.preflight",
+                  status: preflightStatus,
+                });
+                // The native idle this preflight stood in for is still in flight.
+                // Reconcile the next one against the live status instead of
+                // trusting it, so it retires the turn it belongs to rather than
+                // the turn opened below.
+                context.reconcileIdleStatus = true;
+              }
+            }
+            // The status request is a suspension point, so the pump may have
+            // retired the turn while it was in flight. Re-read rather than
+            // trust the id captured before it: on both exits from the block it
+            // can now name a turn OpenCode has already finished.
+            steeringTurnId = context.activeTurnId;
+          }
           const turnId = steeringTurnId ?? freshTurnId;
           const agent = getModelSelectionStringOptionValue(modelSelection, "agent");
           const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
@@ -3166,6 +3229,7 @@ export function makeOpenCodeAdapter(
           context.activeTurnId = turnId;
           if (steeringTurnId === undefined) {
             context.turnTokenUsage = makeOpenCodeTurnTokenUsageAccumulator();
+            context.nativeBusyObservedForActiveTurn = false;
           }
           context.turnTokenUsage?.promptMessageIds.add(messageId);
           context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
@@ -3259,6 +3323,7 @@ export function makeOpenCodeAdapter(
                       const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
                       context.promptAdmission = undefined;
                       context.activeTurnId = undefined;
+                      context.nativeBusyObservedForActiveTurn = false;
                       context.activeAgent = undefined;
                       context.activeVariant = undefined;
                       yield* updateProviderSession(
@@ -3307,6 +3372,7 @@ export function makeOpenCodeAdapter(
                     const tokenUsage = takeOpenCodeTurnTokenUsage(context, false);
                     context.promptAdmission = undefined;
                     context.activeTurnId = undefined;
+                    context.nativeBusyObservedForActiveTurn = false;
                     context.activeAgent = undefined;
                     context.activeVariant = undefined;
                     context.awaitingBusyAfterInterruption = false;


### PR DESCRIPTION
## What Changed

`sendTurn` no longer decides steer-vs-new-turn from the cached `activeTurnId` alone. Before reusing it, the adapter confirms the native session status — but only where an idle reading is actually authoritative for that turn.

An idle reading is *not* authoritative when idle evidence is deliberately withheld (prompt admission, post-interruption, or pending reconciliation each mean a known-stale idle is in flight and the prompt is a genuine mid-turn steer), nor before OpenCode has reported the turn busy, since it then describes the state *before* the turn started rather than after it ended. An unavailable or undecodable status keeps the previous behavior: never guess idle.

Two follow-on details the change needs to be correct:

- Completing a turn from the preflight leaves the native idle it stood in for still in flight, so idle reconciliation is armed. The next idle is checked against live status instead of trusted, and retires the turn it belongs to rather than the turn the follow-up just opened.
- The status request is itself a suspension point, so `activeTurnId` is re-read after it rather than trusting the id captured before it — the event pump can retire the turn while the request is in flight, which is the same race in a narrower window.

Two deterministic regression tests cover both orderings: the idle event arriving before the follow-up, and the idle event landing *during* the preflight. Both were verified to fail against the unfixed adapter with the reported symptom (the follow-up reusing the finished turn's id).

## Why

Fixes #10973.

After an OpenCode task finished and the thread went idle, the first follow-up message was ignored. `activeTurnId` is cleared asynchronously by the event pump once native idle evidence is processed, so a prompt submitted during that gap reused the finished turn's id. That skipped `turn.started` and accrued the new work's tokens to the previous turn — from the user's side, the message looked like it did nothing.

The narrow fix is to confirm the provider's real status before trusting a cached turn id, while leaving every case where the cached id is legitimately still live untouched. In particular, the existing coverage for a mid-turn steer racing a stale idle status is unchanged and still green: that path is classified as withheld idle evidence and skips the status read entirely.

Verification: focused adapter suite 112/112 (run repeatedly for stability), all eight OpenCode test files 195/195, `apps/server` typecheck clean, targeted lint and format clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — N/A, server-only change with no UI surface
- [x] I included a video for animation/interaction changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent follow-up turns to prevent completed turns from being incorrectly reused.
  * Ensured stale or delayed idle-status events do not end newer active turns.
  * Improved recovery when status updates race with turn submission, preserving the correct active turn and running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->