### PR TITLE
feat(threads): add cross-provider conversation forks

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -10,6 +10,8 @@ import type {
   ServerConfig as T3ServerConfig,
   UsageLimitsReport,
 } from "@t3tools/contracts";
+import { ThreadId } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import {
   collectProviderUsageLimits,
   hasProviderUsageLimits,
@@ -46,6 +48,9 @@ import Animated, {
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
 import { armAgentAwarenessLiveActivityForLocalWork } from "../agent-awareness/remoteRegistration";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { uuidv4 } from "../../lib/uuid";
+import { forkThreadCommand } from "../../state/thread-fork";
+import { useAtomCommand } from "../../state/use-atom-command";
 
 import { AppText as Text } from "../../components/AppText";
 import { ComposerAttachmentButton } from "../../components/ComposerAttachmentButton";
@@ -70,6 +75,7 @@ import {
   buildModelOptions,
   groupByProvider,
   isModelSelectionUnavailable,
+  type ModelOption,
 } from "../../lib/modelOptions";
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
@@ -90,6 +96,7 @@ import {
   type ExistingThreadSettingsRouteSession,
   useExistingThreadSettingsRoutePresentation,
 } from "./ThreadSettingsSheet";
+import { forkThreadIdForSelection } from "./thread-settings-route-state";
 import {
   useThreadSettingsSheetPresentation,
   type NavigationWithFinishTransitioning,
@@ -252,8 +259,17 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     editorRef: inputRef,
     isEditorFocused: isFocused,
   });
+  const openThreadSettingsSheet = settingsSheetPresentation.open;
+  const dismissThreadSettingsSheet = settingsSheetPresentation.onDismissed;
   const settingsRoutePresentation = useExistingThreadSettingsRoutePresentation();
+  const presentThreadSettingsRoute = settingsRoutePresentation.present;
+  const refreshThreadSettingsRoute = settingsRoutePresentation.refresh;
+  const clearThreadSettingsRoute = settingsRoutePresentation.clear;
   const settingsRoutePresentedRef = useRef(false);
+  const pendingForkThreadIdRef = useRef<ThreadId | null>(null);
+  const completedForkThreadIdRef = useRef<ThreadId | null>(null);
+  const attemptedForkSelectionKeyRef = useRef<string | null>(null);
+  const forkThreadMutation = useAtomCommand(forkThreadCommand, { reportFailure: false });
   const wasExpandedBeforePreviewRef = useRef(false);
   const inFlightThreadIdsRef = useRef(new Set<string>());
   const { onExpandedChange } = props;
@@ -485,40 +501,154 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     [currentModelOption?.capabilities, currentModelSelection.options],
   );
   const settingsOwnerId = composerOwnerKey;
