### PR TITLE
fix(pr): update labels and reviewers without redundant reloads

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestLabelPicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestLabelPicker.tsx
@@ -33,15 +33,12 @@ export function PullRequestLabelPicker({
   environmentId,
   reference,
   allowed,
-  onChanged,
 }: {
   environmentId: EnvironmentId;
   reference: PullRequestRef;
   /** False where the host would refuse this account's change. Disabled with the reason rather
    * than hidden, like the reviewer control beside it. */
   allowed: boolean;
-  /** The detail carries the labels, so it is re-read once the host has taken the change. */
-  onChanged: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -79,8 +76,6 @@ export function PullRequestLabelPicker({
       });
       return;
     }
-    onChanged();
-    candidatesQuery.refresh();
   };
 
   return (
@@ -94,8 +89,8 @@ export function PullRequestLabelPicker({
       query={query}
       onQueryChange={setQuery}
       searchLabel="Search labels"
-      isPending={candidatesQuery.isPending}
-      error={candidatesQuery.error}
+      isPending={candidatesQuery.isPending && candidatesQuery.data === null}
+      error={candidatesQuery.data === null ? candidatesQuery.error : null}
       candidates={candidates}
       emptyLabel="This repository has no labels."
       noMatchLabel="No label matches that."

--- a/apps/web/src/components/pullRequest/PullRequestReviewerPicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReviewerPicker.tsx
@@ -38,15 +38,12 @@ export function PullRequestReviewerPicker({
   environmentId,
   reference,
   allowed,
-  onRequested,
 }: {
   environmentId: EnvironmentId;
   reference: PullRequestRef;
   /** False where the host would refuse this account's request, which is worth saying rather than
    * hiding: the control disabled with a reason answers the question its absence would raise. */
   allowed: boolean;
-  /** The detail carries who is requested, so it is re-read once the host has taken the change. */
-  onRequested: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -96,8 +93,6 @@ export function PullRequestReviewerPicker({
         ? `Review request to ${candidate.login} taken back`
         : `Review requested from ${candidate.login}`,
     });
-    onRequested();
-    candidatesQuery.refresh();
   };
 
   return (
@@ -111,8 +106,8 @@ export function PullRequestReviewerPicker({
       query={query}
       onQueryChange={setQuery}
       searchLabel="Search people with access"
-      isPending={candidatesQuery.isPending}
-      error={candidatesQuery.error}
+      isPending={candidatesQuery.isPending && candidatesQuery.data === null}
+      error={candidatesQuery.data === null ? candidatesQuery.error : null}
       candidates={candidates}
       emptyLabel="Nobody else has access to this repository."
       noMatchLabel="Nobody with access matches that."

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -683,7 +683,6 @@ export function PullRequestSummaryTab({
                   environmentId={environmentId}
                   reference={reference}
                   allowed={detail.viewerPermissions.requestReviewers}
-                  onRequested={onRefresh}
                 />
               ) : null}
             </span>
@@ -718,7 +717,6 @@ export function PullRequestSummaryTab({
                     environmentId={environmentId}
                     reference={reference}
                     allowed={detail.viewerPermissions.labels !== false}
-                    onChanged={onRefresh}
                   />
                 ) : null}
               </span>

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -1,5 +1,6 @@
 import { EnvironmentId, ProjectId, WS_METHODS, type PullRequestStack } from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Latch from "effect/Latch";
 import * as Layer from "effect/Layer";
@@ -25,6 +26,8 @@ import {
 } from "./pullRequests.ts";
 import { PullRequestDiffLoader } from "./pullRequestDiffHttp.ts";
 import { executeAtomQuery } from "./runtime.ts";
+
+class MutationRefused extends Data.TaggedError("MutationRefused") {}
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -212,6 +215,230 @@ it.effect("refreshes pull request activity after a comment is updated", () =>
         (yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true })).comments[0]
           ?.body,
       ).toBe("after turn");
+    }),
+  ),
+);
+
+it.effect("updates cached labels after successful edits without rereading the host", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      let detailReads = 0;
+      let candidateReads = 0;
+      let refuse = false;
+      const client = {
+        [WS_METHODS.pullRequestsSubscribeRefreshes]: () => Stream.never,
+        [WS_METHODS.pullRequestsDetail]: () =>
+          Effect.sync(() => {
+            detailReads++;
+            return { title: "keep this title", labels: [{ name: "existing", color: "111111" }] };
+          }),
+        [WS_METHODS.pullRequestsLabelCandidates]: () =>
+          Effect.sync(() => {
+            candidateReads++;
+            return {
+              candidates: [
+                { name: "existing", color: "111111", description: null, isApplied: true },
+                {
+                  name: "new",
+                  color: "abcdef",
+                  description: "keep this description",
+                  isApplied: false,
+                },
+              ],
+              truncated: false,
+            };
+          }),
+        [WS_METHODS.pullRequestsSetLabels]: () =>
+          refuse ? Effect.fail(new MutationRefused()) : Effect.void,
+      } as unknown as WsRpcProtocolClient;
+      const { atoms, registry } = yield* makeTestRuntime(client);
+      const target = {
+        environmentId: TARGET.environmentId,
+        input: {
+          projectId: ProjectId.make("project-1"),
+          repository: "acme/web",
+          number: 1,
+          host: "github.example.com",
+        },
+      };
+      const detail = atoms.detail(target);
+      const candidates = atoms.labelCandidates(target);
+      const unmountDetail = registry.mount(detail);
+      let unmountCandidates = registry.mount(candidates);
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          unmountDetail();
+          unmountCandidates();
+        }),
+      );
+      yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true });
+      yield* AtomRegistry.getResult(registry, candidates, { suspendOnWaiting: true });
+
+      const added = yield* Effect.promise(() =>
+        atoms.setLabels.run(registry, {
+          ...target,
+          input: {
+            host: target.input.host,
+            projectId: target.input.projectId,
+            repository: target.input.repository,
+            number: target.input.number,
+            labels: ["new"],
+            applied: true,
+          },
+        }),
+      );
+      expect(AsyncResult.isSuccess(added)).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
+        { name: "existing", color: "111111" },
+        { name: "new", color: "abcdef" },
+      ]);
+      expect((yield* AtomRegistry.getResult(registry, detail)).title).toBe("keep this title");
+      unmountCandidates();
+      unmountCandidates = registry.mount(atoms.labelCandidates(target));
+      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[1]).toEqual({
+        name: "new",
+        color: "abcdef",
+        description: "keep this description",
+        isApplied: true,
+      });
+
+      const removed = yield* Effect.promise(() =>
+        atoms.setLabels.run(registry, {
+          ...target,
+          input: { ...target.input, labels: ["existing"], applied: false },
+        }),
+      );
+      expect(AsyncResult.isSuccess(removed)).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
+        { name: "new", color: "abcdef" },
+      ]);
+      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isApplied).toBe(
+        false,
+      );
+
+      refuse = true;
+      const failed = yield* Effect.promise(() =>
+        atoms.setLabels.run(registry, {
+          ...target,
+          input: { ...target.input, labels: ["new"], applied: false },
+        }),
+      );
+      expect(AsyncResult.isFailure(failed)).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
+        { name: "new", color: "abcdef" },
+      ]);
+      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[1]?.isApplied).toBe(
+        true,
+      );
+      expect(detailReads).toBe(1);
+      expect(candidateReads).toBe(1);
+
+      registry.refresh(detail);
+      expect(
+        (yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true })).labels,
+      ).toEqual([{ name: "existing", color: "111111" }]);
+      expect(detailReads).toBe(2);
+    }),
+  ),
+);
+
+it.effect("updates reviewer requests and enriched reviewers without rereading the host", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      let reads = 0;
+      let refuse = false;
+      const actor = { login: "reviewer", name: "Reviewer", avatarUrl: null };
+      let hostRequested = false;
+      let pauseActivity = false;
+      const activityStarted = yield* Latch.make();
+      const client = {
+        [WS_METHODS.pullRequestsSubscribeRefreshes]: () => Stream.never,
+        [WS_METHODS.pullRequestsDetail]: () =>
+          Effect.sync(() => {
+            reads++;
+            return { reviewers: [] };
+          }),
+        [WS_METHODS.pullRequestsActivity]: () =>
+          Effect.gen(function* () {
+            reads++;
+            if (pauseActivity) {
+              pauseActivity = false;
+              yield* activityStarted.open;
+              return yield* Effect.never;
+            }
+            return { reviewers: hostRequested ? [actor] : [], comments: [] };
+          }),
+        [WS_METHODS.pullRequestsReviewerCandidates]: () =>
+          Effect.sync(() => {
+            reads++;
+            return {
+              candidates: [{ ...actor, id: "12", kind: "user", isRequested: false }],
+              truncated: false,
+            };
+          }),
+        [WS_METHODS.pullRequestsRequestReviewers]: (input: { requested: boolean }) =>
+          refuse
+            ? Effect.fail(new MutationRefused())
+            : Effect.sync(() => {
+                hostRequested = input.requested;
+              }),
+      } as unknown as WsRpcProtocolClient;
+      const { atoms, registry } = yield* makeTestRuntime(client);
+      const target = {
+        environmentId: TARGET.environmentId,
+        input: {
+          projectId: ProjectId.make("project-1"),
+          repository: "acme/web",
+          number: 1,
+          host: "github.example.com",
+        },
+      };
+      const detail = atoms.detail(target);
+      const activity = atoms.activity(target);
+      const candidates = atoms.reviewerCandidates(target);
+      for (const unmount of [
+        registry.mount(detail),
+        registry.mount(activity),
+        registry.mount(candidates),
+      ]) {
+        yield* Effect.addFinalizer(() => Effect.sync(unmount));
+      }
+      yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true });
+      yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true });
+      yield* AtomRegistry.getResult(registry, candidates, { suspendOnWaiting: true });
+      const request = (requested: boolean) =>
+        Effect.promise(() =>
+          atoms.requestReviewers.run(registry, {
+            ...target,
+            input: { ...target.input, reviewers: [{ id: "12", kind: "user" }], requested },
+          }),
+        );
+      expect(AsyncResult.isSuccess(yield* request(true))).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([actor]);
+      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([actor]);
+      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isRequested).toBe(
+        true,
+      );
+      refuse = true;
+      expect(AsyncResult.isFailure(yield* request(false))).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([actor]);
+      refuse = false;
+      expect(AsyncResult.isSuccess(yield* request(false))).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([]);
+      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([]);
+      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isRequested).toBe(
+        false,
+      );
+      expect(reads).toBe(3);
+      // A slow activity read started before the write must not hide the new request.
+      pauseActivity = true;
+      registry.refresh(activity);
+      yield* activityStarted.await;
+      expect(AsyncResult.isSuccess(yield* request(true))).toBe(true);
+      expect(
+        (yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true })).reviewers,
+      ).toEqual([actor]);
+      expect(reads).toBe(5);
     }),
   ),
 );

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -226,6 +226,8 @@ it.effect("updates cached labels after successful edits without rereading the ho
       let candidateReads = 0;
       let refuse = false;
       let failDetail = false;
+      const existing = { name: "existing", color: "111111" };
+      const addedLabel = { name: "new", color: "abcdef" };
       const detailRefreshStarted = yield* Latch.make();
       const releaseDetailRefresh = yield* Latch.make();
       const client = {
@@ -238,20 +240,15 @@ it.effect("updates cached labels after successful edits without rereading the ho
               yield* releaseDetailRefresh.await;
               return yield* Effect.fail(new MutationRefused());
             }
-            return { title: "keep this title", labels: [{ name: "existing", color: "111111" }] };
+            return { title: "keep this title", labels: [existing] };
           }),
         [WS_METHODS.pullRequestsLabelCandidates]: () =>
           Effect.sync(() => {
             candidateReads++;
             return {
               candidates: [
-                { name: "existing", color: "111111", description: null, isApplied: true },
-                {
-                  name: "new",
-                  color: "abcdef",
-                  description: "keep this description",
-                  isApplied: false,
-                },
+                { ...existing, description: null, isApplied: true },
+                { ...addedLabel, description: "description", isApplied: false },
               ],
               truncated: false,
             };
@@ -271,14 +268,8 @@ it.effect("updates cached labels after successful edits without rereading the ho
       };
       const detail = atoms.detail(target);
       const candidates = atoms.labelCandidates(target);
-      const unmountDetail = registry.mount(detail);
-      let unmountCandidates = registry.mount(candidates);
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() => {
-          unmountDetail();
-          unmountCandidates();
-        }),
-      );
+      registry.mount(detail);
+      const unmountCandidates = registry.mount(candidates);
       yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true });
       yield* AtomRegistry.getResult(registry, candidates, { suspendOnWaiting: true });
 
