### PR TITLE
fix(server): give slow OpenCode version probes more time

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -37,6 +37,7 @@ const runtimeMock = {
   state: {
     runVersionError: null as Error | null,
     runVersionPending: false,
+    runVersionDelayMs: null as number | null,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
     connectionError: null as Error | null,
@@ -56,6 +57,7 @@ const runtimeMock = {
   reset() {
     this.state.runVersionError = null;
     this.state.runVersionPending = false;
+    this.state.runVersionDelayMs = null;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
     this.state.connectionError = null;
@@ -128,7 +130,11 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
               cause: runtimeMock.state.runVersionError,
             }),
           )
-        : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
+        : runtimeMock.state.runVersionDelayMs
+          ? Effect.sleep(runtimeMock.state.runVersionDelayMs).pipe(
+              Effect.as({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
+            )
+          : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
   createOpenCodeSdkClient: (input) => {
     runtimeMock.state.sdkClientInputs.push(input);
     return {} as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>;
@@ -230,15 +236,30 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       const probeFiber = yield* checkProvider(makeOpenCodeSettings()).pipe(Effect.forkChild);
 
       yield* Effect.yieldNow;
-      yield* TestClock.adjust("4 seconds");
+      yield* TestClock.adjust("10 seconds");
       const snapshot = yield* Fiber.join(probeFiber);
 
       NodeAssert.equal(snapshot.status, "error");
       NodeAssert.equal(snapshot.installed, true);
       NodeAssert.equal(
         snapshot.message,
-        "Failed to execute OpenCode CLI health check: OpenCode CLI version probe timed out after 4 seconds.",
+        "Failed to execute OpenCode CLI health check: OpenCode CLI version probe timed out after 10 seconds.",
       );
+    }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("waits past the legacy four-second budget for a slow local CLI version probe", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.runVersionDelayMs = 5_000;
+      const probeFiber = yield* checkProvider(makeOpenCodeSettings()).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("5 seconds");
+      const snapshot = yield* Fiber.join(probeFiber);
+
+      NodeAssert.equal(snapshot.status, "warning");
+      NodeAssert.equal(snapshot.installed, true);
+      NodeAssert.equal(snapshot.version, "1.14.19");
     }).pipe(Effect.provide(TestClock.layer())),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -32,7 +32,7 @@ const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
   showInteractionModeToggle: false,
 } as const;
-const OPENCODE_VERSION_PROBE_TIMEOUT = "4 seconds";
+const OPENCODE_VERSION_PROBE_TIMEOUT = "10 seconds";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
   readonly cause?: unknown;


### PR DESCRIPTION
## What Changed

Raise the OpenCode version probe timeout from 4s to 10s.

Fixes #11080

## Why

A cold wrapper around the OpenCode CLI can exceed the hardcoded four-second
`--version` budget, which flips a healthy provider to "Unavailable" until the
next probe. The fix gives slow wrappers room to finish, and covers it with a
test where the probe resolves at 5s. The hanging-probe test now asserts the
ten-second budget.

Tests: `vp test run apps/server/src/provider/Layers/OpenCodeProvider.test.ts` (14 passed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (n/a)
- [ ] I included a video for animation/interaction changes (n/a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the OpenCode CLI version-check timeout to 10 seconds.
  * OpenCode installations that respond within the extended timeout are now recognized with a warning status instead of being incorrectly reported as unavailable.
  * Updated timeout messaging to accurately reflect the 10-second limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->