### PR TITLE
feat: add macOS iOS simulator MCP toolkit

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -30,6 +30,9 @@ import {
 } from "./toolkits/preview/tools.ts";
 import { PullRequestsToolkitHandlersLive } from "./toolkits/pullRequests/handlers.ts";
 import { PullRequestsToolkit } from "./toolkits/pullRequests/tools.ts";
+import { SimulatorToolkitHandlersLive } from "./toolkits/simulator/handlers.ts";
+import { SimulatorToolkit } from "./toolkits/simulator/tools.ts";
+import * as SimulatorHost from "../simulator/SimulatorHost.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -443,6 +446,11 @@ export const PullRequestsToolkitRegistrationLive = McpServer.toolkit(PullRequest
   Layer.provide(PullRequestsToolkitHandlersLive),
 );
 
+export const SimulatorToolkitRegistrationLive = McpServer.toolkit(SimulatorToolkit).pipe(
+  Layer.provide(SimulatorToolkitHandlersLive),
+  Layer.provide(SimulatorHost.layer),
+);
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
@@ -453,4 +461,5 @@ const McpTransportLive = McpServer.layerHttp({
 export const layer = Layer.mergeAll(
   PreviewToolkitRegistrationLive,
   PullRequestsToolkitRegistrationLive,
+  SimulatorToolkitRegistrationLive,
 ).pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -8,7 +8,7 @@ import {
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
-export type McpCapability = "preview" | "pull-requests";
+export type McpCapability = "preview" | "pull-requests" | "simulator";
 
 export interface McpInvocationScope {
   readonly environmentId: EnvironmentId;

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -73,7 +73,7 @@ it.effect("always grants pull-requests and gates preview on the request", () =>
         .resolve(issued.config.authorizationHeader.replace(/^Bearer\s+/, ""))
         .pipe(Effect.map((scope) => [...(scope?.capabilities ?? [])].sort()));
 
-    expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests"]);
+    expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests", "simulator"]);
     expect(yield* capabilitiesOf(withoutPreview)).toEqual(["pull-requests"]);
   }),
 );

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -134,7 +134,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         providerSessionId,
         providerInstanceId: ProviderInstanceId.make(request.providerInstanceId),
         capabilities: new Set<McpInvocationContext.McpCapability>(
-          request.preview ? ["pull-requests", "preview"] : ["pull-requests"],
+          request.preview ? ["pull-requests", "preview", "simulator"] : ["pull-requests"],
         ),
         issuedAt,
       };

--- a/apps/server/src/mcp/toolkits/simulator/handlers.ts
+++ b/apps/server/src/mcp/toolkits/simulator/handlers.ts
@@ -1,0 +1,76 @@
+import * as Effect from "effect/Effect";
+import { SimulatorToolkitError } from "@t3tools/contracts";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import * as SimulatorHost from "../../../simulator/SimulatorHost.ts";
+import { SimulatorToolkit } from "./tools.ts";
+
+const requireCapability = (): Effect.Effect<
+  SimulatorHost.SimulatorHostShape,
+  SimulatorToolkitError,
+  McpInvocationContext.McpInvocationContext | SimulatorHost.SimulatorHost
+> =>
+  Effect.gen(function* () {
+    yield* McpInvocationContext.requireMcpCapability("simulator").pipe(
+      Effect.mapError(
+        (error) => new SimulatorToolkitError({ code: "unsupported_host", detail: error.message }),
+      ),
+    );
+    return yield* SimulatorHost.SimulatorHost;
+  });
+
+const handlers = {
+  simulator_open: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.open(input);
+    }),
+  simulator_tap: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.tap(input);
+    }),
+  simulator_swipe: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.swipe(input);
+    }),
+  simulator_type: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.typeText(input);
+    }),
+  simulator_screenshot: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.screenshot(input);
+    }),
+  simulator_video_start: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.videoStart(input);
+    }),
+  simulator_video_stop: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.videoStop(input);
+    }),
+  simulator_logs: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.logs(input);
+    }),
+  simulator_metrics: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      return yield* host.metrics(input);
+    }),
+  simulator_close: (input) =>
+    Effect.gen(function* () {
+      const host = yield* requireCapability();
+      yield* host.close(input);
+      return {};
+    }),
+} satisfies Parameters<typeof SimulatorToolkit.toLayer>[0];
+
+export const SimulatorToolkitHandlersLive = SimulatorToolkit.toLayer(handlers);