@@ -296,48 +287,33 @@ it.effect("updates cached labels after successful edits without rereading the ho
         }),
       );
       expect(AsyncResult.isSuccess(added)).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
-        { name: "existing", color: "111111" },
-        { name: "new", color: "abcdef" },
-      ]);
-      expect((yield* AtomRegistry.getResult(registry, detail)).title).toBe("keep this title");
+      expect(yield* AtomRegistry.getResult(registry, detail)).toEqual({
+        title: "keep this title",
+        labels: [existing, addedLabel],
+      });
       unmountCandidates();
-      unmountCandidates = registry.mount(atoms.labelCandidates(target));
+      registry.mount(atoms.labelCandidates(target));
       expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[1]).toEqual({
-        name: "new",
-        color: "abcdef",
-        description: "keep this description",
+        ...addedLabel,
+        description: "description",
         isApplied: true,
       });
 
-      const removed = yield* Effect.promise(() =>
-        atoms.setLabels.run(registry, {
-          ...target,
-          input: { ...target.input, labels: ["existing"], applied: false },
-        }),
-      );
-      expect(AsyncResult.isSuccess(removed)).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
-        { name: "new", color: "abcdef" },
-      ]);
-      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isApplied).toBe(
-        false,
-      );
-
-      refuse = true;
-      const failed = yield* Effect.promise(() =>
-        atoms.setLabels.run(registry, {
-          ...target,
-          input: { ...target.input, labels: ["new"], applied: false },
-        }),
-      );
-      expect(AsyncResult.isFailure(failed)).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([
-        { name: "new", color: "abcdef" },
-      ]);
-      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[1]?.isApplied).toBe(
-        true,
-      );
+      for (const name of ["existing", "new"]) {
+        refuse = name === "new";
+        const result = yield* Effect.promise(() =>
+          atoms.setLabels.run(registry, {
+            ...target,
+            input: { ...target.input, labels: [name], applied: false },
+          }),
+        );
+        expect(result._tag).toBe(refuse ? "Failure" : "Success");
+        expect((yield* AtomRegistry.getResult(registry, detail)).labels).toEqual([addedLabel]);
+        expect((yield* AtomRegistry.getResult(registry, candidates)).candidates).toMatchObject([
+          { name: "existing", isApplied: false },
+          { name: "new", isApplied: true },
+        ]);
+      }
       expect(detailReads).toBe(1);
       expect(candidateReads).toBe(1);
 
