### PR TITLE
fix(mobile): add close controls to tablet files and terminal

### DIFF
--- a/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
+++ b/apps/mobile/src/features/files/thread-file-navigator-pane.tsx
@@ -18,6 +18,7 @@ import { useEnvironmentQuery } from "../../state/query";
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { FileTreeBrowser } from "./FileTreeBrowser";
 import { preloadWorkspaceFileContents } from "./preload-workspace-file";
+import { useAdaptiveWorkspaceLayout } from "../layout/AdaptiveWorkspaceLayout";
 
 export function ThreadFileNavigatorPane(props: {
   readonly cwd: string;
@@ -28,6 +29,7 @@ export function ThreadFileNavigatorPane(props: {
   readonly onSelectFile: (path: string) => void;
 }) {
   const [searchQuery, setSearchQuery] = useState("");
+  const { toggleAuxiliaryPane } = useAdaptiveWorkspaceLayout();
   const { themeAppearance: highlightTheme } = useAppearancePreferences();
   const theme = useUniwindTheme();
   const foregroundColor = theme["--color-foreground"];
@@ -64,8 +66,18 @@ export function ThreadFileNavigatorPane(props: {
           type: "button" as const,
           width: 44,
         },
+        {
+          accessibilityLabel: "Close files",
+          icon: { name: "xmark", type: "sfSymbol" as const },
+          identifier: "thread-file-navigator-close",
+          onPress: toggleAuxiliaryPane,
+          sharesBackground: false,
+          tintColor: foregroundColor,
+          type: "button" as const,
+          width: 44,
+        },
       ] as ComponentProps<typeof ScreenStackHeaderConfig>["headerRightBarButtonItems"],
-    [entriesQuery.refresh, foregroundColor],
+    [entriesQuery.refresh, foregroundColor, toggleAuxiliaryPane],
   );
 
   const fileTree = (
@@ -158,6 +170,15 @@ export function ThreadFileNavigatorPane(props: {
               tintColorClassName={"accent-icon-muted"}
               type="monochrome"
             />
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Close files"
+            hitSlop={8}
+            className="h-8 w-8 items-center justify-center rounded-full active:bg-subtle"
+            onPress={toggleAuxiliaryPane}
+          >
+            <SymbolView name="xmark" size={14} tintColorClassName="accent-icon-muted" />
           </Pressable>
         </View>
         <View className="flex-row items-center gap-2 border-t border-border px-3 py-2">

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -850,6 +850,19 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
     [navigation, selectedThread, terminalId],
   );
 
+  const handleCloseTerminal = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+    navigation.dispatch(
+      StackActions.replace("Thread", {
+        environmentId: params.environmentId,
+        threadId: params.threadId,
+      }),
+    );
+  }, [navigation, params.environmentId, params.threadId]);
+
   const navigateAwayAfterExit = useCallback(() => {
     // With other shells still live, fall through to the previous one instead
     // of dropping the user back on the thread.
@@ -1143,7 +1156,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         <AndroidScreenHeader
           title="Terminal"
           subtitle={headerSubtitle}
-          onBack={navigation.canGoBack() ? () => navigation.goBack() : undefined}
+          onBack={handleCloseTerminal}
           trailing={
             <>
               {layout.usesSplitView ? (
@@ -1179,6 +1192,12 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
 
       {layout.usesSplitView ? (
         <NativeHeaderToolbar placement="left">
+          <NativeHeaderToolbar.Button
+            accessibilityLabel="Close terminal"
+            icon="xmark"
+            onPress={handleCloseTerminal}
+            separateBackground
+          />
           <NativeHeaderToolbar.Button
             accessibilityLabel={panes.primarySidebarVisible ? "Maximize terminal" : "Show threads"}
             icon={


### PR DESCRIPTION
On iPad, the persistent Files pane has no local close control, and the split-view Terminal screen hides the navigation back button. Add explicit close buttons so users can dismiss Files or return from Terminal to their thread. This addresses items 7 and 8 in [#10985](https://github.com/pingdotgg/t3code/issues/10985).

Files uses the existing auxiliary-pane visibility action. Terminal goes back when possible and replaces an initial terminal route with its thread when there is no history. The Android header uses the same terminal handler; the iPhone native back-button layout is unchanged. Closing Terminal keeps the shell alive.

Verified on an iPad Pro 13-inch simulator running iPadOS 27: open/close Files, open an existing shell, close Terminal with the keyboard visible, and return to the conversation. Before/after captures use the actual base/head UI source with the same fixture and viewport. The integrated phone compact/expanded composer and keyboard-up send checks passed. Mobile typecheck, targeted lint, and 45 layout/adaptive-navigation/voice-presentation tests passed. Android runtime verification has not been performed.

This PR is independent of the composer animation fix in [#11114](https://github.com/pingdotgg/t3code/pull/11114). It changes only navigation controls.

| Files before | Files after |
| --- | --- |
| ![Files without a close button](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/27ba37220a562fc5/files-before.png) | ![Files with a close button](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/72ea6bd4dcb061a7/files-after.png) |

| Terminal before | Terminal after |
| --- | --- |
| ![Terminal without a close button](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/898017a20339c82d/terminal-before.png) | ![Terminal with a close button](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/79028c7163927b03/terminal-after.png) |

Closing Files, opening an existing terminal, and returning to the thread, at normal speed:

![Files and Terminal close flow](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c5162350ef085a37/pane-close-flow.mp4)

Implemented and verified with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controls to close the file navigator pane on iOS and other mobile layouts.
  - Added consistent terminal closing behavior, including an iOS split-view close button and Android header navigation.
  - Terminal closing now returns to the previous screen when possible, or the thread screen otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->