### PR TITLE
fix(ui): simplify multiple linked pull request badges

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-v2-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-v2-items.tsx
@@ -871,16 +871,22 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
         )}
         {pr ? (
           <View className="flex-row items-center gap-1" accessibilityLabel={pr.accessibilityLabel}>
-            {pr.kind === "stack" ? (
+            {pr.kind === "stack" || pr.others > 0 ? (
               <SymbolView
-                name="square.3.layers.3d"
+                name={pr.kind === "stack" ? "square.3.layers.3d" : "arrow.triangle.pull"}
                 size={12}
                 tintColorClassName={
                   selected
                     ? materialYouStyleLayoutActive
                       ? "accent-thread-selected-foreground"
                       : "accent-user-bubble-foreground"
-                    : "accent-foreground-muted"
+                    : pr.kind === "stack" || pr.isDraft || pr.state === null
+                      ? "accent-foreground-muted"
+                      : pr.state === "open"
+                        ? "accent-adaptive-emerald-600-400"
+                        : pr.state === "merged"
+                          ? "accent-adaptive-violet-600-400"
+                          : "accent-foreground-muted"
                 }
               />
             ) : null}
@@ -896,7 +902,7 @@ export const ThreadListV2Row = memo(function ThreadListV2Row(props: {
               )}
               style={{ fontFamily: MONO_FONT }}
             >
-              {pr.kind === "stack" ? pr.label : `#${pr.label}`}
+              {pr.kind === "stack" || pr.others > 0 ? pr.label : `#${pr.label}`}
             </Text>
           </View>
         ) : null}

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -17,11 +17,12 @@ export interface ThreadPrPresentation {
   readonly number: number;
   readonly state: ThreadPr["state"] | null;
   readonly kind: "pull-request" | "stack";
+  readonly others: number;
   readonly isDraft: boolean;
   /** Provider-side last activity, bounding when a terminal state landed. */
   readonly updatedAt: string | null;
   readonly url: string;
-  /** Compact pull request number label, e.g. "3774". */
+  /** Compact pull request number or linked count, e.g. "3774" or "+2". */
   readonly label: string;
   /** Full, provider-aware label for assistive technologies. */
   readonly accessibilityLabel: string;
@@ -42,6 +43,7 @@ export function presentThreadPr(
   const isDraft = pr.state === "open" && pr.isDraft === true;
   return {
     kind: "pull-request",
+    others: 0,
     number: pr.number,
     state: pr.state,
     isDraft,
@@ -66,9 +68,12 @@ export function presentThreadLinkedPullRequests(
   const label =
     badge.kind === "stack"
       ? String(badge.layers)
-      : `${link.number}${badge.others > 0 ? ` +${badge.others}` : ""}`;
+      : badge.others > 0
+        ? `+${badge.others}`
+        : String(link.number);
   return {
     kind: badge.kind,
+    others: badge.kind === "pull-request" ? badge.others : 0,
     number: link.number,
     state,
     isDraft,

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -87,7 +87,7 @@ describe("presentThreadLinkedPullRequests", () => {
   it("counts unrelated links without labelling them a stack", () => {
     expect(presentThreadLinkedPullRequests([linkedPr(1), linkedPr(2)])).toMatchObject({
       kind: "pull-request",
-      label: "1 +1",
+      label: "+1",
     });
   });
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1485,7 +1485,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: {
     </span>
   );
 
-  // Stacks show their layer count; unrelated links show the current PR and a remainder count.
+  // Stacks show their layer count; unrelated links show only the remainder count.
   // Plain clicks open T3; individual PR links also support opening the host in a new tab.
   const prBadgeShape = supportsMultiplePullRequests
     ? resolveThreadPullRequestBadge(thread.pullRequests)

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -174,10 +174,11 @@ export function ThreadPullRequestBadgeControl({
   const content = (
     <>
       <ThreadPullRequestBadgeIcon icon={badge?.kind ?? "pull-request"} />
-      {isStack ? badge.layers : number}
-      {badge?.kind === "pull-request" && badge.others > 0 ? (
-        <span className="opacity-70">+{badge.others}</span>
-      ) : null}
+      {isStack
+        ? badge.layers
+        : badge?.kind === "pull-request" && badge.others > 0
+          ? `+${badge.others}`
+          : number}
     </>
   );
   return (


### PR DESCRIPTION
Multiple unrelated linked PRs currently show a PR number followed by a faded remainder count. Show only the PR icon and full-color `+N` instead, preserving N as the number of additional links, single-PR numbers, stack badges, accessible labels, and click targets. Applies to the shared web/desktop sidebar and composer badge and both native mobile thread lists.

Verified: 20 web tests, 40 mobile/shared tests, web and mobile typechecks, targeted lint and formatting. In the real web client over a tunnel, the original 11-link thread renders `+10` and both badge clicks load PR #11044 through the server/GitHub path. Native mobile rendering remains unverified: the host has no /dev/kvm, and attempted software Android boot never started its package service; no native screenshots are available. Desktop shell was not launched separately; it uses the verified web components.

Screenshots are matching crops from the real app, using the original thread, at 1280px and 390px web widths.

![web/desktop sidebar before, dark](https://uploads-production-47e4.up.railway.app/files/a64f8ca2-7291-4b1b-8184-414441e77916/beforeDark-sidebar.png)

![web/desktop sidebar after, dark](https://uploads-production-47e4.up.railway.app/files/f94b289f-053b-4fed-9d87-a95566be5246/afterDark-sidebar.png)

![web/desktop sidebar before, light](https://uploads-production-47e4.up.railway.app/files/c6f9601f-32f0-4d1e-b7fe-a848b1b9300b/beforeLight-sidebar.png)

![web/desktop sidebar after, light](https://uploads-production-47e4.up.railway.app/files/df232f29-70cd-4501-8cf7-ed901532dc79/afterLight-sidebar.png)

![web/desktop composer before, dark](https://uploads-production-47e4.up.railway.app/files/c6224f95-56f3-4e0f-88eb-42f47a88474d/beforeDark-composer.png)

![web/desktop composer after, dark](https://uploads-production-47e4.up.railway.app/files/51660f6f-919b-4b13-b424-6f21caadcb83/afterDark-composer.png)

![web/desktop composer before, light](https://uploads-production-47e4.up.railway.app/files/8f819c36-c9f5-4168-990b-bc88867f941a/beforeLight-composer.png)

![web/desktop composer after, light](https://uploads-production-47e4.up.railway.app/files/d92fb388-cbed-4404-b4d4-dbd91be3e646/afterLight-composer.png)

![phone-width web sidebar before](https://uploads-production-47e4.up.railway.app/files/cc46e08a-2847-4f6a-ba99-3815f352a2eb/phoneBeforeSidebar.png)

![phone-width web sidebar after](https://uploads-production-47e4.up.railway.app/files/c95fd8fe-cdd2-4c3d-99bb-f6201c14be2b/phoneAfterSidebar.png)

![phone-width web composer before](https://uploads-production-47e4.up.railway.app/files/d21d27d0-64ab-4414-b82d-ec5ba78b42c7/phoneBeforeComposer.png)

![phone-width web composer after](https://uploads-production-47e4.up.railway.app/files/3f5b4706-3f3e-4cc3-90e2-363e8f7b7c34/phoneAfterComposer.png)

Implemented with GPT-6 in Codex.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull request indicators now appear for threads with multiple related pull requests, including non-stacked links.
  - Indicators use colors that reflect the pull request type and state.
  - Labels now show compact counts such as `+N` when multiple pull requests are represented.
  - Stacked pull requests continue to display their layer count, while unrelated links show the remaining count.

- **Bug Fixes**
  - Improved consistency of pull request badge labels and styling across thread views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->