@@ -346,19 +322,19 @@ it.effect("updates cached labels after successful edits without rereading the ho
       yield* detailRefreshStarted.await;
       expect(registry.get(detail).waiting).toBe(true);
       expect(Option.getOrThrow(AsyncResult.value(registry.get(detail))).labels).toEqual([
-        { name: "new", color: "abcdef" },
+        addedLabel,
       ]);
       yield* releaseDetailRefresh.open;
       yield* Effect.exit(AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true }));
       expect(AsyncResult.isFailure(registry.get(detail))).toBe(true);
       expect(Option.getOrThrow(AsyncResult.value(registry.get(detail))).labels).toEqual([
-        { name: "new", color: "abcdef" },
+        addedLabel,
       ]);
       failDetail = false;
       registry.refresh(detail);
       expect(
         (yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true })).labels,
-      ).toEqual([{ name: "existing", color: "111111" }]);
+      ).toEqual([existing]);
       expect(detailReads).toBe(3);
     }),
   ),
@@ -425,39 +401,29 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
       const detail = atoms.detail(target);
       const activity = atoms.activity(target);
       const candidates = atoms.reviewerCandidates(target);
-      for (const unmount of [
-        registry.mount(detail),
-        registry.mount(activity),
-        registry.mount(candidates),
-      ]) {
-        yield* Effect.addFinalizer(() => Effect.sync(unmount));
-      }
+      registry.mount(detail);
+      registry.mount(activity);
+      registry.mount(candidates);
       yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true });
       yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true });
       yield* AtomRegistry.getResult(registry, candidates, { suspendOnWaiting: true });
-      const request = (requested: boolean) =>
+      const request = (requested: boolean, reference = target) =>
         Effect.promise(() =>
           atoms.requestReviewers.run(registry, {
-            ...target,
-            input: { ...target.input, reviewers: [{ id: "12", kind: "user" }], requested },
+            ...reference,
+            input: { ...reference.input, reviewers: [{ id: "12", kind: "user" }], requested },
           }),
         );
