### PR TITLE
fix(mobile): keep composer transitions aligned

### DIFF
--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -22,7 +22,12 @@ import {
   type ReactNode,
 } from "react";
 import { useWindowDimensions, View } from "react-native";
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+import Animated, {
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import {
@@ -51,6 +56,7 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
 import { ThreadNavigationSidebar } from "../threads/ThreadNavigationSidebar";
 import { WORKSPACE_PANE_TIMING } from "./workspace-pane-animation";
 import { WorkspaceInspectorPane } from "./workspace-inspector-pane";
+import { WorkspaceContentWidthContext } from "./workspace-content-width";
 
 interface AdaptiveWorkspaceContextValue {
   readonly layout: Layout;
@@ -505,6 +511,10 @@ function AdaptiveWorkspaceLayoutContent(
   const contentSettledWidth = layout.usesSplitView
     ? Math.max(0, panes.contentPaneWidth - inspectorColumnTargetWidth)
     : null;
+  const renderedInspectorWidth = useSharedValue(inspectorColumnTargetWidth);
+  const renderedContentWidth = useDerivedValue(() =>
+    Math.max(0, width - renderedSidebarWidth.value - renderedInspectorWidth.value),
+  );
 
   const handleSelectThread = useCallback(
     (thread: EnvironmentThreadShell) => {
@@ -583,10 +593,15 @@ function AdaptiveWorkspaceLayoutContent(
                 contentSettledWidth !== null ? { flex: 1, width: contentSettledWidth } : { flex: 1 }
               }
             >
-              {props.children}
+              <WorkspaceContentWidthContext
+                value={layout.usesSplitView ? renderedContentWidth : null}
+              >
+                {props.children}
+              </WorkspaceContentWidthContext>
             </View>
           </View>
           <WorkspaceInspectorPane
+            renderedInspectorWidth={renderedInspectorWidth}
             active={workspaceInspector?.active ?? false}
             panes={panes}
             renderInspector={workspaceInspector?.render}

--- a/apps/mobile/src/features/layout/workspace-content-width.ts
+++ b/apps/mobile/src/features/layout/workspace-content-width.ts
@@ -1,0 +1,10 @@
+import { createContext, use } from "react";
+import type { SharedValue } from "react-native-reanimated";
+
+// Floating controls follow the visible pane while the expensive navigator/feed
+// stays laid out at its settled width during sidebar and inspector transitions.
+export const WorkspaceContentWidthContext = createContext<SharedValue<number> | null>(null);
+
+export function useWorkspaceContentWidth() {
+  return use(WorkspaceContentWidthContext);
+}

--- a/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
+++ b/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
@@ -4,6 +4,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withTiming,
+  type SharedValue,
 } from "react-native-reanimated";
 
 import { constrainAuxiliaryPaneWidth, type WorkspacePaneLayout } from "../../lib/layout";
@@ -22,6 +23,7 @@ import { WorkspacePaneDivider } from "./workspace-pane-divider";
  * module stays import-cycle-free with AdaptiveWorkspaceLayout.
  */
 export function WorkspaceInspectorPane(props: {
+  readonly renderedInspectorWidth: SharedValue<number>;
   /**
    * When false the pane animates closed but keeps its content mounted for the
    * exit transition (a route that lost focus). `onClosed` fires once the
@@ -45,7 +47,7 @@ export function WorkspaceInspectorPane(props: {
   // inspector at its final position so route replacement never replays an
   // entering transition. Only visibility and explicit resizing change it.
   const inspectorProgress = useSharedValue(inspectorVisible ? 1 : 0);
-  const renderedInspectorWidth = useSharedValue(inspectorVisible ? (inspectorWidth ?? 0) : 0);
+  const { renderedInspectorWidth } = props;
   // The content keeps its own width so the reveal (outer width) clips a
   // fully-laid-out pane instead of reflowing text every frame. When the OPEN
   // pane's target width changes (e.g. the sidebar toggles and reserves

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -37,7 +37,7 @@ import {
 import Animated, {
   FadeIn,
   FadeOut,
-  LinearTransition,
+  type LayoutAnimationFunction,
   ReduceMotion,
   useAnimatedStyle,
   useSharedValue,
@@ -153,10 +153,32 @@ export interface ThreadComposerProps {
 // running alongside that translate reads as jitter. Snapping the layout and
 // letting the keyboard-synced slide be the only motion looks native there.
 export const COMPOSER_TRANSITION_DURATION_MS = 220;
+// Side panes already animate the dock's width. Nested horizontal layout
+// transitions would leave the surface trailing its toolbar's new position.
+// Keep the vertical pill/card morph while horizontal layout follows the dock.
+const composerHeightTransition: LayoutAnimationFunction = (values) => {
+  "worklet";
+  const timing = {
+    duration: COMPOSER_TRANSITION_DURATION_MS,
+    reduceMotion: ReduceMotion.System,
+  };
+  return {
+    initialValues: {
+      originX: values.targetOriginX,
+      originY: values.currentOriginY,
+      width: values.targetWidth,
+      height: values.currentHeight,
+    },
+    animations: {
+      originX: values.targetOriginX,
+      originY: withTiming(values.targetOriginY, timing),
+      width: values.targetWidth,
+      height: withTiming(values.targetHeight, timing),
+    },
+  };
+};
 export const COMPOSER_LAYOUT_TRANSITION =
-  Platform.OS === "android"
-    ? undefined
-    : LinearTransition.duration(COMPOSER_TRANSITION_DURATION_MS).reduceMotion(ReduceMotion.System);
+  Platform.OS === "android" ? undefined : composerHeightTransition;
 
 const COMPOSER_ATTACHMENT_ENTERING =
   Platform.OS === "android"
@@ -351,7 +373,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   );
   const isVoiceInputPresented = voicePresentation.statusLabel !== null;
   // An open draft stays visible; only a collapsed composer becomes a voice strip.
-  const isExpanded = isFocused || settingsSheetPresentation.isActive;
+  const isExpanded = isFocused || settingsSheetPresentation.keepsComposerExpanded;
   const showsCompactDictation = isVoiceInputPresented && !isExpanded;
   const isToolbarVisible = isExpanded || isVoiceInputPresented;
   const attachmentBlockReason = composerAttachmentUploadBlockReason({
@@ -407,11 +429,11 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
   const handleBlur = useCallback(() => {
     setIsFocused(false);
-    if (!settingsSheetPresentation.isActive) {
+    if (!settingsSheetPresentation.keepsComposerExpanded) {
       onExpandedChange?.(false);
     }
     onEditorFocusChange?.(false);
-  }, [onEditorFocusChange, onExpandedChange, settingsSheetPresentation.isActive]);
+  }, [onEditorFocusChange, onExpandedChange, settingsSheetPresentation.keepsComposerExpanded]);
   const handleSend = useCallback(async () => {
     // Typed out in full rather than picked from the menu. Attachments mean the
     // user is sending a prompt, so those go through as usual.

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -58,10 +58,12 @@ import Animated, {
   FadeOut,
   ReduceMotion,
   useAnimatedReaction,
+  useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWorkspaceContentWidth } from "../layout/workspace-content-width";
 
 import { useAppearancePreferences } from "../settings/appearance/AppearancePreferencesProvider";
 import { collectProviderUsageLimits } from "@t3tools/shared/usageLimits";
@@ -647,6 +649,12 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
   const layoutVariant = props.layoutVariant ?? "compact";
   const isSplitLayout = layoutVariant === "split";
   const contentMaxWidth = isSplitLayout ? CHAT_CONTENT_MAX_WIDTH : undefined;
+  const workspaceContentWidth = useWorkspaceContentWidth();
+  const composerWidthStyle = useAnimatedStyle(() =>
+    isSplitLayout && workspaceContentWidth !== null
+      ? { width: workspaceContentWidth.value, right: undefined }
+      : { width: undefined, right: 0 },
+  );
   const selectedInstanceId = props.selectedThread.modelSelection.instanceId;
   useStreamingHaptics(props.selectedThread.id, props.selectedThreadFeed);
   const selectedProviderSkills = useMemo(() => {
@@ -915,7 +923,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
           <Animated.View
             layout={COMPOSER_LAYOUT_TRANSITION}
             pointerEvents="box-none"
-            style={{ position: "absolute", bottom: 0, left: 0, right: 0 }}
+            style={[{ position: "absolute", bottom: 0, left: 0, right: 0 }, composerWidthStyle]}
           >
             {/* No paddingTop here: the overlay's measured height becomes the
                 list's bottom inset, so any padding above the pill/composer

--- a/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
+++ b/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
@@ -91,7 +91,8 @@ export function useThreadSettingsSheetPresentation(input: {
     focusRestoreIdRef.current += 1;
     clearDismissRestoreTimer();
     restorePendingRef.current = false;
-    restoreFocusAfterDismissRef.current = input.isEditorFocused || KeyboardController.isVisible();
+    restoreFocusAfterDismissRef.current =
+      phase === "restoring" || input.isEditorFocused || KeyboardController.isVisible();
     setPhase("opening");
 
     const openingId = openingIdRef.current + 1;
@@ -109,7 +110,7 @@ export function useThreadSettingsSheetPresentation(input: {
       }
       setPhase("visible");
     });
-  }, [clearDismissRestoreTimer, input.editorRef, input.isEditorFocused]);
+  }, [clearDismissRestoreTimer, input.editorRef, input.isEditorFocused, phase]);
 
   const restoreEditorFocus = useCallback(() => {
     const focusRestoreId = focusRestoreIdRef.current + 1;

--- a/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
+++ b/apps/mobile/src/features/threads/use-thread-settings-sheet-presentation.ts
@@ -3,7 +3,7 @@ import { KeyboardController } from "react-native-keyboard-controller";
 
 import type { ComposerEditorHandle } from "../../components/ComposerEditor";
 
-type PresentationPhase = "closed" | "opening" | "visible";
+type PresentationPhase = "closed" | "opening" | "visible" | "restoring";
 
 /**
  * The navigator-level UIKit completion event added by the repo's
@@ -120,12 +120,11 @@ export function useThreadSettingsSheetPresentation(input: {
     // normally succeeds; the retries are insurance against UIKit briefly
     // refusing first-responder status right at the transition boundary.
     const restoreFocus = () => {
-      if (
-        !isMountedRef.current ||
-        focusRestoreIdRef.current !== focusRestoreId ||
-        isEditorFocusedRef.current ||
-        attemptsRemaining <= 0
-      ) {
+      if (!isMountedRef.current || focusRestoreIdRef.current !== focusRestoreId) {
+        return;
+      }
+      if (isEditorFocusedRef.current || attemptsRemaining <= 0) {
+        setPhase("closed");
         return;
       }
 
@@ -157,11 +156,15 @@ export function useThreadSettingsSheetPresentation(input: {
    */
   const onDismissed = useCallback(() => {
     isActiveRef.current = false;
-    setPhase("closed");
 
     if (!restoreFocusAfterDismissRef.current) {
+      setPhase("closed");
       return;
     }
+    // Keep the card expanded across the handoff back to its editor. With a
+    // hardware keyboard there is no software-keyboard travel to hide a collapse
+    // while the sheet dismissal and focus restoration finish.
+    setPhase("restoring");
     restoreFocusAfterDismissRef.current = false;
     restorePendingRef.current = true;
     clearDismissRestoreTimer();
@@ -185,7 +188,8 @@ export function useThreadSettingsSheetPresentation(input: {
   }, [runPendingDismissalRestore]);
 
   return {
-    isActive: phase !== "closed",
+    isActive: phase === "opening" || phase === "visible",
+    keepsComposerExpanded: phase !== "closed",
     isVisible: phase === "visible",
     open,
     onDismissed,


### PR DESCRIPTION
Sidebar toggles can move the toolbar outside the composer while its width catches up. Dismissing model settings with a hardware keyboard briefly collapses the composer before focus returns.

Drive the floating composer's width from the animated side-pane widths while keeping the feed at its settled width. Preserve the 220 ms vertical pill/card animation, and keep the card expanded through the settings-to-editor focus handoff.

Validation: 45 focused layout, navigation, and voice-presentation tests; mobile TypeScript check; native iPad recordings with production JS. Native regression checks passed for iPhone compact/expanded composer, model settings with the software keyboard, New Task draft, iPad portrait/landscape, and opening/closing the Files inspector. Android runtime has not been tested.

Before and after use the same disposable thread and iPad viewport. The recordings show sidebar hide/show and model-settings dismissal; stills capture the dismissal handoff.

| Before | After |
| --- | --- |
| ![Composer collapses during focus handoff](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/24fbe30c80ffb56c/t3-picker-before.png) | ![Composer remains expanded during focus handoff](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/51c34ca1b55da1d8/t3-picker-after.png) |

Before:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f2d247f8c52098fe/t3-composer-before.mp4

After:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/50ccad06540f2916/t3-composer-after.mp4

Phone regression checks:

| Reply with software keyboard | New Task draft |
| --- | --- |
| ![Phone reply composer above keyboard](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/f4bd602e145fb116/t3-phone-keyboard.png) | ![Phone New Task composer](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/846b257e362bdcf7/t3-phone-newtask.png) |

Built with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace split layouts so the thread composer and floating controls match the available content width.
  - Smoothed composer resizing by animating vertical movement and height while avoiding horizontal layout conflicts.
  - Preserved the composer’s expanded state while the settings sheet is open or focus is being restored.
  - Improved focus restoration after dismissing the thread settings sheet, including retry handling.
  - Maintained full-width, right-aligned composer positioning in non-split layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->