### PR TITLE
fix: quiet settled threads and simplify PR badges

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -44,11 +44,11 @@ export const THREAD_LIST_COMPACT_INSET = HOME_HORIZONTAL_INSET;
 const SIDEBAR_ROW_RADIUS = 12;
 
 function pullRequestTintColor(
-  pr: Pick<ThreadPrPresentation, "state" | "isDraft">,
+  pr: Pick<ThreadPrPresentation, "state" | "isDraft" | "others">,
   colorScheme: "light" | "dark",
 ) {
   const dark = colorScheme === "dark";
-  if (pr.state === "open" && pr.isDraft === true) {
+  if (pr.others > 0 || (pr.state === "open" && pr.isDraft === true)) {
     return dark ? "#a1a1aa" : "#71717a";
   }
   switch (pr.state) {

--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -880,13 +880,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
                     ? materialYouStyleLayoutActive
                       ? "accent-thread-selected-foreground"
                       : "accent-user-bubble-foreground"
-                    : pr.kind === "stack" || pr.isDraft || pr.state === null
-                      ? "accent-foreground-muted"
-                      : pr.state === "open"
-                        ? "accent-adaptive-emerald-600-400"
-                        : pr.state === "merged"
-                          ? "accent-adaptive-violet-600-400"
-                          : "accent-foreground-muted"
+                    : "accent-foreground-muted"
                 }
               />
             ) : null}

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -65,11 +65,12 @@ export function presentThreadLinkedPullRequests(
   const snapshot = link.snapshot;
   const state = badge.kind === "stack" ? badge.state : (snapshot?.state ?? null);
   const isDraft = snapshot?.isDraft === true && state === "open";
+  const linkedCount = badge.kind === "pull-request" && badge.others > 0 ? badge.others + 1 : null;
   const label =
     badge.kind === "stack"
       ? String(badge.layers)
-      : badge.others > 0
-        ? `+${badge.others}`
+      : linkedCount !== null
+        ? `+${linkedCount}`
         : String(link.number);
   return {
     kind: badge.kind,
@@ -84,7 +85,10 @@ export function presentThreadLinkedPullRequests(
       badge.kind === "stack"
         ? `${badge.layers} pull requests in stack, ${state ?? "status pending"}`
         : `#${link.number} pull request ${state === null ? "status pending" : isDraft ? "draft" : state}${badge.others > 0 ? `, ${badge.others} more linked` : ""}`,
-    textClassName: state === null || isDraft ? "text-foreground-muted" : PR_STATE_TEXT_CLASS[state],
+    textClassName:
+      linkedCount !== null || state === null || isDraft
+        ? "text-foreground-muted"
+        : PR_STATE_TEXT_CLASS[state],
   };
 }
 

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -87,7 +87,8 @@ describe("presentThreadLinkedPullRequests", () => {
   it("counts unrelated links without labelling them a stack", () => {
     expect(presentThreadLinkedPullRequests([linkedPr(1), linkedPr(2)])).toMatchObject({
       kind: "pull-request",
-      label: "+1",
+      label: "+2",
+      textClassName: "text-foreground-muted",
     });
   });
 

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -88,6 +88,7 @@ describe("presentThreadLinkedPullRequests", () => {
     expect(presentThreadLinkedPullRequests([linkedPr(1), linkedPr(2)])).toMatchObject({
       kind: "pull-request",
       label: "+2",
+      others: 1,
       textClassName: "text-foreground-muted",
     });
   });

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1486,7 +1486,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     </span>
   );
 
-  // Stacks show their layer count; unrelated links show only the remainder count.
+  // Stacks show their layer count; multiple unrelated links show their total count.
   // Plain clicks open T3; individual PR links also support opening the host in a new tab.
   const prBadgeShape = supportsMultiplePullRequests
     ? resolveThreadPullRequestBadge(thread.pullRequests)

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1387,6 +1387,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
   // content; surface is reserved for interaction (hover, multi-select, route).
   const rowSurfaceClassName = cn(
     "group/sidebar-row relative w-full cursor-pointer overflow-hidden rounded-md text-left outline-none select-none",
+    variantAction === "unsettle" && "[&:not(:hover):not(:focus-within)_*]:text-secondary-label/70",
     props.isActive
       ? "bg-sidebar-row-active text-sidebar-foreground"
       : isSelected
@@ -1469,7 +1470,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
                     : "text-foreground/90",
             )
           : cn(
-              "truncate group-hover/sidebar-row:text-foreground",
+              "truncate group-focus-within/sidebar-row:text-foreground group-hover/sidebar-row:text-foreground",
               shouldRecede
                 ? "text-secondary-label/70"
                 : props.isActive || isWoke
@@ -1597,8 +1598,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
             <span
               className={cn(
                 "shrink-0 transition-opacity",
-                !props.isActive &&
-                  "opacity-40 grayscale group-hover/sidebar-row:opacity-100 group-hover/sidebar-row:grayscale-0",
+                (!props.isActive || variantAction === "unsettle") &&
+                  "opacity-40 grayscale group-focus-within/sidebar-row:opacity-100 group-focus-within/sidebar-row:grayscale-0 group-hover/sidebar-row:opacity-100 group-hover/sidebar-row:grayscale-0",
               )}
             >
               {props.project ? <ProjectFavicon project={props.project} className="size-4" /> : null}
@@ -1617,6 +1618,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
               the time/jump label yields to the settle affordance. */}
             {prBadge}
             {prBadge &&
+            variantAction !== "unsettle" &&
             pr &&
             (supportsMultiplePullRequests
               ? visibleThreadPullRequests(thread.pullRequests).length === 0

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -154,6 +154,7 @@ export function ThreadPullRequestBadgeControl({
   onOpenPullRequest: (event: MouseEvent<HTMLAnchorElement>) => void;
 }) {
   const isStack = badge?.kind === "stack";
+  const linkedCount = badge?.kind === "pull-request" && badge.others > 0 ? badge.others + 1 : null;
   if (!isStack && (number === undefined || url === undefined)) return null;
   const label = isStack
     ? `Stack of ${badge.layers} pull requests, ${badge.state}`
@@ -169,16 +170,16 @@ export function ThreadPullRequestBadgeControl({
     "text-xs tabular-nums",
     variant === "ghost" &&
       "font-normal text-xs! active:scale-100 [--control-icon-color:currentColor]",
-    isStack ? PR_STATE_COLOR_CLASS[badge.state] : (status?.colorClass ?? "text-muted-foreground"),
+    linkedCount !== null
+      ? "text-secondary-label"
+      : isStack
+        ? PR_STATE_COLOR_CLASS[badge.state]
+        : (status?.colorClass ?? "text-muted-foreground"),
   );
   const content = (
     <>
       <ThreadPullRequestBadgeIcon icon={badge?.kind ?? "pull-request"} />
-      {isStack
-        ? badge.layers
-        : badge?.kind === "pull-request" && badge.others > 0
-          ? `+${badge.others}`
-          : number}
+      {isStack ? badge.layers : linkedCount !== null ? `+${linkedCount}` : number}
     </>
   );
   return (


### PR DESCRIPTION
Settled threads showed Link PR actions and colored badges that competed with active work. They now hide Link PR actions and mute text and icons until hover or keyboard focus, while existing PR links stay clickable.

Building on [#11104](https://github.com/pingdotgg/t3code/pull/11104), multiple unrelated PR links now use a neutral total count, such as `+11` for eleven links, instead of a colored remainder count. Mobile reuses the existing `others` field. This is shared by the web/desktop sidebar and composer, with matching mobile labels. Single PR and stack badges keep their existing presentation.

Verified in an isolated web app with disposable fixture data, including hover and keyboard focus. Web and mobile typechecks passed; targeted lint passed with existing Sidebar and mobile list warnings. The mobile presentation test covers the new total count and neutral color. Native simulator verification was unavailable on this Linux host, which has no Android SDK installed.

| Before | After |
| --- | --- |
| ![Before: colored PR badges and Link PR action](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/95bf22faa22c9e6d/rebased-before.png) | ![After: neutral count and muted settled rows without Link PR](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/e4f44226b28838ed/rebased-after.png) |

Hover and focus restore the PR status color:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0f78237789565163/hover.mp4

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Unsettled rows now appear dimmed until hovered or focused, while keyboard focus restores emphasis to titles and project icons.
  * Branch-link actions are hidden for unsettled rows.
  * Pull-request indicators show total linked counts in a compact `+N` format with muted styling.
  * Mobile thread lists display icons and labels for linked pull requests, with neutral styling for linked or draft pull requests.
* **Bug Fixes**
  * Pull-request badge labels now accurately represent multiple unrelated linked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->