-      expect(AsyncResult.isSuccess(yield* request(true))).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([actor]);
-      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([actor]);
-      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isRequested).toBe(
-        true,
-      );
-      refuse = true;
-      expect(AsyncResult.isFailure(yield* request(false))).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([actor]);
-      refuse = false;
-      expect(AsyncResult.isSuccess(yield* request(false))).toBe(true);
-      expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual([]);
-      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([]);
-      expect((yield* AtomRegistry.getResult(registry, candidates)).candidates[0]?.isRequested).toBe(
-        false,
-      );
+      for (const operation of ["request", "refuse", "remove"]) {
+        refuse = operation === "refuse";
+        expect((yield* request(operation === "request"))._tag).toBe(refuse ? "Failure" : "Success");
+        const expected = operation === "remove" ? [] : [actor];
+        expect((yield* AtomRegistry.getResult(registry, detail)).reviewers).toEqual(expected);
+        expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual(expected);
+        expect((yield* AtomRegistry.getResult(registry, candidates)).candidates).toMatchObject([
+          { isRequested: operation !== "remove" },
+        ]);
+      }
       expect(reads).toBe(3);
       // A slow activity read started before the write must not hide the new request.
       pauseActivity = true;
@@ -481,15 +447,9 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
       // A caller without an open picker still needs authoritative reviewer identities.
       const otherTarget = { ...target, input: { ...target.input, number: 2 } };
       const otherDetail = atoms.detail(otherTarget);
-      const unmount = registry.mount(otherDetail);
-      yield* Effect.addFinalizer(() => Effect.sync(unmount));
+      registry.mount(otherDetail);
       yield* AtomRegistry.getResult(registry, otherDetail, { suspendOnWaiting: true });
-      yield* Effect.promise(() =>
-        atoms.requestReviewers.run(registry, {
-          ...otherTarget,
-          input: { ...otherTarget.input, reviewers: [{ id: "12", kind: "user" }], requested: true },
-        }),
-      );
+      yield* request(true, otherTarget);
       expect(
         (yield* AtomRegistry.getResult(registry, otherDetail, { suspendOnWaiting: true }))
           .reviewers,

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -225,11 +225,19 @@ it.effect("updates cached labels after successful edits without rereading the ho
       let detailReads = 0;
       let candidateReads = 0;
       let refuse = false;
+      let failDetail = false;
+      const detailRefreshStarted = yield* Latch.make();
+      const releaseDetailRefresh = yield* Latch.make();
       const client = {
         [WS_METHODS.pullRequestsSubscribeRefreshes]: () => Stream.never,
         [WS_METHODS.pullRequestsDetail]: () =>
-          Effect.sync(() => {
+          Effect.gen(function* () {
             detailReads++;
+            if (failDetail) {
+              yield* detailRefreshStarted.open;
+              yield* releaseDetailRefresh.await;
+              return yield* Effect.fail(new MutationRefused());
+            }
             return { title: "keep this title", labels: [{ name: "existing", color: "111111" }] };
           }),
         [WS_METHODS.pullRequestsLabelCandidates]: () =>
@@ -333,11 +341,25 @@ it.effect("updates cached labels after successful edits without rereading the ho
       expect(detailReads).toBe(1);
       expect(candidateReads).toBe(1);
 
+      failDetail = true;
+      registry.refresh(detail);
+      yield* detailRefreshStarted.await;
+      expect(registry.get(detail).waiting).toBe(true);
+      expect(Option.getOrThrow(AsyncResult.value(registry.get(detail))).labels).toEqual([
+        { name: "new", color: "abcdef" },
+      ]);
+      yield* releaseDetailRefresh.open;
+      yield* Effect.exit(AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true }));
+      expect(AsyncResult.isFailure(registry.get(detail))).toBe(true);
+      expect(Option.getOrThrow(AsyncResult.value(registry.get(detail))).labels).toEqual([
+        { name: "new", color: "abcdef" },
+      ]);
+      failDetail = false;
       registry.refresh(detail);
       expect(
         (yield* AtomRegistry.getResult(registry, detail, { suspendOnWaiting: true })).labels,
       ).toEqual([{ name: "existing", color: "111111" }]);
-      expect(detailReads).toBe(2);
+      expect(detailReads).toBe(3);
     }),
   ),
 );
@@ -348,7 +370,9 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
       let reads = 0;
       let refuse = false;
       const actor = { login: "reviewer", name: "Reviewer", avatarUrl: null };
+      const hostActor = { ...actor, login: "Reviewer" };
       let hostRequested = false;
+      let reviewed = false;
       let pauseActivity = false;
       const activityStarted = yield* Latch.make();
       const client = {
@@ -356,7 +380,7 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
         [WS_METHODS.pullRequestsDetail]: () =>
           Effect.sync(() => {
             reads++;
-            return { reviewers: [] };
+            return { reviewers: hostRequested ? [hostActor] : [] };
           }),
         [WS_METHODS.pullRequestsActivity]: () =>
           Effect.gen(function* () {
@@ -366,16 +390,21 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
               yield* activityStarted.open;
               return yield* Effect.never;
             }
-            return { reviewers: hostRequested ? [actor] : [], comments: [] };
-          }),
-        [WS_METHODS.pullRequestsReviewerCandidates]: () =>
-          Effect.sync(() => {
-            reads++;
             return {
-              candidates: [{ ...actor, id: "12", kind: "user", isRequested: false }],
-              truncated: false,
+              reviewers: hostRequested ? [hostActor] : [],
+              comments: reviewed ? [{ kind: "review-comment", author: hostActor }] : [],
             };
           }),
+        [WS_METHODS.pullRequestsReviewerCandidates]: (input: { number: number }) =>
+          input.number === 2
+            ? Effect.never
+            : Effect.sync(() => {
+                reads++;
+                return {
+                  candidates: [{ ...actor, id: "12", kind: "user", isRequested: false }],
+                  truncated: false,
+                };
+              }),
         [WS_METHODS.pullRequestsRequestReviewers]: (input: { requested: boolean }) =>
           refuse
             ? Effect.fail(new MutationRefused())
