### PR TITLE
fix(preview): return to pip when closing the right panel

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4293,10 +4293,21 @@ export default function ChatView(props: ChatViewProps) {
     supportsPullRequests,
     threadDetailLoading,
   ]);
+  const closePreviewPanel = useCallback(() => {
+    if (activeThreadRef) {
+      if (activeRightPanelSurface?.kind === "preview" && activeRightPanelSurface.resourceId) {
+        usePreviewMiniPlayerStore
+          .getState()
+          .open(activeThreadRef, activeRightPanelSurface.resourceId);
+      }
+      setMaximizedRightPanelThreadKey(null);
+      useRightPanelStore.getState().close(activeThreadRef);
+    }
+  }, [activeRightPanelSurface, activeThreadRef]);
   const togglePreviewPanel = useCallback(() => {
     if (!activeThreadRef || !isPreviewSupportedInRuntime()) return;
     if (previewPanelOpen) {
-      useRightPanelStore.getState().close(activeThreadRef);
+      closePreviewPanel();
       return;
     }
     const activeTabId = activePreviewState.activeTabId;
@@ -4305,13 +4316,13 @@ export default function ChatView(props: ChatViewProps) {
     } else {
       createBrowserSurface();
     }
-  }, [activePreviewState.activeTabId, activeThreadRef, createBrowserSurface, previewPanelOpen]);
-  const closePreviewPanel = useCallback(() => {
-    if (activeThreadRef) {
-      setMaximizedRightPanelThreadKey(null);
-      useRightPanelStore.getState().close(activeThreadRef);
-    }
-  }, [activeThreadRef]);
+  }, [
+    activePreviewState.activeTabId,
+    activeThreadRef,
+    closePreviewPanel,
+    createBrowserSurface,
+    previewPanelOpen,
+  ]);
   const addTerminalSurface = useCallback(() => {
     if (!activeThreadRef || !activeThreadId || !activeProject) return;
     const cwd = gitCwd ?? activeProject.workspaceRoot;


### PR DESCRIPTION
closing the right panel with a browser selected now returns that browser to pip, including after restoring it from pip. the preview toggle shares the panel close handler, covering the panel button, keyboard toggle, and sheet dismissal while preserving browser-tab close behavior.

validation: 191 existing tests passed across chat logic, preview view, mini player state, and right panel state; web typecheck, scoped lint, and formatting passed (existing warnings). github ci passed on c4b7c8ca; two independent gpt-6-astra reviews found no code issues. no unresolved github review threads.

recording: recreated browser content, as requested, rendered with the actual preview panel and mini player. the existing panel close handler returns the preview to pip twice, including after restoring it to the panel. electron guest rendering is not exercised by this recreation.

![closing the right panel returns the preview to pip, twice](https://uploads-production-47e4.up.railway.app/files/b04d0314-e174-41b1-8e38-892edb7351e3/preview-close-to-pip.gif)

written by gpt-6 using codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Closing the preview panel now opens the preview mini player for the active resource.

- **Bug Fixes**
  - Preview panel state is now cleared consistently when the panel is closed or toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->