### PR TITLE
fix(web): keep incoming questions from replacing drafts

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2658,6 +2658,12 @@ export default function ChatView(props: ChatViewProps) {
     activeThreadId,
     activePendingUserInput?.requestId,
   ]);
+  const [answeringRequestKey, setAnsweringRequestKey] = useState<string | null>(null);
+  const isAnsweringPendingUserInput =
+    activePendingUserInput !== null && answeringRequestKey === activePendingRequestKey;
+  if (answeringRequestKey !== null && !isAnsweringPendingUserInput) {
+    setAnsweringRequestKey(null);
+  }
   const pendingQuestionDraftKeys = useMemo(
     () =>
       activeThreadId
@@ -6553,7 +6559,7 @@ export default function ChatView(props: ChatViewProps) {
       });
       return;
     }
-    if (activePendingProgress) {
+    if (isAnsweringPendingUserInput && activePendingProgress) {
       if (directAnnotation) {
         notifyDirectAnnotationAttached();
         return;
@@ -7416,14 +7422,17 @@ export default function ChatView(props: ChatViewProps) {
           },
         };
       });
-      promptRef.current = "";
-      composerRef.current?.resetCursorState({ cursor: 0 });
+      if (isAnsweringPendingUserInput) {
+        promptRef.current = "";
+        composerRef.current?.resetCursorState({ cursor: 0 });
+      }
     },
     [
       activePendingProgress?.activeQuestion,
       activePendingUserInput,
       activePendingRequestKey,
       composerRef,
+      isAnsweringPendingUserInput,
     ],
   );
 