--- a/apps/server/src/mcp/toolkits/simulator/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/simulator/tools.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from "@effect/vitest";
+
+import { SimulatorToolkit } from "./tools.ts";
+
+it("exports the complete simulator control surface", () => {
+  expect(Object.values(SimulatorToolkit.tools).map((tool) => tool.name)).toEqual([
+    "simulator_open",
+    "simulator_tap",
+    "simulator_swipe",
+    "simulator_type",
+    "simulator_screenshot",
+    "simulator_video_start",
+    "simulator_video_stop",
+    "simulator_logs",
+    "simulator_metrics",
+    "simulator_close",
+  ]);
+});

--- a/apps/server/src/mcp/toolkits/simulator/tools.ts
+++ b/apps/server/src/mcp/toolkits/simulator/tools.ts
@@ -1,0 +1,150 @@
+import {
+  SimulatorActionReceipt,
+  SimulatorArtifact,
+  SimulatorCloseInput,
+  SimulatorLogsInput,
+  SimulatorMetrics,
+  SimulatorMetricsInput,
+  SimulatorOpenInput,
+  SimulatorScreenshotInput,
+  SimulatorSession,
+  SimulatorSwipeInput,
+  SimulatorTapInput,
+  SimulatorToolkitError,
+  SimulatorTypeInput,
+  SimulatorVideoStartInput,
+  SimulatorVideoStartResult,
+} from "@t3tools/contracts";
+import * as Tool from "effect/unstable/ai/Tool";
+import * as Toolkit from "effect/unstable/ai/Toolkit";
+import * as Schema from "effect/Schema";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import * as SimulatorHost from "../../../simulator/SimulatorHost.ts";
+
+const dependencies = [McpInvocationContext.McpInvocationContext, SimulatorHost.SimulatorHost];
+
+const mutating = <T extends Tool.Any>(tool: T): T =>
+  tool
+    .annotate(Tool.Readonly, false)
+    .annotate(Tool.Destructive, true)
+    .annotate(Tool.OpenWorld, true) as T;
+
+const SimulatorOpenTool = mutating(
+  Tool.make("simulator_open", {
+    description:
+      "Open and boot an iOS Simulator session on this macOS host. Optionally install and launch an app bundle.",
+    parameters: SimulatorOpenInput,
+    success: SimulatorSession,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Open iOS Simulator"),
+);
+
+const SimulatorTapTool = mutating(
+  Tool.make("simulator_tap", {
+    description:
+      "Tap screen coordinates in the active iOS Simulator. Coordinates are macOS screen points and require Accessibility permission.",
+    parameters: SimulatorTapInput,
+    success: SimulatorActionReceipt,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Tap iOS Simulator"),
+);
+
+const SimulatorSwipeTool = mutating(
+  Tool.make("simulator_swipe", {
+    description: "Swipe between two macOS screen points in the active iOS Simulator.",
+    parameters: SimulatorSwipeInput,
+    success: SimulatorActionReceipt,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Swipe iOS Simulator"),
+);
+
+const SimulatorTypeTool = mutating(
+  Tool.make("simulator_type", {
+    description: "Type literal text into the focused iOS Simulator control.",
+    parameters: SimulatorTypeInput,
+    success: SimulatorActionReceipt,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Type in iOS Simulator"),
+);
+
+const SimulatorScreenshotTool = Tool.make("simulator_screenshot", {
+  description: "Capture a PNG screenshot and return its hashed artifact path.",
+  parameters: SimulatorScreenshotInput,
+  success: SimulatorArtifact,
+  failure: SimulatorToolkitError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Screenshot iOS Simulator")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Idempotent, true);
+
+const SimulatorVideoStartTool = mutating(
+  Tool.make("simulator_video_start", {
+    description: "Start recording the active iOS Simulator display to an MP4 artifact.",
+    parameters: SimulatorVideoStartInput,
+    success: SimulatorVideoStartResult,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Start Simulator video"),
+);
+
+const SimulatorVideoStopTool = mutating(
+  Tool.make("simulator_video_stop", {
+    description: "Stop the active Simulator recording and return the finalized MP4 artifact.",
+    parameters: SimulatorCloseInput,
+    success: SimulatorArtifact,
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Stop Simulator video"),
+);
+
+const SimulatorLogsTool = Tool.make("simulator_logs", {
+  description: "Capture recent unified logs from the iOS Simulator as a bounded artifact.",
+  parameters: SimulatorLogsInput,
+  success: SimulatorArtifact,
+  failure: SimulatorToolkitError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Read Simulator logs")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Idempotent, true);
+
+const SimulatorMetricsTool = Tool.make("simulator_metrics", {
+  description: "Sample CPU and memory metrics from the iOS Simulator host.",
+  parameters: SimulatorMetricsInput,
+  success: SimulatorMetrics,
+  failure: SimulatorToolkitError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Read Simulator metrics")
+  .annotate(Tool.Readonly, true)
+  .annotate(Tool.Idempotent, true);
+
+const SimulatorCloseTool = mutating(
+  Tool.make("simulator_close", {
+    description:
+      "Close a Simulator session and stop its owned recording process. Artifact files remain available for review.",
+    parameters: SimulatorCloseInput,
+    success: Schema.Struct({}),
+    failure: SimulatorToolkitError,
+    dependencies,
+  }).annotate(Tool.Title, "Close iOS Simulator"),
+);
+
+export const SimulatorToolkit = Toolkit.make(
+  SimulatorOpenTool,
+  SimulatorTapTool,
+  SimulatorSwipeTool,
+  SimulatorTypeTool,
+  SimulatorScreenshotTool,
+  SimulatorVideoStartTool,
+  SimulatorVideoStopTool,
+  SimulatorLogsTool,
+  SimulatorMetricsTool,
+  SimulatorCloseTool,
+);

--- a/apps/server/src/simulator/SimulatorHost.ts
+++ b/apps/server/src/simulator/SimulatorHost.ts
@@ -1,0 +1,374 @@
+// @effect-diagnostics nodeBuiltinImport:off globalDate:off globalDateInEffect:off preferSchemaOverJson:off
+import * as NodeChildProcess from "node:child_process";
+import * as NodeCrypto from "node:crypto";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
+import { promisify } from "node:util";
+
+import {
+  SimulatorActionId,
+  type SimulatorArtifact,
+  type SimulatorCloseInput,
+  type SimulatorLogsInput,
+  type SimulatorMetricsInput,
+  type SimulatorOpenInput,
+  type SimulatorScreenshotInput,
+  type SimulatorSession,
+  SimulatorSessionId,
+  type SimulatorSwipeInput,
+  type SimulatorTapInput,
+  type SimulatorTypeInput,
+  type SimulatorVideoStartInput,
+  type SimulatorVideoStartResult,
+  SimulatorToolkitError,
+  type SimulatorActionReceipt,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as Semaphore from "effect/Semaphore";
+
+const execFile = promisify(NodeChildProcess.execFile);
+
+export interface SimulatorHostShape {
+  readonly open: (
+    input: SimulatorOpenInput,
+  ) => Effect.Effect<SimulatorSession, SimulatorToolkitError>;
+  readonly tap: (
+    input: SimulatorTapInput,
+  ) => Effect.Effect<SimulatorActionReceipt, SimulatorToolkitError>;
+  readonly swipe: (
+    input: SimulatorSwipeInput,
+  ) => Effect.Effect<SimulatorActionReceipt, SimulatorToolkitError>;
+  readonly typeText: (
+    input: SimulatorTypeInput,
+  ) => Effect.Effect<SimulatorActionReceipt, SimulatorToolkitError>;
+  readonly screenshot: (
+    input: SimulatorScreenshotInput,
+  ) => Effect.Effect<SimulatorArtifact, SimulatorToolkitError>;
+  readonly videoStart: (
+    input: SimulatorVideoStartInput,
+  ) => Effect.Effect<SimulatorVideoStartResult, SimulatorToolkitError>;
+  readonly videoStop: (
+    input: SimulatorCloseInput,
+  ) => Effect.Effect<SimulatorArtifact, SimulatorToolkitError>;
+  readonly logs: (
+    input: SimulatorLogsInput,
+  ) => Effect.Effect<SimulatorArtifact, SimulatorToolkitError>;
+  readonly metrics: (
+    input: SimulatorMetricsInput,
+  ) => Effect.Effect<import("@t3tools/contracts").SimulatorMetrics, SimulatorToolkitError>;
+  readonly close: (input: SimulatorCloseInput) => Effect.Effect<void, SimulatorToolkitError>;
+}
+
+export class SimulatorHost extends Context.Service<SimulatorHost, SimulatorHostShape>()(
+  "t3/simulator/SimulatorHost",
+) {}
+
+interface SessionState {
+  readonly session: SimulatorSession;
+  readonly nextActionId: number;
+  readonly semaphore: Semaphore.Semaphore;
+  readonly videoPath?: string;
+  readonly videoProcess?: NodeChildProcess.ChildProcess;
+}
+
+interface DeviceInfo {
+  readonly udid: string;
+  readonly name: string;
+  readonly state: string;
+  readonly isAvailable: boolean;
+}
+
+const fail = (code: SimulatorToolkitError["code"], detail: string) =>
+  new SimulatorToolkitError({ code, detail });
+
+const command = (file: string, args: ReadonlyArray<string>, maxBuffer = 2_000_000) =>
+  Effect.tryPromise({
+    try: async () => (await execFile(file, args, { maxBuffer })).stdout,
+    catch: (error) => fail("command_failed", `${file} ${args.join(" ")}: ${String(error)}`),
+  });
+
+const commandIgnoringOutput = (file: string, args: ReadonlyArray<string>) =>
+  Effect.tryPromise({
+    try: async () => {
+      await execFile(file, args, { maxBuffer: 2_000_000 });
+    },
+    catch: (error) => fail("command_failed", `${file} ${args.join(" ")}: ${String(error)}`),
+  });
+
+const requireMac = Effect.suspend(() =>
+  NodeProcess.platform === "darwin"
+    ? Effect.succeed(undefined)
+    : Effect.fail(fail("unsupported_host", "iOS Simulator automation requires macOS.")),
+);
+
+const safeLabel = (label: string | undefined, fallback: string) =>
+  (label ?? fallback).replace(/[^a-zA-Z0-9._-]+/g, "-").slice(0, 80) || fallback;
+
+const artifact = (kind: SimulatorArtifact["kind"], path: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const bytes = await NodeFSP.readFile(path);
+      return {
+        kind,
+        path,
+        bytes: bytes.byteLength,
+        sha256: NodeCrypto.createHash("sha256").update(bytes).digest("hex"),
+      } satisfies SimulatorArtifact;
+    },
+    catch: (error) => fail("command_failed", `Could not read artifact ${path}: ${String(error)}`),
+  });
+
+const appleScriptFor = (
+  kind: "tap" | "swipe" | "type",
+  input: SimulatorTapInput | SimulatorSwipeInput | SimulatorTypeInput,
+) => {
+  if (kind === "tap") {
+    const point = (input as SimulatorTapInput).point;
+    return `tell application "System Events" to\n  delay 0.2\n  click at {${point.x}, ${point.y}}\nend tell`;
+  }
+  if (kind === "swipe") {
+    const value = input as SimulatorSwipeInput;
+    const seconds = Math.max(0.05, (value.durationMs ?? 350) / 1000);
+    return `tell application "System Events" to\n  delay 0.2\n  set position of mouse to {${value.from.x}, ${value.from.y}}\n  mouse down\n  delay ${seconds}\n  set position of mouse to {${value.to.x}, ${value.to.y}}\n  mouse up\nend tell`;
+  }
+  const text = (input as SimulatorTypeInput).text.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `tell application "System Events" to\n  delay 0.2\n  keystroke "${text}"\nend tell`;
+};
+
+const make = Effect.gen(function* () {
+  const state = yield* SynchronizedRef.make<ReadonlyMap<string, SessionState>>(new Map());
+  const withSession = (id: SimulatorSessionId) =>
+    Effect.flatMap(SynchronizedRef.get(state), (sessions) => {
+      const found = sessions.get(id);
+      return found
+        ? Effect.succeed(found)
+        : Effect.fail(fail("session_not_found", `Unknown simulator session ${id}.`));
+    });
+  const nextAction = (id: SimulatorSessionId) =>
+    SynchronizedRef.modifyEffect(state, (sessions) => {
+      const current = sessions.get(id);
+      if (!current)
+        return Effect.fail(fail("session_not_found", `Unknown simulator session ${id}.`));
+      const startedAt = Date.now();
+      const next = { ...current, nextActionId: current.nextActionId + 1 };
+      return Effect.succeed([
+        { id: SimulatorActionId.make(current.nextActionId), startedAt },
+        new Map(sessions).set(id, next),
+      ] as const);
+    });
+  const action = (
+    input: SimulatorTapInput | SimulatorSwipeInput | SimulatorTypeInput,
+    kind: "tap" | "swipe" | "type",
+  ) =>
+    Effect.gen(function* () {
+      yield* requireMac;
+      const session = yield* withSession(input.sessionId);
+      return yield* session.semaphore.withPermit(
+        Effect.gen(function* () {
+          const { id: actionId, startedAt } = yield* nextAction(input.sessionId);
+          yield* commandIgnoringOutput("open", ["-a", "Simulator"]);
+          yield* commandIgnoringOutput("osascript", ["-e", appleScriptFor(kind, input)]);
+          return {
+            sessionId: session.session.sessionId,
+            actionId,
+            durationMs: Date.now() - startedAt,
+            state: "completed",
+          } satisfies SimulatorActionReceipt;
+        }),
+      );
+    });
+  const open: SimulatorHostShape["open"] = Effect.fn("SimulatorHost.open")(function* (input) {
+    yield* requireMac;
+    const raw = yield* command("xcrun", ["simctl", "list", "devices", "available", "-j"]);
+    const parsed = JSON.parse(raw) as { devices: Record<string, DeviceInfo[]> };
+    const devices = Object.entries(parsed.devices)
+      .filter(([runtime]) => runtime.includes("iOS"))
+      .flatMap(([, values]) => values)
+      .filter((device) => device.isAvailable);
+    const device =
+      devices.find((item) =>
+        input.udid ? item.udid === input.udid : item.name === input.deviceName,
+      ) ?? devices.find((item) => input.deviceName === undefined);
+    if (!device)
+      return yield* Effect.fail(
+        fail("device_not_found", "No available iOS simulator matched the requested device."),
+      );
+    if (device.state !== "Booted") {
+      yield* commandIgnoringOutput("xcrun", ["simctl", "boot", device.udid]);
+      yield* commandIgnoringOutput("xcrun", ["simctl", "bootstatus", device.udid, "-b"]);
+    }
+    if (input.appPath && input.appBundleId) {
+      yield* commandIgnoringOutput("xcrun", ["simctl", "install", device.udid, input.appPath]);
+      yield* commandIgnoringOutput("xcrun", [
+        "simctl",
+        "launch",
+        device.udid,
+        input.appBundleId,
+        ...(input.launchArgs ?? []),
+      ]);
+    }
+    const sessionId = SimulatorSessionId.make(`sim_${NodeCrypto.randomUUID()}`);
+    const artifactDirectory = NodePath.join(NodeOS.tmpdir(), "t3-simulator", sessionId);
+    yield* Effect.tryPromise({
+      try: () => NodeFSP.mkdir(artifactDirectory, { recursive: true }),
+      catch: (error) => fail("command_failed", String(error)),
+    });
+    const session = {
+      sessionId,
+      udid: device.udid,
+      deviceName: device.name,
+      state: "ready",
+      artifactDirectory,
+      ...(input.appBundleId ? { appBundleId: input.appBundleId } : {}),
+    } satisfies SimulatorSession;
+    const semaphore = yield* Semaphore.make(1);
+    yield* SynchronizedRef.update(state, (sessions) =>
+      new Map(sessions).set(sessionId, { session, nextActionId: 1, semaphore }),
+    );
+    return session;
+  });
+  const screenshot: SimulatorHostShape["screenshot"] = Effect.fn("SimulatorHost.screenshot")(
+    function* (input) {
+      yield* requireMac;
+      const session = yield* withSession(input.sessionId);
+      const path = NodePath.join(
+        session.session.artifactDirectory,
+        `${safeLabel(input.label, "screenshot")}.png`,
+      );
+      yield* commandIgnoringOutput("xcrun", [
+        "simctl",
+        "io",
+        session.session.udid,
+        "screenshot",
+        path,
+      ]);
+      return yield* artifact("screenshot", path);
+    },
+  );
+  const videoStart: SimulatorHostShape["videoStart"] = Effect.fn("SimulatorHost.videoStart")(
+    function* (input) {
+      yield* requireMac;
+      const session = yield* withSession(input.sessionId);
+      const path = NodePath.join(
+        session.session.artifactDirectory,
+        `${safeLabel(input.label, "recording")}.mp4`,
+      );
+      const process = NodeChildProcess.spawn(
+        "xcrun",
+        ["simctl", "io", session.session.udid, "recordVideo", "--codec=h264", "--force", path],
+        { stdio: "ignore" },
+      );
+      yield* SynchronizedRef.update(state, (sessions) =>
+        new Map(sessions).set(input.sessionId, {
+          ...session,
+          videoPath: path,
+          videoProcess: process,
+        }),
+      );
+      return {
+        sessionId: input.sessionId,
+        state: "recording",
+        path,
+      } satisfies SimulatorVideoStartResult;
+    },
+  );
+  const videoStop: SimulatorHostShape["videoStop"] = Effect.fn("SimulatorHost.videoStop")(
+    function* (input) {
+      const session = yield* withSession(input.sessionId);
+      if (!session.videoProcess || !session.videoPath)
+        return yield* Effect.fail(
+          fail("recording_not_started", "No recording is active for this simulator session."),
+        );
+      session.videoProcess.kill("SIGINT");
+      if (session.videoProcess.exitCode === null) {
+        yield* Effect.tryPromise({
+          try: () =>
+            new Promise<void>((resolve) => session.videoProcess?.once("exit", () => resolve())),
+          catch: (error) => fail("command_failed", String(error)),
+        });
+      }
+      return yield* artifact("video", session.videoPath);
+    },
+  );
+  const logs: SimulatorHostShape["logs"] = Effect.fn("SimulatorHost.logs")(function* (input) {
+    yield* requireMac;
+    const session = yield* withSession(input.sessionId);
+    const path = NodePath.join(session.session.artifactDirectory, `logs-${Date.now()}.log`);
+    const output = yield* command(
+      "xcrun",
+      [
+        "simctl",
+        "spawn",
+        session.session.udid,
+        "log",
+        "show",
+        "--last",
+        `${input.lastSeconds ?? 30}s`,
+        "--style",
+        "compact",
+      ],
+      20_000_000,
+    );
+    yield* Effect.tryPromise({
+      try: () => NodeFSP.writeFile(path, output),
+      catch: (error) => fail("command_failed", String(error)),
+    });
+    return yield* artifact("logs", path);
+  });
+  const metrics: SimulatorHostShape["metrics"] = Effect.fn("SimulatorHost.metrics")(
+    function* (input) {
+      yield* requireMac;
+      const session = yield* withSession(input.sessionId);
+      const output = yield* command("xcrun", [
+        "simctl",
+        "spawn",
+        session.session.udid,
+        "top",
+        "-l",
+        "1",
+        "-stats",
+        "pid,cpu,mem",
+      ]).pipe(Effect.catch(() => Effect.succeed("")));
+      const match = /\s(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)([MGK])/u.exec(output);
+      const multiplier = match?.[3] === "G" ? 1e9 : match?.[3] === "M" ? 1e6 : 1e3;
+      return {
+        sessionId: input.sessionId,
+        sampledAt: new Date().toISOString(),
+        cpuPercent: match ? Number(match[1]) : null,
+        memoryBytes: match ? Number(match[2]) * multiplier : null,
+      };
+    },
+  );
+  const close: SimulatorHostShape["close"] = Effect.fn("SimulatorHost.close")(function* (input) {
+    const sessions = yield* SynchronizedRef.get(state);
+    const session = sessions.get(input.sessionId);
+    if (!session) return;
+    if (session.videoProcess) session.videoProcess.kill("SIGINT");
+    yield* SynchronizedRef.update(state, (sessions) => {
+      const next = new Map(sessions);
+      next.delete(input.sessionId);
+      return next;
+    });
+  });
+  return {
+    open,
+    tap: (input) => action(input, "tap"),
+    swipe: (input) => action(input, "swipe"),
+    typeText: (input) => action(input, "type"),
+    screenshot,
+    videoStart,
+    videoStop,
+    logs,
+    metrics,
+    close,
+  } satisfies SimulatorHostShape;
+});
+
+export const layer = Layer.effect(SimulatorHost, make);
+
+export const appleScriptForInput = appleScriptFor;

--- a/docs/internals/ios-simulator-toolkit.md
+++ b/docs/internals/ios-simulator-toolkit.md
@@ -1,0 +1,15 @@
+# iOS Simulator toolkit
+
+The server exposes a provider-neutral MCP surface for exercising an iOS Simulator on a macOS host. The session tools are `simulator_open`, `simulator_tap`, `simulator_swipe`, `simulator_type`, `simulator_screenshot`, `simulator_video_start`, `simulator_video_stop`, `simulator_logs`, `simulator_metrics`, and `simulator_close`.
+
+`simulator_open` boots an available device and can install and launch an `.app` bundle. Input actions use macOS screen coordinates through System Events, so the host needs Accessibility permission for the process running T3. Screenshots, videos, and logs stay in a per-session temporary artifact directory after `simulator_close`. Tool results return the absolute path, byte count, and SHA-256 digest.
+
+The host boundary is macOS-only. Other hosts return a typed `unsupported_host` error. The quick real-host check is:
+
+```sh
+pnpm verify:simulator -- --device "iPhone 17 Pro"
+```
+
+It boots the named device when needed and proves screenshot, log, and metric collection. Input automation is intentionally opt-in through the MCP tools because it can move the user's pointer and requires Accessibility permission.
+
+The service keeps one typed session record per simulator and serializes input actions with a per-session semaphore. A resident launchd daemon was considered, but would add installation, discovery, and protocol versioning before T3 needed those capabilities. The existing authenticated MCP server already provides the provider-neutral transport, so the server-owned host service keeps the first implementation smaller and easier to verify.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:marketing": "vp run --filter @t3tools/marketing preview",
     "start:mock-update-server": "node scripts/mock-update-server.ts",
     "screenshots:mobile": "node scripts/mobile-showcase.ts",
+    "verify:simulator": "node scripts/verify-ios-simulator-toolkit.ts",
     "icons:export": "node scripts/export-brand-icons.ts",
     "icons:check": "node scripts/export-brand-icons.ts --check",
     "icons:export:android": "node scripts/export-android-icons.ts",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -39,3 +39,4 @@ export * from "./previewAutomation.ts";
 export * from "./resourceTelemetry.ts";
 export * from "./usage.ts";
 export * from "./rpc.ts";
+export * from "./simulatorAutomation.ts";

--- a/packages/contracts/src/simulatorAutomation.ts
+++ b/packages/contracts/src/simulatorAutomation.ts
@@ -1,0 +1,123 @@
+import { Schema } from "effect";
+
+import { NonNegativeInt, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+export const SimulatorSessionId = TrimmedNonEmptyString.pipe(Schema.brand("SimulatorSessionId"));
+export type SimulatorSessionId = typeof SimulatorSessionId.Type;
+
+export const SimulatorActionId = PositiveInt.pipe(Schema.brand("SimulatorActionId"));
+export type SimulatorActionId = typeof SimulatorActionId.Type;
+
+export const SimulatorPoint = Schema.Struct({
+  x: NonNegativeInt,
+  y: NonNegativeInt,
+});
+export type SimulatorPoint = typeof SimulatorPoint.Type;
+
+export const SimulatorOpenInput = Schema.Struct({
+  udid: Schema.optional(TrimmedNonEmptyString),
+  deviceName: Schema.optional(TrimmedNonEmptyString),
+  appBundleId: Schema.optional(TrimmedNonEmptyString),
+  appPath: Schema.optional(TrimmedNonEmptyString),
+  launchArgs: Schema.optional(Schema.Array(Schema.String)),
+});
+export type SimulatorOpenInput = typeof SimulatorOpenInput.Type;
+
+export const SimulatorSession = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  udid: TrimmedNonEmptyString,
+  deviceName: TrimmedNonEmptyString,
+  state: Schema.Literals(["ready", "closed"]),
+  appBundleId: Schema.optional(TrimmedNonEmptyString),
+  artifactDirectory: TrimmedNonEmptyString,
+});
+export type SimulatorSession = typeof SimulatorSession.Type;
+
+export const SimulatorTapInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  point: SimulatorPoint,
+});
+export type SimulatorTapInput = typeof SimulatorTapInput.Type;
+
+export const SimulatorSwipeInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  from: SimulatorPoint,
+  to: SimulatorPoint,
+  durationMs: Schema.optional(PositiveInt),
+});
+export type SimulatorSwipeInput = typeof SimulatorSwipeInput.Type;
+
+export const SimulatorTypeInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  text: Schema.String.check(Schema.isNonEmpty()).check(Schema.isMaxLength(4_000)),
+});
+export type SimulatorTypeInput = typeof SimulatorTypeInput.Type;
+
+export const SimulatorScreenshotInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  label: Schema.optional(TrimmedNonEmptyString),
+});
+export type SimulatorScreenshotInput = typeof SimulatorScreenshotInput.Type;
+
+export const SimulatorVideoStartInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  label: Schema.optional(TrimmedNonEmptyString),
+});
+export type SimulatorVideoStartInput = typeof SimulatorVideoStartInput.Type;
+
+export const SimulatorArtifact = Schema.Struct({
+  kind: Schema.Literals(["screenshot", "video", "logs"]),
+  path: TrimmedNonEmptyString,
+  bytes: NonNegativeInt,
+  sha256: TrimmedNonEmptyString,
+});
+export type SimulatorArtifact = typeof SimulatorArtifact.Type;
+
+export const SimulatorActionReceipt = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  actionId: SimulatorActionId,
+  durationMs: NonNegativeInt,
+  state: Schema.Literal("completed"),
+});
+export type SimulatorActionReceipt = typeof SimulatorActionReceipt.Type;
+
+export const SimulatorVideoStartResult = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  state: Schema.Literal("recording"),
+  path: TrimmedNonEmptyString,
+});
+export type SimulatorVideoStartResult = typeof SimulatorVideoStartResult.Type;
+
+export const SimulatorLogsInput = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  lastSeconds: Schema.optional(PositiveInt),
+});
+export type SimulatorLogsInput = typeof SimulatorLogsInput.Type;
+
+export const SimulatorMetricsInput = Schema.Struct({ sessionId: SimulatorSessionId });
+export type SimulatorMetricsInput = typeof SimulatorMetricsInput.Type;
+
+export const SimulatorMetrics = Schema.Struct({
+  sessionId: SimulatorSessionId,
+  sampledAt: Schema.String,
+  cpuPercent: Schema.NullOr(Schema.Number),
+  memoryBytes: Schema.NullOr(Schema.Number),
+});
+export type SimulatorMetrics = typeof SimulatorMetrics.Type;
+
+export const SimulatorCloseInput = Schema.Struct({ sessionId: SimulatorSessionId });
+export type SimulatorCloseInput = typeof SimulatorCloseInput.Type;
+
+export class SimulatorToolkitError extends Schema.TaggedError<SimulatorToolkitError>()(
+  "SimulatorToolkitError",
+  {
+    code: Schema.Literals([
+      "unsupported_host",
+      "session_not_found",
+      "device_not_found",
+      "command_failed",
+      "recording_not_started",
+    ]),
+    detail: Schema.String,
+  },
+) {}