@@ -437,8 +466,34 @@ it.effect("updates reviewer requests and enriched reviewers without rereading th
       expect(AsyncResult.isSuccess(yield* request(true))).toBe(true);
       expect(
         (yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true })).reviewers,
-      ).toEqual([actor]);
+      ).toEqual([hostActor]);
       expect(reads).toBe(5);
+      expect(AsyncResult.isSuccess(yield* request(false))).toBe(true);
+      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([]);
+
+      reviewed = true;
+      yield* request(true);
+      registry.refresh(activity);
+      yield* AtomRegistry.getResult(registry, activity, { suspendOnWaiting: true });
+      yield* request(false);
+      expect((yield* AtomRegistry.getResult(registry, activity)).reviewers).toEqual([hostActor]);
+
+      // A caller without an open picker still needs authoritative reviewer identities.
+      const otherTarget = { ...target, input: { ...target.input, number: 2 } };
+      const otherDetail = atoms.detail(otherTarget);
+      const unmount = registry.mount(otherDetail);
+      yield* Effect.addFinalizer(() => Effect.sync(unmount));
+      yield* AtomRegistry.getResult(registry, otherDetail, { suspendOnWaiting: true });
+      yield* Effect.promise(() =>
+        atoms.requestReviewers.run(registry, {
+          ...otherTarget,
+          input: { ...otherTarget.input, reviewers: [{ id: "12", kind: "user" }], requested: true },
+        }),
+      );
+      expect(
+        (yield* AtomRegistry.getResult(registry, otherDetail, { suspendOnWaiting: true }))
+          .reviewers,
+      ).toEqual([hostActor]);
     }),
   ),
 );

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -1,7 +1,10 @@
 import {
   WS_METHODS,
+  type EnvironmentId,
+  type PullRequestActor,
   type PullRequestDetail,
   type PullRequestDiffInput,
+  type PullRequestRef,
   type PullRequestSummary,
   type VcsStatusResult,
 } from "@t3tools/contracts";
@@ -9,7 +12,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as SubscriptionRef from "effect/SubscriptionRef";
-import { Atom } from "effect/unstable/reactivity";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import {
   createAtomCommandScheduler,
@@ -35,6 +38,35 @@ export class EnvironmentHttpConnectionNotReadyError extends Data.TaggedError(
 )<{ readonly message: string }> {}
 
 const LINKED_PULL_REQUEST_IDLE_TTL_MS = 5_000;
+
+/** Keep confirmed edits on the same cached reference regardless of input property order. */
+function writableQueryFamily<A>(
+  family: (target: {
+    readonly environmentId: EnvironmentId;
+    readonly input: PullRequestRef;
+  }) => Atom.Atom<A>,
+) {
+  const writable = Atom.family((source: Atom.Atom<A>) =>
+    Atom.writable(
+      (get) => get(source),
+      (context, value: A) => context.setSelf(value),
+      (refresh) => refresh(source),
+    ).pipe(Atom.setIdleTTL(5 * 60_000)),
+  );
+  return ({
+    environmentId,
+    input: { projectId, host, repository, number },
+  }: {
+    readonly environmentId: EnvironmentId;
+    readonly input: PullRequestRef;
+  }) =>
+    writable(
+      family({
+        environmentId,
+        input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
+      }),
+    );
+}
 
 function createPullRequestRefreshAtomFamily<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
@@ -92,7 +124,7 @@ export function pullRequestDetailToVcsStatus(
 /**
  * Reopening a PR within a minute reuses detail and activity. Explicit refreshes and
  * turn notifications still revalidate. Mutations run serially per environment: actions on the same
- * pull request are order-sensitive, and the detail view refetches after each one.
+ * pull request are order-sensitive. Confirmed label and reviewer edits update cached state.
  */
 export function createPullRequestEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | PullRequestDiffLoader | R, E>,
@@ -103,12 +135,36 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     mode: "serial",
     key: ({ environmentId }: { readonly environmentId: string }) => environmentId,
   } as const;
-  const activity = createEnvironmentRpcQueryAtomFamily(runtime, {
-    label: "environment-data:pull-requests:activity",
-    tag: WS_METHODS.pullRequestsActivity,
-    staleTimeMs: 60_000,
-    refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
-  });
+  const activity = writableQueryFamily(
+    createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:activity",
+      tag: WS_METHODS.pullRequestsActivity,
+      staleTimeMs: 60_000,
+      refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
+    }),
+  );
+  const detail = writableQueryFamily(
+    createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:detail",
+      tag: WS_METHODS.pullRequestsDetail,
+      staleTimeMs: 60_000,
+      refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
+    }),
+  );
+  const labelCandidates = writableQueryFamily(
+    createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:label-candidates",
+      tag: WS_METHODS.pullRequestsLabelCandidates,
+      staleTimeMs: 60_000,
+    }),
+  );
+  const reviewerCandidates = writableQueryFamily(
+    createEnvironmentRpcQueryAtomFamily(runtime, {
+      label: "environment-data:pull-requests:reviewer-candidates",
+      tag: WS_METHODS.pullRequestsReviewerCandidates,
+      staleTimeMs: 60_000,
+    }),
+  );
   return {
     refreshes,
     linkedThreads: createEnvironmentRpcQueryAtomFamily(runtime, {
@@ -137,12 +193,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
     }),
-    detail: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:pull-requests:detail",
-      tag: WS_METHODS.pullRequestsDetail,
-      staleTimeMs: 60_000,
-      refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
-    }),
+    detail,
     activity,
     threadComments: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:thread-comments",
