### PR TITLE
fix(server): keep Claude builtins in the command list

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -56,6 +56,19 @@ const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
 } as const;
+
+/**
+ * Builtins the CLI advertises on a live session's `system/init`
+ * `slash_commands` but no longer returns from `initializationResult().commands`
+ * (SDK 0.3.260 returns skills only), so a capability probe alone loses them.
+ * Keep this list to stable builtins that do not depend on plugins or config.
+ */
+const CLAUDE_BUILTIN_SLASH_COMMANDS: ReadonlyArray<ServerProviderSlashCommand> = [
+  { name: "context" },
+  { name: "reload-plugins" },
+  { name: "reload-skills" },
+];
+
 function toTitleCaseWords(value: string): string {
   const parts: Array<string> = [];
   for (const part of value.split(/[\s_-]+/g)) {
@@ -533,7 +546,11 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     ? yield* resolveCapabilities(claudeSettings).pipe(Effect.orElseSucceed(() => undefined))
     : undefined;
   const skills = yield* discoverClaudeSkills(claudeSettings, cwd, resolvedEnvironment);
-  const slashCommands = [COMPACT_SLASH_COMMAND, ...(capabilities?.slashCommands ?? [])];
+  const slashCommands = [
+    COMPACT_SLASH_COMMAND,
+    ...CLAUDE_BUILTIN_SLASH_COMMANDS,
+    ...(capabilities?.slashCommands ?? []),
+  ];
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
   if (!capabilities) {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -428,6 +428,10 @@ const runClaudeCommand = Effect.fn("runClaudeCommand")(function* (
   return yield* spawnAndCollect(claudeSettings.binaryPath, command);
 });
 
+/**
+ * Builds the Claude provider snapshot: version and auth, models, skills, usage
+ * limits, and the slash commands the composer should offer.
+ */
 export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(function* (
   claudeSettings: ClaudeSettings,
   resolveCapabilities?: (

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -54,7 +54,6 @@ import {
   resolveProviderStatusCachePath,
   writeProviderStatusCache,
 } from "../providerStatusCache.ts";
-import { COMPACT_SLASH_COMMAND } from "../providerSnapshot.ts";
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import * as ProviderInstanceRegistry from "../Services/ProviderInstanceRegistry.ts";
 import * as ProviderRegistry from "../Services/ProviderRegistry.ts";
@@ -2671,6 +2670,37 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         ),
       );
 
+      it.effect("keeps Claude builtins in the completion list when the SDK omits them", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            claudeCapabilities({
+              slashCommands: [{ name: "review", description: "Review changes" }],
+            }),
+          );
+          const names = new Set(status.slashCommands.map((command) => command.name));
+          assert.ok(names.has("compact"));
+          assert.ok(names.has("context"));
+          assert.ok(names.has("reload-plugins"));
+          assert.ok(names.has("reload-skills"));
+          assert.ok(names.has("review"));
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("returns ready and labels Bedrock-backed Claude as authenticated", () =>
         Effect.gen(function* () {
           // Bedrock authenticates via external AWS credentials, so the SDK init
@@ -2839,13 +2869,16 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             }),
           );
 
-          assert.deepStrictEqual(status.slashCommands.slice(1), [
-            {
-              name: "review",
-              description: "Review a pull request",
-              input: { hint: "pr-or-branch" },
-            },
-          ]);
+          assert.deepStrictEqual(
+            status.slashCommands.filter((command) => command.name === "review"),
+            [
+              {
+                name: "review",
+                description: "Review a pull request",
+                input: { hint: "pr-or-branch" },
+              },
+            ],
+          );
         }).pipe(
           Effect.provide(
             mockSpawnerLayer((args) => {
@@ -2882,14 +2915,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             }),
           );
 
-          assert.deepStrictEqual(status.slashCommands, [
-            COMPACT_SLASH_COMMAND,
-            {
-              name: "ui",
-              description: "Explore and refine UI",
-              input: { hint: "component-or-screen" },
-            },
-          ]);
+          assert.deepStrictEqual(
+            status.slashCommands.map((command) => command.name),
+            ["compact", "context", "reload-plugins", "reload-skills", "ui"],
+          );
+          assert.deepStrictEqual(status.slashCommands.at(-1), {
+            name: "ui",
+            description: "Explore and refine UI",
+            input: { hint: "component-or-screen" },
+          });
         }).pipe(
           Effect.provide(
             mockSpawnerLayer((args) => {


### PR DESCRIPTION
## What Changed

Merge a small `CLAUDE_BUILTIN_SLASH_COMMANDS` fallback (`context`, `reload-plugins`, `reload-skills`) into the Claude provider's `slashCommands` snapshot before deduping.

Fixes #11039

## Why

`probeClaudeCapabilities` builds the completion list from `initializationResult().commands`, which now returns skills only. The CLI advertises its builtins on a live session's `system/init.slash_commands`, which T3 does not read, so `/context`, `/reload-plugins`, and `/reload-skills` disappeared from the `/` menu even though typing them still works. The fallback is intentionally limited to stable, config-independent builtins; merging the live `system/init` list (and `commands_changed`) would be the durable follow-up.

Tests: `vp test run apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/server/src/provider/Layers/ClaudeCapabilitiesProbe.test.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts` (180 passed)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (n/a)
- [ ] I included a video for animation/interaction changes (n/a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude provider status now consistently includes built-in slash commands, even when they are omitted by the SDK.
  * Custom slash commands continue to be preserved and merged without duplicates.
* **Tests**
  * Updated coverage verifies built-in commands remain available alongside custom commands and retain their metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->