### PR TITLE
fix(web): center pull request unavailable states

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1451,6 +1451,7 @@ export function PullRequestDetailPanel({
         className={cn(
           "@container/pr-header grid min-w-0 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2",
           detail && "border-b border-border/60",
+          !detail && !onClose && "hidden",
         )}
       >
         <div className="ml-4 grid h-7 min-w-0 items-center overflow-hidden">

--- a/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestDetailPanel.tsx
@@ -1447,7 +1447,12 @@ export function PullRequestDetailPanel({
           onPickerOpenChange={setThreadPickerOpen}
         />
       ) : null}
-      <div className="@container/pr-header grid min-w-0 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 border-b border-border/60">
+      <div
+        className={cn(
+          "@container/pr-header grid min-w-0 shrink-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2",
+          detail && "border-b border-border/60",
+        )}
+      >
         <div className="ml-4 grid h-7 min-w-0 items-center overflow-hidden">
           <div
             aria-hidden={condensed}
@@ -2519,7 +2524,7 @@ export function PullRequestDetailPanel({
       </div>
 
       <div
-        className="relative min-h-0 flex-1 overflow-hidden"
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
         onScrollCapture={(event) => {
           const scroller = event.target as HTMLElement;
           scrollerRef.current = scroller;

--- a/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestsUnavailableState.tsx
@@ -25,7 +25,7 @@ export function PullRequestsUnavailableState({
   gitHubUrl?: string;
 }) {
   return (
-    <Empty className="px-4 py-16 md:px-4">
+    <Empty className="min-h-0 justify-center-safe overflow-y-auto px-4 py-16 md:px-4 [&>*]:shrink-0">
       <EmptyMedia variant="icon">
         <GitPullRequestIcon />
       </EmptyMedia>

--- a/apps/web/src/routes/_chat.pull-requests.tsx
+++ b/apps/web/src/routes/_chat.pull-requests.tsx
@@ -2360,7 +2360,7 @@ function PullRequestsColumn({
         {/* The top padding is the shared fade band's height, the same pairing the
             settings page makes: at rest the controls sit fully below the mask, and only
             content actually passing under the chrome fades. */}
-        <WorkspacePageContainer width="expanded" className="gap-4">
+        <WorkspacePageContainer width="expanded" className="min-h-full gap-4">
           <div className="flex flex-col gap-3">
             <div ref={inFlowSearchRef} className="flex flex-wrap items-center gap-2">
               <div className="min-w-0 basis-full @lg/pr-list:basis-0 @lg/pr-list:flex-1">


### PR DESCRIPTION
pull request errors sat near the top of the detail panel beneath an empty header divider. center unavailable states in their panels, remove the empty header when no detail or close control is present, and let short panels scroll to the existing actions. the pull request list now fills its available height too.

verified with real server error responses in the list and thread panels, retry, scrolling to both actions at 580×300, and a narrow light-mode panel. 105 focused tests, web typecheck, and scoped lint/format checks pass. audited all shared callers; desktop shares these web components and native mobile is unchanged.

before:

![before: pull request error beneath the divider](https://uploads-production-47e4.up.railway.app/files/1953143e-8c9b-4256-bb41-e530c6e21a6e/pr-centered-before.png)

after:

![after: centered pull request error without the divider](https://uploads-production-47e4.up.railway.app/files/c2af7db4-ceda-4139-af8c-622ef9b6b4dd/pr-centered-after.png)

thread panel:

![centered error in the thread panel](https://uploads-production-47e4.up.railway.app/files/0611ab14-bcb0-4146-9db9-bb5fa29c05e9/browser-screenshot-100-92-30-110-mtwcxhu2-2fcafc78.png)

model: gpt-6. harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request detail panel layout when content or detail data is unavailable.
  * Updated pull request unavailable states to support constrained-height scrolling and stable element sizing.
  * Ensured the pull request list fills the available height of its scroll area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