--- a/scripts/verify-ios-simulator-toolkit.ts
+++ b/scripts/verify-ios-simulator-toolkit.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// @effect-diagnostics nodeBuiltinImport:off globalDate:off globalDateInEffect:off
+import * as ChildProcess from "node:child_process";
+import * as FSP from "node:fs/promises";
+import * as OS from "node:os";
+import * as Path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(ChildProcess.execFile);
+const deviceName = process.argv.includes("--device")
+  ? process.argv[process.argv.indexOf("--device") + 1]
+  : (process.env.T3_SIMULATOR_DEVICE ?? "iPhone 17 Pro");
+
+if (process.platform !== "darwin") {
+  console.error("iOS Simulator verification requires macOS.");
+  process.exit(2);
+}
+
+const run = async (file: string, args: string[], maxBuffer = 4_000_000) =>
+  (await execFile(file, args, { maxBuffer })).stdout;
+const listed = JSON.parse(await run("xcrun", ["simctl", "list", "devices", "available", "-j"])) as {
+  devices: Record<
+    string,
+    Array<{ udid: string; name: string; state: string; isAvailable: boolean }>
+  >;
+};
+const device = Object.entries(listed.devices)
+  .filter(([runtime]) => runtime.includes("iOS"))
+  .flatMap(([, devices]) => devices)
+  .find((candidate) => candidate.name === deviceName && candidate.isAvailable);
+if (!device) throw new Error(`No available iOS simulator named '${deviceName}'.`);
+if (device.state !== "Booted") {
+  await run("xcrun", ["simctl", "boot", device.udid]);
+  await run("xcrun", ["simctl", "bootstatus", device.udid, "-b"]);
+}
+
+const directory = await FSP.mkdtemp(Path.join(OS.tmpdir(), "t3-simulator-verify-"));
+const screenshot = Path.join(directory, "screen.png");
+const logs = Path.join(directory, "logs.txt");
+await run("xcrun", ["simctl", "io", device.udid, "screenshot", screenshot]);
+await FSP.writeFile(
+  logs,
+  (
+    await run(
+      "xcrun",
+      ["simctl", "spawn", device.udid, "log", "show", "--last", "1s", "--style", "compact"],
+      20_000_000,
+    )
+  ).slice(-200_000),
+);
+const metrics = await run("xcrun", [
+  "simctl",
+  "spawn",
+  device.udid,
+  "top",
+  "-l",
+  "1",
+  "-stats",
+  "pid,cpu,mem",
+]).catch(() => "unavailable");
+const [screenStat, logStat] = await Promise.all([FSP.stat(screenshot), FSP.stat(logs)]);
+if (screenStat.size === 0 || logStat.size === 0) throw new Error("Simulator artifacts were empty.");
+console.log(
+  JSON.stringify(
+    {
+      device: { name: device.name, udid: device.udid },
+      artifacts: { screenshot, logs },
+      metrics: metrics.slice(0, 2_000),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What changed

T3 Code agents can now drive an iOS Simulator on a macOS host through a provider-neutral MCP toolkit. The toolkit owns typed sessions, serializes input actions, captures hashed screenshot/video/log artifacts, and samples metrics without exposing `xcrun` details to providers.

## Tools

`simulator_open`, `simulator_tap`, `simulator_swipe`, `simulator_type`, `simulator_screenshot`, `simulator_video_start`, `simulator_video_stop`, `simulator_logs`, `simulator_metrics`, and `simulator_close`.

The host returns a typed `unsupported_host` error on non-macOS systems. Input actions use System Events and require Accessibility permission.

## Validation

- `pnpm exec tsc --noEmit -p apps/server/tsconfig.json`
- Focused MCP, registry, and toolkit tests. 22 tests passed.
- `node scripts/verify-ios-simulator-toolkit.ts --device 'iPhone 17 Pro'` on the local iOS 26.5 simulator. Device discovery, boot, screenshot, and logs passed. Metrics were unavailable in that runtime and returned the documented nullable values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iOS Simulator automation through MCP, including device control, screenshots, video recording, logs, metrics, and session management.
  * Added structured simulator session, artifact, result, and error handling.
  * Simulator capabilities are now available for preview-enabled sessions.
  * Added a verification command for validating simulator environments on macOS.

* **Documentation**
  * Added documentation covering simulator tools, supported environments, artifacts, and verification.

* **Tests**
  * Added coverage confirming the complete simulator toolset is exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->