+  const commitFork = useCallback(
+    async (option: ModelOption) => {
+      const currentThreadId = pendingForkThreadIdRef.current;
+      if (currentThreadId === null) {
+        return false;
+      }
+      const selectionKey = JSON.stringify(option.selection);
+      const newThreadId = forkThreadIdForSelection({
+        threadId: currentThreadId,
+        attemptedSelectionKey: attemptedForkSelectionKeyRef.current,
+        nextSelectionKey: selectionKey,
+        createThreadId: () => ThreadId.make(uuidv4()),
+      });
+      pendingForkThreadIdRef.current = newThreadId;
+      attemptedForkSelectionKeyRef.current = selectionKey;
+      const result = await forkThreadMutation({
+        environmentId: props.environmentId,
+        input: {
+          sourceThreadId: props.selectedThread.id,
+          newThreadId,
+          modelSelection: option.selection,
+        },
+      });
+      if (result._tag === "Failure") {
+        const error = Cause.squash(result.cause);
+        Alert.alert(
+          "Could not fork conversation",
+          error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : "The conversation could not be forked.",
+        );
+        return false;
+      }
+      completedForkThreadIdRef.current = result.value.threadId;
+      return true;
+    },
+    [forkThreadMutation, props.environmentId, props.selectedThread.id],
+  );
+  const openForkedThread = useCallback(() => {
+    const threadId = completedForkThreadIdRef.current;
+    if (threadId === null) {
+      return;
+    }
+    completedForkThreadIdRef.current = null;
+    pendingForkThreadIdRef.current = null;
+    attemptedForkSelectionKeyRef.current = null;
+    navigation.dispatch(
+      StackActions.replace("Thread", {
+        environmentId: String(props.environmentId),
+        threadId: String(threadId),
+      }),
+    );
+  }, [navigation, props.environmentId]);
+  const openForkSettings = useCallback(() => {
+    const newThreadId = ThreadId.make(uuidv4());
+    pendingForkThreadIdRef.current = newThreadId;
+    completedForkThreadIdRef.current = null;
+    attemptedForkSelectionKeyRef.current = null;
+    presentThreadSettingsRoute({
+      ownerId: settingsOwnerId,
+      presentationId: `${settingsOwnerId}:fork:${newThreadId}`,
+      purpose: "fork",
+      title: "Fork conversation",
+      commitLabel: "Fork",
+      environmentId: props.environmentId,
+      providerGroups: providerGroups.flatMap((group) => {
+        const models = group.models.filter(
+          (option) =>
+            option.selection.instanceId !== currentModelSelection.instanceId ||
+            option.selection.model !== currentModelSelection.model,
+        );
+        return models.length > 0 ? [{ ...group, models }] : [];
+      }),
+      selectedModel: null,
+      onSelectModel: () => undefined,
+      optionDescriptors: [],
+      onUpdateOptionSelections: () => undefined,
+      runtimeMode: currentRuntimeMode,
+      onUpdateRuntimeMode: () => undefined,
+      onCommitModel: commitFork,
+      onCommitSucceeded: openForkedThread,
+      requiresModelSelection: true,
+      showRuntimeOption: false,
+    });
+  }, [
+    commitFork,
+    currentModelSelection.instanceId,
+    currentModelSelection.model,
+    currentRuntimeMode,
+    openForkedThread,
+    props.environmentId,
+    providerGroups,
+    settingsOwnerId,
+    presentThreadSettingsRoute,
+  ]);
+  const onUpdateModelSelection = props.onUpdateModelSelection;
+  const onUpdateRuntimeMode = props.onUpdateRuntimeMode;
+  const supportsThreadForking = props.serverConfig?.environment.capabilities.threadForking === true;
   const settingsRouteSession = useMemo<ExistingThreadSettingsRouteSession>(
     () => ({
       ownerId: settingsOwnerId,
+      purpose: "settings",
       environmentId: props.environmentId,
       providerInstanceId: currentModelSelection.instanceId,
       providerGroups: threadProviderGroups,
       selectedModel: currentModelSelection,
-      onSelectModel: (option) => props.onUpdateModelSelection(option.selection),
+      onSelectModel: (option) => onUpdateModelSelection(option.selection),
       optionDescriptors: providerOptionDescriptors,
       onUpdateOptionSelections: (options) =>
-        props.onUpdateModelSelection({ ...currentModelSelection, options }),
+        onUpdateModelSelection({ ...currentModelSelection, options }),
       runtimeMode: currentRuntimeMode,
-      onUpdateRuntimeMode: props.onUpdateRuntimeMode,
+      onUpdateRuntimeMode,
+      ...(supportsThreadForking
+        ? {
+            footerAction: {
+              label: "Fork conversation with another provider/model",
+              detail: "Create a new thread with this context. The original stays unchanged.",
+              onPress: openForkSettings,
+            },
+          }
+        : {}),
     }),
     [
       currentModelSelection,
       currentRuntimeMode,
-      props.onUpdateModelSelection,
-      props.onUpdateRuntimeMode,
+      onUpdateModelSelection,
+      onUpdateRuntimeMode,
+      openForkSettings,
+      props.environmentId,
       providerOptionDescriptors,
       settingsOwnerId,
+      supportsThreadForking,
       threadProviderGroups,
     ],
   );
   const openSettings = useCallback(() => {
-    settingsRoutePresentation.present(settingsRouteSession);
-    settingsSheetPresentation.open();
-  }, [settingsRoutePresentation.present, settingsRouteSession, settingsSheetPresentation.open]);
+    pendingForkThreadIdRef.current = null;
+    completedForkThreadIdRef.current = null;
+    attemptedForkSelectionKeyRef.current = null;
+    presentThreadSettingsRoute(settingsRouteSession);
+    openThreadSettingsSheet();
+  }, [openThreadSettingsSheet, presentThreadSettingsRoute, settingsRouteSession]);
 
   useEffect(() => {
     if (settingsSheetPresentation.isActive) {
-      settingsRoutePresentation.present(settingsRouteSession);
+      refreshThreadSettingsRoute(settingsRouteSession);
     }
-  }, [settingsRoutePresentation.present, settingsRouteSession, settingsSheetPresentation.isActive]);
+  }, [refreshThreadSettingsRoute, settingsRouteSession, settingsSheetPresentation.isActive]);
 
   useEffect(() => {
     if (!settingsSheetPresentation.isVisible || settingsRoutePresentedRef.current) {
@@ -536,9 +666,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       }
 
       settingsRoutePresentedRef.current = false;
-      settingsSheetPresentation.onDismissed();
-      settingsRoutePresentation.clear(settingsOwnerId);
-    }, [settingsOwnerId, settingsRoutePresentation.clear, settingsSheetPresentation.onDismissed]),
+      pendingForkThreadIdRef.current = null;
+      completedForkThreadIdRef.current = null;
+      attemptedForkSelectionKeyRef.current = null;
+      dismissThreadSettingsSheet();
+      clearThreadSettingsRoute(settingsOwnerId);
+    }, [clearThreadSettingsRoute, dismissThreadSettingsSheet, settingsOwnerId]),
   );
 
   useEffect(

--- a/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
+++ b/apps/mobile/src/features/threads/ThreadSettingsSheet.tsx
@@ -14,7 +14,12 @@ import {
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
 } from "@t3tools/shared/model";
-import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
+import {
+  useNavigation,
+  usePreventRemove,
+  useRoute,
+  type RouteProp,
+} from "@react-navigation/native";
 import {
   createNativeStackNavigator,
   type NativeStackNavigationProp,
@@ -26,6 +31,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -69,6 +75,7 @@ import {
   pendingModelAfterPress,
   providerSectionIsCollapsed,
 } from "./thread-settings-sheet-state";
+import { refreshThreadSettingsRouteSession } from "./thread-settings-route-state";
 
 /**
  * Everyday harnesses start expanded; every other provider (OpenRouter catalogs
@@ -317,6 +324,8 @@ type ThreadSettingsSubmenuPage =
   | { readonly kind: "runtime" };
 
 type ThreadSettingsSessionProps = {
+  readonly title?: string;
+  readonly commitLabel?: string;
   readonly environmentId: EnvironmentId | null;
   readonly providerInstanceId?: ProviderInstanceId;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
@@ -326,15 +335,27 @@ type ThreadSettingsSessionProps = {
   readonly onUpdateOptionSelections: (selections: ReadonlyArray<ProviderOptionSelection>) => void;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
+  readonly onCommitModel?: (option: ModelOption) => boolean | Promise<boolean>;
+  readonly onCommitSucceeded?: () => void;
+  readonly requiresModelSelection?: boolean;
+  readonly showRuntimeOption?: boolean;
+  readonly footerAction?: {
+    readonly label: string;
+    readonly detail: string;
+    readonly onPress: () => void;
+  };
 };
 
 export type ExistingThreadSettingsRouteSession = ThreadSettingsSessionProps & {
   readonly ownerId: string;
+  readonly presentationId?: string;
+  readonly purpose?: "settings" | "fork";
 };
 
 type ExistingThreadSettingsRouteContextValue = {
   readonly session: ExistingThreadSettingsRouteSession | null;
   readonly present: (session: ExistingThreadSettingsRouteSession) => void;
+  readonly refresh: (session: ExistingThreadSettingsRouteSession) => void;
   readonly clear: (ownerId: string) => void;
 };
 
@@ -347,10 +368,16 @@ export function ExistingThreadSettingsRouteProvider(props: { readonly children: 
   const present = useCallback((nextSession: ExistingThreadSettingsRouteSession) => {
     setSession(nextSession);
   }, []);
+  const refresh = useCallback((nextSession: ExistingThreadSettingsRouteSession) => {
+    setSession((current) => refreshThreadSettingsRouteSession(current, nextSession));
+  }, []);
   const clear = useCallback((ownerId: string) => {
     setSession((current) => (current?.ownerId === ownerId ? null : current));
   }, []);
-  const value = useMemo(() => ({ session, present, clear }), [clear, present, session]);
+  const value = useMemo(
+    () => ({ session, present, refresh, clear }),
+    [clear, present, refresh, session],
+  );
 
   return (
     <ExistingThreadSettingsRouteContext.Provider value={value}>
@@ -370,11 +397,16 @@ export function useExistingThreadSettingsRoutePresentation() {
 }
 
 type ThreadSettingsSessionValue = {
+  readonly title: string;
+  readonly commitLabel: string;
   readonly environmentId: EnvironmentId | null;
   readonly providerInstanceId?: ProviderInstanceId;
   readonly providerGroups: ReadonlyArray<ProviderGroup>;
   readonly runtimeMode: RuntimeMode;
   readonly onUpdateRuntimeMode: (mode: RuntimeMode) => void;
+  readonly onCommitSucceeded?: () => void;
+  readonly showRuntimeOption: boolean;
+  readonly footerAction?: ThreadSettingsSessionProps["footerAction"];
   readonly displayedDescriptors: ReadonlyArray<ProviderOptionDescriptor>;
   readonly providerExpansionOverrides: ReadonlySet<string>;
   readonly hasLegacyModels: boolean;
@@ -383,7 +415,9 @@ type ThreadSettingsSessionValue = {
   readonly searchQuery: string;
   readonly showLegacy: boolean;
   readonly applyOptionChange: (id: string, value: string | boolean) => void;
-  readonly commitPendingModel: () => boolean;
+  readonly canCommit: boolean;
+  readonly commitPendingModel: () => Promise<boolean>;
+  readonly isCommitting: boolean;
   readonly isApplied: (option: ModelOption) => boolean;
   readonly isDisplayed: (option: ModelOption) => boolean;
   readonly pressModel: (option: ModelOption) => void;
@@ -406,6 +440,8 @@ function ThreadSettingsSessionProvider(
     () => new Set(),
   );
   const [pendingModel, setPendingModel] = useState<ModelOption | null>(null);
+  const [isCommitting, setIsCommitting] = useState(false);
+  const isCommittingRef = useRef(false);
 
   const isApplied = useCallback(
     (option: ModelOption) =>
@@ -439,7 +475,10 @@ function ThreadSettingsSessionProvider(
     () => props.providerGroups.some((group) => group.models.some((model) => model.isLegacy)),
     [props.providerGroups],
   );
-  const commitPendingModel = useCallback(() => {
+  const commitPendingModel = useCallback(async () => {
+    if (isCommittingRef.current || (props.requiresModelSelection && !pendingModel)) {
+      return false;
+    }
     if (pendingModel) {
       if (!canCommitPendingModel(pendingModel, props.providerGroups)) {
         Alert.alert(
@@ -449,10 +488,22 @@ function ThreadSettingsSessionProvider(
         return false;
       }
       void Haptics.selectionAsync();
-      props.onSelectModel(pendingModel);
+      isCommittingRef.current = true;
+      setIsCommitting(true);
+      try {
+        const committed = props.onCommitModel
+          ? await props.onCommitModel(pendingModel)
+          : (props.onSelectModel(pendingModel), true);
+        if (!committed) {
+          return false;
+        }
+      } finally {
+        isCommittingRef.current = false;
+        setIsCommitting(false);
+      }
     }
     return true;
-  }, [pendingModel, props.onSelectModel, props.providerGroups]);
+  }, [pendingModel, props]);
 
   const applyOptionChange = useCallback(
     (id: string, value: string | boolean) => {
@@ -498,14 +549,21 @@ function ThreadSettingsSessionProvider(
 
   const value = useMemo<ThreadSettingsSessionValue>(
     () => ({
+      title: props.title ?? "Thread settings",
+      commitLabel: props.commitLabel ?? (pendingModel ? "Save" : "Done"),
       environmentId: props.environmentId,
       providerInstanceId: props.providerInstanceId,
       providerGroups: props.providerGroups,
       runtimeMode: props.runtimeMode,
       onUpdateRuntimeMode: props.onUpdateRuntimeMode,
+      onCommitSucceeded: props.onCommitSucceeded,
+      showRuntimeOption: props.showRuntimeOption !== false,
+      footerAction: props.footerAction,
       displayedDescriptors,
       providerExpansionOverrides,
       hasLegacyModels,
+      canCommit: !isCommitting && (!props.requiresModelSelection || pendingModel !== null),
+      isCommitting,
       pendingModel,
       providerFilter,
       searchQuery,
@@ -529,8 +587,15 @@ function ThreadSettingsSessionProvider(
       isApplied,
       isDisplayed,
       props.environmentId,
+      props.commitLabel,
+      props.footerAction,
+      props.onCommitSucceeded,
       props.providerInstanceId,
+      props.requiresModelSelection,
+      props.showRuntimeOption,
+      props.title,
       pendingModel,
+      isCommitting,
       pressModel,
       providerFilter,
       props.onUpdateRuntimeMode,
@@ -713,59 +778,90 @@ function ThreadSettingsOptionsItem(props: {
     Platform.OS === "ios" && NATIVE_MAIL_SEARCH_TOOLBAR_SUPPORTED
       ? NATIVE_MAIL_SEARCH_TOOLBAR_CONTENT_INSET
       : 0;
+  const showsOptions = session.displayedDescriptors.length > 0 || session.showRuntimeOption;
 
   return (
     <View style={{ paddingBottom: insets.bottom + bottomToolbarInset + 12 }}>
-      <Text className="px-5 pb-2 pt-2 text-sm font-t3-medium text-foreground-muted">Options</Text>
-      <Animated.View
-        className="mx-4 overflow-hidden rounded-2xl bg-card"
-        layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
-      >
-        {session.displayedDescriptors.map((descriptor) => {
-          if (descriptor.type === "select") {
-            return (
-              <Animated.View
-                key={descriptor.id}
-                entering={
-                  props.animationsReady ? THREAD_SETTINGS_OPTION_ENTER_TRANSITION : undefined
-                }
-                exiting={props.animationsReady ? THREAD_SETTINGS_OPTION_EXIT_TRANSITION : undefined}
-                layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
-              >
+      {showsOptions ? (
+        <>
+          <Text className="px-5 pb-2 pt-2 text-sm font-t3-medium text-foreground-muted">
+            Options
+          </Text>
+          <Animated.View
+            className="mx-4 overflow-hidden rounded-2xl bg-card"
+            layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
+          >
+            {session.displayedDescriptors.map((descriptor) => {
+              if (descriptor.type === "select") {
+                return (
+                  <Animated.View
+                    key={descriptor.id}
+                    entering={
+                      props.animationsReady ? THREAD_SETTINGS_OPTION_ENTER_TRANSITION : undefined
+                    }
+                    exiting={
+                      props.animationsReady ? THREAD_SETTINGS_OPTION_EXIT_TRANSITION : undefined
+                    }
+                    layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
+                  >
+                    <DisclosureRow
+                      label={descriptor.label}
+                      value={getProviderOptionCurrentLabel(descriptor)}
+                      onPress={() => props.onOpenSubmenu({ kind: "descriptor", id: descriptor.id })}
+                    />
+                  </Animated.View>
+                );
+              }
+              return (
+                <Animated.View
+                  key={descriptor.id}
+                  entering={
+                    props.animationsReady ? THREAD_SETTINGS_OPTION_ENTER_TRANSITION : undefined
+                  }
+                  exiting={
+                    props.animationsReady ? THREAD_SETTINGS_OPTION_EXIT_TRANSITION : undefined
+                  }
+                  layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
+                >
+                  <SwitchRow
+                    label={descriptor.label}
+                    value={descriptor.currentValue ?? false}
+                    onValueChange={(value) => session.applyOptionChange(descriptor.id, value)}
+                  />
+                </Animated.View>
+              );
+            })}
+            {session.showRuntimeOption ? (
+              <Animated.View layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}>
                 <DisclosureRow
-                  label={descriptor.label}
-                  value={getProviderOptionCurrentLabel(descriptor)}
-                  onPress={() => props.onOpenSubmenu({ kind: "descriptor", id: descriptor.id })}
+                  isLast
+                  label="Runtime"
+                  value={
+                    RUNTIME_MODE_CHOICES.find((choice) => choice.mode === session.runtimeMode)
+                      ?.label
+                  }
+                  onPress={() => props.onOpenSubmenu({ kind: "runtime" })}
                 />
               </Animated.View>
-            );
-          }
-          return (
-            <Animated.View
-              key={descriptor.id}
-              entering={props.animationsReady ? THREAD_SETTINGS_OPTION_ENTER_TRANSITION : undefined}
-              exiting={props.animationsReady ? THREAD_SETTINGS_OPTION_EXIT_TRANSITION : undefined}
-              layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}
-            >
-              <SwitchRow
-                label={descriptor.label}
-                value={descriptor.currentValue ?? false}
-                onValueChange={(value) => session.applyOptionChange(descriptor.id, value)}
-              />
-            </Animated.View>
-          );
-        })}
-        <Animated.View layout={THREAD_SETTINGS_OPTIONS_LAYOUT_TRANSITION}>
-          <DisclosureRow
-            isLast
-            label="Runtime"
-            value={
-              RUNTIME_MODE_CHOICES.find((choice) => choice.mode === session.runtimeMode)?.label
-            }
-            onPress={() => props.onOpenSubmenu({ kind: "runtime" })}
-          />
-        </Animated.View>
-      </Animated.View>
+            ) : null}
+          </Animated.View>
+        </>
+      ) : null}
+
+      {session.footerAction ? (
+        <Pressable
+          accessibilityRole="button"
+          className="mx-4 mt-6 rounded-2xl bg-card px-4 py-3 active:bg-subtle"
+          onPress={session.footerAction.onPress}
+        >
+          <Text className="text-base font-t3-medium text-foreground">
+            {session.footerAction.label}
+          </Text>
+          <Text className="mt-0.5 text-sm leading-5 text-foreground-muted">
+            {session.footerAction.detail}
+          </Text>
+        </Pressable>
+      ) : null}
 
       {Platform.OS !== "ios" && session.hasLegacyModels ? (
         <>
@@ -1006,6 +1102,9 @@ function ThreadSettingsModelsScreen() {
     [refreshProvidersCommand],
   );
   const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
+  const [commitSucceeded, setCommitSucceeded] = useState(false);
+  const removalBlocked = session.isCommitting;
+  usePreventRemove(removalBlocked, () => undefined);
   const refreshProviders = useCallback(() => {
     if (!session.environmentId || isRefreshingProviders) return;
     setIsRefreshingProviders(true);
@@ -1015,10 +1114,27 @@ function ThreadSettingsModelsScreen() {
       if (error) Alert.alert("Could not refresh models", error);
     });
   }, [isRefreshingProviders, refreshProviderCatalog, session.environmentId]);
-  const commitAndClose = useCallback(() => {
-    if (!session.commitPendingModel()) return;
+  const commitAndClose = useCallback(async () => {
+    if (!(await session.commitPendingModel())) return;
+    if (session.onCommitSucceeded) {
+      setCommitSucceeded(true);
+      return;
+    }
     presentation.onClose();
   }, [presentation, session]);
+  const onCommitSucceeded = session.onCommitSucceeded;
+  useEffect(() => {
+    if (removalBlocked || !commitSucceeded || !onCommitSucceeded) {
+      return;
+    }
+    const frame = requestAnimationFrame(onCommitSucceeded);
+    return () => cancelAnimationFrame(frame);
+  }, [commitSucceeded, onCommitSucceeded, removalBlocked]);
+  const close = useCallback(() => {
+    if (!removalBlocked) {
+      presentation.onClose();
+    }
+  }, [presentation, removalBlocked]);
   const filterMenu = useMemo(
     () => ({
       title: "Model filters",
@@ -1069,13 +1185,14 @@ function ThreadSettingsModelsScreen() {
               onPress: refreshProviders,
             },
             {
-              accessibilityLabel: session.pendingModel ? "Save thread settings" : "Done",
+              accessibilityLabel: session.commitLabel,
+              disabled: !session.canCommit,
               icon: "checkmark",
-              onPress: commitAndClose,
+              onPress: () => void commitAndClose(),
             },
           ]}
-          onBack={presentation.onClose}
-          title="Thread settings"
+          onBack={close}
+          title={session.title}
         />
       ) : null}
       <NativeStackScreenOptions
@@ -1085,6 +1202,7 @@ function ThreadSettingsModelsScreen() {
           session.showLegacy,
         ]}
         options={{
+          title: session.title,
           unstable_headerToolbarItems: usesNativeMailSearchToolbar
             ? () => [
                 createNativeMailSearchToolbarItem({
@@ -1127,9 +1245,9 @@ function ThreadSettingsModelsScreen() {
       />
       <NativeHeaderToolbar placement="left">
         <NativeHeaderToolbar.Button
-          accessibilityLabel="Cancel thread settings"
+          accessibilityLabel={`Cancel ${session.title.toLowerCase()}`}
           label="Cancel"
-          onPress={presentation.onClose}
+          onPress={close}
         />
       </NativeHeaderToolbar>
       <NativeHeaderToolbar placement="right">
@@ -1141,9 +1259,10 @@ function ThreadSettingsModelsScreen() {
           separateBackground
         />
         <NativeHeaderToolbar.Button
-          accessibilityLabel={session.pendingModel ? "Save thread settings" : "Done"}
-          label={session.pendingModel ? "Save" : "Done"}
-          onPress={commitAndClose}
+          accessibilityLabel={session.commitLabel}
+          disabled={!session.canCommit}
+          label={session.isCommitting ? `${session.commitLabel}…` : session.commitLabel}
+          onPress={() => void commitAndClose()}
         />
       </NativeHeaderToolbar>
       {Platform.OS === "ios" && !usesNativeMailSearchToolbar ? (
@@ -1275,7 +1394,7 @@ export function ExistingThreadSettingsRouteScreen() {
   const { ownerId: _ownerId, ...settings } = session;
 
   return (
-    <ThreadSettingsSessionProvider {...settings}>
+    <ThreadSettingsSessionProvider key={session.presentationId ?? session.ownerId} {...settings}>
       <ThreadSettingsPickerNavigator onClose={() => navigation.goBack()} />
     </ThreadSettingsSessionProvider>
   );

--- a/apps/mobile/src/features/threads/thread-settings-route-state.test.ts
+++ b/apps/mobile/src/features/threads/thread-settings-route-state.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  forkThreadIdForSelection,
+  refreshThreadSettingsRouteSession,
+} from "./thread-settings-route-state";
+
+describe("refreshThreadSettingsRouteSession", () => {
+  it("does not replace an active fork picker with reactive source-thread settings", () => {
+    const fork = { ownerId: "environment:source", purpose: "fork" as const, revision: 1 };
+    const settings = { ownerId: "environment:source", purpose: "settings" as const, revision: 2 };
+
+    expect(refreshThreadSettingsRouteSession(fork, settings)).toBe(fork);
+  });
+
+  it("refreshes ordinary settings and sessions owned by another thread", () => {
+    const settings = { ownerId: "environment:source", purpose: "settings" as const, revision: 1 };
+    const refreshed = { ...settings, revision: 2 };
+    const other = { ownerId: "environment:other", purpose: "settings" as const, revision: 3 };
+
+    expect(refreshThreadSettingsRouteSession(settings, refreshed)).toBe(refreshed);
+    expect(refreshThreadSettingsRouteSession(settings, other)).toBe(other);
+  });
+});
+
+describe("forkThreadIdForSelection", () => {
+  it("keeps the target id for retries and replaces it after any selection change", () => {
+    const createThreadId = () => "replacement";
+    const medium = JSON.stringify({
+      instanceId: "codex",
+      model: "gpt",
+      options: [{ id: "effort", value: "medium" }],
+    });
+    const high = JSON.stringify({
+      instanceId: "codex",
+      model: "gpt",
+      options: [{ id: "effort", value: "high" }],
+    });
+
+    expect(
+      forkThreadIdForSelection({
+        threadId: "original",
+        attemptedSelectionKey: null,
+        nextSelectionKey: medium,
+        createThreadId,
+      }),
+    ).toBe("original");
+    expect(
+      forkThreadIdForSelection({
+        threadId: "original",
+        attemptedSelectionKey: medium,
+        nextSelectionKey: medium,
+        createThreadId,
+      }),
+    ).toBe("original");
+    expect(
+      forkThreadIdForSelection({
+        threadId: "original",
+        attemptedSelectionKey: medium,
+        nextSelectionKey: high,
+        createThreadId,
+      }),
+    ).toBe("replacement");
+  });
+});

--- a/apps/mobile/src/features/threads/thread-settings-route-state.ts
+++ b/apps/mobile/src/features/threads/thread-settings-route-state.ts
@@ -1,0 +1,25 @@
+export type ThreadSettingsRouteSessionIdentity = {
+  readonly ownerId: string;
+  readonly purpose?: "settings" | "fork";
+};
+
+/** Keep an active fork picker stable while the source thread continues updating behind its sheet. */
+export function refreshThreadSettingsRouteSession<
+  Current extends ThreadSettingsRouteSessionIdentity,
+  Next extends ThreadSettingsRouteSessionIdentity,
+>(current: Current | null, next: Next): Current | Next {
+  return current?.ownerId === next.ownerId && current.purpose === "fork" ? current : next;
+}
+
+/** Retry one target idempotently; choosing another model starts a distinct fork request. */
+export function forkThreadIdForSelection<ThreadId>(input: {
+  readonly threadId: ThreadId;
+  readonly attemptedSelectionKey: string | null;
+  readonly nextSelectionKey: string;
+  readonly createThreadId: () => ThreadId;
+}): ThreadId {
+  return input.attemptedSelectionKey !== null &&
+    input.attemptedSelectionKey !== input.nextSelectionKey
+    ? input.createThreadId()
+    : input.threadId;
+}

--- a/apps/mobile/src/state/thread-fork.ts
+++ b/apps/mobile/src/state/thread-fork.ts
@@ -1,0 +1,13 @@
+import { forkThread } from "@t3tools/client-runtime/operations/threadFork";
+import { createEnvironmentCommand } from "@t3tools/client-runtime/state/runtime";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const forkThreadCommand = createEnvironmentCommand(connectionAtomRuntime, {
+  label: "fork thread",
+  execute: forkThread,
+  concurrency: {
+    mode: "singleFlight",
+    key: ({ environmentId, input }) => `${environmentId}:${input.newThreadId}`,
+  },
+});

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -107,6 +107,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.assetsCreateUrl]: AuthOrchestrationReadScope,
   [WS_METHODS.attachmentsCreateUploadUrl]: AuthOrchestrationOperateScope,
   [WS_METHODS.attachmentsDelete]: AuthOrchestrationOperateScope,
+  [WS_METHODS.threadsFork]: AuthOrchestrationOperateScope,
   [WS_METHODS.providerUploadFeedback]: AuthOrchestrationOperateScope,
   [WS_METHODS.subscribeVcsStatus]: AuthOrchestrationReadScope,
   [WS_METHODS.subscribeResourceTelemetry]: AuthOrchestrationReadScope,

--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -169,6 +169,7 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
       expect(second.capabilities.usagePriceOverrides).toBe(true);
       expect(second.capabilities.threadActiveReorder).toBe(true);
       expect(second.capabilities.threadTitleRegeneration).toBe(true);
+      expect(second.capabilities.threadForking).toBe(true);
       expect(second.capabilities.threadPullRequests).toBe(true);
       expect(second.capabilities.threadPullRequestLinking).toBe(true);
       expect(second.capabilities.agentActivityPublishing).toBe(false);

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -230,6 +230,7 @@ export const make = Effect.gen(function* () {
       threadPinReorder: true,
       threadActiveReorder: true,
       threadTitleRegeneration: true,
+      threadForking: true,
       threadPullRequests: true,
       pullRequestStackActions: true,
       threadPullRequestLinking: true,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -830,6 +830,108 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
+  effectIt.effect(
+    "starts a cross-provider child handoff without reusing or stopping the source session",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            threadModelSelection: {
+              instanceId: ProviderInstanceId.make("claudeAgent"),
+              model: "claude-sonnet-4-6",
+            },
+          }),
+        );
+        let sent = yield* Deferred.make<void>();
+        let targetThreadId = ThreadId.make("thread-1");
+        harness.sendTurn.mockImplementation(() =>
+          Deferred.succeed(sent, undefined).pipe(
+            Effect.as({ threadId: targetThreadId, turnId: asTurnId(`turn-${targetThreadId}`) }),
+          ),
+        );
+        const createdAt = "2026-01-01T00:00:00.000Z";
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("source-turn"),
+          threadId: targetThreadId,
+          message: {
+            messageId: asMessageId("source-message"),
+            role: "user",
+            text: "Original task",
+            attachments: [],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          createdAt,
+        });
+        yield* Deferred.await(sent);
+        yield* Effect.promise(harness.drain);
+        const sourceBefore = (yield* Effect.promise(harness.readModel)).threads[0];
+        const sourceSession = structuredClone(harness.runtimeSessions[0]);
+
+        targetThreadId = ThreadId.make("thread-2");
+        const modelSelection = {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        };
+        yield* harness.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.make("child-create"),
+          threadId: targetThreadId,
+          projectId: asProjectId("project-1"),
+          title: "Fork of Thread",
+          modelSelection,
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+        });
+        const transcript = {
+          type: "file" as const,
+          id: "thread-2-aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa-txt",
+          name: "conversation.txt",
+          mimeType: "text/plain",
+          sizeBytes: 150_000,
+        };
+        sent = yield* Deferred.make<void>();
+        yield* harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("child-handoff"),
+          threadId: targetThreadId,
+          message: {
+            messageId: asMessageId("child-message"),
+            role: "user",
+            text: "Read the attached source conversation and wait for my next request.",
+            attachments: [transcript],
+          },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          createdAt,
+        });
+        yield* Deferred.await(sent);
+        yield* Effect.promise(harness.drain);
+
+        expect(harness.startSession).toHaveBeenCalledTimes(2);
+        expect(harness.startSession.mock.calls[1]?.[0]).toBe(targetThreadId);
+        expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({ modelSelection });
+        expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+        expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
+          threadId: targetThreadId,
+          attachments: [transcript],
+        });
+        expect(harness.runtimeSessions[0]).toEqual(sourceSession);
+        expect(harness.runtimeSessions[1]?.resumeCursor).not.toEqual(sourceSession?.resumeCursor);
+        expect(
+          (yield* Effect.promise(harness.readModel)).threads.find(
+            (thread) => thread.id === sourceBefore?.id,
+          ),
+        ).toEqual(sourceBefore);
+        expect(harness.stopSession).not.toHaveBeenCalled();
+        expect(harness.interruptTurn).not.toHaveBeenCalled();
+      }),
+  );
+
   it("reacts to thread.turn.start by ensuring session and sending provider turn", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -22,6 +22,7 @@ import {
   type OrchestrationShellStreamItem,
   OrchestrationThreadDetailSnapshot,
   type OrchestrationThreadStreamItem,
+  type OrchestrationThread,
   type OrchestrationThreadActivity,
   type OrchestrationThreadShell,
   TerminalNotRunningError,
@@ -11698,4 +11699,179 @@ it.live(
       assert.deepEqual(transferBudgetViolations(runs), []);
     }).pipe(Effect.provide(NodeServices.layer)),
   120_000,
+);
+
+it.effect("forks a thread through one idempotent transcript handoff operation", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-thread-fork-test-" });
+    const paths = yield* ServerConfig.deriveServerPaths(baseDir, undefined);
+    const source: OrchestrationThread = {
+      ...makeDefaultOrchestrationReadModel().threads[0]!,
+      title: "Long source thread",
+      messages: Array.from({ length: 240 }, (_, index) => ({
+        id: MessageId.make(`source-message-${index}`),
+        role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+        text: `${index % 2 === 0 ? "Question" : "Answer"} ${index}`,
+        turnId: TurnId.make(`source-turn-${Math.floor(index / 2)}`),
+        streaming: false,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })),
+    };
+    const targets = new Map<ThreadId, OrchestrationThread>();
+    const acceptedCommandIds = new Set<CommandId>();
+    const rejectedCommandIds = new Map<CommandId, OrchestrationListenerCallbackError>();
+    const commands: OrchestrationCommand[] = [];
+    let sequence = 0;
+    let failNextTurn = false;
+    const provider = {
+      instanceId: defaultModelSelection.instanceId,
+      driver: ProviderDriverKind.make("codex"),
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready" as const,
+      auth: { status: "authenticated" as const },
+      checkedAt: "2026-01-01T00:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+    };
+
+    yield* buildAppUnderTest({
+      config: { baseDir },
+      layers: {
+        providerRegistry: { getProviders: Effect.succeed([provider]) },
+        projectionSnapshotQuery: {
+          getSnapshotSequence: () => Effect.succeed({ snapshotSequence: sequence }),
+          getThreadDetailById: (threadId) =>
+            Effect.succeed(
+              threadId === source.id
+                ? Option.some(source)
+                : Option.fromNullishOr(targets.get(threadId)),
+            ),
+        },
+        orchestrationEngine: {
+          dispatch: (command) =>
+            Effect.gen(function* () {
+              commands.push(command);
+              if (acceptedCommandIds.has(command.commandId)) return { sequence };
+              const priorRejection = rejectedCommandIds.get(command.commandId);
+              if (priorRejection) return yield* priorRejection;
+              if (command.type === "thread.create") {
+                if (targets.has(command.threadId)) {
+                  return yield* new OrchestrationListenerCallbackError({
+                    listener: "domain-event",
+                    detail: "thread already exists",
+                  });
+                }
+                targets.set(command.threadId, {
+                  ...source,
+                  id: command.threadId,
+                  title: command.title,
+                  modelSelection: command.modelSelection,
+                  messages: [],
+                });
+              } else if (command.type === "thread.turn.start") {
+                if (failNextTurn) {
+                  failNextTurn = false;
+                  const rejection = new OrchestrationListenerCallbackError({
+                    listener: "domain-event",
+                    detail: "turn dispatch failed",
+                  });
+                  rejectedCommandIds.set(command.commandId, rejection);
+                  return yield* rejection;
+                }
+                const target = targets.get(command.threadId)!;
+                targets.set(command.threadId, {
+                  ...target,
+                  messages: [
+                    {
+                      id: command.message.messageId,
+                      role: command.message.role,
+                      text: command.message.text,
+                      attachments: command.message.attachments,
+                      turnId: null,
+                      streaming: false,
+                      createdAt: command.createdAt,
+                      updatedAt: command.createdAt,
+                    },
+                  ],
+                });
+              }
+              sequence += 1;
+              acceptedCommandIds.add(command.commandId);
+              return { sequence };
+            }),
+        },
+      },
+    });
+    const wsUrl = yield* getWsServerUrl("/ws");
+    const input = {
+      sourceThreadId: source.id,
+      newThreadId: ThreadId.make("parallel-fork"),
+      modelSelection: defaultModelSelection,
+    };
+
+    const parallel = yield* Effect.all(
+      [
+        Effect.scoped(withWsRpcClient(wsUrl, (client) => client[WS_METHODS.threadsFork](input))),
+        Effect.scoped(withWsRpcClient(wsUrl, (client) => client[WS_METHODS.threadsFork](input))),
+      ],
+      { concurrency: "unbounded" },
+    );
+    assert.deepEqual(
+      parallel.map(({ threadId }) => threadId),
+      [input.newThreadId, input.newThreadId],
+    );
+    assert.deepEqual(
+      commands.map(({ type }) => type),
+      ["thread.create", "thread.turn.start"],
+    );
+    const target = targets.get(input.newThreadId)!;
+    assert.equal(source.messages.length, 240);
+    assert.equal(target.projectId, source.projectId);
+    assert.deepEqual(target.modelSelection, input.modelSelection);
+    const attachment = target.messages[0]!.attachments![0]!;
+    const transcript = yield* fs.readFileString(`${paths.attachmentsDir}/${attachment.id}.md`);
+    assert.include(transcript, "Question 0");
+    assert.include(transcript, "Answer 239");
+
+    const conflict = yield* Effect.scoped(
+      withWsRpcClient(wsUrl, (client) =>
+        client[WS_METHODS.threadsFork]({
+          ...input,
+          sourceThreadId: ThreadId.make("different-source"),
+        }),
+      ),
+    ).pipe(Effect.result);
+    assertTrue(conflict._tag === "Failure");
+    assertTrue(conflict.failure._tag === "ThreadForkError");
+    assert.equal(conflict.failure.reason, "target_conflict");
+
+    const retryThreadId = ThreadId.make("failed-then-retried-fork");
+    failNextTurn = true;
+    const failed = yield* Effect.scoped(
+      withWsRpcClient(wsUrl, (client) =>
+        client[WS_METHODS.threadsFork]({ ...input, newThreadId: retryThreadId }),
+      ),
+    ).pipe(Effect.result);
+    assertTrue(failed._tag === "Failure");
+    assertTrue(failed.failure._tag === "ThreadForkError");
+    assert.isTrue(targets.has(retryThreadId));
+    assert.equal(targets.get(retryThreadId)?.messages.length, 0);
+    const retried = yield* Effect.scoped(
+      withWsRpcClient(wsUrl, (client) =>
+        client[WS_METHODS.threadsFork]({ ...input, newThreadId: retryThreadId }),
+      ),
+    );
+    assert.equal(retried.threadId, retryThreadId);
+    assert.equal(targets.get(retryThreadId)?.messages.length, 1);
+    const retryTurnCommands = commands.filter(
+      (command) => command.type === "thread.turn.start" && command.threadId === retryThreadId,
+    );
+    assert.equal(retryTurnCommands.length, 2);
+    assert.notEqual(retryTurnCommands[0]!.commandId, retryTurnCommands[1]!.commandId);
+  }).pipe(Effect.provide(NodeHttpServer.layerTest), Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/threadFork.test.ts
+++ b/apps/server/src/threadFork.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ThreadId, type OrchestrationThread } from "@t3tools/contracts";
+
+import {
+  makeThreadForkAttachment,
+  makeThreadForkHandoffPrompt,
+  makeThreadForkTranscript,
+  threadForkMessageId,
+  findThreadForkTranscriptAttachment,
+} from "./threadFork.ts";
+
+const source = {
+  id: ThreadId.make("source-thread"),
+  title: "Investigate the issue",
+  messages: [
+    {
+      id: "m1",
+      role: "user",
+      text: "First question",
+      attachments: [
+        {
+          type: "file",
+          id: "source-file",
+          name: "notes.txt",
+          mimeType: "text/plain",
+          sizeBytes: 4,
+        },
+      ],
+    },
+    { id: "m2", role: "system", text: "hidden runtime note" },
+    { id: "m3", role: "assistant", text: "First answer" },
+  ],
+} as unknown as OrchestrationThread;
+
+describe("thread fork handoff", () => {
+  it("serializes persisted conversation text without copying provider internals", () => {
+    const transcript = makeThreadForkTranscript(source);
+
+    expect(transcript).toContain("Source thread: Investigate the issue");
+    expect(transcript).toContain("## USER\n\nFirst question");
+    expect(transcript).toContain("[Attachments referenced but not copied: notes.txt]");
+    expect(transcript).toContain("## ASSISTANT\n\nFirst answer");
+    expect(transcript).not.toContain("hidden runtime note");
+    expect(transcript.indexOf("First question")).toBeLessThan(transcript.indexOf("First answer"));
+  });
+
+  it("derives stable operation, message, and child-owned attachment identities", () => {
+    const threadId = ThreadId.make("new-thread");
+    const transcript = makeThreadForkTranscript(source);
+    const first = makeThreadForkAttachment({
+      attachmentsDir: "/tmp/attachments",
+      threadId,
+      transcript,
+    });
+    const second = makeThreadForkAttachment({
+      attachmentsDir: "/tmp/attachments",
+      threadId,
+      transcript,
+    });
+
+    expect(threadForkMessageId(threadId)).toBe("thread-fork:new-thread:handoff");
+    expect(first).toEqual(second);
+    expect(first?.attachment.id).toMatch(/^new-thread-[0-9a-f-]+-md$/);
+    expect(first?.path).toBe(`/tmp/attachments/${first?.attachment.id}.md`);
+  });
+
+  it("makes the first turn a context handoff that waits for the user", () => {
+    expect(makeThreadForkHandoffPrompt(source)).toContain("source-thread");
+    expect(makeThreadForkHandoffPrompt(source)).toContain("Wait for the user's next request");
+  });
+
+  it("flattens the recognized transcript when forking an existing fork", () => {
+    const forkId = ThreadId.make("first-fork");
+    const inherited = makeThreadForkTranscript(source);
+    const stored = makeThreadForkAttachment({
+      attachmentsDir: "/tmp/attachments",
+      threadId: forkId,
+      transcript: inherited,
+    });
+    expect(stored).not.toBeNull();
+    const fork = {
+      ...source,
+      id: forkId,
+      title: "Investigate the issue (fork)",
+      messages: [
+        {
+          id: threadForkMessageId(forkId),
+          role: "user",
+          text: makeThreadForkHandoffPrompt(source),
+          attachments: [stored!.attachment],
+        },
+        { id: "fork-answer", role: "assistant", text: "Ready for the next request" },
+        { id: "fork-user", role: "user", text: "Continue with this constraint" },
+      ],
+    } as unknown as OrchestrationThread;
+
+    expect(findThreadForkTranscriptAttachment(fork)).toEqual(stored!.attachment);
+    const nextTranscript = makeThreadForkTranscript(fork, inherited);
+    expect(nextTranscript).toContain("First question");
+    expect(nextTranscript).toContain("First answer");
+    expect(nextTranscript).toContain("Continue with this constraint");
+    expect(nextTranscript).not.toContain(makeThreadForkHandoffPrompt(source));
+  });
+
+  it("rejects transcripts larger than the provider file limit instead of truncating them", () => {
+    const tooLarge = "x".repeat(50 * 1024 * 1024 + 1);
+    expect(
+      makeThreadForkAttachment({
+        attachmentsDir: "/tmp/attachments",
+        threadId: ThreadId.make("new-thread"),
+        transcript: tooLarge,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/threadFork.ts
+++ b/apps/server/src/threadFork.ts
@@ -1,0 +1,145 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeCrypto from "node:crypto";
+
+import {
+  CommandId,
+  MessageId,
+  PROVIDER_SEND_TURN_MAX_FILE_BYTES,
+  type ChatFileAttachment,
+  type OrchestrationMessage,
+  type OrchestrationThread,
+  type ModelSelection,
+  type ThreadId,
+} from "@t3tools/contracts";
+
+import { resolveAttachmentPath, toSafeThreadAttachmentSegment } from "./attachmentStore.ts";
+
+const THREAD_FORK_TRANSCRIPT_NAME = "conversation-transcript.md";
+
+export function threadForkCreateCommandId(sourceThreadId: ThreadId, threadId: ThreadId): CommandId {
+  return CommandId.make(`thread-fork:${threadId}:from:${sourceThreadId}:create`);
+}
+
+export function threadForkMessageId(threadId: ThreadId): MessageId {
+  return MessageId.make(`thread-fork:${threadId}:handoff`);
+}
+
+function deterministicUuid(value: string): string {
+  const hex = NodeCrypto.createHash("sha256").update(value).digest("hex").slice(0, 32);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function threadForkAttachmentId(threadId: ThreadId): string | null {
+  const threadSegment = toSafeThreadAttachmentSegment(threadId);
+  return threadSegment === null
+    ? null
+    : `${threadSegment}-${deterministicUuid(`thread-fork:${threadId}`)}-md`;
+}
+
+export function findThreadForkTranscriptAttachment(
+  source: OrchestrationThread,
+): ChatFileAttachment | null {
+  const message = source.messages.find(
+    (candidate) => candidate.id === threadForkMessageId(source.id),
+  );
+  const expectedAttachmentId = threadForkAttachmentId(source.id);
+  if (!message || expectedAttachmentId === null) return null;
+  const attachment = (message.attachments ?? []).find(
+    (candidate): candidate is ChatFileAttachment =>
+      candidate.type === "file" &&
+      candidate.id === expectedAttachmentId &&
+      candidate.name === THREAD_FORK_TRANSCRIPT_NAME &&
+      candidate.mimeType === "text/markdown",
+  );
+  return attachment ?? null;
+}
+
+export function makeThreadForkTranscript(
+  source: OrchestrationThread,
+  inheritedTranscript?: string,
+): string {
+  const generatedHandoffMessageId = threadForkMessageId(source.id);
+  const messages = source.messages.filter(
+    (message): message is OrchestrationMessage & { readonly role: "user" | "assistant" } =>
+      (message.role === "user" || message.role === "assistant") &&
+      (inheritedTranscript === undefined || message.id !== generatedHandoffMessageId),
+  );
+  const transcript = messages.map((message) => {
+    const attachmentNames = (message.attachments ?? []).map((attachment) => attachment.name);
+    return [
+      `## ${message.role === "user" ? "USER" : "ASSISTANT"}`,
+      message.text,
+      ...(attachmentNames.length === 0
+        ? []
+        : [`[Attachments referenced but not copied: ${attachmentNames.join(", ")}]`]),
+    ].join("\n\n");
+  });
+
+  return [
+    "# T3 Code conversation transcript",
+    "",
+    `Source thread: ${source.title}`,
+    `Source thread ID: ${source.id}`,
+    "",
+    "This handoff contains persisted user and assistant text in chronological order.",
+    "Binary attachments, provider tool activity, hidden provider state, and checkpoints are not copied.",
+    "",
+    ...(inheritedTranscript === undefined
+      ? []
+      : [
+          "## CONTEXT INHERITED BY THE SOURCE FORK",
+          "",
+          inheritedTranscript,
+          "",
+          "## CONTINUATION AFTER THAT FORK",
+          "",
+        ]),
+    ...transcript,
+  ].join("\n");
+}
+
+export function makeThreadForkAttachment(input: {
+  readonly attachmentsDir: string;
+  readonly threadId: ThreadId;
+  readonly transcript: string;
+}): { readonly attachment: ChatFileAttachment; readonly path: string } | null {
+  const id = threadForkAttachmentId(input.threadId);
+  if (id === null) return null;
+  const sizeBytes = Buffer.byteLength(input.transcript);
+  if (sizeBytes === 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_FILE_BYTES) return null;
+  const attachment = {
+    type: "file" as const,
+    id,
+    name: THREAD_FORK_TRANSCRIPT_NAME,
+    mimeType: "text/markdown",
+    sizeBytes,
+  } satisfies ChatFileAttachment;
+  const path = resolveAttachmentPath({ attachmentsDir: input.attachmentsDir, attachment });
+  return path === null ? null : { attachment, path };
+}
+
+export function makeThreadForkHandoffPrompt(source: Pick<OrchestrationThread, "id" | "title">) {
+  return [
+    `T3 source thread: ${source.id}.`,
+    `This conversation was forked from "${source.title}".`,
+    `Read the attached ${THREAD_FORK_TRANSCRIPT_NAME} as prior conversation context.`,
+    "Do not continue any task yet. Wait for the user's next request.",
+  ].join(" ");
+}
+
+export function isSameThreadForkModelSelection(
+  left: ModelSelection,
+  right: ModelSelection,
+): boolean {
+  if (left.instanceId !== right.instanceId || left.model !== right.model) return false;
+  const normalize = (selection: ModelSelection) =>
+    [...(selection.options ?? [])]
+      .map((option) => `${option.id}:${typeof option.value}:${String(option.value)}`)
+      .sort();
+  const leftOptions = normalize(left);
+  const rightOptions = normalize(right);
+  return (
+    leftOptions.length === rightOptions.length &&
+    leftOptions.every((option, index) => option === rightOptions[index])
+  );
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -7,9 +7,11 @@ import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as PartitionedSemaphore from "effect/PartitionedSemaphore";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -66,6 +68,7 @@ import {
   RpcClientId,
   EnvironmentAuthorizationError,
   ThreadId,
+  ThreadForkError,
   type TerminalAttachStreamEvent,
   type TerminalError,
   type TerminalEvent,
@@ -117,6 +120,7 @@ import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import { issueAssetUrl } from "./assets/AssetAccess.ts";
 import { deletePendingAttachment, issueAttachmentUploadUrl } from "./assets/AttachmentUpload.ts";
+import { resolveAttachmentPath } from "./attachmentStore.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
 import * as WorkspaceEntries from "./workspace/WorkspaceEntries.ts";
 import * as WorkspaceFileSystem from "./workspace/WorkspaceFileSystem.ts";
@@ -162,7 +166,18 @@ import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
+import {
+  makeThreadForkAttachment,
+  makeThreadForkHandoffPrompt,
+  makeThreadForkTranscript,
+  findThreadForkTranscriptAttachment,
+  threadForkCreateCommandId,
+  threadForkMessageId,
+  isSameThreadForkModelSelection,
+} from "./threadFork.ts";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+const isThreadForkError = Schema.is(ThreadForkError);
+const threadForkLocks = PartitionedSemaphore.makeUnsafe<ThreadId>({ permits: 1 });
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const CONFIG_DISCOVERY_TIMEOUT = Duration.seconds(5);
@@ -482,6 +497,8 @@ const makeWsRpcLayer = (
     Effect.gen(function* () {
       const currentSessionId = currentSession.sessionId;
       const crypto = yield* Crypto.Crypto;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
       const sql = yield* SqlClient.SqlClient;
       const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
       /** A reference's host-level link key; the project's own host where the ref names none. */
@@ -1245,6 +1262,229 @@ const makeWsRpcLayer = (
             ),
           );
       };
+
+      const forkThreadUnlocked = Effect.fn("WsRpc.forkThreadUnlocked")(function* (input: {
+        readonly sourceThreadId: ThreadId;
+        readonly newThreadId: ThreadId;
+        readonly modelSelection: import("@t3tools/contracts").ModelSelection;
+      }) {
+        const handoffMessageId = threadForkMessageId(input.newThreadId);
+        const existingTarget = yield* projectionSnapshotQuery.getThreadDetailById(
+          input.newThreadId,
+          { activityKinds: [] },
+        );
+        if (Option.isSome(existingTarget)) {
+          const handoff = existingTarget.value.messages.find(
+            (message) => message.id === handoffMessageId,
+          );
+          if (
+            handoff?.text.startsWith(`T3 source thread: ${input.sourceThreadId}.`) === true &&
+            findThreadForkTranscriptAttachment(existingTarget.value) !== null &&
+            isSameThreadForkModelSelection(
+              existingTarget.value.modelSelection,
+              input.modelSelection,
+            )
+          ) {
+            const { snapshotSequence } = yield* projectionSnapshotQuery.getSnapshotSequence();
+            return { threadId: input.newThreadId, sequence: snapshotSequence };
+          }
+          if (existingTarget.value.messages.length > 0) {
+            return yield* new ThreadForkError({
+              sourceThreadId: input.sourceThreadId,
+              newThreadId: input.newThreadId,
+              reason: "target_conflict",
+            });
+          }
+        }
+
+        const sourceOption = yield* projectionSnapshotQuery.getThreadDetailById(
+          input.sourceThreadId,
+          { activityKinds: [] },
+        );
+        if (Option.isNone(sourceOption)) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "source_not_found",
+          });
+        }
+        const source = sourceOption.value;
+        const [pendingTurnStart] = yield* sql<{ readonly exists: number }>`
+          SELECT EXISTS(
+            SELECT 1
+            FROM projection_turns
+            WHERE thread_id = ${input.sourceThreadId}
+              AND turn_id IS NULL
+              AND state = 'pending'
+          ) AS "exists"
+        `;
+        if (
+          pendingTurnStart?.exists === 1 ||
+          source.latestTurn?.state === "running" ||
+          source.messages.some((message) => message.streaming) ||
+          source.session?.status === "starting" ||
+          source.session?.status === "running"
+        ) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "source_busy",
+          });
+        }
+        if (
+          Option.isSome(existingTarget) &&
+          (existingTarget.value.projectId !== source.projectId ||
+            !isSameThreadForkModelSelection(
+              existingTarget.value.modelSelection,
+              input.modelSelection,
+            ) ||
+            existingTarget.value.messages.length > 0)
+        ) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "target_conflict",
+          });
+        }
+
+        const providers = yield* providerRegistry.getProviders;
+        const targetProvider = providers.find(
+          (provider) => provider.instanceId === input.modelSelection.instanceId,
+        );
+        if (
+          targetProvider === undefined ||
+          !targetProvider.enabled ||
+          !targetProvider.installed ||
+          targetProvider.status === "disabled" ||
+          targetProvider.availability === "unavailable"
+        ) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "target_provider_unavailable",
+          });
+        }
+
+        const inheritedAttachment = findThreadForkTranscriptAttachment(source);
+        const hasGeneratedHandoff = source.messages.some(
+          (message) => message.id === threadForkMessageId(source.id),
+        );
+        if (hasGeneratedHandoff && inheritedAttachment === null) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "internal",
+            detail: "The source fork's inherited transcript is missing.",
+          });
+        }
+        const inheritedTranscript = yield* inheritedAttachment === null
+          ? Effect.succeed(undefined)
+          : Effect.gen(function* () {
+              const inheritedPath = resolveAttachmentPath({
+                attachmentsDir: config.attachmentsDir,
+                attachment: inheritedAttachment,
+              });
+              if (inheritedPath === null) {
+                return yield* new ThreadForkError({
+                  sourceThreadId: input.sourceThreadId,
+                  newThreadId: input.newThreadId,
+                  reason: "internal",
+                  detail: "The source fork's inherited transcript path is invalid.",
+                });
+              }
+              return yield* fileSystem.readFileString(inheritedPath);
+            });
+        const transcript = makeThreadForkTranscript(source, inheritedTranscript);
+        const stored = makeThreadForkAttachment({
+          attachmentsDir: config.attachmentsDir,
+          threadId: input.newThreadId,
+          transcript,
+        });
+        if (stored === null) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "transcript_too_large",
+          });
+        }
+
+        const createdAt = yield* nowIso;
+        const createCommand = {
+          type: "thread.create" as const,
+          commandId: threadForkCreateCommandId(input.sourceThreadId, input.newThreadId),
+          threadId: input.newThreadId,
+          projectId: source.projectId,
+          title: `${source.title} (fork)`,
+          modelSelection: input.modelSelection,
+          runtimeMode: source.runtimeMode,
+          interactionMode: source.interactionMode,
+          branch: source.branch,
+          worktreePath: source.worktreePath,
+          createdAt,
+        } satisfies OrchestrationCommand;
+        const created = yield* dispatchFromClient(createCommand).pipe(
+          Effect.mapError((error) =>
+            Option.isSome(existingTarget)
+              ? new ThreadForkError({
+                  sourceThreadId: input.sourceThreadId,
+                  newThreadId: input.newThreadId,
+                  reason: "target_conflict",
+                })
+              : error,
+          ),
+        );
+        yield* threadDeletionReactor.drainThrough(created.sequence);
+        const liveTarget = yield* projectionSnapshotQuery.getThreadDetailById(input.newThreadId, {
+          activityKinds: [],
+        });
+        if (Option.isNone(liveTarget)) {
+          return yield* new ThreadForkError({
+            sourceThreadId: input.sourceThreadId,
+            newThreadId: input.newThreadId,
+            reason: "target_conflict",
+          });
+        }
+        yield* fileSystem.makeDirectory(path.dirname(stored.path), { recursive: true });
+        yield* fileSystem.writeFileString(stored.path, transcript);
+        const command = {
+          type: "thread.turn.start" as const,
+          // Rejected command IDs cannot be retried. Successful retries are
+          // recognized by the persisted handoff message before reaching here.
+          commandId: yield* serverCommandId("thread-fork-turn"),
+          threadId: input.newThreadId,
+          message: {
+            messageId: handoffMessageId,
+            role: "user" as const,
+            text: makeThreadForkHandoffPrompt(source),
+            attachments: [stored.attachment],
+          },
+          modelSelection: input.modelSelection,
+          runtimeMode: source.runtimeMode,
+          interactionMode: source.interactionMode,
+          createdAt,
+        } satisfies OrchestrationCommand;
+
+        const result = yield* dispatchNormalizedCommand(command);
+        yield* recordClientCommandAnalytics(createCommand);
+        yield* recordClientCommandAnalytics(command);
+        return { threadId: input.newThreadId, sequence: result.sequence };
+      });
+      const forkThread = (input: Parameters<typeof forkThreadUnlocked>[0]) =>
+        threadForkLocks
+          .withPermit(input.newThreadId)(forkThreadUnlocked(input))
+          .pipe(
+            Effect.mapError((error) =>
+              isThreadForkError(error)
+                ? error
+                : new ThreadForkError({
+                    sourceThreadId: input.sourceThreadId,
+                    newThreadId: input.newThreadId,
+                    reason: "internal",
+                    detail:
+                      error instanceof Error ? error.message : "Failed to fork the conversation.",
+                  }),
+            ),
+          );
 
       // Only clients that answer /usage-limits themselves see it in the catalogs;
       // an older client would send the injected command to the provider.
