### PR TITLE
fix(server): queue messages during context compaction

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -175,6 +175,8 @@ describe("ProviderCommandReactor", () => {
     readonly titleRegenerationBeforeStart?: "one" | "two";
     readonly serverActivation?: Effect.Effect<void>;
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
+    readonly beforeTurnStartDispatch?: () => Effect.Effect<void>;
+    readonly afterTurnStartDispatch?: () => Effect.Effect<void>;
     readonly compactThreadEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly interruptTurnEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
     readonly stopSessionEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
@@ -434,8 +436,19 @@ describe("ProviderCommandReactor", () => {
             return (
               command.type === "thread.session.set" && command.session.status === "ready"
                 ? (input?.beforeReadySessionDispatch?.() ?? Effect.void)
-                : Effect.void
-            ).pipe(Effect.andThen(engine.dispatch(command)));
+                : command.type === "thread.turn.start" &&
+                    command.commandId.startsWith("server:after-compaction:")
+                  ? (input?.beforeTurnStartDispatch?.() ?? Effect.void)
+                  : Effect.void
+            ).pipe(
+              Effect.andThen(engine.dispatch(command)),
+              Effect.tap(() =>
+                command.type === "thread.turn.start" &&
+                command.commandId.startsWith("server:after-compaction:")
+                  ? (input?.afterTurnStartDispatch?.() ?? Effect.void)
+                  : Effect.void,
+              ),
+            );
           },
           get streamDomainEvents() {
             return engine.streamDomainEvents;
@@ -973,86 +986,149 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect("keeps turns blocked until compaction restores the session", () =>
-    Effect.gen(function* () {
-      const readyDispatchStarted = yield* Deferred.make<void>();
-      const releaseReadyDispatch = yield* Deferred.make<void>();
-      let blockReadyDispatch = false;
-      const harness = yield* Effect.promise(() =>
-        createHarness({
-          beforeReadySessionDispatch: () =>
-            blockReadyDispatch
-              ? Deferred.succeed(readyDispatchStarted, undefined).pipe(
-                  Effect.andThen(Deferred.await(releaseReadyDispatch)),
-                )
-              : Effect.void,
-        }),
-      );
-      const threadId = ThreadId.make("thread-1");
-      const now = "2026-01-01T00:00:00.000Z";
-      const dispatchTurn = (id: string, text: string, createdAt: string) =>
-        harness.engine.dispatch({
-          type: "thread.turn.start",
-          commandId: CommandId.make(`cmd-${id}`),
+  effectIt.effect.each([false, true])(
+    "queues messages until compaction restores the session (stop before resume: %s)",
+    (stopBeforeResume) =>
+      Effect.gen(function* () {
+        const readyDispatchStarted = yield* Deferred.make<void>();
+        const releaseReadyDispatch = yield* Deferred.make<void>();
+        const firstSent = yield* Deferred.make<void>();
+        const queuedSent = yield* Deferred.make<void>();
+        const resumeStarted = yield* Deferred.make<void>();
+        const releaseResume = yield* Deferred.make<void>();
+        const resumeDispatched = yield* Deferred.make<void>();
+        let blockReadyDispatch = false;
+        const harness = yield* Effect.promise(() =>
+          createHarness({
+            beforeTurnStartDispatch: () =>
+              stopBeforeResume
+                ? Deferred.succeed(resumeStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseResume)),
+                  )
+                : Effect.void,
+            afterTurnStartDispatch: () => Deferred.succeed(resumeDispatched, undefined),
+            beforeReadySessionDispatch: () =>
+              blockReadyDispatch
+                ? Deferred.succeed(readyDispatchStarted, undefined).pipe(
+                    Effect.andThen(Deferred.await(releaseReadyDispatch)),
+                  )
+                : Effect.void,
+          }),
+        );
+        const threadId = ThreadId.make("thread-1");
+        let sentCount = 0;
+        harness.sendTurn.mockImplementation(() =>
+          Effect.succeed({ threadId, turnId: asTurnId("turn-1") }).pipe(
+            Effect.tap(() => {
+              sentCount++;
+              return sentCount === 1
+                ? Deferred.succeed(firstSent, undefined)
+                : sentCount === 3
+                  ? Deferred.succeed(queuedSent, undefined)
+                  : Effect.void;
+            }),
+          ),
+        );
+        const now = "2026-01-01T00:00:00.000Z";
+        const dispatchTurn = (id: string, text: string, createdAt: string) =>
+          harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.make(`cmd-${id}`),
+            threadId,
+            message: {
+              messageId: asMessageId(`user-message-${id}`),
+              role: "user",
+              text,
+              attachments: [],
+            },
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            runtimeMode: "approval-required",
+            createdAt,
+          });
+
+        yield* dispatchTurn("before-blocked-compact", "hello", now);
+        yield* Deferred.await(firstSent);
+        yield* harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-session-ready-before-blocked-compact"),
           threadId,
-          message: {
-            messageId: asMessageId(`user-message-${id}`),
-            role: "user",
-            text,
-            attachments: [],
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            providerInstanceId: ProviderInstanceId.make("codex"),
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
           },
-          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-          runtimeMode: "approval-required",
-          createdAt,
+          createdAt: now,
         });
 
-      yield* dispatchTurn("before-blocked-compact", "hello", now);
-      yield* Effect.promise(() => waitFor(() => harness.sendTurn.mock.calls.length === 1));
-      yield* harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.make("cmd-session-ready-before-blocked-compact"),
-        threadId,
-        session: {
-          threadId,
-          status: "ready",
-          providerName: "codex",
-          providerInstanceId: ProviderInstanceId.make("codex"),
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: now,
-        },
-        createdAt: now,
-      });
+        blockReadyDispatch = true;
+        yield* dispatchTurn("blocked-compact", "/compact", "2026-01-01T00:00:01.000Z");
+        yield* Deferred.await(readyDispatchStarted);
 
-      blockReadyDispatch = true;
-      yield* dispatchTurn("blocked-compact", "/compact", "2026-01-01T00:00:01.000Z");
-      yield* Deferred.await(readyDispatchStarted);
+        yield* dispatchTurn("during-compact-recovery", "first queued", "2026-01-01T00:00:02.000Z");
+        yield* dispatchTurn(
+          "during-compact-recovery-2",
+          "second queued",
+          "2026-01-01T00:00:03.000Z",
+        );
+        yield* Effect.promise(() => harness.drain());
+        expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+        const beforeRestore = (yield* Effect.promise(() => harness.readModel())).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        expect(
+          beforeRestore?.activities.filter(
+            (activity) => activity.kind === "provider.turn.start.failed",
+          ),
+        ).toEqual([]);
+        expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([
+          { threadId: "thread-1" },
+        ]);
 
-      yield* dispatchTurn("during-compact-recovery", "too soon", "2026-01-01T00:00:02.000Z");
-      yield* Effect.promise(() =>
-        waitFor(async () => {
-          const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
-          return (
-            thread?.activities.some(
-              (activity) => activity.kind === "provider.turn.start.failed",
-            ) === true
+        yield* Deferred.succeed(releaseReadyDispatch, undefined);
+        if (stopBeforeResume) {
+          yield* Deferred.await(resumeStarted);
+          yield* harness.engine.dispatch({
+            type: "thread.session.stop",
+            commandId: CommandId.make("cmd-stop-before-queued-resume"),
+            threadId,
+            createdAt: "2026-01-01T00:00:04.000Z",
+          });
+          yield* Effect.promise(() => harness.drain());
+          yield* Deferred.succeed(releaseResume, undefined);
+          yield* Deferred.await(resumeDispatched);
+          yield* Effect.promise(() => harness.drain());
+          expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+          const stoppedThread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+            (entry) => entry.id === threadId,
           );
-        }),
-      );
-      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
-      expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([
-        { threadId: "thread-1" },
-      ]);
-
-      yield* Deferred.succeed(releaseReadyDispatch, undefined);
-      yield* Effect.promise(() =>
-        waitFor(async () => {
-          const thread = (await harness.readModel()).threads.find((entry) => entry.id === threadId);
-          return thread?.session?.status === "ready";
-        }),
-      );
-    }),
+          expect(stoppedThread?.session?.status).toBe("stopped");
+          expect(
+            stoppedThread?.activities.filter(
+              (activity) => activity.summary === "Queued message was not sent",
+            ),
+          ).toHaveLength(2);
+          return;
+        }
+        yield* Deferred.await(queuedSent);
+        expect(harness.sendTurn.mock.calls.slice(1).map(([request]) => request)).toEqual([
+          expect.objectContaining({ input: "first queued" }),
+          expect.objectContaining({ input: "second queued" }),
+        ]);
+        const afterRestore = (yield* Effect.promise(() => harness.readModel())).threads.find(
+          (entry) => entry.id === threadId,
+        );
+        expect(
+          afterRestore?.messages.filter((message) => message.text === "first queued"),
+        ).toHaveLength(1);
+        expect(
+          afterRestore?.messages.filter((message) => message.text === "second queued"),
+        ).toHaveLength(1);
+      }),
   );
 
   effectIt.effect("does not overwrite concurrent session state after compaction failure", () =>
@@ -1137,6 +1213,21 @@ describe("ProviderCommandReactor", () => {
       );
       expect(compactingThread?.session?.status).toBe("starting");
       yield* harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-queued-before-stop"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-queued-before-stop"),
+          role: "user",
+          text: "do not restart after stopping",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      });
+      yield* Effect.promise(() => harness.drain());
+      yield* harness.engine.dispatch({
         type: "thread.session.stop",
         commandId: CommandId.make("cmd-stop-during-compact"),
         threadId,
@@ -1151,7 +1242,7 @@ describe("ProviderCommandReactor", () => {
           );
           return (
             compactingThread?.activities.some(
-              (activity) => activity.kind === "provider.turn.start.failed",
+              (activity) => activity.summary === "Context compaction failed",
             ) === true
           );
         }),
@@ -1167,6 +1258,14 @@ describe("ProviderCommandReactor", () => {
         (entry) => entry.id === threadId,
       );
       expect(recoveredThread?.session?.status).toBe("ready");
+      expect(harness.sendTurn).toHaveBeenCalledTimes(1);
+      expect(
+        recoveredThread?.activities.find(
+          (activity) => activity.summary === "Queued message was not sent",
+        ),
+      ).toMatchObject({
+        payload: { requestId: "user-message-queued-before-stop" },
+      });
       expect(
         recoveredThread?.activities.find(
           (activity) => activity.kind === "provider.session.stop.failed",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -986,10 +986,11 @@ describe("ProviderCommandReactor", () => {
     }),
   );
 
-  effectIt.effect.each([false, true])(
-    "queues messages until compaction restores the session (stop before resume: %s)",
-    (stopBeforeResume) =>
+  effectIt.effect.each(["resume", "stop before resume", "stop after send"])(
+    "queues messages until compaction restores the session (%s)",
+    (scenario) =>
       Effect.gen(function* () {
+        const stopBeforeResume = scenario === "stop before resume";
         const readyDispatchStarted = yield* Deferred.make<void>();
         const releaseReadyDispatch = yield* Deferred.make<void>();
         const firstSent = yield* Deferred.make<void>();
@@ -997,6 +998,8 @@ describe("ProviderCommandReactor", () => {
         const resumeStarted = yield* Deferred.make<void>();
         const releaseResume = yield* Deferred.make<void>();
         const resumeDispatched = yield* Deferred.make<void>();
+        const queuedSendStarted = yield* Deferred.make<void>();
+        const releaseQueuedSend = yield* Deferred.make<void>();
         let blockReadyDispatch = false;
         const harness = yield* Effect.promise(() =>
           createHarness({
@@ -1023,9 +1026,13 @@ describe("ProviderCommandReactor", () => {
               sentCount++;
               return sentCount === 1
                 ? Deferred.succeed(firstSent, undefined)
-                : sentCount === 3
-                  ? Deferred.succeed(queuedSent, undefined)
-                  : Effect.void;
+                : sentCount === 2 && scenario === "stop after send"
+                  ? Deferred.succeed(queuedSendStarted, undefined).pipe(
+                      Effect.andThen(Deferred.await(releaseQueuedSend)),
+                    )
+                  : sentCount === 3
+                    ? Deferred.succeed(queuedSent, undefined)
+                    : Effect.void;
             }),
           ),
         );
@@ -1104,6 +1111,35 @@ describe("ProviderCommandReactor", () => {
         ]);
 
         yield* Deferred.succeed(releaseReadyDispatch, undefined);
+        if (scenario === "stop after send") {
+          yield* Deferred.await(queuedSendStarted);
+          yield* harness.engine.dispatch({
+            type: "thread.session.stop",
+            commandId: CommandId.make("cmd-stop-after-queued-send"),
+            threadId,
+            createdAt: "2026-01-01T00:00:04.000Z",
+          });
+          yield* Effect.promise(() => harness.drain());
+          const stoppedThread = (yield* Effect.promise(() => harness.readModel())).threads.find(
+            (entry) => entry.id === threadId,
+          );
+          expect(stoppedThread?.session?.status).toBe("stopped");
+          expect(
+            stoppedThread?.activities.filter(
+              (activity) => activity.summary === "Queued message was not sent",
+            ),
+          ).toEqual([
+            expect.objectContaining({
+              payload: {
+                requestId: "user-message-during-compact-recovery-2",
+                detail: expect.any(String),
+              },
+            }),
+          ]);
+          expect(harness.sendTurn).toHaveBeenCalledTimes(2);
+          yield* Deferred.succeed(releaseQueuedSend, undefined);
+          return;
+        }
         if (stopBeforeResume) {
           yield* Deferred.await(resumeStarted);
           yield* dispatchTurn("compact-during-resume", "/compact", "2026-01-01T00:00:04.000Z");

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -433,20 +433,19 @@ describe("ProviderCommandReactor", () => {
                 return Effect.die(new Error("Injected title regeneration completion failure"));
               }
             }
-            return (
+            const isReplay =
+              command.type === "thread.turn.start" &&
+              command.commandId.startsWith("server:after-compaction:");
+            const before =
               command.type === "thread.session.set" && command.session.status === "ready"
-                ? (input?.beforeReadySessionDispatch?.() ?? Effect.void)
-                : command.type === "thread.turn.start" &&
-                    command.commandId.startsWith("server:after-compaction:")
-                  ? (input?.beforeTurnStartDispatch?.() ?? Effect.void)
-                  : Effect.void
-            ).pipe(
+                ? input?.beforeReadySessionDispatch
+                : isReplay
+                  ? input?.beforeTurnStartDispatch
+                  : undefined;
+            return (before?.() ?? Effect.void).pipe(
               Effect.andThen(engine.dispatch(command)),
               Effect.tap(() =>
-                command.type === "thread.turn.start" &&
-                command.commandId.startsWith("server:after-compaction:")
-                  ? (input?.afterTurnStartDispatch?.() ?? Effect.void)
-                  : Effect.void,
+                isReplay ? (input?.afterTurnStartDispatch?.() ?? Effect.void) : Effect.void,
               ),
             );
           },

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1069,7 +1069,21 @@ describe("ProviderCommandReactor", () => {
         yield* dispatchTurn("blocked-compact", "/compact", "2026-01-01T00:00:01.000Z");
         yield* Deferred.await(readyDispatchStarted);
 
+        yield* harness.engine.dispatch({
+          type: "thread.interaction-mode.set",
+          commandId: CommandId.make("cmd-queued-mode-plan"),
+          threadId,
+          interactionMode: "plan",
+          createdAt: now,
+        });
         yield* dispatchTurn("during-compact-recovery", "first queued", "2026-01-01T00:00:02.000Z");
+        yield* harness.engine.dispatch({
+          type: "thread.interaction-mode.set",
+          commandId: CommandId.make("cmd-queued-mode-default"),
+          threadId,
+          interactionMode: "default",
+          createdAt: now,
+        });
         yield* dispatchTurn(
           "during-compact-recovery-2",
           "second queued",
@@ -1092,6 +1106,9 @@ describe("ProviderCommandReactor", () => {
         yield* Deferred.succeed(releaseReadyDispatch, undefined);
         if (stopBeforeResume) {
           yield* Deferred.await(resumeStarted);
+          yield* dispatchTurn("compact-during-resume", "/compact", "2026-01-01T00:00:04.000Z");
+          yield* Effect.promise(() => harness.drain());
+          expect(harness.compactThread).toHaveBeenCalledTimes(1);
           yield* harness.engine.dispatch({
             type: "thread.session.stop",
             commandId: CommandId.make("cmd-stop-before-queued-resume"),
@@ -1107,6 +1124,7 @@ describe("ProviderCommandReactor", () => {
             (entry) => entry.id === threadId,
           );
           expect(stoppedThread?.session?.status).toBe("stopped");
+          expect(yield* Effect.promise(() => harness.readPendingTurnStarts())).toEqual([]);
           expect(
             stoppedThread?.activities.filter(
               (activity) => activity.summary === "Queued message was not sent",
@@ -1116,8 +1134,8 @@ describe("ProviderCommandReactor", () => {
         }
         yield* Deferred.await(queuedSent);
         expect(harness.sendTurn.mock.calls.slice(1).map(([request]) => request)).toEqual([
-          expect.objectContaining({ input: "first queued" }),
-          expect.objectContaining({ input: "second queued" }),
+          expect.objectContaining({ input: "first queued", interactionMode: "plan" }),
+          expect.objectContaining({ input: "second queued", interactionMode: "default" }),
         ]);
         const afterRestore = (yield* Effect.promise(() => harness.readModel())).threads.find(
           (entry) => entry.id === threadId,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -353,7 +353,11 @@ const make = Effect.gen(function* () {
   const turnsAfterCompaction = new Map<ThreadId, CompactionTurnQueue>();
   const resumedTurnStarts = new Map<
     CommandId,
-    { readonly sent: Deferred.Deferred<void>; readonly queued: CompactionTurnQueue }
+    {
+      readonly sent: Deferred.Deferred<void>;
+      readonly queued: CompactionTurnQueue;
+      readonly event: CompactionTurnQueue[number];
+    }
   >();
   const stoppingThreadIds = new Set<ThreadId>();
 
@@ -412,7 +416,17 @@ const make = Effect.gen(function* () {
         turnId: null,
         createdAt: DateTime.formatIso(yield* DateTime.now),
         requestId: event.payload.messageId,
-      });
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.interrupt
+            : Effect.logWarning("failed to report canceled queued message", {
+                threadId,
+                messageId: event.payload.messageId,
+                cause: Cause.pretty(cause),
+              }),
+        ),
+      );
     }
   });
 
@@ -442,7 +456,7 @@ const make = Effect.gen(function* () {
       // pending slot. Reusing the message id preserves a single user bubble.
       const commandId = yield* serverCommandId("after-compaction");
       const sent = yield* Deferred.make<void>();
-      resumedTurnStarts.set(commandId, { sent, queued });
+      resumedTurnStarts.set(commandId, { sent, queued, event });
       yield* orchestrationEngine
         .dispatch({
           type: "thread.turn.start",
@@ -1265,14 +1279,26 @@ const make = Effect.gen(function* () {
   );
 
   const processTurnStartRequested = Effect.fn("processTurnStartRequested")(function* (
-    event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
+    receivedEvent: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
   ) {
+    const resumed =
+      receivedEvent.commandId !== null ? resumedTurnStarts.get(receivedEvent.commandId) : undefined;
+    const event = resumed ? { ...receivedEvent, payload: resumed.event.payload } : receivedEvent;
     const key = turnStartKeyForEvent(event);
     if (yield* hasHandledTurnStartRecently(key)) {
       return;
     }
-    const resumed = event.commandId !== null ? resumedTurnStarts.get(event.commandId) : undefined;
     if (resumed && turnsAfterCompaction.get(event.payload.threadId) !== resumed.queued) {
+      yield* appendProviderFailureActivity({
+        threadId: event.payload.threadId,
+        kind: "provider.turn.start.failed",
+        summary: "Canceled queued message was not resumed",
+        detail:
+          "This queued message was canceled before it could resume. Send it again to continue.",
+        turnId: null,
+        createdAt: event.payload.createdAt,
+        requestId: event.payload.messageId,
+      });
       return;
     }
 
@@ -1469,6 +1495,7 @@ const make = Effect.gen(function* () {
       const latestThread = yield* resolveThreadShell(event.payload.threadId);
       if (
         compactingThreadIds.has(event.payload.threadId) ||
+        turnsAfterCompaction.has(event.payload.threadId) ||
         latestThread?.session?.status === "starting" ||
         latestThread?.session?.status === "running"
       ) {
@@ -1502,6 +1529,9 @@ const make = Effect.gen(function* () {
         Effect.andThen(resumeTurnsAfterCompaction(event.payload.threadId)),
         Effect.catchCause((cause) =>
           recoverCompactionFailure(cause).pipe(
+            Effect.ensuring(
+              Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId)),
+            ),
             Effect.andThen(
               cancelTurnsAfterCompaction(
                 event.payload.threadId,
@@ -1510,7 +1540,6 @@ const make = Effect.gen(function* () {
             ),
           ),
         ),
-        Effect.ensuring(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
         Effect.forkScoped,
       );
       return;
@@ -1757,16 +1786,16 @@ const make = Effect.gen(function* () {
     const now = event.payload.createdAt;
     const wasCompacting = compactingThreadIds.has(thread.id);
     stoppingThreadIds.add(thread.id);
-    yield* cancelTurnsAfterCompaction(
-      thread.id,
-      "The session was stopped during context compaction. Send this message again to continue.",
-    );
     const clearStopping = Effect.sync(() => void stoppingThreadIds.delete(thread.id));
-    yield* (
-      thread.session && thread.session.status !== "stopped"
-        ? providerService.stopSession({ threadId: thread.id })
-        : Effect.void
-    ).pipe(
+    yield* Effect.gen(function* () {
+      yield* cancelTurnsAfterCompaction(
+        thread.id,
+        "The session was stopped during context compaction. Send this message again to continue.",
+      );
+      if (thread.session && thread.session.status !== "stopped") {
+        yield* providerService.stopSession({ threadId: thread.id });
+      }
+    }).pipe(
       Effect.matchCauseEffect({
         onFailure: (cause) => {
           if (Cause.hasInterruptsOnly(cause)) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -480,7 +480,7 @@ const make = Effect.gen(function* () {
         })
         .pipe(Effect.onError(() => Effect.sync(() => void resumedTurnStarts.delete(commandId))));
       yield* Deferred.await(sent);
-      queued.shift();
+      if (queued[0] === event) queued.shift();
       resumedTurnStarts.delete(commandId);
     }
     if (turnsAfterCompaction.get(threadId) === queued) turnsAfterCompaction.delete(threadId);
@@ -1575,11 +1575,13 @@ const make = Effect.gen(function* () {
     const send = providerService
       .sendTurn(sendTurnRequest.value)
       .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure));
-    const sent =
-      event.commandId !== null ? resumedTurnStarts.get(event.commandId)?.sent : undefined;
-    if (sent && event.commandId !== null) {
+    if (resumed && event.commandId !== null) {
+      resumed.queued.shift();
       resumedTurnStarts.delete(event.commandId);
-      yield* send.pipe(Effect.ensuring(Deferred.succeed(sent, undefined)), Effect.forkScoped);
+      yield* send.pipe(
+        Effect.ensuring(Deferred.succeed(resumed.sent, undefined)),
+        Effect.forkScoped,
+      );
     } else {
       yield* Effect.forkScoped(send);
     }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -347,16 +347,17 @@ const make = Effect.gen(function* () {
 
   const threadModelSelections = new Map<string, ModelSelection>();
   const compactingThreadIds = new Set<ThreadId>();
-  type CompactionTurnQueue = Array<
-    Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>
-  >;
-  const turnsAfterCompaction = new Map<ThreadId, CompactionTurnQueue>();
+  type QueuedTurnStart = Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>;
+  // Turn starts received while a thread compacts, replayed in order once its session is restored.
+  const turnsAfterCompaction = new Map<ThreadId, Array<QueuedTurnStart>>();
+  // Replay command id → the queued turn start it re-requests. `sent` settles once the replay's
+  // provider send finishes, which is what lets the next queued turn follow it in order.
   const resumedTurnStarts = new Map<
     CommandId,
     {
+      readonly event: QueuedTurnStart;
+      readonly queued: Array<QueuedTurnStart>;
       readonly sent: Deferred.Deferred<void>;
-      readonly queued: CompactionTurnQueue;
-      readonly event: CompactionTurnQueue[number];
     }
   >();
   const stoppingThreadIds = new Set<ThreadId>();
@@ -405,7 +406,7 @@ const make = Effect.gen(function* () {
     threadId: ThreadId,
     detail: string,
   ) {
-    const queued = [...(turnsAfterCompaction.get(threadId) ?? [])];
+    const queued = turnsAfterCompaction.get(threadId) ?? [];
     turnsAfterCompaction.delete(threadId);
     for (const event of queued) {
       yield* appendProviderFailureActivity({
@@ -416,17 +417,7 @@ const make = Effect.gen(function* () {
         turnId: null,
         createdAt: DateTime.formatIso(yield* DateTime.now),
         requestId: event.payload.messageId,
-      }).pipe(
-        Effect.catchCause((cause) =>
-          Cause.hasInterruptsOnly(cause)
-            ? Effect.interrupt
-            : Effect.logWarning("failed to report canceled queued message", {
-                threadId,
-                messageId: event.payload.messageId,
-                cause: Cause.pretty(cause),
-              }),
-        ),
-      );
+      }).pipe(Effect.ignore({ log: true, message: "failed to report canceled queued message" }));
     }
   });
 
@@ -435,52 +426,40 @@ const make = Effect.gen(function* () {
   ) {
     const queued = turnsAfterCompaction.get(threadId) ?? [];
     while (queued.length > 0 && turnsAfterCompaction.get(threadId) === queued) {
-      const event = queued[0]!;
-      const thread = yield* resolveThreadShell(threadId);
-      if (!thread || stoppingThreadIds.has(threadId) || thread.session?.status === "stopped") {
-        yield* cancelTurnsAfterCompaction(
-          threadId,
-          "The session was stopped during context compaction. Send this message again to continue.",
-        );
-        return;
-      }
+      // In flight from here on: a cancellation reports it when the replay runs, not from the queue.
+      const event = queued.shift()!;
       const turnStart = yield* projectionSnapshotQuery.getTurnStartMessage({
         threadId,
         messageId: event.payload.messageId,
       });
-      if (Option.isNone(turnStart)) {
-        queued.shift();
-        continue;
-      }
+      if (Option.isNone(turnStart)) continue;
       // Reissue the durable request after restoration clears compaction's
       // pending slot. Reusing the message id preserves a single user bubble.
       const commandId = yield* serverCommandId("after-compaction");
       const sent = yield* Deferred.make<void>();
-      resumedTurnStarts.set(commandId, { sent, queued, event });
+      resumedTurnStarts.set(commandId, { event, queued, sent });
+      const { messageId, ...request } = event.payload;
       yield* orchestrationEngine
         .dispatch({
           type: "thread.turn.start",
           commandId,
-          threadId,
+          ...request,
           message: {
-            messageId: event.payload.messageId,
+            messageId,
             role: "user",
             text: turnStart.value.message.text,
             attachments: turnStart.value.message.attachments ?? [],
           },
-          ...(event.payload.modelSelection !== undefined
-            ? { modelSelection: event.payload.modelSelection }
-            : {}),
-          ...(event.payload.sourceProposedPlan !== undefined
-            ? { sourceProposedPlan: event.payload.sourceProposedPlan }
-            : {}),
-          interactionMode: event.payload.interactionMode,
-          runtimeMode: event.payload.runtimeMode,
-          createdAt: event.payload.createdAt,
         })
-        .pipe(Effect.onError(() => Effect.sync(() => void resumedTurnStarts.delete(commandId))));
+        .pipe(
+          Effect.onError(() =>
+            Effect.sync(() => {
+              resumedTurnStarts.delete(commandId);
+              queued.unshift(event);
+            }),
+          ),
+        );
       yield* Deferred.await(sent);
-      if (queued[0] === event) queued.shift();
       resumedTurnStarts.delete(commandId);
     }
     if (turnsAfterCompaction.get(threadId) === queued) turnsAfterCompaction.delete(threadId);
@@ -1288,19 +1267,6 @@ const make = Effect.gen(function* () {
     if (yield* hasHandledTurnStartRecently(key)) {
       return;
     }
-    if (resumed && turnsAfterCompaction.get(event.payload.threadId) !== resumed.queued) {
-      yield* appendProviderFailureActivity({
-        threadId: event.payload.threadId,
-        kind: "provider.turn.start.failed",
-        summary: "Canceled queued message was not resumed",
-        detail:
-          "This queued message was canceled before it could resume. Send it again to continue.",
-        turnId: null,
-        createdAt: event.payload.createdAt,
-        requestId: event.payload.messageId,
-      });
-      return;
-    }
 
     const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
@@ -1333,6 +1299,12 @@ const make = Effect.gen(function* () {
         createdAt: event.payload.createdAt,
         requestId: event.payload.messageId,
       });
+    if (resumed && turnsAfterCompaction.get(event.payload.threadId) !== resumed.queued) {
+      return yield* appendTurnStartFailure(
+        "Queued message was not sent",
+        "The queued message was canceled before it could resume. Send it again to continue.",
+      );
+    }
 
     const handleTurnStartFailure = (cause: Cause.Cause<unknown>) => {
       if (Cause.hasInterruptsOnly(cause)) {
@@ -1506,6 +1478,9 @@ const make = Effect.gen(function* () {
         return;
       }
       compactingThreadIds.add(event.payload.threadId);
+      const clearCompacting = Effect.sync(
+        () => void compactingThreadIds.delete(event.payload.threadId),
+      );
       yield* Effect.gen(function* () {
         yield* ensureSessionForThread(
           event.payload.threadId,
@@ -1525,13 +1500,11 @@ const make = Effect.gen(function* () {
         );
       }).pipe(
         Effect.andThen(restoreCompaction(event.payload.threadId, true)),
-        Effect.andThen(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
+        Effect.andThen(clearCompacting),
         Effect.andThen(resumeTurnsAfterCompaction(event.payload.threadId)),
         Effect.catchCause((cause) =>
           recoverCompactionFailure(cause).pipe(
-            Effect.ensuring(
-              Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId)),
-            ),
+            Effect.ensuring(clearCompacting),
             Effect.andThen(
               cancelTurnsAfterCompaction(
                 event.payload.threadId,
@@ -1545,9 +1518,9 @@ const make = Effect.gen(function* () {
       return;
     }
     if (
+      !resumed &&
       (compactingThreadIds.has(event.payload.threadId) ||
-        turnsAfterCompaction.has(event.payload.threadId)) &&
-      (event.commandId === null || !resumedTurnStarts.has(event.commandId))
+        turnsAfterCompaction.has(event.payload.threadId))
     ) {
       const queued = turnsAfterCompaction.get(event.payload.threadId) ?? [];
       queued.push(event);
@@ -1575,16 +1548,12 @@ const make = Effect.gen(function* () {
     const send = providerService
       .sendTurn(sendTurnRequest.value)
       .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure));
-    if (resumed && event.commandId !== null) {
-      resumed.queued.shift();
-      resumedTurnStarts.delete(event.commandId);
-      yield* send.pipe(
-        Effect.ensuring(Deferred.succeed(resumed.sent, undefined)),
-        Effect.forkScoped,
-      );
-    } else {
-      yield* Effect.forkScoped(send);
-    }
+    // The forked send settles `sent` from here on, so drop the entry the post-processing hook uses.
+    if (resumed && event.commandId !== null) resumedTurnStarts.delete(event.commandId);
+    yield* send.pipe(
+      Effect.ensuring(resumed ? Deferred.succeed(resumed.sent, undefined) : Effect.void),
+      Effect.forkScoped,
+    );
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (
@@ -1789,15 +1758,15 @@ const make = Effect.gen(function* () {
     const wasCompacting = compactingThreadIds.has(thread.id);
     stoppingThreadIds.add(thread.id);
     const clearStopping = Effect.sync(() => void stoppingThreadIds.delete(thread.id));
-    yield* Effect.gen(function* () {
-      yield* cancelTurnsAfterCompaction(
-        thread.id,
-        "The session was stopped during context compaction. Send this message again to continue.",
-      );
-      if (thread.session && thread.session.status !== "stopped") {
-        yield* providerService.stopSession({ threadId: thread.id });
-      }
-    }).pipe(
+    yield* cancelTurnsAfterCompaction(
+      thread.id,
+      "The session was stopped during context compaction. Send this message again to continue.",
+    ).pipe(
+      Effect.andThen(
+        thread.session && thread.session.status !== "stopped"
+          ? providerService.stopSession({ threadId: thread.id })
+          : Effect.void,
+      ),
       Effect.matchCauseEffect({
         onFailure: (cause) => {
           if (Cause.hasInterruptsOnly(cause)) {
@@ -1911,11 +1880,12 @@ const make = Effect.gen(function* () {
 
   const processDomainEventSafely = (event: ProviderIntentEvent) =>
     processDomainEvent(event).pipe(
+      // A replay that returned before forking its send still holds its entry; settle it so
+      // the compaction queue moves on. Forked sends drop the entry first and settle it themselves.
       Effect.ensuring(
-        Effect.gen(function* () {
-          const sent =
-            event.commandId !== null ? resumedTurnStarts.get(event.commandId)?.sent : undefined;
-          if (sent) yield* Deferred.succeed(sent, undefined);
+        Effect.suspend(() => {
+          const resumed = event.commandId !== null && resumedTurnStarts.get(event.commandId);
+          return resumed ? Deferred.succeed(resumed.sent, undefined) : Effect.void;
         }),
       ),
       Effect.catchCause((cause) => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -18,6 +18,7 @@ import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
@@ -346,6 +347,14 @@ const make = Effect.gen(function* () {
 
   const threadModelSelections = new Map<string, ModelSelection>();
   const compactingThreadIds = new Set<ThreadId>();
+  type CompactionTurnQueue = Array<
+    Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>
+  >;
+  const turnsAfterCompaction = new Map<ThreadId, CompactionTurnQueue>();
+  const resumedTurnStarts = new Map<
+    CommandId,
+    { readonly sent: Deferred.Deferred<void>; readonly queued: CompactionTurnQueue }
+  >();
   const stoppingThreadIds = new Set<ThreadId>();
 
   const appendProviderFailureActivity = (input: {
@@ -387,6 +396,81 @@ const make = Effect.gen(function* () {
         }),
       ),
     );
+
+  const cancelTurnsAfterCompaction = Effect.fn("cancelTurnsAfterCompaction")(function* (
+    threadId: ThreadId,
+    detail: string,
+  ) {
+    const queued = [...(turnsAfterCompaction.get(threadId) ?? [])];
+    turnsAfterCompaction.delete(threadId);
+    for (const event of queued) {
+      yield* appendProviderFailureActivity({
+        threadId,
+        kind: "provider.turn.start.failed",
+        summary: "Queued message was not sent",
+        detail,
+        turnId: null,
+        createdAt: DateTime.formatIso(yield* DateTime.now),
+        requestId: event.payload.messageId,
+      });
+    }
+  });
+
+  const resumeTurnsAfterCompaction = Effect.fn("resumeTurnsAfterCompaction")(function* (
+    threadId: ThreadId,
+  ) {
+    const queued = turnsAfterCompaction.get(threadId) ?? [];
+    while (queued.length > 0 && turnsAfterCompaction.get(threadId) === queued) {
+      const event = queued[0]!;
+      const thread = yield* resolveThreadShell(threadId);
+      if (!thread || stoppingThreadIds.has(threadId) || thread.session?.status === "stopped") {
+        yield* cancelTurnsAfterCompaction(
+          threadId,
+          "The session was stopped during context compaction. Send this message again to continue.",
+        );
+        return;
+      }
+      const turnStart = yield* projectionSnapshotQuery.getTurnStartMessage({
+        threadId,
+        messageId: event.payload.messageId,
+      });
+      if (Option.isNone(turnStart)) {
+        queued.shift();
+        continue;
+      }
+      // Reissue the durable request after restoration clears compaction's
+      // pending slot. Reusing the message id preserves a single user bubble.
+      const commandId = yield* serverCommandId("after-compaction");
+      const sent = yield* Deferred.make<void>();
+      resumedTurnStarts.set(commandId, { sent, queued });
+      yield* orchestrationEngine
+        .dispatch({
+          type: "thread.turn.start",
+          commandId,
+          threadId,
+          message: {
+            messageId: event.payload.messageId,
+            role: "user",
+            text: turnStart.value.message.text,
+            attachments: turnStart.value.message.attachments ?? [],
+          },
+          ...(event.payload.modelSelection !== undefined
+            ? { modelSelection: event.payload.modelSelection }
+            : {}),
+          ...(event.payload.sourceProposedPlan !== undefined
+            ? { sourceProposedPlan: event.payload.sourceProposedPlan }
+            : {}),
+          interactionMode: event.payload.interactionMode,
+          runtimeMode: event.payload.runtimeMode,
+          createdAt: event.payload.createdAt,
+        })
+        .pipe(Effect.onError(() => Effect.sync(() => void resumedTurnStarts.delete(commandId))));
+      yield* Deferred.await(sent);
+      queued.shift();
+      resumedTurnStarts.delete(commandId);
+    }
+    if (turnsAfterCompaction.get(threadId) === queued) turnsAfterCompaction.delete(threadId);
+  });
 
   const formatFailureDetail = (cause: Cause.Cause<unknown>): string => {
     const failReason = cause.reasons.find(Cause.isFailReason);
@@ -1187,6 +1271,10 @@ const make = Effect.gen(function* () {
     if (yield* hasHandledTurnStartRecently(key)) {
       return;
     }
+    const resumed = event.commandId !== null ? resumedTurnStarts.get(event.commandId) : undefined;
+    if (resumed && turnsAfterCompaction.get(event.payload.threadId) !== resumed.queued) {
+      return;
+    }
 
     const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
@@ -1410,17 +1498,32 @@ const make = Effect.gen(function* () {
         );
       }).pipe(
         Effect.andThen(restoreCompaction(event.payload.threadId, true)),
-        Effect.catchCause(recoverCompactionFailure),
+        Effect.andThen(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
+        Effect.andThen(resumeTurnsAfterCompaction(event.payload.threadId)),
+        Effect.catchCause((cause) =>
+          recoverCompactionFailure(cause).pipe(
+            Effect.andThen(
+              cancelTurnsAfterCompaction(
+                event.payload.threadId,
+                "Context compaction failed. Send this message again to continue.",
+              ),
+            ),
+          ),
+        ),
         Effect.ensuring(Effect.sync(() => void compactingThreadIds.delete(event.payload.threadId))),
         Effect.forkScoped,
       );
       return;
     }
-    if (compactingThreadIds.has(event.payload.threadId)) {
-      return yield* appendTurnStartFailure(
-        "Provider turn start failed",
-        "Wait for context compaction to finish before sending another message.",
-      );
+    if (
+      (compactingThreadIds.has(event.payload.threadId) ||
+        turnsAfterCompaction.has(event.payload.threadId)) &&
+      (event.commandId === null || !resumedTurnStarts.has(event.commandId))
+    ) {
+      const queued = turnsAfterCompaction.get(event.payload.threadId) ?? [];
+      queued.push(event);
+      turnsAfterCompaction.set(event.payload.threadId, queued);
+      return;
     }
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
@@ -1440,14 +1543,26 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* providerService
+    const send = providerService
       .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+      .pipe(Effect.asVoid, Effect.catchCause(recoverTurnStartFailure));
+    const sent =
+      event.commandId !== null ? resumedTurnStarts.get(event.commandId)?.sent : undefined;
+    if (sent && event.commandId !== null) {
+      resumedTurnStarts.delete(event.commandId);
+      yield* send.pipe(Effect.ensuring(Deferred.succeed(sent, undefined)), Effect.forkScoped);
+    } else {
+      yield* Effect.forkScoped(send);
+    }
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-interrupt-requested" }>,
   ) {
+    yield* cancelTurnsAfterCompaction(
+      event.payload.threadId,
+      "Context compaction was interrupted. Send this message again to continue.",
+    );
     const thread = yield* resolveThreadShell(event.payload.threadId);
     if (!thread) {
       return;
@@ -1642,6 +1757,10 @@ const make = Effect.gen(function* () {
     const now = event.payload.createdAt;
     const wasCompacting = compactingThreadIds.has(thread.id);
     stoppingThreadIds.add(thread.id);
+    yield* cancelTurnsAfterCompaction(
+      thread.id,
+      "The session was stopped during context compaction. Send this message again to continue.",
+    );
     const clearStopping = Effect.sync(() => void stoppingThreadIds.delete(thread.id));
     yield* (
       thread.session && thread.session.status !== "stopped"
@@ -1761,6 +1880,13 @@ const make = Effect.gen(function* () {
 
   const processDomainEventSafely = (event: ProviderIntentEvent) =>
     processDomainEvent(event).pipe(
+      Effect.ensuring(
+        Effect.gen(function* () {
+          const sent =
+            event.commandId !== null ? resumedTurnStarts.get(event.commandId)?.sent : undefined;
+          if (sent) yield* Deferred.succeed(sent, undefined);
+        }),
+      ),
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
           return Effect.interrupt;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -426,12 +426,14 @@ const make = Effect.gen(function* () {
   ) {
     const queued = turnsAfterCompaction.get(threadId) ?? [];
     while (queued.length > 0 && turnsAfterCompaction.get(threadId) === queued) {
-      // In flight from here on: a cancellation reports it when the replay runs, not from the queue.
-      const event = queued.shift()!;
+      const event = queued[0]!;
       const turnStart = yield* projectionSnapshotQuery.getTurnStartMessage({
         threadId,
         messageId: event.payload.messageId,
       });
+      if (turnsAfterCompaction.get(threadId) !== queued) return;
+      // In flight from here on: a cancellation reports it when the replay runs, not from the queue.
+      queued.shift();
       if (Option.isNone(turnStart)) continue;
       // Reissue the durable request after restoration clears compaction's
       // pending slot. Reusing the message id preserves a single user bubble.


### PR DESCRIPTION
Messages sent during manual compaction previously failed with "Wait for context compaction to finish before sending another message." They now remain visible above the compaction indicator and dispatch in order after the provider session is restored, preserving message ids and pending-turn correlation.

Stopping or interrupting the session cancels queued sends. Compaction failure reports which queued messages were not sent. This is an independent follow-up to #11103.

Verified with a real Codex session: sent two messages while `/compact` ran, saw both above the compaction indicator with no failure activity, and confirmed in the event log that each was replayed under a `server:after-compaction` command id reusing its original message id, with the second replay dispatched only after the first send settled. Codex answered "first" and then "second". All 64 reactor tests and the server typecheck pass; scoped lint has pre-existing warnings.

![Two messages queued above the compaction indicator while the first replayed turn starts](https://uploads-production-47e4.up.railway.app/files/68a7925f-44a7-4a47-ba93-05d76965a5a8/during-compaction.png)

![Both replies after compaction](https://uploads-production-47e4.up.railway.app/files/a8e75de0-0a7a-4dd0-9493-e2edfc52e40b/after-compaction.png)

![Sending two messages during compaction and receiving both replies](https://uploads-production-47e4.up.railway.app/files/8e7b1710-4db5-43d1-a297-76134c3c37ba/queued-messages-during-compaction.gif)

[Same recording as mp4](https://uploads-production-47e4.up.railway.app/files/7139c108-1134-4438-87d2-7b4c3fbf2b59/queued-messages-during-compaction.mp4)

Implemented with GPT-6 in Codex; trimmed and re-verified with Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Messages sent during context compaction are queued and resumed automatically after recovery.
  - Queued messages retain their original identifiers and interaction modes and are not processed multiple times.
  - Queued messages are marked as unsent when compaction fails, is interrupted, or the session stops.
  - Stopped sessions no longer restart unexpectedly because of queued messages.
  - Compaction failures display clearer activity status.
  - Queued requests no longer remain pending after recovery or session termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