@@ -8530,7 +8539,15 @@ export default function ChatView(props: ChatViewProps) {
                             activePendingApproval={activePendingApproval}
                             pendingApprovals={pendingApprovals}
                             pendingUserInputs={pendingUserInputs}
-                            activePendingProgress={activePendingProgress}
+                            activePendingProgress={
+                              isAnsweringPendingUserInput ? activePendingProgress : null
+                            }
+                            onToggleAnsweringPendingUserInput={() => {
+                              setAnsweringRequestKey(
+                                isAnsweringPendingUserInput ? null : activePendingRequestKey,
+                              );
+                              scheduleComposerFocus();
+                            }}
                             activePendingResolvedAnswers={activePendingResolvedAnswers}
                             activePendingIsResponding={activePendingIsResponding}
                             activePendingDraftAnswers={activePendingDraftAnswers}

--- a/apps/web/src/components/chat/ChatComposer.pendingUserInput.test.tsx
+++ b/apps/web/src/components/chat/ChatComposer.pendingUserInput.test.tsx
@@ -1,0 +1,280 @@
+import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import {
+  ApprovalRequestId,
+  DEFAULT_CLIENT_SETTINGS,
+  DEFAULT_UNIFIED_SETTINGS,
+  EnvironmentId,
+  ThreadId,
+} from "@t3tools/contracts";
+import { act, type ComponentProps } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { derivePendingUserInputProgress } from "../../pendingUserInput";
+import { questionAttachmentDraftId } from "../../questionAttachments";
+import type { ComposerPromptEditor } from "../ComposerPromptEditor";
+import { ChatComposer, type ChatComposerProps } from "./ChatComposer";
+
+// Keep composer state and draft storage real; omit the DOM editor and unrelated RPCs.
+vi.mock("../ComposerPromptEditor", () => ({
+  ComposerPromptEditor: (props: ComponentProps<typeof ComposerPromptEditor>) => {
+    editor = props;
+    return null;
+  },
+}));
+vi.mock("../../hooks/useSettings", () => ({
+  useClientSettings: (select: (settings: typeof DEFAULT_CLIENT_SETTINGS) => unknown) =>
+    select(DEFAULT_CLIENT_SETTINGS),
+  useEnvironmentIdentificationMode: () => "none",
+}));
+vi.mock("./PierreEntryIcon", () => ({ PierreEntryIcon: () => null }));
+vi.mock("../../state/use-atom-command", () => ({ useAtomCommand: () => vi.fn() }));
+vi.mock("../../lib/composerPathSearchState", () => ({
+  useComposerPathSearch: () => ({ entries: [], error: null, isPending: false }),
+}));
+vi.mock("./ProviderModelPicker", () => ({ ProviderModelPicker: () => null }));
+vi.mock("../SidebarStageBackdrop", () => ({
+  StageBackdropButtonArt: () => null,
+  useSidebarStageBackdropVariant: () => null,
+}));
+
+const threadRef = scopeThreadRef(EnvironmentId.make("test-env"), ThreadId.make("test-thread"));
+const pendingInput = {
+  requestId: ApprovalRequestId.make("test-request"),
+  createdAt: "2026-08-15T00:00:00.000Z",
+  questions: [{ id: "approach", header: "Approach", question: "Which approach?", options: [] }],
+  dismissible: true,
+};
+
+let renderer: ReactTestRenderer | undefined;
+let props: ChatComposerProps;
+let editor: ComponentProps<typeof ComposerPromptEditor>;
+
+function renderComposer() {
+  return act(() => {
+    if (renderer) renderer.update(<ChatComposer {...props} />);
+    else renderer = create(<ChatComposer {...props} />);
+  });
+}
+
+function toggle(label: string) {
+  return renderer!.root.find((node) => node.type === "button" && node.children.includes(label));
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("Element", EventTarget);
+  vi.stubGlobal("document", Object.assign(new EventTarget(), { activeElement: null }));
+  vi.stubGlobal(
+    "window",
+    Object.assign(new EventTarget(), {
+      Element,
+      performance,
+      matchMedia: () => Object.assign(new EventTarget(), { matches: false }),
+      setTimeout,
+      clearTimeout,
+      requestAnimationFrame: () => 0,
+      cancelAnimationFrame: () => {},
+    }),
+  );
+  useComposerDraftStore.setState({ draftsByThreadKey: {} });
+  props = {
+    composerDraftTarget: threadRef,
+    environmentId: threadRef.environmentId,
+    attachmentUploadsCapabilityKnown: false,
+    supportsAttachmentUploads: false,
+    supportsQuestionAttachments: true,
+    maxFileAttachmentBytes: null,
+    routeKind: "server",
+    routeThreadRef: threadRef,
+    draftId: null,
+    activeThreadId: threadRef.threadId,
+    activeThreadEnvironmentId: threadRef.environmentId,
+    activeThread: undefined,
+    activeThreadShell: null,
+    promptHistoryMessages: [],
+    isServerThread: true,
+    isLocalDraftThread: false,
+    forceExpandedOnMobile: false,
+    projectSelectionRequired: false,
+    phase: "ready",
+    isConnecting: false,
+    isSendBusy: false,
+    sendDisabledReason: null,
+    isPreparingWorktree: false,
+    bannerItems: [],
+    environmentUnavailable: null,
+    activePendingApproval: null,
+    pendingApprovals: [],
+    pendingUserInputs: [],
+    activePendingProgress: null,
+    activePendingResolvedAnswers: null,
+    activePendingIsResponding: false,
+    activePendingDraftAnswers: {},
+    activePendingQuestionIndex: 0,
+    respondingRequestIds: [],
+    showPlanFollowUpPrompt: false,
+    activeProposedPlan: null,
+    activeTasksProgress: null,
+    activeTaskSteps: null,
+    threadSyncPhase: null,
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    lockedProvider: null,
+    providerStatuses: [],
+    providerCatalogKnown: false,
+    activeProjectDefaultModelSelection: null,
+    activeThreadModelSelection: null,
+    activeContextWindow: null,
+    compactThreadUnavailable: true,
+    compactDisabled: true,
+    compactDisabledReason: null,
+    resolvedTheme: "dark",
+    settings: DEFAULT_UNIFIED_SETTINGS,
+    keybindings: [],
+    terminalOpen: false,
+    gitCwd: null,
+    restingControlsHost: null,
+    restingControlsHaveLeadingContext: false,
+    onRestingControlsVisibilityChange: () => {},
+    getTimelineScrollableNode: () => null,
+    isTimelineAtLogicalEnd: () => true,
+    timelineOverflows: false,
+    onComposerOverlayHeightChange: () => {},
+    onRestingChange: () => {},
+    promptRef: { current: "" },
+    composerImagesRef: { current: [] },
+    composerFilesRef: { current: [] },
+    composerTerminalContextsRef: { current: [] },
+    composerElementContextsRef: { current: [] },
+    composerRef: { current: null },
+    onPageScrollKeyDown: () => {},
+    onPageScrollKeyUp: () => {},
+    onPageScrollRelease: () => {},
+    onSend: () => {},
+    onInterrupt: () => {},
+    onImplementPlanInNewThread: () => {},
+    onRespondToApproval: async () => {},
+    onSelectActivePendingUserInputOption: () => {},
+    onAdvanceActivePendingUserInput: () => {},
+    onDismissActivePendingUserInput: () => {},
+    onPreviousActivePendingUserInputQuestion: () => {},
+    onChangeActivePendingUserInputCustomAnswer: (questionId, customAnswer) => {
+      props.activePendingDraftAnswers[questionId] = { selectedOptionValues: [], customAnswer };
+      props.activePendingProgress = derivePendingUserInputProgress(
+        pendingInput.questions,
+        props.activePendingDraftAnswers,
+        0,
+      );
+      renderer!.update(<ChatComposer {...props} />);
+    },
+    onToggleAnsweringPendingUserInput: () => {
+      props.activePendingProgress = props.activePendingProgress
+        ? null
+        : derivePendingUserInputProgress(
+            pendingInput.questions,
+            props.activePendingDraftAnswers,
+            0,
+          );
+      renderer!.update(<ChatComposer {...props} />);
+    },
+    onProviderModelSelect: () => {},
+    onOpenProviderSetup: () => {},
+    getModelDisabledReason: () => null,
+    toggleInteractionMode: () => {},
+    handleRuntimeModeChange: () => {},
+    handleInteractionModeChange: () => {},
+    focusComposer: () => {},
+    scheduleComposerFocus: () => {},
+    setThreadError: () => {},
+    onExpandImage: () => {},
+    onFileOpen: () => {},
+  };
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  useComposerDraftStore.setState({ draftsByThreadKey: {} });
+  vi.unstubAllGlobals();
+});
+
+it("keeps typing in the message until answering, and restores each draft and its attachments", async () => {
+  const store = useComposerDraftStore.getState();
+  store.setPrompt(threadRef, "Use the existing migration and ");
+  const file = new File(["notes"], "message.txt", { type: "text/plain" });
+  const attachment = {
+    type: "file" as const,
+    id: "message-file",
+    name: file.name,
+    mimeType: file.type,
+    sizeBytes: file.size,
+    file,
+  };
+  store.addFiles(threadRef, [attachment]);
+  await renderComposer();
+
+  props.pendingUserInputs = [pendingInput];
+  await renderComposer();
+  expect(editor.value).toBe("Use the existing migration and ");
+  expect(props.composerFilesRef.current).toEqual([attachment]);
+  props.respondingRequestIds = [pendingInput.requestId];
+  await renderComposer();
+  expect(toggle("Answer question").props.disabled).toBe(true);
+  expect(editor.disabled).toBe(false);
+  props.respondingRequestIds = [];
+  await renderComposer();
+
+  const message = "Use the existing migration and keep the API unchanged.";
+  await act(() => editor.onChange(message, message.length, message.length, false, []));
+  expect(props.composerRef.current?.getSendContext()).toMatchObject({
+    prompt: message,
+    files: [attachment],
+  });
+
+  await act(() => toggle("Answer question").props.onClick());
+  expect(editor.value).toBe("");
+  expect(props.composerFilesRef.current).toEqual([]);
+  await act(() => editor.onChange("Incrementally", 13, 13, false, []));
+  const answerAttachment = { ...attachment, id: "answer-file", name: "answer.txt" };
+  await act(() =>
+    store.addFiles(
+      questionAttachmentDraftId(
+        threadRef.environmentId,
+        threadRef.threadId,
+        pendingInput.requestId,
+        "approach",
+      ),
+      [answerAttachment],
+    ),
+  );
+
+  await act(() => toggle("Back to message").props.onClick());
+  expect(editor.value).toBe(message);
+  expect(props.composerRef.current?.getSendContext()).toMatchObject({
+    prompt: message,
+    files: [attachment],
+  });
+
+  await act(() => toggle("Answer question").props.onClick());
+  expect(editor.value).toBe("Incrementally");
+  expect(props.composerRef.current?.getSendContext()).toMatchObject({
+    prompt: "Incrementally",
+    files: [answerAttachment],
+  });
+  props.activePendingIsResponding = true;
+  await renderComposer();
+  expect(toggle("Back to message").props.disabled).toBe(true);
+  expect(editor.disabled).toBe(true);
+
+  props.pendingUserInputs = [];
+  props.activePendingProgress = null;
+  props.activePendingIsResponding = false;
+  await renderComposer();
+  expect(editor.value).toBe(message);
+  expect(props.composerRef.current?.getSendContext()).toMatchObject({
+    prompt: message,
+    files: [attachment],
+  });
+});

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1280,6 +1280,7 @@ export interface ChatComposerProps {
   activePendingApproval: PendingApproval | null;
   pendingApprovals: PendingApproval[];
   pendingUserInputs: PendingUserInput[];
+  onToggleAnsweringPendingUserInput: () => void;
   activePendingProgress: {
     questionIndex: number;
     isLastQuestion: boolean;
@@ -1418,7 +1419,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     environmentUnavailable,
     activePendingApproval,
     pendingApprovals,
-    pendingUserInputs,
+    pendingUserInputs: availablePendingUserInputs,
+    onToggleAnsweringPendingUserInput,
     activePendingProgress,
     activePendingResolvedAnswers,
     activePendingIsResponding,
@@ -1481,6 +1483,9 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     onExpandImage,
     onFileOpen,
   } = props;
+  const isAnsweringPendingUserInput = activePendingProgress !== null;
+  // Only an explicitly chosen question can own the editor and its attachments.
+  const pendingUserInputs = isAnsweringPendingUserInput ? availablePendingUserInputs : [];
   const activeTasksProgress = props.threadSyncPhase === null ? props.activeTasksProgress : null;
   const activeTaskSteps = props.threadSyncPhase === null ? props.activeTaskSteps : null;
   // ------------------------------------------------------------------
@@ -2178,12 +2183,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
 
   const isComposerApprovalState = activePendingApproval !== null;
-  const activePendingUserInput = pendingUserInputs[0] ?? null;
+  const activePendingUserInput = availablePendingUserInputs[0] ?? null;
   const isChoiceOnlyPendingQuestion =
     activePendingProgress?.activeQuestion?.allowCustomAnswer === false;
   const showComposerTopDrawer =
     isComposerApprovalState ||
-    pendingUserInputs.length > 0 ||
+    availablePendingUserInputs.length > 0 ||
     (!isComposerCollapsedMobile && showPlanFollowUpPrompt && activeProposedPlan !== null);
   const showCollapsedMobilePromptRow =
     isComposerCollapsedMobile && !isComposerApprovalState && pendingUserInputs.length === 0;
@@ -2407,9 +2412,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Sync refs back to parent
   // ------------------------------------------------------------------
   useEffect(() => {
+    if (isAnsweringPendingUserInput) return;
     promptRef.current = prompt;
     setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
-  }, [prompt, promptRef]);
+  }, [isAnsweringPendingUserInput, prompt, promptRef]);
 
   useEffect(() => {
     if (composerSubmissionError === null) return;
@@ -3837,7 +3843,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, []);
   const hasBannerItems = props.bannerItems.length > 0;
   const hasBlockingComposerTopDrawer =
-    activePendingApproval !== null || pendingUserInputs.length > 0;
+    activePendingApproval !== null || availablePendingUserInputs.length > 0;
   const showInlineTasksBadge =
     activeTasksProgress !== null &&
     activeTaskSteps !== null &&
@@ -5046,9 +5052,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       />
                     </ComposerBanner.Actions>
                   </ComposerBanner.Row>
-                ) : !isComposerCollapsedMobile && pendingUserInputs.length > 0 ? (
+                ) : availablePendingUserInputs.length > 0 &&
+                  (!isComposerCollapsedMobile || !isAnsweringPendingUserInput) ? (
                   <ComposerPendingUserInputPanel
-                    pendingUserInputs={pendingUserInputs}
+                    pendingUserInputs={availablePendingUserInputs}
                     respondingRequestIds={
                       activePendingIsResponding && activePendingUserInput
                         ? [...respondingRequestIds, activePendingUserInput.requestId]
@@ -5059,6 +5066,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     onToggleOption={onSelectActivePendingUserInputOption}
                     onAdvance={onAdvanceActivePendingUserInput}
                     onDismiss={onDismissActivePendingUserInput}
+                    isAnswering={isAnsweringPendingUserInput}
+                    onToggleAnswering={onToggleAnsweringPendingUserInput}
                   />
                 ) : !isComposerCollapsedMobile && showPlanFollowUpPrompt && activeProposedPlan ? (
                   <ComposerPlanFollowUpBanner
@@ -5079,6 +5088,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       onToggleOption={onSelectActivePendingUserInputOption}
                       onAdvance={onAdvanceActivePendingUserInput}
                       onDismiss={onDismissActivePendingUserInput}
+                      isAnswering={isAnsweringPendingUserInput}
+                      onToggleAnswering={onToggleAnsweringPendingUserInput}
                     />
                     {!isChoiceOnlyPendingQuestion ||
                     activePendingProgress?.activeQuestion?.multiSelect ? (
@@ -5737,7 +5748,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     isComposerApprovalState ||
                     projectSelectionRequired ||
                     isChoiceOnlyPendingQuestion ||
-                    activePendingIsResponding
+                    (isAnsweringPendingUserInput && activePendingIsResponding)
                   }
                 />
                 {isComposerResting ? collapsedComposerImagePreviews : null}

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -33,6 +33,8 @@ function renderPanel(pendingUserInput: PendingUserInput = prompt) {
       onToggleOption={() => {}}
       onAdvance={() => {}}
       onDismiss={() => {}}
+      isAnswering={false}
+      onToggleAnswering={() => {}}
     />,
   );
 }

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -9,6 +9,7 @@ import { CheckIcon } from "lucide-react";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
+import { Button } from "../ui/button";
 
 interface PendingUserInputPanelProps {
   pendingUserInputs: PendingUserInput[];
@@ -18,6 +19,8 @@ interface PendingUserInputPanelProps {
   onToggleOption: (questionId: string, optionValue: string) => void;
   onAdvance: () => void;
   onDismiss: (requestId: ApprovalRequestId) => void;
+  isAnswering: boolean;
+  onToggleAnswering: () => void;
 }
 
 export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserInputPanel({
@@ -28,6 +31,8 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
   onToggleOption,
   onAdvance,
   onDismiss,
+  isAnswering,
+  onToggleAnswering,
 }: PendingUserInputPanelProps) {
   if (pendingUserInputs.length === 0) return null;
   const activePrompt = pendingUserInputs[0];
@@ -43,6 +48,8 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
       onToggleOption={onToggleOption}
       onAdvance={onAdvance}
       onDismiss={onDismiss}
+      isAnswering={isAnswering}
+      onToggleAnswering={onToggleAnswering}
     />
   );
 });
@@ -55,6 +62,8 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   onToggleOption,
   onAdvance,
   onDismiss,
+  isAnswering,
+  onToggleAnswering,
 }: {
   prompt: PendingUserInput;
   isResponding: boolean;
@@ -63,6 +72,8 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   onToggleOption: (questionId: string, optionValue: string) => void;
   onAdvance: () => void;
   onDismiss: (requestId: ApprovalRequestId) => void;
+  isAnswering: boolean;
+  onToggleAnswering: () => void;
 }) {
   const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
   const activeQuestion = progress.activeQuestion;
@@ -287,6 +298,16 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
               );
             })}
           </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-1"
