### PR TITLE
feat(web): use a compact right-panel surface menu

### DIFF
--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -13,7 +13,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
     "flex items-center justify-between gap-2",
     mode === "embedded" ? "px-2" : "px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
+      ? "drag-region h-[var(--workspace-topbar-height)] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
       : "flex h-10 min-h-10 shrink-0 items-center border-b border-border/60 bg-background in-data-[preview-panel-mode=inline]:mb-3 in-data-[preview-panel-mode=inline]:h-7 in-data-[preview-panel-mode=inline]:min-h-7 in-data-[preview-panel-mode=inline]:border-b-transparent",
   );
 }

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -165,7 +165,7 @@ const LAUNCHER_SHORTCUT_BLOCKING_LAYERS = [
   '[data-slot="autocomplete-popup"]',
 ].join(",");
 
-/** One-line unavailability hints for the empty-state cards. */
+/** One-line unavailability hints for the empty-state rows. */
 const SURFACE_UNAVAILABLE_HINTS = {
   browser: "Only available in the desktop app.",
   terminal: "Available when a project is open.",
@@ -296,7 +296,7 @@ function SurfaceMenuItem(props: {
 }
 
 /**
- * Card launcher shown when the right panel has no surfaces. Keyboard-first
+ * List launcher shown when the right panel has no surfaces. Keyboard-first
  * without palette chrome: a surface's letter opens it directly from anywhere
  * outside a typing context, and arrows plus Enter work while the launcher is
  * focused. The highlight only appears on hover or arrow use. Unavailable
@@ -327,7 +327,6 @@ function RightPanelEmptyState(props: {
   const actions = [
     {
       label: "Browser",
-      description: "Open a local app or URL.",
       icon: Globe2,
       shortcut: "B",
       available: props.browserAvailable,
@@ -337,7 +336,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Terminal",
-      description: "Start a shell in this workspace.",
       icon: TerminalSquare,
       shortcut: "T",
       available: props.terminalAvailable,
@@ -347,7 +345,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Files",
-      description: "Browse and read workspace files.",
       icon: Files,
       shortcut: "F",
       available: props.filesAvailable,
@@ -357,7 +354,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Diff",
-      description: "Review changes in this thread.",
       icon: FileDiff,
       shortcut: "D",
       available: props.diffAvailable,
@@ -367,7 +363,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Pull request",
-      description: "Open this branch's pull request.",
       icon: GitPullRequest,
       shortcut: "P",
       available: props.pullRequestAvailable,
@@ -377,7 +372,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Linked pull requests",
-      description: "Every pull request this thread has linked, stacks included.",
       icon: GitPullRequestArrow,
       shortcut: "L",
       available: props.pullRequestsAvailable,
@@ -387,7 +381,6 @@ function RightPanelEmptyState(props: {
     },
     {
       label: "Agents",
-      description: "Follow subagents and workflows.",
       icon: Bot,
       shortcut: "A",
       available: props.agentsAvailable,
@@ -444,7 +437,7 @@ function RightPanelEmptyState(props: {
       return;
     }
     if (event.key === "Enter") {
-      // A focused card button owns its own activation; only open from the
+      // A focused row button owns its own activation; only open from the
       // highlight when the container itself has focus.
       if (event.target instanceof HTMLElement && event.target.closest("button")) return;
       const action = availableActions[highlightIndex];
@@ -480,10 +473,6 @@ function RightPanelEmptyState(props: {
     );
   };
 
-  const cardShellClass =
-    "rounded-lg border border-border/80 bg-card dark:border-transparent dark:shadow-none dark:inset-ring-1 dark:inset-ring-white/5";
-  const highlightedCardClass = "bg-accent/60 dark:inset-ring-white/20";
-
   return (
     <div
       ref={focusOnMount}
@@ -494,24 +483,19 @@ function RightPanelEmptyState(props: {
       className={cn(
         "flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-6 pt-6 outline-none",
         // The panel topbar sits above this container; matching bottom padding
-        // keeps the cards centered against the full panel, not the leftover.
+        // keeps the list centered against the full panel, not the leftover.
         "pb-[calc(var(--workspace-topbar-height)+--spacing(6))]",
       )}
     >
-      <div className="relative w-full max-w-lg">
-        <div className="absolute inset-x-0 bottom-full mb-5 text-center">
-          <h3 className="font-medium text-foreground text-sm">Open a surface</h3>
-          <p className="mt-1 text-muted-foreground text-xs">
-            Choose what to show in the right panel.
-          </p>
-        </div>
-        <div className="grid grid-cols-2 gap-2">
+      <div className="w-full max-w-xs">
+        <h3 className="mb-3 text-center font-medium text-foreground text-sm">Open a surface</h3>
+        <div className="flex flex-col gap-0.5">
           {actions.map((action) =>
             action.available ? (
-              // The card is itself a button, so the profile chooser sits beside
+              // The row is itself a button, so the profile chooser sits beside
               // it in a wrapper rather than inside it. Hover lives on the
-              // wrapper: the chooser overlays the card, and a pointer moving
-              // onto it must not read as leaving the card.
+              // wrapper: the chooser overlays the row, and a pointer moving
+              // onto it must not read as leaving the row.
               <div
                 key={action.label}
                 className="group relative"
@@ -526,25 +510,23 @@ function RightPanelEmptyState(props: {
                   type="button"
                   onClick={action.onClick}
                   className={cn(
-                    // Full height: the wrapper is the grid item that stretches
-                    // to the row, so the button must fill it to stay level with
-                    // its neighbour and keep the chooser anchored inside.
-                    "relative flex h-full w-full cursor-pointer flex-col items-start p-4 text-left transition group-hover:border-border group-hover:bg-accent/60",
-                    cardShellClass,
-                    isHighlighted(action) && highlightedCardClass,
+                    "flex h-8 w-full cursor-pointer items-center gap-2.5 rounded-[var(--control-radius)] px-2.5 text-left text-sm transition-colors group-hover:bg-accent/60",
+                    isHighlighted(action) && "bg-accent/60",
                   )}
                 >
-                  <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
-                  <span className="flex items-center gap-2 pe-8">
-                    {actionIcon(action)}
-                    <span className="font-medium text-sm">{action.label}</span>
+                  {actionIcon(action, "size-4")}
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate",
+                      action.label === "Browser" && props.browserProfiles.length > 1 && "pr-7",
+                    )}
+                  >
+                    {action.label}
                   </span>
-                  <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
-                    {action.description}
-                  </span>
+                  <Kbd>{action.shortcut}</Kbd>
                 </button>
                 {/*
-                  Same choice the tab bar's "+" menu offers: the card opens the
+                  Same choice the tab bar's "+" menu offers: the row opens the
                   default profile, the chevron picks another. Only worth showing
                   once there is something to choose between.
                 */}
@@ -554,7 +536,7 @@ function RightPanelEmptyState(props: {
                       render={
                         <Button
                           aria-label="Open browser in a profile"
-                          className="absolute right-3 bottom-3 [--control-icon-color:currentColor]"
+                          className="absolute top-1/2 right-8 -translate-y-1/2 [--control-icon-color:currentColor]"
                           size="icon-xs"
                           variant="ghost-muted"
                         />
@@ -581,22 +563,19 @@ function RightPanelEmptyState(props: {
                 ) : null}
               </div>
             ) : (
-              <div
+              <DisabledReasonTooltip
                 key={action.label}
-                className={cn(
-                  "relative flex w-full flex-col items-start p-4 opacity-40",
-                  cardShellClass,
-                )}
-              >
-                <Kbd className="absolute top-3 right-3">{action.shortcut}</Kbd>
-                <span className="flex items-center gap-2 pe-8">
-                  {actionIcon(action)}
-                  <span className="font-medium text-sm">{action.label}</span>
-                </span>
-                <span className="mt-1.5 text-muted-foreground text-xs leading-relaxed">
-                  {action.disabledReason}
-                </span>
-              </div>
+                reason={action.disabledReason}
+                trigger={
+                  <div className="flex h-8 w-full cursor-default items-center gap-2.5 rounded-[var(--control-radius)] px-2.5 text-left text-sm opacity-50">
+                    {actionIcon(action, "size-4")}
+                    <span className="shrink-0">{action.label}</span>
+                    <span className="ml-auto min-w-0 truncate text-muted-foreground text-xs">
+                      {action.disabledReason}
+                    </span>
+                  </div>
+                }
+              />
             ),
           )}
         </div>

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -567,7 +567,10 @@ function RightPanelEmptyState(props: {
                 key={action.label}
                 reason={action.disabledReason}
                 trigger={
-                  <div className="flex h-8 w-full cursor-default items-center gap-2.5 rounded-[var(--control-radius)] px-2.5 text-left text-sm opacity-50">
+                  <div
+                    tabIndex={0}
+                    className="flex h-8 w-full cursor-default items-center gap-2.5 rounded-[var(--control-radius)] px-2.5 text-left text-sm opacity-50"
+                  >
                     {actionIcon(action, "size-4")}
                     <span className="shrink-0">{action.label}</span>
                     <span className="ml-auto min-w-0 truncate text-muted-foreground text-xs">

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -568,13 +568,12 @@ function RightPanelEmptyState(props: {
                 trigger={
                   <div
                     tabIndex={0}
+                    aria-disabled="true"
                     className="flex h-8 w-full cursor-default items-center gap-2.5 rounded-[var(--control-radius)] px-2.5 text-left text-sm opacity-50"
                   >
                     {actionIcon(action, "size-4")}
-                    <span className="shrink-0">{action.label}</span>
-                    <span className="ml-auto min-w-0 truncate text-muted-foreground text-xs">
-                      {action.disabledReason}
-                    </span>
+                    <span className="min-w-0 flex-1 truncate">{action.label}</span>
+                    <Kbd>{action.shortcut}</Kbd>
                   </div>
                 }
               />

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -437,9 +437,8 @@ function RightPanelEmptyState(props: {
       return;
     }
     if (event.key === "Enter") {
-      // A focused row button owns its own activation; only open from the
-      // highlight when the container itself has focus.
-      if (event.target instanceof HTMLElement && event.target.closest("button")) return;
+      // Only activate the highlight when the launcher itself has focus.
+      if (event.target !== event.currentTarget) return;
       const action = availableActions[highlightIndex];
       if (!action) return;
       event.preventDefault();

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -560,7 +560,7 @@ function Toasts({ position }: { position: ToastPosition }) {
     <Toast.Portal data-slot="toast-portal">
       <Toast.Viewport
         className={cn(
-          "fixed z-100 mx-auto flex w-[calc(100%-var(--toast-inset)*2)] max-w-90 [--toast-header-offset:52px] [--toast-inset:--spacing(4)] sm:[--toast-inset:--spacing(8)]",
+          "fixed z-100 mx-auto flex w-[calc(100%-var(--toast-inset)*2)] max-w-90 [--toast-header-offset:var(--workspace-topbar-height)] [--toast-inset:--spacing(4)] sm:[--toast-inset:--spacing(8)]",
           // Vertical positioning
           "data-[position*=top]:top-[calc(var(--toast-inset)+var(--toast-header-offset))]",
           "data-[position*=bottom]:bottom-(--toast-inset)",

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -243,7 +243,13 @@ function GlassAppearanceSync() {
   const glassOpacity = useClientSettings((settings) => settings.glassOpacity);
 
   useEffect(() => {
-    document.documentElement.style.setProperty("--glass-opacity", `${glassOpacity}%`);
+    const style = document.documentElement.style;
+    style.setProperty("--glass-opacity", `${glassOpacity}%`);
+    if (glassOpacity === 100) {
+      style.setProperty("--glass-blur", "0px");
+    } else {
+      style.removeProperty("--glass-blur");
+    }
   }, [glassOpacity]);
 
   return null;


### PR DESCRIPTION
Replaces the empty right-panel card grid with a compact surface list. Unavailable options show dimmed shortcut keys, with explanations available in focusable tooltips. Preserves existing actions, keyboard handling, and browser profile selection. Disables glass blur at 100% opacity and uses the shared workspace toolbar height for the diff header and toast offset.

Verified in the real web client in light and dark themes at 1280×800 and the narrow sheet at 900×700: launcher and terminal open/close, keyboard activation, and focusable unavailable-option tooltips. All 49 focused panel, toast, and settings tests and web typecheck pass; targeted lint has only existing warnings. Verified the opacity setting at 100% disables blur and returning to 80% restores it in both themes. Desktop browser profile selection is unverified.

![before: right-panel cards, dark](https://uploads-production-47e4.up.railway.app/files/f2e8c9cc-31e4-4b9c-9496-8890be26caeb/browser-screenshot-t3-sff-tailda84d5-ts-net-mtvvbswl-58374077.png)

![before: right-panel cards, light](https://uploads-production-47e4.up.railway.app/files/5c4be5f4-1ab4-49b4-8f21-2cceb8f82334/browser-screenshot-t3-sff-tailda84d5-ts-net-mtvvc5ez-1bb71fa9.png)

![compact menu before and after disabled shortcuts, dark and light](https://uploads-production-47e4.up.railway.app/files/42bf513c-8079-47bf-b814-2a2f86aa1040/t3-panel-shortcuts-before-after.png)

![terminal opened from the compact menu and closed through confirmation](https://uploads-production-47e4.up.railway.app/files/541cc140-808b-4f33-a3ed-5f30bcac7bdb/t3-menu-interaction.gif)

Built with GPT-6 in Codex through T3 Code.
