### PR TITLE
fix(media): preserve playback during fullscreen transitions

### DIFF
--- a/apps/mobile/src/components/MediaVideoPlayer.tsx
+++ b/apps/mobile/src/components/MediaVideoPlayer.tsx
@@ -19,6 +19,7 @@ function LoadedMediaVideo(props: {
 }) {
   const focused = useIsFocused();
   const active = useRef(focused && AppState.currentState === "active");
+  const fullscreen = useRef(false);
   const [attempt, setAttempt] = useState(0);
   // Expo's Android player also reports completed playback as idle.
   const [loadState, setLoadState] = useState<"pending" | "complete" | "error">("pending");
@@ -38,11 +39,12 @@ function LoadedMediaVideo(props: {
 
   useEffect(() => {
     active.current = focused && !props.paused && AppState.currentState === "active";
-    if (!focused || props.paused) player.pause();
+    if (!focused || props.paused || (!active.current && !fullscreen.current)) player.pause();
     // Native background handling distinguishes Android's fullscreen activity
     // from leaving the app; React Native reports both as background.
     const subscription = AppState.addEventListener("change", (state) => {
       active.current = focused && !props.paused && state === "active";
+      if (state === "inactive" || (state === "background" && !fullscreen.current)) player.pause();
     });
     return () => subscription.remove();
   }, [focused, player, props.paused]);
@@ -71,6 +73,12 @@ function LoadedMediaVideo(props: {
         nativeControls
         contentFit="contain"
         fullscreenOptions={{ enable: true }}
+        onFullscreenEnter={() => {
+          fullscreen.current = true;
+        }}
+        onFullscreenExit={() => {
+          fullscreen.current = false;
+        }}
         allowsPictureInPicture={false}
       />
       {loadState === "error" || (loadState === "complete" && status === "error") ? (

--- a/apps/mobile/src/components/MediaVideoPlayer.tsx
+++ b/apps/mobile/src/components/MediaVideoPlayer.tsx
@@ -38,10 +38,11 @@ function LoadedMediaVideo(props: {
 
   useEffect(() => {
     active.current = focused && !props.paused && AppState.currentState === "active";
-    if (!active.current) player.pause();
+    if (!focused || props.paused) player.pause();
+    // Native background handling distinguishes Android's fullscreen activity
+    // from leaving the app; React Native reports both as background.
     const subscription = AppState.addEventListener("change", (state) => {
       active.current = focused && !props.paused && state === "active";
-      if (!active.current) player.pause();
     });
     return () => subscription.remove();
   }, [focused, player, props.paused]);

--- a/apps/web/src/components/media/MediaVideoPlayer.tsx
+++ b/apps/web/src/components/media/MediaVideoPlayer.tsx
@@ -93,11 +93,19 @@ export function MediaVideoPlayer({
     const video = videoRef.current;
     if (!video) return;
     const pauseWhenHidden = () => {
-      if (document.hidden) video.pause();
+      // Native fullscreen can hide the inline page while this video is still visible.
+      const fullscreen =
+        document.fullscreenElement?.contains(video) ||
+        ("webkitDisplayingFullscreen" in video && video.webkitDisplayingFullscreen === true);
+      if (document.hidden && !fullscreen) video.pause();
     };
     document.addEventListener("visibilitychange", pauseWhenHidden);
+    document.addEventListener("fullscreenchange", pauseWhenHidden);
+    video.addEventListener("webkitendfullscreen", pauseWhenHidden);
     return () => {
       document.removeEventListener("visibilitychange", pauseWhenHidden);
+      document.removeEventListener("fullscreenchange", pauseWhenHidden);
+      video.removeEventListener("webkitendfullscreen", pauseWhenHidden);
       video.pause();
     };
   }, [src, failed, loadAttempt]);


### PR DESCRIPTION
fullscreen transitions can hide the inline page or background android's react activity, causing our visibility handlers to pause a playing video. the shared web/desktop player now exempts its fullscreen video from hidden-page pausing and checks again on fullscreen exit; mobile tracks native fullscreen and preserves explicit pausing for ordinary background, inactive, focus, and sharing transitions.

validation: web and mobile typechecks, scoped lint/format, and 29 existing video first-frame/PR markdown tests passed. actual desktop fullscreen entry/exit and the requested success recording remain unverified because the preview's native fullscreen control does not enter fullscreen; this environment also has no usable android emulator. native verification is still required.

model: gpt-6. harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video playback now continues during fullscreen mode on Android, even when background app events occur.
  * Web video no longer pauses while playing in native fullscreen mode.
  * Video visibility and fullscreen transitions are handled more reliably across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->