+            disabled={isResponding}
+            onClick={onToggleAnswering}
+          >
+            {isAnswering ? "Back to message" : "Answer question"}
+          </Button>
         </ComposerBanner.Body>
       </CollapsiblePanel>
     </Collapsible>

--- a/docs/user/question-attachments.md
+++ b/docs/user/question-attachments.md
@@ -1,6 +1,6 @@
 # Files in question answers
 
-When an agent asks a question that accepts a custom answer, use **Attach files** or paste an image into the answer field. On mobile, use the attachment button to choose photos or files. You can send a file by itself, with a selected option, or with a typed answer.
+When an agent asks a question that accepts a custom answer, choose **Answer question** on web or desktop, then use **Attach files** or paste an image into the answer field. **Back to message** returns to your normal draft. On mobile, use the attachment button to choose photos or files. You can send a file by itself, with a selected option, or with a typed answer.
 
 Each question keeps its own attachments as you move between questions. Your normal prompt draft stays separate. Wait for uploads to finish before submitting; retry or remove any failed upload. A failed response keeps the draft available to try again.
 


### PR DESCRIPTION
Incoming questions replaced the active message editor with an empty answer draft and redirected Send. Continuing a sentence could send only its second half to the agent.

Keep the composer on the message draft until the user chooses **Answer question**. **Back to message** restores that draft. Reuse the existing question editor, attachments, option selection, and submission flow. Selecting an option directly no longer resets the message cursor.

