### PR TITLE
feat(git): configure generated worktree branch names

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -173,6 +173,7 @@ describe("ProviderCommandReactor", () => {
     readonly unreadableHistory?: boolean;
     readonly titleRegenerationCompletionDispatchFailures?: number;
     readonly titleRegenerationBeforeStart?: "one" | "two";
+    readonly worktreeBranchPrefix?: string;
     readonly serverActivation?: Effect.Effect<void>;
     readonly beforeReadySessionDispatch?: () => Effect.Effect<void>;
     readonly compactThreadEffect?: () => Effect.Effect<void, ProviderAdapterRequestError>;
@@ -475,7 +476,13 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(
+        ServerSettingsService.layerTest(
+          input?.worktreeBranchPrefix === undefined
+            ? {}
+            : { worktreeBranchPrefix: input.worktreeBranchPrefix },
+        ),
+      ),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
@@ -2221,72 +2228,93 @@ describe("ProviderCommandReactor", () => {
     expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ input: prompt });
   });
 
-  it("generates a worktree branch name for the first turn", async () => {
-    const harness = await createHarness();
-    const now = "2026-01-01T00:00:00.000Z";
-    const prompt = `Add a safer reconnect backoff. ${serializeAssistantCitation(assistantCitation)}`;
-    const statusRefreshed = await harness.runEffect(Deferred.make<void>());
-    const refreshStatus = harness.refreshStatus.getMockImplementation()!;
-    harness.refreshStatus.mockImplementation((cwd) =>
-      refreshStatus(cwd).pipe(Effect.tap(() => Deferred.succeed(statusRefreshed, undefined))),
-    );
+  it.each([
+    {
+      prefix: undefined,
+      request: "Add a safer reconnect backoff.",
+      generated: "feature/reconnect-backoff",
+      expected: "t3code/feature/reconnect-backoff",
+    },
+    {
+      prefix: "my-team",
+      request: "Add a safer reconnect backoff.",
+      generated: "t3code/feature/reconnect-backoff",
+      expected: "my-team/feature/reconnect-backoff",
+    },
+    {
+      prefix: "feature",
+      request: "FE-1234 Update the readme.",
+      generated: "t3code/feature/fe-1234-update-readme",
+      expected: "feature/FE-1234-update-readme",
+    },
+    {
+      prefix: "",
+      request: "Update the readme for https://jira.example.com/browse/FE-1234.",
+      generated: "update-readme",
+      expected: "FE-1234-update-readme",
+    },
+  ])(
+    "generates a worktree branch with prefix $prefix for $request",
+    async ({ prefix, request, generated, expected }) => {
+      const harness = await createHarness(
+        prefix === undefined ? undefined : { worktreeBranchPrefix: prefix },
+      );
+      const now = "2026-01-01T00:00:00.000Z";
+      const prompt = `${request} ${serializeAssistantCitation(assistantCitation)}`;
+      const statusRefreshed = await harness.runEffect(Deferred.make<void>());
+      const refreshStatus = harness.refreshStatus.getMockImplementation()!;
+      harness.refreshStatus.mockImplementation((cwd) =>
+        refreshStatus(cwd).pipe(Effect.tap(() => Deferred.succeed(statusRefreshed, undefined))),
+      );
 
-    await harness.runEffect(
-      harness.engine.dispatch({
-        type: "thread.meta.update",
-        commandId: CommandId.make("cmd-thread-branch"),
-        threadId: ThreadId.make("thread-1"),
-        branch: "t3code/1234abcd",
-        worktreePath: "/tmp/provider-project-worktree",
-      }),
-    );
+      await harness.runEffect(
+        harness.engine.dispatch({
+          type: "thread.meta.update",
+          commandId: CommandId.make("cmd-thread-branch"),
+          threadId: ThreadId.make("thread-1"),
+          branch: "t3code/1234abcd",
+          worktreePath: "/tmp/provider-project-worktree",
+        }),
+      );
 
-    harness.generateBranchName.mockImplementation((input: unknown) =>
-      Effect.succeed({
-        branch:
-          typeof input === "object" &&
-          input !== null &&
-          "modelSelection" in input &&
-          typeof input.modelSelection === "object" &&
-          input.modelSelection !== null &&
-          "model" in input.modelSelection &&
-          typeof input.modelSelection.model === "string"
-            ? `feature/${input.modelSelection.model}`
-            : "feature/generated",
-      }),
-    );
+      harness.generateBranchName.mockReturnValue(Effect.succeed({ branch: generated }));
 
-    await harness.runEffect(
-      harness.engine.dispatch({
-        type: "thread.turn.start",
-        commandId: CommandId.make("cmd-turn-start-branch-model"),
-        threadId: ThreadId.make("thread-1"),
-        message: {
-          messageId: asMessageId("user-message-branch-model"),
-          role: "user",
-          text: prompt,
-          attachments: [],
-        },
-        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
-        runtimeMode: "approval-required",
-        createdAt: now,
-      }),
-    );
+      await harness.runEffect(
+        harness.engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.make("cmd-turn-start-branch-model"),
+          threadId: ThreadId.make("thread-1"),
+          message: {
+            messageId: asMessageId("user-message-branch-model"),
+            role: "user",
+            text: prompt,
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt: now,
+        }),
+      );
 
-    await harness.runEffect(Deferred.await(statusRefreshed));
-    await harness.drain();
-    expect(harness.generateBranchName.mock.calls[0]?.[0].message).toBe(
-      `Add a safer reconnect backoff. ${assistantQuoteText}`,
-    );
-    expect(harness.generateBranchName.mock.calls[0]?.[0].message).not.toContain("t3-citation://");
-    expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
-    const readModel = await harness.readModel();
-    expect(
-      readModel.threads
-        .find((entry) => entry.id === ThreadId.make("thread-1"))
-        ?.messages.find((entry) => entry.id === asMessageId("user-message-branch-model"))?.text,
-    ).toBe(prompt);
-  });
+      await harness.runEffect(Deferred.await(statusRefreshed));
+      await harness.drain();
+      expect(harness.generateBranchName.mock.calls[0]?.[0].message).toBe(
+        `${request} ${assistantQuoteText}`,
+      );
+      expect(harness.generateBranchName.mock.calls[0]?.[0].message).not.toContain("t3-citation://");
+      expect(harness.refreshStatus.mock.calls[0]?.[0]).toBe("/tmp/provider-project-worktree");
+      expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+        oldBranch: "t3code/1234abcd",
+        newBranch: expected,
+      });
+      const readModel = await harness.readModel();
+      expect(
+        readModel.threads
+          .find((entry) => entry.id === ThreadId.make("thread-1"))
+          ?.messages.find((entry) => entry.id === asMessageId("user-message-branch-model"))?.text,
+      ).toBe(prompt);
+    },
+  );
 
   it("recreates a missing worktree from the thread branch before starting a turn", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -13,7 +13,11 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { assistantCitationsToPlainText } from "@t3tools/shared/assistantCitations";
-import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import {
+  isTemporaryWorktreeBranch,
+  sanitizeBranchFragment,
+  WORKTREE_BRANCH_PREFIX,
+} from "@t3tools/shared/git";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -293,27 +297,40 @@ function stalePendingRequestDetail(
   return `Stale pending ${requestKind} request: ${requestId}. Provider callback state does not survive app restarts or recovered sessions. Restart the turn to continue.`;
 }
 
-function buildGeneratedWorktreeBranchName(raw: string): string {
+const JIRA_ISSUE_KEY_PATTERN = /\b([a-z][a-z0-9_]*-\d+)\b/i;
+
+function extractJiraIssueKey(message: string): string | undefined {
+  return JIRA_ISSUE_KEY_PATTERN.exec(message)?.[1]?.toUpperCase();
+}
+
+function buildGeneratedWorktreeBranchName(raw: string, prefix: string, issueKey?: string): string {
   const normalized = raw
     .trim()
     .toLowerCase()
     .replace(/^refs\/heads\//, "")
     .replace(/['"`]/g, "");
 
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
+  const withoutLegacyPrefix =
+    normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`) &&
+    !(prefix.length > 0 && normalized.startsWith(`${prefix}/`))
+      ? normalized.slice(WORKTREE_BRANCH_PREFIX.length + 1)
+      : normalized;
+  const withoutPrefix =
+    prefix.length > 0 && withoutLegacyPrefix.startsWith(`${prefix}/`)
+      ? withoutLegacyPrefix.slice(prefix.length + 1)
+      : withoutLegacyPrefix;
 
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+  const issueKeyLower = issueKey?.toLowerCase();
+  const withoutIssueKey = issueKeyLower
+    ? withoutPrefix
+        .split("/")
+        .map((segment) => segment.replaceAll(issueKeyLower, "").replace(/^[-_]+|[-_]+$/g, ""))
+        .filter(Boolean)
+        .join("/")
+    : withoutPrefix;
+  const safeFragment = sanitizeBranchFragment(withoutIssueKey);
+  const namedFragment = issueKey ? `${issueKey}-${safeFragment}` : safeFragment;
+  return prefix.length > 0 ? `${prefix}/${namedFragment}` : namedFragment;
 }
 
 const make = Effect.gen(function* () {
@@ -934,7 +951,11 @@ const make = Effect.gen(function* () {
       });
       if (!generated) return;
 
-      const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+      const targetBranch = buildGeneratedWorktreeBranchName(
+        generated.branch,
+        settings.worktreeBranchPrefix,
+        extractJiraIssueKey(input.messageText),
+      );
       if (targetBranch === oldBranch) return;
 
       const renamed = yield* gitWorkflow.renameBranch({ cwd, oldBranch, newBranch: targetBranch });

--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -121,6 +121,7 @@ describe("buildBranchNamePrompt", () => {
 
     expect(result.prompt).toContain("User message:");
     expect(result.prompt).toContain("Fix the login timeout bug");
+    expect(result.prompt).toContain("the server adds configured category and issue prefixes");
     expect(result.prompt).not.toContain("Attachment metadata:");
   });
 

--- a/apps/server/src/textGeneration/TextGenerationPrompts.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.ts
@@ -189,7 +189,8 @@ export function buildBranchNamePrompt(input: BranchNamePromptInput) {
     rules: [
       "Branch should describe the requested work from the user message.",
       "Keep it short and specific (2-6 words).",
-      "Use plain words only, no issue prefixes and no punctuation-heavy text.",
+      "Return descriptive branch words only; the server adds configured category and issue prefixes.",
+      "Use plain words and avoid punctuation-heavy text.",
       "If images are attached, use them as primary context for visual/UI issues.",
     ],
     message: input.message,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -42,6 +42,7 @@ import {
   type QuitConfirmationMode,
 } from "@t3tools/contracts/settings";
 import { resolveServerBackgroundActivitySettings } from "@t3tools/shared/backgroundActivitySettings";
+import { sanitizeBranchFragment } from "@t3tools/shared/git";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -571,6 +572,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin
         ? ["New worktrees start from origin"]
         : []),
+      ...(settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix
+        ? ["Worktree branch prefix"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -610,6 +614,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
+      settings.worktreeBranchPrefix,
       settings.diffIgnoreWhitespace,
       settings.diffLayout,
       settings.proactivePanelsEnabled,
@@ -730,6 +735,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+      worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
@@ -2609,6 +2615,41 @@ export function GeneralSettingsPanel() {
                 updateSettings({ newWorktreesStartFromOrigin: Boolean(checked) })
               }
               aria-label="Start new worktrees from origin by default"
+            />
+          }
+        />
+        <SettingsRow
+          serverScoped
+          {...searchableSetting("worktree-branch-prefix")}
+          description="Prefix for generated worktree branch names. Jira keys from the first message are added automatically. Leave blank for no prefix."
+          resetAction={
+            settings.worktreeBranchPrefix !== DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix ? (
+              <SettingResetButton
+                label="worktree branch prefix"
+                onClick={() =>
+                  updateSettings({
+                    worktreeBranchPrefix: DEFAULT_UNIFIED_SETTINGS.worktreeBranchPrefix,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <DraftInput
+              size="sm"
+              className="w-full sm:w-72"
+              value={settings.worktreeBranchPrefix}
+              placeholder="No prefix"
+              spellCheck={false}
+              aria-label="Worktree branch prefix"
+              onCommit={(value) => {
+                const worktreeBranchPrefix = /[a-z0-9]/i.test(value)
+                  ? sanitizeBranchFragment(value)
+                  : "";
+                if (worktreeBranchPrefix !== settings.worktreeBranchPrefix) {
+                  updateSettings({ worktreeBranchPrefix });
+                }
+              }}
             />
           }
         />

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -261,6 +261,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     searchTerms: ["new worktrees latest matching remote branch local"],
   },
   {
+    id: "worktree-branch-prefix",
+    title: "Worktree branch prefix",
+    to: "/settings/general",
+    searchTerms: ["git generated branch name custom namespace no prefix"],
+  },
+  {
     id: "add-project-starts-in",
     title: "Add project starts in",
     to: "/settings/general",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -616,6 +616,26 @@ describe("ServerSettings worktree defaults", () => {
       decodeServerSettingsPatch({ newWorktreesStartFromOrigin: false }).newWorktreesStartFromOrigin,
     ).toBe(false);
   });
+
+  it("defaults the worktree branch prefix for legacy configs", () => {
+    expect(decodeServerSettings({}).worktreeBranchPrefix).toBe("t3code");
+  });
+
+  it.each(["", "team", "my-team", "team/backend", "team_1"])(
+    "accepts the worktree branch prefix %j",
+    (worktreeBranchPrefix) => {
+      expect(decodeServerSettingsPatch({ worktreeBranchPrefix }).worktreeBranchPrefix).toBe(
+        worktreeBranchPrefix,
+      );
+    },
+  );
+
+  it.each(["../unsafe", "team//backend", "Team", "-team", "team-", "a".repeat(65)])(
+    "rejects the unsafe worktree branch prefix %j",
+    (worktreeBranchPrefix) => {
+      expect(() => decodeServerSettingsPatch({ worktreeBranchPrefix })).toThrow();
+    },
+  );
 });
 
 describe("ServerSettings.sourceControlWritingStyle", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -267,6 +267,12 @@ export const BrowserLinkTarget = Schema.Literals(["system", "app"]);
 export type BrowserLinkTarget = typeof BrowserLinkTarget.Type;
 export const DEFAULT_BROWSER_LINK_TARGET: BrowserLinkTarget = "system";
 
+const WorktreeBranchPrefix = TrimmedString.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^(?:[a-z0-9](?:[a-z0-9/_-]*[a-z0-9])?)?$/),
+  Schema.makeFilter((value) => !value.includes("//") || "must not contain adjacent slashes"),
+);
+
 export const LoadBalancingWeights = Schema.Record(
   TrimmedNonEmptyString,
   Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 100 })),
@@ -1032,6 +1038,9 @@ export const ServerSettings = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.Boolean.pipe(
     Schema.withDecodingDefault(Effect.succeed(true)),
   ),
+  worktreeBranchPrefix: WorktreeBranchPrefix.pipe(
+    Schema.withDecodingDefault(Effect.succeed("t3code")),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -1277,6 +1286,7 @@ export const ServerSettingsPatch = Schema.Struct({
   environmentIcon: Schema.optionalKey(Schema.NullOr(EnvironmentMachineKind)),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
+  worktreeBranchPrefix: Schema.optionalKey(WorktreeBranchPrefix),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   sourceControlWritingStyle: Schema.optionalKey(


### PR DESCRIPTION
Generated worktree branches always used the t3code prefix, which prevented teams from following their own naming conventions and carrying Jira issue keys into branch names.

This adds a server-scoped branch prefix setting, including an empty-prefix option. The server extracts the first Jira-style key from the initial message or pasted Jira URL and deterministically combines it with the generated semantic slug. Settings search, validation, reset behavior, and focused tests are included.

Tests:
- 208 focused tests passed
- Contracts typecheck passed
- Web typecheck passed
- Targeted formatting and lint passed (existing warnings only)

Created with GPT-5.6 Sol through the T3 Code Codex harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable **Worktree branch prefix** setting under General settings.
  - Branch names now support custom prefixes and automatically include detected Jira issue keys.
  - Added settings search support for the new branch prefix option.
  - Prefix values are validated and sanitized to ensure safe Git branch names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->