### PR TITLE
fix(web): emphasize primary pull request actions

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1728,7 +1728,7 @@ export function PullRequestDetailPanel({
                       <span className="inline-flex shrink-0">
                         <Button
                           size="xs"
-                          variant="ghost"
+                          variant="default"
                           disabled={handoff !== null}
                           onClick={startResolveConflicts}
                           aria-label={
@@ -1754,15 +1754,12 @@ export function PullRequestDetailPanel({
                       <span className="inline-flex shrink-0">
                         <Button
                           size="xs"
-                          variant="ghost"
+                          variant="default"
                           disabled={actionPending}
                           onClick={() => void perform("ready")}
                           aria-label="Ready for review"
                         >
-                          <GitPullRequestIcon
-                            aria-hidden
-                            className="hidden size-3.5 @max-[30rem]/pr-header:inline"
-                          />
+                          <GitPullRequestIcon aria-hidden className="size-3.5" />
                           <span className="@max-[30rem]/pr-header:hidden">Ready for review</span>
                         </Button>
                       </span>
@@ -1777,7 +1774,7 @@ export function PullRequestDetailPanel({
                       <span className="inline-flex shrink-0">
                         <Button
                           size="xs"
-                          variant="ghost"
+                          variant="default"
                           disabled={actionPending}
                           onClick={() =>
                             setConfirmation({ open: true, action: "enable-auto-merge" })
@@ -1829,17 +1826,14 @@ export function PullRequestDetailPanel({
                       <span className="inline-flex shrink-0">
                         <Button
                           size="xs"
-                          variant="ghost"
+                          variant="default"
                           disabled={actionPending}
                           onClick={() => setConfirmation({ open: true, action: "merge" })}
                           aria-label={
                             pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel
                           }
                         >
-                          <GitMergeIcon
-                            aria-hidden
-                            className="hidden size-3.5 @max-[30rem]/pr-header:inline"
-                          />
+                          <GitMergeIcon aria-hidden className="size-3.5" />
                           <span className="@max-[30rem]/pr-header:hidden">
                             {pendingAction === "merge" ? "Merging..." : selectedMergeMethodLabel}
                           </span>


### PR DESCRIPTION
The PR header rendered its main actions as ghost buttons, and Merge and Ready for review hid their icons at wider widths. Resolve conflicts, Ready for review, Enable auto-merge, and Merge now use primary styling with consistently visible icons. This matches the existing Merge stack action. Narrow headers retain icon-only controls and their accessible labels.

Applies to the shared web/desktop PR detail panel, including the pull request browser and thread side panel. Action selection, confirmations, and enabled/disabled behavior are unchanged.

Stacked above [#11101](https://github.com/pingdotgg/t3code/pull/11101).

Verified with web typecheck, targeted lint with existing warnings, all 100 PR-detail logic tests, and the real web app. Before and after use the same PR, viewport, and panel state. No animation or interaction behavior changed.

| Before | After |
| --- | --- |
| ![Before: ghost merge action without an icon](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/3a6197d5a76389ff/primary-before.png) | ![After: primary merge action with a visible icon](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/d84e42f5d018e254/primary-after.png) |

Model: GPT-6. Harness: Codex.
