### PR TITLE
fix(mobile): keep Android markdown icons aligned

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/android/src/main/java/expo/modules/t3markdowntext/T3MarkdownTextSelectionModule.kt
+++ b/apps/mobile/modules/t3-markdown-text/android/src/main/java/expo/modules/t3markdowntext/T3MarkdownTextSelectionModule.kt
@@ -3,6 +3,8 @@ package expo.modules.t3markdowntext
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.text.Spannable
+import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.ReplacementSpan
 import android.view.ActionMode
@@ -17,6 +19,14 @@ import kotlin.math.max
 import kotlin.math.min
 
 private const val OBJECT_REPLACEMENT_CHARACTER = "\uFFFC"
+
+// Match React Native's measurement buffer. Android orders tied line-height
+// spans differently in SpannableString, shifting inline images once RN's
+// span priorities are exhausted.
+private object MarkdownSpannableFactory : Spannable.Factory() {
+  override fun newSpannable(source: CharSequence): Spannable =
+    SpannableStringBuilder(source)
+}
 
 private fun copyTextWithoutInlineImages(
   text: CharSequence,
@@ -85,6 +95,7 @@ class T3MarkdownTextSelectionModule : Module() {
         if (currentCallback is SanitizingSelectionActionModeCallback) {
           return@runOnUiQueueThread
         }
+        textView.setSpannableFactory(MarkdownSpannableFactory)
         textView.customSelectionActionModeCallback =
           SanitizingSelectionActionModeCallback(textView, currentCallback)
       }


### PR DESCRIPTION
## What Changed

Keep Android Markdown text in a `SpannableStringBuilder` so inline file and link icons stay vertically aligned. This uses the existing native text hook and preserves selection across the whole message.

This addresses the vertical drift from #11079, which was reverted in #11098. 
**Icon wrapping is a separate issue and is not addressed by this change.** An icon can still stay on the previous line when its filename wraps.

## Why

React Native measures text with `SpannableStringBuilder`, but Android's selectable `TextView` normally converts it to `SpannableString`. After React Native exhausts its 256 span priorities, those buffer types can apply overlapping line-height spans in different orders. Icons use the measured baselines while text uses the displayed layout, so they drift apart.

A small `Spannable.Factory` override keeps measurement and display consistent. This is Android native code and requires a new Android binary to ship.

Verified with a release build on a physical Redmi Note 8 Pro running Android 11. The minimal case, 18 plain bullets followed by one file-reference bullet, went from 11 px of drift to zero. The vertical drift in the original nested-list reproduction is fixed too. Whole-message selection works, and copied text matches the unchanged app.

## UI Changes

Same message on the same phone, before and after:

| Before | After |
| --- | --- |
| ![Before: file and GitHub icons drift below their labels on Android](https://github-pr-attachments.none23.workers.dev/a/2a89d293-f917-4c50-8297-1cc4c916a156/factory-before-original.png) | ![After: inline icons stay vertically aligned; icon wrapping is a separate issue](https://github-pr-attachments.none23.workers.dev/a/e71bff88-76c7-4fc4-9bef-69899271a632/factory-restored-ready.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes. Not applicable; this fixes static layout.

Model: GPT-6. Harness: Codex.
Credits @SunkenInTime for a good reproduction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android markdown text handling to preserve inline image ordering during text measurement and selection.
  - Enhanced consistency when copying markdown content containing inline images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->