@@ -2424,6 +2664,10 @@ const makeWsRpcLayer = (
             deletePendingAttachment(input.attachmentId),
             { "rpc.aggregate": "workspace" },
           ),
+        [WS_METHODS.threadsFork]: (input) =>
+          observeRpcEffect(WS_METHODS.threadsFork, forkThread(input), {
+            "rpc.aggregate": "orchestration",
+          }),
         [WS_METHODS.agentSessionsScan]: () =>
           observeRpcEffect(WS_METHODS.agentSessionsScan, agentSessionScanner.scan, {
             "rpc.aggregate": "workspace",

--- a/apps/web/src/components/ForkThreadDialog.logic.test.ts
+++ b/apps/web/src/components/ForkThreadDialog.logic.test.ts
@@ -1,0 +1,132 @@
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { deriveProviderInstanceEntries } from "../providerInstances";
+import {
+  findInitialForkModelSelection,
+  isForkModelSelectionReady,
+  isSameForkModelSelection,
+} from "./ForkThreadDialog.logic";
+
+const codex = ProviderInstanceId.make("codex");
+const claude = ProviderInstanceId.make("claudeAgent");
+
+function provider(input: {
+  instanceId: ProviderInstanceId;
+  driver: "codex" | "claudeAgent";
+  models: ReadonlyArray<string>;
+  status?: "ready" | "error";
+}): ServerProvider {
+  return {
+    instanceId: input.instanceId,
+    driver: ProviderDriverKind.make(input.driver),
+    displayName: null,
+    accentColor: null,
+    enabled: true,
+    installed: true,
+    availability: "available",
+    status: input.status ?? "ready",
+    auth: { status: "authenticated" },
+    models: input.models.map((slug) => ({ slug, name: slug, isCustom: false, capabilities: {} })),
+  } as unknown as ServerProvider;
+}
+
+describe("fork model selection", () => {
+  it("selects the first ready provider/model pair that differs from the source", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({ instanceId: codex, driver: "codex", models: ["gpt-5.6", "gpt-5.5"] }),
+      provider({ instanceId: claude, driver: "claudeAgent", models: ["claude-opus"] }),
+    ]);
+    const options = new Map([
+      [
+        codex,
+        [
+          { slug: "gpt-5.6", name: "GPT-5.6", isCustom: false },
+          { slug: "gpt-5.5", name: "GPT-5.5", isCustom: false },
+        ],
+      ],
+      [claude, [{ slug: "claude-opus", name: "Claude Opus", isCustom: false }]],
+    ]);
+
+    expect(
+      findInitialForkModelSelection({
+        source: { instanceId: codex, model: "gpt-5.6" },
+        entries,
+        modelOptionsByInstance: options,
+      }),
+    ).toEqual({ instanceId: claude, model: "claude-opus" });
+  });
+
+  it("skips providers that cannot currently start a session", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({
+        instanceId: claude,
+        driver: "claudeAgent",
+        models: ["claude-opus"],
+        status: "error",
+      }),
+    ]);
+    const options = new Map([
+      [claude, [{ slug: "claude-opus", name: "Claude Opus", isCustom: false }]],
+    ]);
+
+    expect(
+      findInitialForkModelSelection({
+        source: { instanceId: codex, model: "gpt-5.6" },
+        entries,
+        modelOptionsByInstance: options,
+      }),
+    ).toBeNull();
+  });
+
+  it("compares both provider instance and model", () => {
+    expect(
+      isSameForkModelSelection(
+        { instanceId: codex, model: "gpt-5.6" },
+        { instanceId: codex, model: "gpt-5.6" },
+      ),
+    ).toBe(true);
+    expect(
+      isSameForkModelSelection(
+        { instanceId: codex, model: "gpt-5.6" },
+        { instanceId: claude, model: "gpt-5.6" },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a selection when its provider or model stops being available", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({ instanceId: claude, driver: "claudeAgent", models: ["claude-opus"] }),
+    ]);
+    const selection = { instanceId: claude, model: "claude-opus" };
+
+    expect(
+      isForkModelSelectionReady({
+        selection,
+        entries,
+        modelOptionsByInstance: new Map([
+          [claude, [{ slug: "claude-opus", name: "Claude Opus", isCustom: false }]],
+        ]),
+      }),
+    ).toBe(true);
+    expect(
+      isForkModelSelectionReady({
+        selection,
+        entries,
+        modelOptionsByInstance: new Map([
+          [
+            claude,
+            [
+              {
+                slug: "claude-opus",
+                name: "Claude Opus",
+                isCustom: false,
+                isUnavailable: true,
+              },
+            ],
+          ],
+        ]),
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/ForkThreadDialog.logic.ts
+++ b/apps/web/src/components/ForkThreadDialog.logic.ts
@@ -1,0 +1,44 @@
+import type { ModelSelection, ProviderInstanceId } from "@t3tools/contracts";
+
+import type { ModelEsque } from "./chat/providerIconUtils";
+import type { ProviderInstanceEntry } from "../providerInstances";
+
+export function isSameForkModelSelection(
+  left: Pick<ModelSelection, "instanceId" | "model">,
+  right: Pick<ModelSelection, "instanceId" | "model">,
+): boolean {
+  return left.instanceId === right.instanceId && left.model === right.model;
+}
+
+export function isForkModelSelectionReady(input: {
+  readonly selection: Pick<ModelSelection, "instanceId" | "model">;
+  readonly entries: ReadonlyArray<ProviderInstanceEntry>;
+  readonly modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+}): boolean {
+  const entry = input.entries.find(
+    (candidate) => candidate.instanceId === input.selection.instanceId,
+  );
+  if (!entry?.enabled || !entry.isAvailable || entry.status !== "ready") return false;
+  return (input.modelOptionsByInstance.get(entry.instanceId) ?? []).some(
+    (model) => model.slug === input.selection.model && !model.isUnavailable,
+  );
+}
+
+export function findInitialForkModelSelection(input: {
+  readonly source: Pick<ModelSelection, "instanceId" | "model">;
+  readonly entries: ReadonlyArray<ProviderInstanceEntry>;
+  readonly modelOptionsByInstance: ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>>;
+}): ModelSelection | null {
+  for (const preferDifferentInstance of [true, false]) {
+    for (const entry of input.entries) {
+      if (!entry.enabled || !entry.isAvailable || entry.status !== "ready") continue;
+      if (preferDifferentInstance !== (entry.instanceId !== input.source.instanceId)) continue;
+      for (const model of input.modelOptionsByInstance.get(entry.instanceId) ?? []) {
+        const selection = { instanceId: entry.instanceId, model: model.slug };
+        if (!model.isUnavailable && !isSameForkModelSelection(selection, input.source))
+          return selection;
+      }
+    }
+  }
+  return null;
+}

--- a/apps/web/src/components/ForkThreadDialogHost.tsx
+++ b/apps/web/src/components/ForkThreadDialogHost.tsx
@@ -1,0 +1,246 @@
+import { useAtomValue } from "@effect/atom-react";
+import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
+import {
+  isAtomCommandInterrupted,
+  settlePromise,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import type { ModelSelection, ScopedThreadRef } from "@t3tools/contracts";
+import { createModelSelection } from "@t3tools/shared/model";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useMemo, useState } from "react";
+
+import { closeForkThreadDialog, useForkThreadDialogStore } from "../forkThreadDialog";
+import { useEnvironmentSettings } from "../hooks/useSettings";
+import { newThreadId } from "../lib/utils";
+import { getCustomModelOptionsByInstance } from "../modelSelection";
+import {
+  applyProviderInstanceSettings,
+  deriveProviderInstanceEntries,
+  NO_PROVIDER_MODEL_SELECTION,
+  sortProviderInstanceEntries,
+} from "../providerInstances";
+import { readThreadShell } from "../state/entities";
+import { serverEnvironment } from "../state/server";
+import { forkThread } from "../state/threads";
+import { useAtomCommand } from "../state/use-atom-command";
+import { buildThreadRouteParams } from "../threadRoutes";
+import { ProviderModelPicker } from "./chat/ProviderModelPicker";
+import {
+  findInitialForkModelSelection,
+  isForkModelSelectionReady,
+  isSameForkModelSelection,
+} from "./ForkThreadDialog.logic";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Spinner } from "./ui/spinner";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+
+function ForkThreadDialog({ sourceRef }: { readonly sourceRef: ScopedThreadRef }) {
+  const navigate = useNavigate();
+  const executeFork = useAtomCommand(forkThread, { reportFailure: false });
+  const serverConfig = useAtomValue(serverEnvironment.configValueAtom(sourceRef.environmentId));
+  const settings = useEnvironmentSettings(sourceRef.environmentId);
+  const sourceThread = readThreadShell(sourceRef);
+  const sourceSelection = useMemo<ModelSelection>(
+    () =>
+      sourceThread
+        ? {
+            instanceId:
+              sourceThread.session?.providerInstanceId ?? sourceThread.modelSelection.instanceId,
+            model: sourceThread.modelSelection.model,
+          }
+        : NO_PROVIDER_MODEL_SELECTION,
+    [sourceThread],
+  );
+  const providers = serverConfig?.providers ?? [];
+  const entries = useMemo(
+    () =>
+      sortProviderInstanceEntries(
+        applyProviderInstanceSettings(deriveProviderInstanceEntries(providers), settings),
+      ),
+    [providers, settings],
+  );
+  const modelOptionsByInstance = useMemo(
+    () => getCustomModelOptionsByInstance(settings, providers),
+    [providers, settings],
+  );
+  const initialSelection = useMemo(
+    () =>
+      findInitialForkModelSelection({
+        source: sourceSelection,
+        entries,
+        modelOptionsByInstance,
+      }),
+    [entries, modelOptionsByInstance, sourceSelection],
+  );
+  const [selection, setSelection] = useState<ModelSelection | null>(initialSelection);
+  const [attempt, setAttempt] = useState(() => ({ key: null as string | null, id: newThreadId() }));
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveSelection = selection ?? initialSelection;
+  const selectionReady =
+    effectiveSelection !== null &&
+    isForkModelSelectionReady({ selection: effectiveSelection, entries, modelOptionsByInstance });
+
+  const selectModel = useCallback((instanceId: ModelSelection["instanceId"], model: string) => {
+    setSelection(createModelSelection(instanceId, model));
+    setAttempt({ key: null, id: newThreadId() });
+    setError(null);
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (
+      pending ||
+      !selectionReady ||
+      effectiveSelection === null ||
+      isSameForkModelSelection(effectiveSelection, sourceSelection)
+    )
+      return;
+    setPending(true);
+    setError(null);
+    const requestKey = JSON.stringify([effectiveSelection.instanceId, effectiveSelection.model]);
+    const targetThreadId = attempt.key === requestKey ? attempt.id : newThreadId();
+    if (attempt.key !== requestKey) setAttempt({ key: requestKey, id: targetThreadId });
+    const result = await executeFork({
+      environmentId: sourceRef.environmentId,
+      input: {
+        sourceThreadId: sourceRef.threadId,
+        newThreadId: targetThreadId,
+        modelSelection: effectiveSelection,
+      },
+    });
+    if (result._tag === "Failure") {
+      setPending(false);
+      if (!isAtomCommandInterrupted(result)) {
+        const cause = squashAtomCommandFailure(result);
+        setError(cause instanceof Error ? cause.message : "Could not fork this conversation.");
+      }
+      return;
+    }
+
+    closeForkThreadDialog();
+    const targetRef = scopeThreadRef(sourceRef.environmentId, result.value.threadId);
+    const navigation = await settlePromise(() =>
+      navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(targetRef),
+      }),
+    );
+    if (navigation._tag === "Failure") {
+      const cause = squashAtomCommandFailure(navigation);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Conversation forked, but navigation failed",
+          description: cause instanceof Error ? cause.message : "An error occurred.",
+        }),
+      );
+    }
+  }, [
+    effectiveSelection,
+    executeFork,
+    navigate,
+    pending,
+    attempt,
+    selectionReady,
+    sourceRef,
+    sourceSelection,
+  ]);
+
+  const displaySelection = effectiveSelection ?? sourceSelection;
+  const hasAlternative = initialSelection !== null;
+  const sourceMissing = sourceThread === null;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !pending) closeForkThreadDialog();
+      }}
+    >
+      <DialogPopup className="w-full sm:w-[30rem]">
+        <DialogHeader>
+          <DialogTitle>Fork conversation</DialogTitle>
+          <DialogDescription>
+            Create a new thread with this conversation as context. The original thread stays
+            unchanged.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="space-y-3">
+          <div className="space-y-1.5">
+            <div className="text-xs font-medium text-muted-foreground">Provider and model</div>
+            <ProviderModelPicker
+              activeInstanceId={displaySelection.instanceId}
+              model={displaySelection.model}
+              lockedProvider={null}
+              instanceEntries={entries}
+              modelOptionsByInstance={modelOptionsByInstance}
+              triggerVariant="outline"
+              triggerClassName="w-full max-w-none"
+              triggerAriaLabel="Choose provider and model for fork"
+              disabled={pending || sourceMissing}
+              getModelDisabledReason={(instanceId, model) =>
+                isSameForkModelSelection({ instanceId, model }, sourceSelection)
+                  ? "Choose a different provider or model."
+                  : null
+              }
+              onInstanceModelChange={selectModel}
+            />
+          </div>
+          {sourceMissing ? (
+            <p className="text-destructive text-xs">The source thread is no longer available.</p>
+          ) : effectiveSelection !== null && !selectionReady ? (
+            <p className="text-muted-foreground text-xs">
+              The selected provider or model is no longer available. Choose another target.
+            </p>
+          ) : !hasAlternative ? (
+            <p className="text-muted-foreground text-xs">
+              No other ready provider or model is available in this environment.
+            </p>
+          ) : null}
+          {error ? <p className="text-destructive text-xs">{error}</p> : null}
+        </DialogPanel>
+        <DialogFooter>
+          <Button variant="outline" size="sm" disabled={pending} onClick={closeForkThreadDialog}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            disabled={
+              pending ||
+              sourceMissing ||
+              !selectionReady ||
+              effectiveSelection === null ||
+              isSameForkModelSelection(effectiveSelection, sourceSelection)
+            }
+            onClick={() => void submit()}
+          >
+            {pending ? (
+              <>
+                <Spinner aria-hidden /> Forking…
+              </>
+            ) : (
+              "Fork"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+export function ForkThreadDialogHost() {
+  const sourceRef = useForkThreadDialogStore((state) => state.sourceThreadRef);
+  if (sourceRef === null) return null;
+  return <ForkThreadDialog key={scopedThreadKey(sourceRef)} sourceRef={sourceRef} />;
+}

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -204,7 +204,8 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { environmentServerConfigsAtom, primaryServerKeybindingsAtom } from "../state/server";
+import { openForkThreadDialog } from "../forkThreadDialog";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -1154,6 +1155,7 @@ interface SidebarProjectItemProps {
 }
 
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
+  const serverConfigs = useAtomValue(environmentServerConfigsAtom);
   const {
     project,
     isThreadListExpanded,
@@ -2253,6 +2255,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           ...(thread.branch
             ? [{ id: "new-thread-on-branch", label: `New thread on ${thread.branch}` }]
             : []),
+          ...(serverConfigs.get(thread.environmentId)?.environment.capabilities.threadForking ===
+          true
+            ? [
+                {
+                  id: "fork-thread",
+                  label: "Fork conversation with another provider/model",
+                  icon: "message-square-plus",
+                },
+              ]
+            : []),
           { id: "rename", label: "Rename thread" },
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
@@ -2262,6 +2274,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         ],
         position,
       );
+
+      if (clicked === "fork-thread") {
+        openForkThreadDialog(threadRef);
+        return;
+      }
 
       if (clicked === "project-settings") {
         if (isMobile) setOpenMobile(false);
@@ -2360,6 +2377,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       project.projectKey,
       project.workspaceRoot,
       router,
+      serverConfigs,
       setOpenMobile,
       startThreadRename,
     ],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -146,6 +146,7 @@ import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
 import { cn } from "~/lib/utils";
 import { EnvironmentMachineIcon } from "./EnvironmentMachineIcon";
 import { buildThreadActionMenuItems } from "./threadActionMenu.logic";
+import { openForkThreadDialog } from "../forkThreadDialog";
 import {
   animateSidebarLayoutChanges,
   applySidebarThreadDrop,
@@ -3993,6 +3994,8 @@ export default function Sidebar() {
         const supportsTitleRegeneration =
           serverConfigs.get(thread.environmentId)?.environment.capabilities
             .threadTitleRegeneration === true;
+        const supportsThreadForking =
+          serverConfigs.get(thread.environmentId)?.environment.capabilities.threadForking === true;
         const isRegeneratingTitle = thread.titleRegeneration != null;
         const isSettled = settledThreadKeysRef.current.has(threadKey);
         const isSnoozed = snoozedThreadKeysRef.current.has(threadKey);
@@ -4011,6 +4014,7 @@ export default function Sidebar() {
               isRunning:
                 thread.session?.status === "running" && thread.session.activeTurnId != null,
               supports: {
+                forking: supportsThreadForking,
                 settlement: supportsSettlement,
                 snooze: supportsSnooze,
                 pinning: supportsPinning,
@@ -4030,6 +4034,9 @@ export default function Sidebar() {
           return;
         }
         switch (clicked.value) {
+          case "fork-thread":
+            openForkThreadDialog(threadRef);
+            return;
           case "project-settings": {
             const projectGroup = projectGroupsRef.current.find((group) =>
               group.memberProjectRefs.some(

--- a/apps/web/src/components/threadActionMenu.logic.test.ts
+++ b/apps/web/src/components/threadActionMenu.logic.test.ts
@@ -10,7 +10,13 @@ const baseState: ThreadActionMenuState = {
   canSnoozeNow: true,
   isRegeneratingTitle: false,
   isRunning: false,
-  supports: { settlement: true, snooze: true, pinning: true, titleRegeneration: true },
+  supports: {
+    forking: true,
+    settlement: true,
+    snooze: true,
+    pinning: true,
+    titleRegeneration: true,
+  },
   snoozePresets: [
     { id: "hour", label: "In 1 hour", whenLabel: "3:00 PM", snoozedUntil: "2026-08-07T15:00:00Z" },
   ],
@@ -31,9 +37,22 @@ describe("buildThreadActionMenuItems", () => {
     expect(
       ids({
         ...baseState,
-        supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
+        supports: {
+          forking: false,
+          settlement: false,
+          snooze: false,
+          pinning: false,
+          titleRegeneration: false,
+        },
       }),
     ).toEqual(["rename", "mark-unread", "copy", "project-settings", "archive", "delete"]);
+  });
+
+  it("shows conversation forking only when the server advertises support", () => {
+    expect(ids(baseState)).toContain("fork-thread");
+    expect(
+      ids({ ...baseState, supports: { ...baseState.supports, forking: false } }),
+    ).not.toContain("fork-thread");
   });
 
   it("groups project settings with utility actions before archive", () => {
@@ -95,7 +114,13 @@ describe("buildThreadActionMenuItems", () => {
     expect(
       ids({
         ...baseState,
-        supports: { settlement: false, snooze: false, pinning: false, titleRegeneration: false },
+        supports: {
+          forking: false,
+          settlement: false,
+          snooze: false,
+          pinning: false,
+          titleRegeneration: false,
+        },
       }),
     ).toContain("archive");
   });

--- a/apps/web/src/components/threadActionMenu.logic.ts
+++ b/apps/web/src/components/threadActionMenu.logic.ts
@@ -8,6 +8,7 @@ import type { SnoozePreset } from "@t3tools/client-runtime/state/thread-settled"
  */
 export type ThreadActionMenuId =
   | "new-thread-on-branch"
+  | "fork-thread"
   | "project-settings"
   | "pin"
   | "unpin"
@@ -36,6 +37,7 @@ export interface ThreadActionMenuState {
   /** Archive rejects a thread with an active turn, so disable it here rather than let the action fail. */
   readonly isRunning: boolean;
   readonly supports: {
+    readonly forking: boolean;
     readonly settlement: boolean;
     readonly snooze: boolean;
     readonly pinning: boolean;
@@ -58,6 +60,15 @@ export function buildThreadActionMenuItems(
           {
             id: "new-thread-on-branch" as const,
             label: `New thread on ${state.branch}`,
+            icon: "message-square-plus",
+          },
+        ]
+      : []),
+    ...(state.supports.forking
+      ? [
+          {
+            id: "fork-thread" as const,
+            label: "Fork conversation with another provider/model",
             icon: "message-square-plus",
           },
         ]

--- a/apps/web/src/forkThreadDialog.ts
+++ b/apps/web/src/forkThreadDialog.ts
@@ -1,0 +1,20 @@
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import { create } from "zustand";
+
+interface ForkThreadDialogStore {
+  readonly sourceThreadRef: ScopedThreadRef | null;
+  readonly setSourceThreadRef: (sourceThreadRef: ScopedThreadRef | null) => void;
+}
+
+export const useForkThreadDialogStore = create<ForkThreadDialogStore>((set) => ({
+  sourceThreadRef: null,
+  setSourceThreadRef: (sourceThreadRef) => set({ sourceThreadRef }),
+}));
+
+export function openForkThreadDialog(source: ScopedThreadRef): void {
+  useForkThreadDialogStore.getState().setSourceThreadRef(source);
+}
+
+export function closeForkThreadDialog(): void {
+  useForkThreadDialogStore.getState().setSourceThreadRef(null);
+}

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -22,6 +22,7 @@ import {
   readEnvironmentSupportsPinning,
   readEnvironmentSupportsSettlement,
   readEnvironmentSupportsSnooze,
+  readEnvironmentSupportsThreadForking,
   readEnvironmentSupportsTitleRegeneration,
   readThreadShell,
   useProjects,
@@ -39,6 +40,7 @@ import { useCopyToClipboard } from "./useCopyToClipboard";
 import { useNewThreadHandler } from "./useHandleNewThread";
 import { useClientSettings } from "./useSettings";
 import { useThreadActions } from "./useThreadActions";
+import { openForkThreadDialog } from "../forkThreadDialog";
 
 function failureToast(title: string, error: unknown) {
   toastManager.add(
@@ -130,6 +132,7 @@ export function useThreadActionMenu(input: {
         if (!thread) return;
         const now = new Date();
         const supports = {
+          forking: readEnvironmentSupportsThreadForking(threadRef.environmentId),
           settlement: readEnvironmentSupportsSettlement(threadRef.environmentId),
           snooze: readEnvironmentSupportsSnooze(threadRef.environmentId),
           pinning: readEnvironmentSupportsPinning(threadRef.environmentId),
@@ -190,6 +193,9 @@ export function useThreadActionMenu(input: {
           }
         };
         switch (action) {
+          case "fork-thread":
+            openForkThreadDialog(threadRef);
+            return;
           case "project-settings": {
             const project = projects.find(
               (candidate) =>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import { resolveServerBackedAppDisplayName } from "../branding.logic";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
 import { ConfirmDialogHost } from "../components/ConfirmDialogHost";
+import { ForkThreadDialogHost } from "../components/ForkThreadDialogHost";
 import { FirstRunGate } from "../components/onboarding/FirstRunGate";
 import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDialog";
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
@@ -198,6 +199,7 @@ function RootRouteView() {
           <SshPasswordPromptDialog />
           <SnapShotCoordinator />
           <ConfirmDialogHost />
+          <ForkThreadDialogHost />
           <SlowRpcRequestToastCoordinator />
           <HostedStaticEnvironmentBootstrap />
           {primaryEnvironmentAuthenticated ? (

--- a/apps/web/src/state/entities.ts
+++ b/apps/web/src/state/entities.ts
@@ -220,6 +220,14 @@ export function readEnvironmentSupportsTitleRegeneration(environmentId: Environm
   );
 }
 
+/** Whether the environment's server can fork a thread into a fresh provider session. */
+export function readEnvironmentSupportsThreadForking(environmentId: EnvironmentId): boolean {
+  return (
+    appAtomRegistry.get(environmentServerConfigsAtom).get(environmentId)?.environment.capabilities
+      .threadForking === true
+  );
+}
+
 /** Whether the environment's server understands thread.pin.reorder (and
     orderKey on thread.pin). Same version-skew contract as settlement. */
 export function readEnvironmentSupportsPinReorder(environmentId: EnvironmentId): boolean {

--- a/apps/web/src/state/threads.ts
+++ b/apps/web/src/state/threads.ts
@@ -7,7 +7,8 @@ import {
   type EnvironmentThreadState,
   createThreadEnvironmentAtoms,
 } from "@t3tools/client-runtime/state/threads";
-import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { createEnvironmentRpcCommand } from "@t3tools/client-runtime/state/runtime";
+import { WS_METHODS, type EnvironmentId, type ThreadId } from "@t3tools/contracts";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
@@ -16,6 +17,10 @@ import { connectionAtomRuntime } from "../connection/runtime";
 import { environmentSnapshotAtom } from "./shell";
 
 export const threadEnvironment = createThreadEnvironmentAtoms(connectionAtomRuntime);
+export const forkThread = createEnvironmentRpcCommand(connectionAtomRuntime, {
+  label: "environment-data:threads:fork",
+  tag: WS_METHODS.threadsFork,
+});
 const environmentThreads = createEnvironmentThreadStateAtoms(connectionAtomRuntime);
 export const environmentThreadDetails = createEnvironmentThreadDetailAtoms(
   environmentThreads.stateAtom,

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -20,6 +20,24 @@ on Windows and Linux to start a new thread and immediately open another draft. T
 next draft keeps the workspace mode and base branch you selected. With **New
 worktree**, each background submission creates its own worktree.
 
+## Continue with another provider
+
+Choose **Fork conversation with another provider/model** from a thread's menu on
+web or desktop, or from its model settings on mobile. Select the target provider
+and model, then choose **Fork**. T3 opens a new thread
+with a text transcript of the conversation for the new agent to read. The original
+thread and its provider session stay intact. If a response is running, wait for it
+to finish or stop it before forking.
+
+The fork uses the same workspace, so later code changes are visible to both
+threads. It carries recorded conversation text, not the original provider's hidden
+state, checkpoint history, or attached images and files. The new provider may need
+permission to read the transcript. Once it has read the context, send your next
+request in the new thread.
+
+If the new provider fails to start, correct its setup and fork the original
+conversation again.
+
 ## Pin and reorder threads
 
 Pin a thread from its menu to keep it above your active work.

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -75,6 +75,10 @@
       "types": "./src/operations/projects.ts",
       "default": "./src/operations/projects.ts"
     },
+    "./operations/threadFork": {
+      "types": "./src/operations/threadFork.ts",
+      "default": "./src/operations/threadFork.ts"
+    },
     "./platform": {
       "types": "./src/platform/index.ts",
       "default": "./src/platform/index.ts"

--- a/packages/client-runtime/src/operations/index.ts
+++ b/packages/client-runtime/src/operations/index.ts
@@ -1,2 +1,3 @@
 export * from "./commands.ts";
 export * from "./projects.ts";
+export * from "./threadFork.ts";

--- a/packages/client-runtime/src/operations/threadFork.ts
+++ b/packages/client-runtime/src/operations/threadFork.ts
@@ -1,0 +1,5 @@
+import { WS_METHODS, type ThreadForkInput } from "@t3tools/contracts";
+
+import { request } from "../rpc/client.ts";
+
+export const forkThread = (input: ThreadForkInput) => request(WS_METHODS.threadsFork, input);

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -123,6 +123,8 @@ export const ExecutionEnvironmentCapabilities = Schema.Struct({
   /** Server understands regenerateTitle on thread.meta.update. Absent on
       older servers, so clients hide the action instead of sending it. */
   threadTitleRegeneration: Schema.optionalKey(Schema.Boolean),
+  /** Server can create a new provider session from a persisted thread transcript. */
+  threadForking: Schema.optionalKey(Schema.Boolean),
   /** Server supports legacy linkedPullRequest updates through thread.meta.update.
       Independent of threadPullRequests; servers supporting both advertise both. */
   threadPullRequestLinking: Schema.optionalKey(Schema.Boolean),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -33,6 +33,7 @@ export * from "./agentSessions.ts";
 export * from "./assets.ts";
 export * from "./review.ts";
 export * from "./browserImport.ts";
+export * from "./threadFork.ts";
 export * from "./browserProfile.ts";
 export * from "./preview.ts";
 export * from "./previewAutomation.ts";

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 import * as Rpc from "effect/unstable/rpc/Rpc";
 import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { ThreadForkError, ThreadForkInput, ThreadForkResult } from "./threadFork.ts";
 import {
   ProviderAuthCancelInput,
   ProviderAuthCompleteInput,
@@ -258,6 +259,7 @@ export const WS_METHODS = {
   assetsCreateUrl: "assets.createUrl",
   attachmentsCreateUploadUrl: "attachments.createUploadUrl",
   attachmentsDelete: "attachments.delete",
+  threadsFork: "threads.fork",
 
   // Provider methods
   providerUploadFeedback: "provider.uploadFeedback",
@@ -872,6 +874,12 @@ const WsAttachmentsDeleteRpc = Rpc.make(WS_METHODS.attachmentsDelete, {
   error: EnvironmentAuthorizationError,
 });
 
+const WsThreadsForkRpc = Rpc.make(WS_METHODS.threadsFork, {
+  payload: ThreadForkInput,
+  success: ThreadForkResult,
+  error: Schema.Union([ThreadForkError, EnvironmentAuthorizationError]),
+});
+
 const WsProviderUploadFeedbackRpc = Rpc.make(WS_METHODS.providerUploadFeedback, {
   payload: ProviderUploadFeedbackInput,
   success: ProviderUploadFeedbackResult,
@@ -1272,6 +1280,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsAssetsCreateUrlRpc,
   WsAttachmentsCreateUploadUrlRpc,
   WsAttachmentsDeleteRpc,
+  WsThreadsForkRpc,
   WsProviderUploadFeedbackRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,

--- a/packages/contracts/src/threadFork.ts
+++ b/packages/contracts/src/threadFork.ts
@@ -1,0 +1,51 @@
+import * as Schema from "effect/Schema";
+
+import { NonNegativeInt, ThreadId } from "./baseSchemas.ts";
+import { ModelSelection } from "./orchestration.ts";
+
+export const ThreadForkInput = Schema.Struct({
+  sourceThreadId: ThreadId,
+  newThreadId: ThreadId,
+  modelSelection: ModelSelection,
+});
+export type ThreadForkInput = typeof ThreadForkInput.Type;
+
+export const ThreadForkResult = Schema.Struct({
+  threadId: ThreadId,
+  sequence: NonNegativeInt,
+});
+export type ThreadForkResult = typeof ThreadForkResult.Type;
+
+export const ThreadForkFailureReason = Schema.Literals([
+  "source_not_found",
+  "source_busy",
+  "target_conflict",
+  "target_provider_unavailable",
+  "transcript_too_large",
+  "internal",
+]);
+export type ThreadForkFailureReason = typeof ThreadForkFailureReason.Type;
+
+export class ThreadForkError extends Schema.TaggedError<ThreadForkError>()("ThreadForkError", {
+  sourceThreadId: ThreadId,
+  newThreadId: ThreadId,
+  reason: ThreadForkFailureReason,
+  detail: Schema.optionalKey(Schema.String),
+}) {
+  override get message(): string {
+    switch (this.reason) {
+      case "source_not_found":
+        return "The conversation to fork was not found.";
+      case "source_busy":
+        return "Wait for the current response to finish, or stop it, before forking this conversation.";
+      case "target_conflict":
+        return "A different conversation already uses the requested fork identifier.";
+      case "target_provider_unavailable":
+        return "The selected provider is not available in this environment.";
+      case "transcript_too_large":
+        return "This conversation is too large to hand off as a single transcript.";
+      case "internal":
+        return this.detail ?? "Failed to fork the conversation.";
+    }
+  }
+}


### PR DESCRIPTION
When a provider's quota is exhausted, users need a way to continue their conversation with another provider without changing the original session. This adds a manual conversation fork on web, desktop, and mobile: choose a provider/model, create a new thread, and open it after the transcript handoff is recorded.

The environment reads the full persisted user/assistant history and carries it as a child-owned transcript attachment through the existing provider turn flow. The new session does not reuse the source resume cursor or modify the source session. Forks retain textual source identification, support retries and forks of forks, and require no database migration. Older servers do not expose the action.

The child displays the handoff and attachment rather than cloned historical bubbles. Binary attachments, tool activity, provider internals, and checkpoint history are excluded. The source must have no active or pending turn; transcript size, provider permissions, and context capacity still apply. Both threads share the workspace.

Related to #3797, which describes switching within the original conversation. This implementation creates a separate thread. Potential overlap with the orchestration work in #2829 needs maintainer review.

Validation:
- 108 focused tests passed, covering source preservation, fresh provider sessions, transcript completeness, routing, concurrency, retries, authorization, and client selection state.
- Typechecks passed for server, contracts, client-runtime, web, and mobile.
- Targeted lint, formatting, and diff checks passed. Existing lint warnings remain.
- No repository-wide checks were run. Native mobile linters were unavailable; no Swift/Kotlin files changed.

Before marking ready for review:
- [ ] Verify the integrated web/desktop and mobile flows in real clients.
- [ ] Verify a handoff between live providers.
- [ ] Attach before/after UI screenshots.
- [ ] Confirm scope and overlap with the related upstream work.

Model/harness: GPT-6 / Codex, with native subagents.