@@ -241,28 +292,133 @@ export function createPullRequestEnvironmentAtoms<R, E>(
      * for a minute, because who has access to a repository changes far more slowly than the
      * change request it is being read for.
      */
-    reviewerCandidates: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:pull-requests:reviewer-candidates",
-      tag: WS_METHODS.pullRequestsReviewerCandidates,
-      staleTimeMs: 60_000,
-    }),
+    reviewerCandidates,
     requestReviewers: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:request-reviewers",
       tag: WS_METHODS.pullRequestsRequestReviewers,
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
+      onSuccess: (
+        { environmentId, input: { projectId, host, repository, number, reviewers, requested } },
+        registry,
+      ) =>
+        Effect.sync(() => {
+          const target = {
+            environmentId,
+            input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
+          };
+          const candidatesAtom = reviewerCandidates(target);
+          const candidates = Option.getOrNull(AsyncResult.value(registry.get(candidatesAtom)));
+          const selected =
+            candidates?.candidates.filter((candidate) =>
+              reviewers.some(
+                (reviewer) => reviewer.id === candidate.id && reviewer.kind === candidate.kind,
+              ),
+            ) ?? [];
+          // A read started before this write can still return the old reviewers.
+          if (registry.get(candidatesAtom).waiting) registry.refresh(candidatesAtom);
+          if (registry.get(detail(target)).waiting) registry.refresh(detail(target));
+          if (registry.get(activity(target)).waiting) registry.refresh(activity(target));
+          registry.update(
+            candidatesAtom,
+            AsyncResult.map((value) => ({
+              ...value,
+              candidates: value.candidates.map((candidate) =>
+                selected.includes(candidate) ? { ...candidate, isRequested: requested } : candidate,
+              ),
+            })),
+          );
+          const updateReviewers = (actors: ReadonlyArray<PullRequestActor>) =>
+            requested
+              ? [
+                  ...actors,
+                  ...selected
+                    .filter((candidate) => !actors.some((actor) => actor.login === candidate.login))
+                    .map(({ login, name, avatarUrl }) => ({ login, name, avatarUrl })),
+                ]
+              : actors.filter(
+                  (actor) => !selected.some((candidate) => candidate.login === actor.login),
+                );
+          registry.update(
+            detail(target),
+            AsyncResult.map((value) => ({
+              ...value,
+              reviewers: updateReviewers(value.reviewers),
+            })),
+          );
+          registry.update(
+            activity(target),
+            AsyncResult.map((value) => ({
+              ...value,
+              ...(value.reviewers === undefined
+                ? {}
+                : {
+                    reviewers: requested
+                      ? updateReviewers(value.reviewers)
+                      : value.reviewers.filter(
+                          (actor) =>
+                            !selected.some((candidate) => candidate.login === actor.login) ||
+                            value.comments.some(
+                              (comment) =>
+                                comment.kind === "review" && comment.author?.login === actor.login,
+                            ),
+                        ),
+                  }),
+            })),
+          );
+        }),
     }),
     /** Read when the label menu opens, and kept for a minute, like the reviewer candidates. */
