### PR TITLE
fix(server): stop an oversized provider diff from exhausting the backend heap

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -1233,6 +1233,45 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("carries a turn diff once instead of mirroring it into the raw payload", () =>
+    Effect.gen(function* () {
+      const { adapter, runtime } = yield* startLifecycleRuntime();
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      const diff = `diff --git a/file.ts b/file.ts
++${"x".repeat(4_096)}
+`;
+      yield* runtime.emit({
+        id: asEventId("evt-turn-diff"),
+        kind: "notification",
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        method: "turn/diff/updated",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        payload: { threadId: "thread-1", turnId: "turn-1", diff },
+      });
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+      NodeAssert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      const mapped = firstEvent.value;
+      NodeAssert.equal(mapped.type, "turn.diff.updated");
+      if (mapped.type !== "turn.diff.updated") {
+        return;
+      }
+      NodeAssert.equal(mapped.payload.unifiedDiff, diff);
+
+      const rawPayload = mapped.raw?.payload as { readonly diff?: unknown } | undefined;
+      NodeAssert.equal(
+        rawPayload?.diff,
+        `[omitted by t3, ${diff.length} characters in payload.unifiedDiff]`,
+      );
+    }),
+  );
+
   it.effect("labels MCP lifecycle entries with server and tool names", () =>
     Effect.gen(function* () {
       const { adapter, runtime } = yield* startLifecycleRuntime();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -990,6 +990,23 @@ function runtimeEventBase(
   };
 }
 
+/**
+ * Replaces the diff in a mirrored `turn/diff/updated` payload with a short
+ * marker. `payload.unifiedDiff` on the canonical event already carries the same
+ * string, and a turn diff is large enough that serializing it twice has
+ * exhausted the backend heap while logging the event.
+ */
+function elideNativeTurnDiff(payload: unknown): unknown {
+  if (typeof payload !== "object" || payload === null) return payload;
+  const fields = payload as Record<string, unknown>;
+  const diff = fields.diff;
+  if (typeof diff !== "string") return payload;
+  return {
+    ...fields,
+    diff: `[omitted by t3, ${diff.length} characters in payload.unifiedDiff]`,
+  };
+}
+
 function mapItemLifecycle(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
@@ -1648,9 +1665,12 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
+    const base = runtimeEventBase(event, canonicalThreadId);
+    const raw = base.raw;
     return [
       {
-        ...runtimeEventBase(event, canonicalThreadId),
+        ...base,
+        ...(raw ? { raw: { ...raw, payload: elideNativeTurnDiff(raw.payload) } } : {}),
         type: "turn.diff.updated",
         payload: {
           unifiedDiff: payload.diff,

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./EventNdjsonLogger.ts";
 
 const encodeUnknownJson = Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+const decodeUnknownJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
 
 function ownedLogPath(basePath: string, segment: string): string {
   const basename = NodePath.basename(basePath);
@@ -121,6 +122,156 @@ describe("EventNdjsonLogger", () => {
           second.payload,
           '{"type":"turn.completed","threadId":"provider-thread-2","id":"evt-2"}',
         );
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("truncates oversized string values before serializing an event", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-canonical.ndjson");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          maxStringLength: 64,
+        });
+        assert.notEqual(logger, undefined);
+        if (!logger) {
+          return;
+        }
+
+        // A real Codex turn diff reaches hundreds of MiB. Serializing it whole,
+        // twice over, is what exhausted the backend heap.
+        const diff = "d".repeat(200_000);
+        yield* logger.write(
+          {
+            type: "turn.diff.updated",
+            id: "evt-diff",
+            payload: { unifiedDiff: diff },
+            raw: { method: "turn/diff/updated", payload: { diff } },
+          },
+          ThreadId.make("thread-diff"),
+        );
+        yield* logger.close();
+
+        const line = NodeFS.readFileSync(ownedLogPath(basePath, "thread-diff"), "utf8").trim();
+        assert.equal(line.length < 1_000, true);
+        assert.notInclude(line, "d".repeat(65));
+        assert.include(line, "[truncated by t3, 200000 characters total]");
+        assert.include(line, '"id":"evt-diff"');
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("bounds the whole record, not only each value", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-canonical.ndjson");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          maxStringLength: 64,
+          maxRecordLength: 128,
+        });
+        assert.notEqual(logger, undefined);
+        if (!logger) {
+          return;
+        }
+
+        // Every value here clears the per-value cap on its own; only the record
+        // budget stops ten of them from adding up to an oversized line.
+        const fields = Object.fromEntries(
+          Array.from({ length: 10 }, (_, index) => [`field${index}`, "v".repeat(64)]),
+        );
+        yield* logger.write({ id: "evt-budget", ...fields }, ThreadId.make("thread-budget"));
+        yield* logger.close();
+
+        const line = NodeFS.readFileSync(ownedLogPath(basePath, "thread-budget"), "utf8").trim();
+        assert.equal((line.match(/v/gu) ?? []).length <= 128, true);
+        assert.include(line, "[truncated by t3, 64 characters total]");
+        assert.include(line, '"id":"evt-budget"');
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("charges truncation markers against the record budget", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-canonical.ndjson");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          maxStringLength: 32,
+          maxRecordLength: 2_048,
+        });
+        assert.notEqual(logger, undefined);
+        if (!logger) {
+          return;
+        }
+
+        // Two hundred oversized values. Each marker runs to about 40 characters,
+        // so leaving them unbilled would spend roughly 8,000 against a budget of
+        // 2,048 that already reads as exhausted.
+        const fields = Object.fromEntries(
+          Array.from({ length: 200 }, (_, index) => [`f${index}`, "w".repeat(5_000)]),
+        );
+        yield* logger.write(fields, ThreadId.make("thread-markers"));
+        yield* logger.close();
+
+        const line = NodeFS.readFileSync(ownedLogPath(basePath, "thread-markers"), "utf8").trim();
+        const record = decodeUnknownJson(parseLogLine(line).payload) as Record<string, string>;
+        const retained = Object.values(record).reduce((total, value) => total + value.length, 0);
+        assert.equal(retained <= 2_048, true);
+        assert.include(line, "[truncated by t3, 5000 characters total]");
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.effect("keeps short identifying values behind an oversized one", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-canonical.ndjson");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          maxStringLength: 4_096,
+          maxRecordLength: 512,
+        });
+        assert.notEqual(logger, undefined);
+        if (!logger) {
+          return;
+        }
+
+        // Key order puts a provider's bulky `raw` payload ahead of `type`, so
+        // without a reserve the identifiers behind it are emptied and the record
+        // no longer says what it is.
+        yield* logger.write(
+          {
+            raw: "r".repeat(100_000),
+            type: "turn.diff.updated",
+            eventId: "evt-legible",
+          },
+          ThreadId.make("thread-legible"),
+        );
+        yield* logger.close();
+
+        const line = NodeFS.readFileSync(ownedLogPath(basePath, "thread-legible"), "utf8").trim();
+        const record = decodeUnknownJson(parseLogLine(line).payload) as Record<string, string>;
+        assert.equal(record.type, "turn.diff.updated");
+        assert.equal(record.eventId, "evt-legible");
+        assert.include(record.raw ?? "", "[truncated by t3, 100000 characters total]");
       } finally {
         NodeFS.rmSync(tempDir, { recursive: true, force: true });
       }

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -648,6 +648,44 @@ describe("EventNdjsonLogger", () => {
     }),
   );
 
+  it.effect("reads each field once when rebuilding a record that needs bounding", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-canonical.ndjson");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          maxStringLength: 64,
+        });
+        assert.exists(logger);
+        if (!logger) return;
+
+        // An accessor that grows between reads. If the rebuilt record re-read it
+        // instead of keeping the value it bounded, the later, oversized read would
+        // reach the encoder unbounded.
+        let reads = 0;
+        const event = {
+          get note(): string {
+            reads += 1;
+            return reads === 1 ? "short" : "n".repeat(100_000);
+          },
+          raw: "r".repeat(100_000),
+          id: "evt-accessor",
+        };
+        yield* logger.write(event, ThreadId.make("thread-accessor"));
+        yield* logger.close();
+
+        const line = NodeFS.readFileSync(ownedLogPath(basePath, "thread-accessor"), "utf8").trim();
+        assert.equal(line.length < 1_000, true);
+        assert.notInclude(line, "n".repeat(65));
+        assert.include(line, '"id":"evt-accessor"');
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
   it.effect("serializes concurrent first writes for the same segment", () =>
     Effect.gen(function* () {
       const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -612,6 +612,42 @@ describe("EventNdjsonLogger", () => {
     }),
   );
 
+  it.effect("drops a record whose enumerable accessor throws while it is bounded", () =>
+    Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "events.log");
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, {
+          stream: "canonical",
+          batchWindowMs: 0,
+        });
+        assert.exists(logger);
+        if (!logger) return;
+
+        // Bounding reads every enumerable property before the encoder runs, so a
+        // throwing getter has to be contained there as well as in encoding.
+        const hostile = {
+          id: "evt-hostile",
+          get payload(): unknown {
+            throw new Error("blocked");
+          },
+        };
+        yield* logger.write(hostile, ThreadId.make("thread-hostile-getter"));
+        yield* logger.write({ id: "evt-after" }, ThreadId.make("thread-hostile-getter"));
+        yield* logger.close();
+
+        const lines = NodeFS.readFileSync(ownedLogPath(basePath, "thread-hostile-getter"), "utf8")
+          .trim()
+          .split("\n");
+        assert.equal(lines.length, 1);
+        assert.include(lines[0] ?? "", '"id":"evt-after"');
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }),
+  );
+
   it.effect("serializes concurrent first writes for the same segment", () =>
     Effect.gen(function* () {
       const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -162,6 +162,14 @@ describe("EventNdjsonLogger", () => {
         assert.notInclude(line, "d".repeat(65));
         assert.include(line, "[truncated by t3, 200000 characters total]");
         assert.include(line, '"id":"evt-diff"');
+
+        // The marker is part of the value, so the cap bounds the whole replacement.
+        const record = decodeUnknownJson(parseLogLine(line).payload) as {
+          readonly payload: { readonly unifiedDiff: string };
+          readonly raw: { readonly payload: { readonly diff: string } };
+        };
+        assert.equal(record.payload.unifiedDiff.length <= 64, true);
+        assert.equal(record.raw.payload.diff.length <= 64, true);
       } finally {
         NodeFS.rmSync(tempDir, { recursive: true, force: true });
       }
@@ -210,7 +218,7 @@ describe("EventNdjsonLogger", () => {
       try {
         const logger = yield* makeEventNdjsonLogger(basePath, {
           stream: "canonical",
-          maxStringLength: 32,
+          maxStringLength: 64,
           maxRecordLength: 2_048,
         });
         assert.notEqual(logger, undefined);

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -32,6 +32,17 @@ const DEFAULT_MAX_AGE_MS = 14 * DAY_MS;
 const DEFAULT_RETENTION_CHECK_INTERVAL_MS = 5 * 60 * 1_000;
 const DEFAULT_MAX_BUFFERED_BYTES = MEBIBYTE;
 const DEFAULT_MAX_BUFFERED_RECORDS = 512;
+// Per string value, in UTF-16 code units rather than bytes: `String.length` is
+// O(1), while measuring real bytes would scan every string on the write path.
+const DEFAULT_MAX_STRING_LENGTH = 256 * 1024;
+// Across all string values of one record, so that many merely large values
+// cannot add up to a line the per-value cap would have allowed individually.
+const DEFAULT_MAX_RECORD_LENGTH = 4 * MEBIBYTE;
+// Values this short are the identifiers that make a record legible - `type`,
+// `method`, ids. They draw from a reserve a long value may not touch, because
+// key order puts a provider's bulky `raw` payload ahead of `type`, so without
+// one a single large field would empty every identifier behind it.
+const SHORT_VALUE_RESERVE = 256;
 const GLOBAL_THREAD_SEGMENT = "_global";
 const LOG_SCOPE = "provider-observability";
 const encodeUnknownJsonString = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
@@ -80,6 +91,8 @@ export interface EventNdjsonLogStoreOptions {
   readonly retentionCheckIntervalMs?: number;
   readonly maxBufferedBytes?: number;
   readonly maxBufferedRecords?: number;
+  readonly maxStringLength?: number;
+  readonly maxRecordLength?: number;
   readonly attribution?: ResourceAttribution["Service"];
 }
 
@@ -126,6 +139,8 @@ interface ResolvedOptions {
   readonly retentionCheckIntervalMs: number;
   readonly maxBufferedBytes: number;
   readonly maxBufferedRecords: number;
+  readonly maxStringLength: number;
+  readonly maxRecordLength: number;
   readonly attribution: ResourceAttribution["Service"] | undefined;
 }
 
@@ -373,6 +388,8 @@ function resolveOptions(
       options.retentionCheckIntervalMs ?? DEFAULT_RETENTION_CHECK_INTERVAL_MS,
     maxBufferedBytes: options.maxBufferedBytes ?? DEFAULT_MAX_BUFFERED_BYTES,
     maxBufferedRecords: options.maxBufferedRecords ?? DEFAULT_MAX_BUFFERED_RECORDS,
+    maxStringLength: options.maxStringLength ?? DEFAULT_MAX_STRING_LENGTH,
+    maxRecordLength: options.maxRecordLength ?? DEFAULT_MAX_RECORD_LENGTH,
     attribution: options.attribution,
   } satisfies ResolvedOptions;
 
@@ -385,6 +402,8 @@ function resolveOptions(
     ["retentionCheckIntervalMs", resolved.retentionCheckIntervalMs, 1],
     ["maxBufferedBytes", resolved.maxBufferedBytes, 1],
     ["maxBufferedRecords", resolved.maxBufferedRecords, 1],
+    ["maxStringLength", resolved.maxStringLength, 1],
+    ["maxRecordLength", resolved.maxRecordLength, 1],
   ] as const;
 
   for (const [option, value, minimum] of validations) {
@@ -492,6 +511,115 @@ function drainPending(input: {
       lastRetentionAt: retentionDue ? input.now : input.state.lastRetentionAt,
     },
   ];
+}
+
+function truncationMarker(length: number): string {
+  return `[truncated by t3, ${length} characters total]`;
+}
+
+/**
+ * Keeps the head of an oversized value and records how long the original was, so
+ * a truncated record still says which file a diff touched and how much was cut.
+ */
+function truncateString(value: string, headLength: number): string {
+  // Never cut between a surrogate pair; a lone surrogate would survive into the log line.
+  const lastCode = value.charCodeAt(headLength - 1);
+  const keep = lastCode >= 0xd800 && lastCode <= 0xdbff ? headLength - 1 : headLength;
+  return `${value.slice(0, Math.max(keep, 0))}${truncationMarker(value.length)}`;
+}
+
+/**
+ * Answers whether a value can be rebuilt field by field. Anything else reaches the
+ * encoder untouched, because a class instance or a `toJSON` carrier such as `Date`
+ * would not survive being copied into a plain object.
+ */
+function isPlainContainer(value: object): boolean {
+  if (Array.isArray(value)) return true;
+  const prototype = Reflect.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Bounds the string values of one event before it is serialized. A provider can
+ * hand us a payload far larger than any log record should be (a Codex
+ * `turn/diff/updated` diff reaches hundreds of MiB on a big turn), and encoding
+ * it whole materializes an equally large line that can exhaust the heap.
+ *
+ * Two bounds apply. No single value keeps more than `maxLength` characters, and
+ * the string values of one record, truncation markers included, together keep no
+ * more than the record budget, so an event carrying many merely large values
+ * cannot add up to a line the per-value cap would have allowed on its own. Once
+ * the budget cannot even fit a marker, the value is dropped. The budget is spent
+ * in encounter order, which is stable for a given event shape, and short values
+ * keep a reserve of it so the identifiers behind a bulky field survive.
+ *
+ * Values that already fit are returned by reference, so an event that needs no
+ * truncation copies no object or array. Anything that is not a plain object or
+ * array is left alone, because `toJSON` carriers such as `Date` must reach the
+ * encoder intact. A cycle is returned untouched at the point it closes, so
+ * serialization still fails the way it did before and `serializeEvent` reports it.
+ */
+function clampStrings(
+  value: unknown,
+  maxLength: number,
+  budget: { remaining: number },
+  ancestors: Set<object>,
+): unknown {
+  if (typeof value === "string") {
+    const spendable =
+      value.length <= SHORT_VALUE_RESERVE
+        ? budget.remaining
+        : Math.max(budget.remaining - SHORT_VALUE_RESERVE, 0);
+
+    if (value.length <= maxLength && value.length <= spendable) {
+      budget.remaining -= value.length;
+      return value;
+    }
+    // The marker is itself part of the record, so it is charged like any other
+    // retained text. Otherwise a run of oversized values would keep spending
+    // marker-sized bites of a budget that reads as exhausted.
+    const marker = truncationMarker(value.length);
+    if (marker.length > spendable) return "";
+
+    const replacement = truncateString(value, Math.min(maxLength, spendable - marker.length));
+    budget.remaining -= replacement.length;
+    return replacement;
+  }
+  if (typeof value !== "object" || value === null) return value;
+  if (!isPlainContainer(value) || ancestors.has(value)) return value;
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const entries = value as ReadonlyArray<unknown>;
+      let clampedEntries: Array<unknown> | undefined;
+      for (let index = 0; index < entries.length; index += 1) {
+        const entry = entries[index];
+        const clamped = clampStrings(entry, maxLength, budget, ancestors);
+        if (clamped !== entry && clampedEntries === undefined) {
+          clampedEntries = entries.slice(0, index);
+        }
+        clampedEntries?.push(clamped);
+      }
+      return clampedEntries ?? value;
+    }
+
+    const fields = value as Record<string, unknown>;
+    let clampedFields: Record<string, unknown> | undefined;
+    // `for...in` rather than `Object.entries`: this runs on every logged event,
+    // and the entries array would be allocated even when nothing is truncated.
+    for (const key in fields) {
+      if (!Object.hasOwn(fields, key)) continue;
+      const entry = fields[key];
+      const clamped = clampStrings(entry, maxLength, budget, ancestors);
+      if (clamped === entry) continue;
+      clampedFields ??= { ...fields };
+      clampedFields[key] = clamped;
+    }
+    return clampedFields ?? value;
+  } finally {
+    ancestors.delete(value);
+  }
 }
 
 const serializeEvent = Effect.fnUntraced(function* (event: unknown) {
@@ -613,7 +741,14 @@ export const makeEventNdjsonLogStore = Effect.fnUntraced(function* (
 
     const write = Effect.fnUntraced(function* (event: unknown, threadId: ThreadId | null) {
       if (!shouldPersist(stream, event)) return;
-      const payload = yield* serializeEvent(event);
+      const payload = yield* serializeEvent(
+        clampStrings(
+          event,
+          resolved.maxStringLength,
+          { remaining: resolved.maxRecordLength },
+          new Set(),
+        ),
+      );
       if (payload === undefined) return;
 
       const observedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -617,13 +617,14 @@ function fitsLimits(
  * and short values keep a reserve of it so the identifiers behind a bulky field
  * survive.
  *
- * Every plain object and array is copied, and each field is read exactly once
- * and stored as data, so an accessor cannot hand the encoder a different,
- * unbounded value afterwards. Objects are copied without a prototype so a
- * `__proto__` key stays an ordinary field. Anything that is not a plain object
- * or array is left alone, because `toJSON` carriers such as `Date` must reach
- * the encoder intact. A cycle is returned untouched at the point it closes, so
- * serialization still fails the way it did before and `serializeEvent` reports it.
+ * Every plain object and array is copied, and this pass reads each field once
+ * and stores it as data, so the encoder sees only values that were bounded
+ * rather than whatever an accessor returns on a later read. Objects are copied
+ * without a prototype so a `__proto__` key stays an ordinary field. Anything
+ * that is not a plain object or array is left alone, because `toJSON` carriers
+ * such as `Date` must reach the encoder intact. A cycle is returned untouched at
+ * the point it closes, so serialization still fails the way it did before and
+ * `serializeEvent` reports it.
  */
 function clampStrings(
   value: unknown,
@@ -682,6 +683,12 @@ function clampStrings(
  * it whole materializes an equally large line that can exhaust the heap. An
  * event that already fits is returned as it came, so the ordinary path copies
  * no object or array; only one that does not fit is rebuilt.
+ *
+ * The read-once guarantee therefore belongs to the rebuild. An event that fits
+ * reaches the encoder as it came, which reads its accessors again, exactly as it
+ * did before any bounding existed; an event that is rebuilt has its accessors
+ * read twice, once by each pass. Logged events are JSON-decoded payloads and
+ * object literals, so neither case arises in practice.
  */
 function boundEvent(
   event: unknown,

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -545,13 +545,14 @@ function isPlainContainer(value: object): boolean {
  * `turn/diff/updated` diff reaches hundreds of MiB on a big turn), and encoding
  * it whole materializes an equally large line that can exhaust the heap.
  *
- * Two bounds apply. No single value keeps more than `maxLength` characters, and
- * the string values of one record, truncation markers included, together keep no
- * more than the record budget, so an event carrying many merely large values
- * cannot add up to a line the per-value cap would have allowed on its own. Once
- * the budget cannot even fit a marker, the value is dropped. The budget is spent
- * in encounter order, which is stable for a given event shape, and short values
- * keep a reserve of it so the identifiers behind a bulky field survive.
+ * Two bounds apply, and a truncation marker counts against both. No single value
+ * keeps more than `maxLength` characters, and the string values of one record
+ * together keep no more than the record budget, so an event carrying many merely
+ * large values cannot add up to a line the per-value cap would have allowed on
+ * its own. Once a limit cannot even fit a marker, the value is dropped. The
+ * budget is spent in encounter order, which is stable for a given event shape,
+ * and short values keep a reserve of it so the identifiers behind a bulky field
+ * survive.
  *
  * Values that already fit are returned by reference, so an event that needs no
  * truncation copies no object or array. Anything that is not a plain object or
@@ -575,13 +576,15 @@ function clampStrings(
       budget.remaining -= value.length;
       return value;
     }
-    // The marker is itself part of the record, so it is charged like any other
-    // retained text. Otherwise a run of oversized values would keep spending
-    // marker-sized bites of a budget that reads as exhausted.
+    // The marker is itself part of the value, so it counts against both limits
+    // like any other retained text. Otherwise a truncated value would outgrow its
+    // cap, and a run of oversized values would keep spending marker-sized bites
+    // of a budget that reads as exhausted.
+    const room = Math.min(maxLength, spendable);
     const marker = truncationMarker(value.length);
-    if (marker.length > spendable) return "";
+    if (marker.length > room) return "";
 
-    const replacement = truncateString(value, Math.min(maxLength, spendable - marker.length));
+    const replacement = truncateString(value, room - marker.length);
     budget.remaining -= replacement.length;
     return replacement;
   }

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -553,10 +553,60 @@ function isPlainContainer(value: object): boolean {
 }
 
 /**
- * Bounds the string values of one event before it is serialized. A provider can
- * hand us a payload far larger than any log record should be (a Codex
- * `turn/diff/updated` diff reaches hundreds of MiB on a big turn), and encoding
- * it whole materializes an equally large line that can exhaust the heap.
+ * How much of the record budget a string may draw on. Values this short are the
+ * identifiers that make a record legible, so they may also spend the reserve.
+ */
+function spendableFor(value: string, budget: { remaining: number }): number {
+  return value.length <= SHORT_VALUE_RESERVE
+    ? budget.remaining
+    : Math.max(budget.remaining - SHORT_VALUE_RESERVE, 0);
+}
+
+/**
+ * Answers whether an event already fits both limits, reading it without copying
+ * anything. It spends the budget exactly the way `clampStrings` does, so an event
+ * it accepts would come out of `clampStrings` unchanged. This is the only pass an
+ * ordinary event takes, which is why it walks objects with `for...in` rather
+ * than allocating an `Object.entries` array for each one.
+ */
+function fitsLimits(
+  value: unknown,
+  maxLength: number,
+  budget: { remaining: number },
+  ancestors: Set<object>,
+): boolean {
+  if (typeof value === "string") {
+    if (value.length > maxLength || value.length > spendableFor(value, budget)) return false;
+    budget.remaining -= value.length;
+    return true;
+  }
+  if (typeof value !== "object" || value === null) return true;
+  if (!isPlainContainer(value) || ancestors.has(value)) return true;
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const entries = value as ReadonlyArray<unknown>;
+      for (let index = 0; index < entries.length; index += 1) {
+        if (!fitsLimits(entries[index], maxLength, budget, ancestors)) return false;
+      }
+      return true;
+    }
+
+    const fields = value as Record<string, unknown>;
+    for (const key in fields) {
+      if (Object.hasOwn(fields, key) && !fitsLimits(fields[key], maxLength, budget, ancestors)) {
+        return false;
+      }
+    }
+    return true;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/**
+ * Rebuilds an event that does not fit, bounding its string values on the way.
  *
  * Two bounds apply, and a truncation marker counts against both. No single value
  * keeps more than `maxLength` characters, and the string values of one record
@@ -567,10 +617,12 @@ function isPlainContainer(value: object): boolean {
  * and short values keep a reserve of it so the identifiers behind a bulky field
  * survive.
  *
- * Values that already fit are returned by reference, so an event that needs no
- * truncation copies no object or array. Anything that is not a plain object or
- * array is left alone, because `toJSON` carriers such as `Date` must reach the
- * encoder intact. A cycle is returned untouched at the point it closes, so
+ * Every plain object and array is copied, and each field is read exactly once
+ * and stored as data, so an accessor cannot hand the encoder a different,
+ * unbounded value afterwards. Objects are copied without a prototype so a
+ * `__proto__` key stays an ordinary field. Anything that is not a plain object
+ * or array is left alone, because `toJSON` carriers such as `Date` must reach
+ * the encoder intact. A cycle is returned untouched at the point it closes, so
  * serialization still fails the way it did before and `serializeEvent` reports it.
  */
 function clampStrings(
@@ -580,11 +632,7 @@ function clampStrings(
   ancestors: Set<object>,
 ): unknown {
   if (typeof value === "string") {
-    const spendable =
-      value.length <= SHORT_VALUE_RESERVE
-        ? budget.remaining
-        : Math.max(budget.remaining - SHORT_VALUE_RESERVE, 0);
-
+    const spendable = spendableFor(value, budget);
     if (value.length <= maxLength && value.length <= spendable) {
       budget.remaining -= value.length;
       return value;
@@ -608,34 +656,50 @@ function clampStrings(
   try {
     if (Array.isArray(value)) {
       const entries = value as ReadonlyArray<unknown>;
-      let clampedEntries: Array<unknown> | undefined;
+      const bounded: Array<unknown> = [];
       for (let index = 0; index < entries.length; index += 1) {
-        const entry = entries[index];
-        const clamped = clampStrings(entry, maxLength, budget, ancestors);
-        if (clamped !== entry && clampedEntries === undefined) {
-          clampedEntries = entries.slice(0, index);
-        }
-        clampedEntries?.push(clamped);
+        bounded.push(clampStrings(entries[index], maxLength, budget, ancestors));
       }
-      return clampedEntries ?? value;
+      return bounded;
     }
 
     const fields = value as Record<string, unknown>;
-    let clampedFields: Record<string, unknown> | undefined;
-    // `for...in` rather than `Object.entries`: this runs on every logged event,
-    // and the entries array would be allocated even when nothing is truncated.
+    const bounded: Record<string, unknown> = Object.create(null);
     for (const key in fields) {
       if (!Object.hasOwn(fields, key)) continue;
-      const entry = fields[key];
-      const clamped = clampStrings(entry, maxLength, budget, ancestors);
-      if (clamped === entry) continue;
-      clampedFields ??= { ...fields };
-      clampedFields[key] = clamped;
+      bounded[key] = clampStrings(fields[key], maxLength, budget, ancestors);
     }
-    return clampedFields ?? value;
+    return bounded;
   } finally {
     ancestors.delete(value);
   }
+}
+
+/**
+ * Bounds the string values of one event before it is serialized. A provider can
+ * hand us a payload far larger than any log record should be (a Codex
+ * `turn/diff/updated` diff reaches hundreds of MiB on a big turn), and encoding
+ * it whole materializes an equally large line that can exhaust the heap. An
+ * event that already fits is returned as it came, so the ordinary path copies
+ * no object or array; only one that does not fit is rebuilt.
+ */
+function boundEvent(
+  event: unknown,
+  limits: Pick<ResolvedOptions, "maxStringLength" | "maxRecordLength">,
+): unknown {
+  const fits = fitsLimits(
+    event,
+    limits.maxStringLength,
+    { remaining: limits.maxRecordLength },
+    new Set(),
+  );
+  if (fits) return event;
+  return clampStrings(
+    event,
+    limits.maxStringLength,
+    { remaining: limits.maxRecordLength },
+    new Set(),
+  );
 }
 
 const serializeEvent = Effect.fnUntraced(function* (
@@ -645,8 +709,7 @@ const serializeEvent = Effect.fnUntraced(function* (
   // Bounding the record reads every enumerable property before the encoder does,
   // so a hostile accessor can throw there too; both sit behind the same guard.
   return yield* Effect.try({
-    try: () =>
-      clampStrings(event, limits.maxStringLength, { remaining: limits.maxRecordLength }, new Set()),
+    try: () => boundEvent(event, limits),
     catch: (cause) => new EventNdjsonLogRecordError({ cause }),
   }).pipe(
     Effect.flatMap((bounded) => encodeUnknownJsonString(bounded)),

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -37,6 +37,8 @@ const DEFAULT_MAX_BUFFERED_RECORDS = 512;
 const DEFAULT_MAX_STRING_LENGTH = 256 * 1024;
 // Across all string values of one record, so that many merely large values
 // cannot add up to a line the per-value cap would have allowed individually.
+// It bounds retained text, not the encoded line: keys and JSON syntax are not
+// counted, and escaping can grow the text at most sixfold (`\u0000`).
 const DEFAULT_MAX_RECORD_LENGTH = 4 * MEBIBYTE;
 // Values this short are the identifiers that make a record legible - `type`,
 // `method`, ids. They draw from a reserve a long value may not touch, because
@@ -123,6 +125,17 @@ export class EventNdjsonLogDirectoryError extends Schema.TaggedError<EventNdjson
 ) {
   override get message(): string {
     return `Failed to create provider event log directory '${this.directory}'`;
+  }
+}
+
+class EventNdjsonLogRecordError extends Schema.TaggedError<EventNdjsonLogRecordError>()(
+  "EventNdjsonLogRecordError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to read a provider event while bounding its log record";
   }
 }
 
@@ -625,8 +638,18 @@ function clampStrings(
   }
 }
 
-const serializeEvent = Effect.fnUntraced(function* (event: unknown) {
-  return yield* encodeUnknownJsonString(event).pipe(
+const serializeEvent = Effect.fnUntraced(function* (
+  event: unknown,
+  limits: Pick<ResolvedOptions, "maxStringLength" | "maxRecordLength">,
+) {
+  // Bounding the record reads every enumerable property before the encoder does,
+  // so a hostile accessor can throw there too; both sit behind the same guard.
+  return yield* Effect.try({
+    try: () =>
+      clampStrings(event, limits.maxStringLength, { remaining: limits.maxRecordLength }, new Set()),
+    catch: (cause) => new EventNdjsonLogRecordError({ cause }),
+  }).pipe(
+    Effect.flatMap((bounded) => encodeUnknownJsonString(bounded)),
     Effect.catch((error) =>
       logWarning("failed to serialize provider event log record", {
         errorTag: errorTag(error),
@@ -744,14 +767,7 @@ export const makeEventNdjsonLogStore = Effect.fnUntraced(function* (
 
     const write = Effect.fnUntraced(function* (event: unknown, threadId: ThreadId | null) {
       if (!shouldPersist(stream, event)) return;
-      const payload = yield* serializeEvent(
-        clampStrings(
-          event,
-          resolved.maxStringLength,
-          { remaining: resolved.maxRecordLength },
-          new Set(),
-        ),
-      );
+      const payload = yield* serializeEvent(event, resolved);
       if (payload === undefined) return;
 
       const observedAt = yield* DateTime.now.pipe(Effect.map(DateTime.formatIso));


### PR DESCRIPTION
Fixes #10924.

## Problem

A Codex `turn/diff/updated` notification carries the whole turn diff, which reaches hundreds of MiB on a large turn. Two things then multiply it:

- `CodexAdapter` attaches the native payload as `raw` and maps the same string onto `payload.unifiedDiff`, so the canonical event holds the diff twice.
- `ProviderService.publishRuntimeEvent` writes that event to the canonical provider log before publishing it, and `EventNdjsonLogger.write` JSON-encodes the whole event and holds the resulting line in memory. `turn.diff.updated` is not transient, and there is no per-record size cap — rotation (10 MiB) and the flush watermark (1 MiB) both run *after* serialization.

One notification therefore materializes a multi-hundred-MiB line, which is enough to stop the backend with an out-of-memory error.

## Change

**`EventNdjsonLogger`** bounds an event's string values before `serializeEvent`, under two limits: no single value keeps more than `maxStringLength` characters (default 262,144), and the values of one record together keep no more than `maxRecordLength` (default 4 MiB of characters). Both are configurable.

- An oversized value is replaced by its head plus `[truncated by t3, <n> characters total]`, so the record keeps its shape, its type/method, and the original size.
- The marker counts against both limits like any other retained text, so a truncated value stays within its cap. Once a limit cannot fit even a marker, the value is dropped, so a run of oversized values cannot walk past the record limit on marker text alone.
- Short values keep a small reserve of the budget. `runtimeEventBase` puts a provider's bulky `raw` payload ahead of `type` in key order, so without it a single large field would empty every identifier behind it and the record would no longer say what it is.
- Both limits are enforced while walking the event, not by measuring the encoded line: measuring means the oversized string has already been materialized. The unit is UTF-16 code units because `String.length` is O(1), while counting real bytes would scan every string on the write path. `maxRecordLength` therefore bounds retained text rather than the encoded line: keys and JSON syntax are not counted, and escaping can grow the text at most sixfold.

A read-only first pass settles whether an event fits, so an ordinary event is written as it came and copies no object or array. Only an event that does not fit is rebuilt, in a pass that reads every field once and stores it as data, so the rebuilt record carries only values that were bounded. Anything that is not a plain object or array is left alone, so `toJSON` carriers such as `Date` still reach the encoder intact, and a cycle is returned untouched where it closes so serialization fails the way it did before. Bounding runs inside the same guard as the encoder, so an event whose accessor throws is still dropped with a warning rather than failing the write. This guards the native, canonical, and orchestration streams for every provider, not only Codex.

**`CodexAdapter`** no longer mirrors the diff into `raw.payload` for `turn/diff/updated`. It leaves a short marker pointing at `payload.unifiedDiff`, which carries the same string. Nothing reads `raw.payload.diff`.

## Effect

One canonical `turn.diff.updated` built from a 128 MiB native diff, written through the real `EventNdjsonLogger`. The "before" row drives the same logger with limits large enough that nothing is clamped and the diff mirrored into `raw`, which is the path `main` takes today.

| | log line written | heap growth across the write | under a 512 MiB heap cap |
| --- | --- | --- | --- |
| before | 259.2 MiB | +649.6 MiB | `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` |
| after | 0.3 MiB | +1.3 MiB | completes in 24 ms |

The line written after the change still carries `type`, `eventId`, and the truncation marker with the original length.

## Tests

- `EventNdjsonLogger.test.ts` — a 200,000-character diff on both fields produces a record under 1 KB carrying the truncation marker, with each truncated field (marker included) inside the 64-character cap, while short values in the same event are still written verbatim. Fails when the marker is not counted against the cap.
- `EventNdjsonLogger.test.ts` — ten values that each clear the per-value cap are still held to the record budget between them.
- `EventNdjsonLogger.test.ts` — 200 oversized values against a 2,048-character budget stay within it; unbilled markers would have spent roughly 8,000. Fails when the marker charging is removed.
- `EventNdjsonLogger.test.ts` — `type` and `eventId` survive behind a 100,000-character `raw` value. Fails when the short-value reserve is removed.
- `EventNdjsonLogger.test.ts` — an event whose enumerable getter throws is dropped, and the next write to the same thread still lands. Fails when bounding runs outside the serialization guard.
- `EventNdjsonLogger.test.ts` — a getter that grows between reads is written at the value the rebuild bounded, not read again unbounded. Fails when the rebuild re-reads fields.
- `CodexAdapter.test.ts` — a mapped `turn/diff/updated` keeps the full diff on `payload.unifiedDiff` and the marker on `raw.payload.diff`.

On the rebased branch, `vp test run src/provider src/orchestration/Layers/ProviderRuntimeIngestion.test.ts` in `apps/server` gives 1,306 passed and 2 failed. Both failures are Windows-host issues in files this PR does not touch (`CursorProvider` symlink `EPERM`, a `userInputAttachments` path assertion), and both fail the same way on `main`. `vp fmt --check`, `vp lint`, `tsc --noEmit` for `apps/server`, and `knip:check` are clean.

No UI surface changes, so no screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event logs now limit oversized string values and overall record sizes, helping prevent excessively large log entries.
  - Log size limits can be configured for string values and complete records.

- **Bug Fixes**
  - Large code diffs retain their full canonical version while duplicate raw payload details are represented by a size marker.
  - Malformed or unreadable event records are safely dropped and logged without interrupting subsequent writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->