Fixes #11116.

Verified the failure on main before changing code. The fixed client preserves text, focus, caret, and the complete `thread.turn.start` payload. Browser checks cover explicit answers, returning to either draft, multiple questions, choice-only questions, dismissal, attachment separation, and the 390px web layout. These checks use the real app with synthetic question snapshots and captured outgoing commands. Desktop shares this composer; native mobile has a separate questionnaire.

168 focused tests and web typecheck pass. Targeted lint passes with warnings; formatting and diff checks pass. Rebased on current main (`32b6909340`); its intervening Android-only change leaves the verified web source unchanged.

| Before | After |
| --- | --- |
| ![Before: only the second half remains in the answer editor](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11116/before.png) | ![After: the full message remains in the composer](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11116/after.png) |

Interaction recordings: [before](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11116/before-demo.webm) · [after](https://github.com/Gigioxx/t3code/releases/download/evidence-issue-11116/after-demo.webm).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included a video for interaction changes

Built with GPT-6 in the Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit **Answer question** mode for pending questions in chat.
  * Users can switch between answering a pending question and returning to their normal message draft.
  * Preserved message drafts and attachments when switching between modes.
  * Composer behavior now adapts while answering, including option selection and attachment support.

* **Documentation**
  * Updated attachment guidance with web and desktop instructions for answering questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->