-    labelCandidates: createEnvironmentRpcQueryAtomFamily(runtime, {
-      label: "environment-data:pull-requests:label-candidates",
-      tag: WS_METHODS.pullRequestsLabelCandidates,
-      staleTimeMs: 60_000,
-    }),
+    labelCandidates,
     setLabels: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-labels",
       tag: WS_METHODS.pullRequestsSetLabels,
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
+      onSuccess: (
+        { environmentId, input: { projectId, host, repository, number, labels, applied } },
+        registry,
+      ) =>
+        Effect.sync(() => {
+          const target = {
+            environmentId,
+            input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
+          };
+          const candidatesAtom = labelCandidates(target);
+          const candidates = Option.getOrNull(AsyncResult.value(registry.get(candidatesAtom)));
+          const names = new Set(labels);
+          // Replace only reads already in flight; ready caches need no host round trip.
+          if (registry.get(candidatesAtom).waiting) registry.refresh(candidatesAtom);
+          if (registry.get(detail(target)).waiting) registry.refresh(detail(target));
+          registry.update(
+            candidatesAtom,
+            AsyncResult.map((value) => ({
+              ...value,
+              candidates: value.candidates.map((candidate) =>
+                names.has(candidate.name) ? { ...candidate, isApplied: applied } : candidate,
+              ),
+            })),
+          );
+          registry.update(
+            detail(target),
+            AsyncResult.map((value) => ({
+              ...value,
+              labels: applied
+                ? [
+                    ...value.labels,
+                    ...labels
+                      .filter((name) => !value.labels.some((label) => label.name === name))
+                      .map((name) => ({
+                        name,
+                        color:
+                          candidates?.candidates.find((candidate) => candidate.name === name)
+                            ?.color ?? null,
+                      })),
+                  ]
+                : value.labels.filter((label) => !names.has(label.name)),
+            })),
+          );
+        }),
     }),
     setThreadResolution: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-thread-resolution",

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -40,16 +40,25 @@ export class EnvironmentHttpConnectionNotReadyError extends Data.TaggedError(
 const LINKED_PULL_REQUEST_IDLE_TTL_MS = 5_000;
 
 /** Keep confirmed edits on the same cached reference regardless of input property order. */
-function writableQueryFamily<A>(
+function writableQueryFamily<A, E>(
   family: (target: {
     readonly environmentId: EnvironmentId;
     readonly input: PullRequestRef;
-  }) => Atom.Atom<A>,
+  }) => Atom.Atom<AsyncResult.AsyncResult<A, E>>,
 ) {
-  const writable = Atom.family((source: Atom.Atom<A>) =>
+  const writable = Atom.family((source: Atom.Atom<AsyncResult.AsyncResult<A, E>>) =>
     Atom.writable(
-      (get) => get(source),
-      (context, value: A) => context.setSelf(value),
+      (get) => {
+        const result = get(source);
+        if (result._tag === "Success" && !result.waiting) return result;
+        const previous = get.self<AsyncResult.AsyncResult<A, E>>();
+        const value = Option.flatMap(previous, AsyncResult.value);
+        if (Option.isNone(value)) return result;
+        return result._tag === "Failure"
+          ? AsyncResult.failureWithPrevious(result.cause, { previous, waiting: result.waiting })
+          : AsyncResult.success<A, E>(value.value, result);
+      },
+      (context, value: AsyncResult.AsyncResult<A, E>) => context.setSelf(value),
       (refresh) => refresh(source),
     ).pipe(Atom.setIdleTTL(5 * 60_000)),
   );
@@ -317,8 +326,13 @@ export function createPullRequestEnvironmentAtoms<R, E>(
             ) ?? [];
           // A read started before this write can still return the old reviewers.
           if (registry.get(candidatesAtom).waiting) registry.refresh(candidatesAtom);
-          if (registry.get(detail(target)).waiting) registry.refresh(detail(target));
-          if (registry.get(activity(target)).waiting) registry.refresh(activity(target));
+          const missingIdentities = selected.length < reviewers.length;
+          if (missingIdentities || registry.get(detail(target)).waiting) {
+            registry.refresh(detail(target));
+          }
+          if (missingIdentities || registry.get(activity(target)).waiting) {
+            registry.refresh(activity(target));
+          }
           registry.update(
             candidatesAtom,
             AsyncResult.map((value) => ({
@@ -328,17 +342,23 @@ export function createPullRequestEnvironmentAtoms<R, E>(
               ),
             })),
           );
+          const selectedLogins = new Set(
+            selected.map((candidate) => candidate.login.toLowerCase()),
+          );
           const updateReviewers = (actors: ReadonlyArray<PullRequestActor>) =>
             requested
               ? [
                   ...actors,
                   ...selected
-                    .filter((candidate) => !actors.some((actor) => actor.login === candidate.login))
+                    .filter(
+                      (candidate) =>
+                        !actors.some(
+                          (actor) => actor.login.toLowerCase() === candidate.login.toLowerCase(),
+                        ),
+                    )
                     .map(({ login, name, avatarUrl }) => ({ login, name, avatarUrl })),
                 ]
-              : actors.filter(
-                  (actor) => !selected.some((candidate) => candidate.login === actor.login),
-                );
+              : actors.filter((actor) => !selectedLogins.has(actor.login.toLowerCase()));
           registry.update(
             detail(target),
             AsyncResult.map((value) => ({
@@ -357,10 +377,11 @@ export function createPullRequestEnvironmentAtoms<R, E>(
                       ? updateReviewers(value.reviewers)
                       : value.reviewers.filter(
                           (actor) =>
-                            !selected.some((candidate) => candidate.login === actor.login) ||
+                            !selectedLogins.has(actor.login.toLowerCase()) ||
                             value.comments.some(
                               (comment) =>
-                                comment.kind === "review" && comment.author?.login === actor.login,
+                                (comment.kind === "review" || comment.kind === "review-comment") &&
+                                comment.author?.login.toLowerCase() === actor.login.toLowerCase(),
                             ),
                         ),
                   }),

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -12,7 +12,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as SubscriptionRef from "effect/SubscriptionRef";
-import { AsyncResult, Atom } from "effect/unstable/reactivity";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import {
   createAtomCommandScheduler,
@@ -65,16 +65,24 @@ function writableQueryFamily<A, E>(
   return ({
     environmentId,
     input: { projectId, host, repository, number },
-  }: {
-    readonly environmentId: EnvironmentId;
-    readonly input: PullRequestRef;
-  }) =>
+  }: Parameters<typeof family>[0]) =>
     writable(
       family({
         environmentId,
         input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
       }),
     );
+}
+
+/** Restart pre-mutation reads before patching so they cannot restore stale values. */
+function updateCached<A, E>(
+  registry: AtomRegistry.AtomRegistry,
+  atom: Atom.Writable<AsyncResult.AsyncResult<A, E>>,
+  update: (value: A) => A,
+  refresh = false,
+) {
+  if (refresh || registry.get(atom).waiting) registry.refresh(atom);
+  registry.update(atom, AsyncResult.map(update));
 }
 
 function createPullRequestRefreshAtomFamily<R, E>(
@@ -307,15 +315,9 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       tag: WS_METHODS.pullRequestsRequestReviewers,
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
-      onSuccess: (
-        { environmentId, input: { projectId, host, repository, number, reviewers, requested } },
-        registry,
-      ) =>
+      onSuccess: (target, registry) =>
         Effect.sync(() => {
-          const target = {
-            environmentId,
-            input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
-          };
+          const { reviewers, requested } = target.input;
           const candidatesAtom = reviewerCandidates(target);
           const candidates = Option.getOrNull(AsyncResult.value(registry.get(candidatesAtom)));
           const selected =
@@ -324,28 +326,20 @@ export function createPullRequestEnvironmentAtoms<R, E>(
                 (reviewer) => reviewer.id === candidate.id && reviewer.kind === candidate.kind,
               ),
             ) ?? [];
-          // A read started before this write can still return the old reviewers.
-          if (registry.get(candidatesAtom).waiting) registry.refresh(candidatesAtom);
           const missingIdentities = selected.length < reviewers.length;
-          if (missingIdentities || registry.get(detail(target)).waiting) {
-            registry.refresh(detail(target));
-          }
-          if (missingIdentities || registry.get(activity(target)).waiting) {
-            registry.refresh(activity(target));
-          }
-          registry.update(
-            candidatesAtom,
-            AsyncResult.map((value) => ({
-              ...value,
-              candidates: value.candidates.map((candidate) =>
-                selected.includes(candidate) ? { ...candidate, isRequested: requested } : candidate,
-              ),
-            })),
-          );
+          updateCached(registry, candidatesAtom, (value) => ({
+            ...value,
+            candidates: value.candidates.map((candidate) =>
+              selected.includes(candidate) ? { ...candidate, isRequested: requested } : candidate,
+            ),
+          }));
           const selectedLogins = new Set(
             selected.map((candidate) => candidate.login.toLowerCase()),
           );
-          const updateReviewers = (actors: ReadonlyArray<PullRequestActor>) =>
+          const updateReviewers = (
+            actors: ReadonlyArray<PullRequestActor>,
+            keep = (_actor: PullRequestActor) => false,
+          ) =>
             requested
               ? [
                   ...actors,
@@ -358,34 +352,35 @@ export function createPullRequestEnvironmentAtoms<R, E>(
                     )
                     .map(({ login, name, avatarUrl }) => ({ login, name, avatarUrl })),
                 ]
-              : actors.filter((actor) => !selectedLogins.has(actor.login.toLowerCase()));
-          registry.update(
+              : actors.filter(
+                  (actor) => !selectedLogins.has(actor.login.toLowerCase()) || keep(actor),
+                );
+          updateCached(
+            registry,
             detail(target),
-            AsyncResult.map((value) => ({
+            (value) => ({
               ...value,
               reviewers: updateReviewers(value.reviewers),
-            })),
+            }),
+            missingIdentities,
           );
-          registry.update(
+          updateCached(
+            registry,
             activity(target),
-            AsyncResult.map((value) => ({
+            (value) => ({
               ...value,
-              ...(value.reviewers === undefined
-                ? {}
-                : {
-                    reviewers: requested
-                      ? updateReviewers(value.reviewers)
-                      : value.reviewers.filter(
-                          (actor) =>
-                            !selectedLogins.has(actor.login.toLowerCase()) ||
-                            value.comments.some(
-                              (comment) =>
-                                (comment.kind === "review" || comment.kind === "review-comment") &&
-                                comment.author?.login.toLowerCase() === actor.login.toLowerCase(),
-                            ),
-                        ),
-                  }),
-            })),
+              reviewers:
+                value.reviewers === undefined
+                  ? undefined
+                  : updateReviewers(value.reviewers, (actor) =>
+                      value.comments.some(
+                        (comment) =>
+                          (comment.kind === "review" || comment.kind === "review-comment") &&
+                          comment.author?.login.toLowerCase() === actor.login.toLowerCase(),
+                      ),
+                    ),
+            }),
+            missingIdentities,
           );
         }),
     }),
@@ -396,49 +391,34 @@ export function createPullRequestEnvironmentAtoms<R, E>(
       tag: WS_METHODS.pullRequestsSetLabels,
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
-      onSuccess: (
-        { environmentId, input: { projectId, host, repository, number, labels, applied } },
-        registry,
-      ) =>
+      onSuccess: (target, registry) =>
         Effect.sync(() => {
-          const target = {
-            environmentId,
-            input: { projectId, ...(host === undefined ? {} : { host }), repository, number },
-          };
+          const { labels, applied } = target.input;
           const candidatesAtom = labelCandidates(target);
           const candidates = Option.getOrNull(AsyncResult.value(registry.get(candidatesAtom)));
           const names = new Set(labels);
-          // Replace only reads already in flight; ready caches need no host round trip.
-          if (registry.get(candidatesAtom).waiting) registry.refresh(candidatesAtom);
-          if (registry.get(detail(target)).waiting) registry.refresh(detail(target));
-          registry.update(
-            candidatesAtom,
-            AsyncResult.map((value) => ({
-              ...value,
-              candidates: value.candidates.map((candidate) =>
-                names.has(candidate.name) ? { ...candidate, isApplied: applied } : candidate,
-              ),
-            })),
-          );
-          registry.update(
-            detail(target),
-            AsyncResult.map((value) => ({
-              ...value,
-              labels: applied
-                ? [
-                    ...value.labels,
-                    ...labels
-                      .filter((name) => !value.labels.some((label) => label.name === name))
-                      .map((name) => ({
-                        name,
-                        color:
-                          candidates?.candidates.find((candidate) => candidate.name === name)
-                            ?.color ?? null,
-                      })),
-                  ]
-                : value.labels.filter((label) => !names.has(label.name)),
-            })),
-          );
+          updateCached(registry, candidatesAtom, (value) => ({
+            ...value,
+            candidates: value.candidates.map((candidate) =>
+              names.has(candidate.name) ? { ...candidate, isApplied: applied } : candidate,
+            ),
+          }));
+          updateCached(registry, detail(target), (value) => ({
+            ...value,
+            labels: applied
+              ? [
+                  ...value.labels,
+                  ...labels
+                    .filter((name) => !value.labels.some((label) => label.name === name))
+                    .map((name) => ({
+                      name,
+                      color:
+                        candidates?.candidates.find((candidate) => candidate.name === name)
+                          ?.color ?? null,
+                    })),
+                ]
+              : value.labels.filter((label) => !names.has(label.name)),
+          }));
         }),
     }),
     setThreadResolution: createEnvironmentRpcCommand(runtime, {


### PR DESCRIPTION
Label and reviewer edits update cached options and PR metadata after GitHub confirms the change. Background reads keep the options visible and cannot undo a confirmed edit.

Verified add/remove/reopen through the real web client and restored the original GitHub state. Focused tests, client-runtime typecheck, and scoped lint pass; web typecheck and GitHub label tests passed on the preceding implementation. Both independent reviewers approved 29aed0112b. Web and desktop share these controls; mobile has no corresponding picker.

![labels: add, remove, and reopen without reloading](https://uploads-production-47e4.up.railway.app/files/abfe68c1-2056-44d4-8f50-f0efd2bf0bf6/pr-labels-fixed.gif)

![reviewers: request, remove, and reopen without reloading](https://uploads-production-47e4.up.railway.app/files/db581af9-97cd-4d8c-acdb-e86c220b8434/pr-reviewers-fixed.gif)

Recordings keep the real interaction timing; idle waiting is trimmed. Model: gpt-6. Harness: Codex.
