### PR TITLE
feat(agents): make the roster easier to scan

### DIFF
--- a/apps/web/src/components/AgentsPanel.logic.test.ts
+++ b/apps/web/src/components/AgentsPanel.logic.test.ts
@@ -1,0 +1,99 @@
+import type {
+  AgentPanelModel,
+  AgentPanelWorkflowGroup,
+  RuntimeSubagent,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+import { describe, expect, it } from "vite-plus/test";
+
+import { allPanelAgents, workflowIsVisible } from "./AgentsPanel.logic";
+
+function agent(overrides: Partial<RuntimeSubagent> & { id: string }): RuntimeSubagent {
+  return {
+    kind: "subagent",
+    title: overrides.id,
+    role: null,
+    model: null,
+    effort: null,
+    status: "running",
+    activationCount: 1,
+    usage: null,
+    progress: null,
+    lastToolName: null,
+    result: null,
+    error: null,
+    outputFile: null,
+    parentAgentId: null,
+    agentIndex: null,
+    phaseIndex: null,
+    phaseTitle: null,
+    attempt: null,
+    workflowName: null,
+    phases: [],
+    runHandles: null,
+    recentActivity: [],
+    firstSeenAt: "2026-09-10T00:00:00.000Z",
+    startedAt: "2026-09-10T00:00:00.000Z",
+    completedAt: null,
+    updatedAt: "2026-09-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function workflowGroup(
+  workflow: RuntimeSubagent,
+  members: ReadonlyArray<RuntimeSubagent>,
+): AgentPanelWorkflowGroup {
+  return {
+    workflow,
+    phases: [
+      {
+        index: 0,
+        title: "Review",
+        members,
+        state: members.length === 0 ? "pending" : "done",
+        activeCount: 0,
+        settledCount: members.length,
+      },
+    ],
+    unphasedMembers: [],
+  };
+}
+
+function panelModel(workflows: ReadonlyArray<AgentPanelWorkflowGroup>): AgentPanelModel {
+  return {
+    workflows,
+    directAgents: [],
+    runningCount: 1,
+    waitingCount: 0,
+    idleCount: 0,
+    settledCount: 0,
+    totalTokens: 0,
+    hasAgents: true,
+    liveCount: 1,
+  };
+}
+
+describe("Agents panel workflow visibility", () => {
+  it("keeps a running coordinator visible before its first member starts", () => {
+    const group = workflowGroup(agent({ id: "workflow", kind: "workflow" }), []);
+
+    expect(workflowIsVisible(group)).toBe(true);
+    expect(allPanelAgents(panelModel([group])).map((entry) => entry.id)).toEqual(["workflow"]);
+  });
+
+  it("keeps the workflow visible between phases without duplicating its coordinator", () => {
+    const group = workflowGroup(agent({ id: "workflow", kind: "workflow" }), [
+      agent({ id: "reviewer", status: "completed", parentAgentId: "workflow" }),
+    ]);
+
+    expect(workflowIsVisible(group)).toBe(true);
+    expect(allPanelAgents(panelModel([group])).map((entry) => entry.id)).toEqual(["reviewer"]);
+  });
+
+  it("retains a failed memberless coordinator in the finished roster", () => {
+    const group = workflowGroup(agent({ id: "workflow", kind: "workflow", status: "failed" }), []);
+
+    expect(workflowIsVisible(group)).toBe(false);
+    expect(allPanelAgents(panelModel([group])).map((entry) => entry.id)).toEqual(["workflow"]);
+  });
+});

--- a/apps/web/src/components/AgentsPanel.logic.ts
+++ b/apps/web/src/components/AgentsPanel.logic.ts
@@ -1,0 +1,30 @@
+import type {
+  AgentPanelModel,
+  AgentPanelWorkflowGroup,
+  RuntimeSubagent,
+} from "@t3tools/client-runtime/state/subagentRuntime";
+import { isActiveSubagentStatus } from "@t3tools/client-runtime/state/subagentRuntime";
+
+/** Flatten phase members in their displayed order, followed by unphased members. */
+export function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
+  return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
+}
+
+/** Count a memberless coordinator as an agent; coordinators with children remain containers. */
+function workflowAgents(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
+  const members = workflowMembers(group);
+  return members.length === 0 ? [group.workflow] : members;
+}
+
+/** Return every visible agent once, preserving workflow and spawn order. */
+export function allPanelAgents(model: AgentPanelModel): ReadonlyArray<RuntimeSubagent> {
+  return [...model.workflows.flatMap(workflowAgents), ...model.directAgents];
+}
+
+/** Keep a live coordinator visible before its first child and between sequential phases. */
+export function workflowIsVisible(group: AgentPanelWorkflowGroup): boolean {
+  return (
+    isActiveSubagentStatus(group.workflow.status) ||
+    workflowMembers(group).some((agent) => isActiveSubagentStatus(agent.status))
+  );
+}

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -200,6 +200,7 @@ function AgentRow({ agent }: { agent: RuntimeSubagent }) {
   );
 }
 
+/** Keep workflow presentation expanded while its coordinator has not settled. */
 function workflowIsLive(group: AgentPanelWorkflowGroup): boolean {
   const status = group.workflow.status;
   return (

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -30,6 +30,7 @@ import { cn } from "~/lib/utils";
 import { orchestrationEnvironment } from "~/state/orchestration";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Button } from "~/components/ui/button";
+import { allPanelAgents, workflowIsVisible, workflowMembers } from "./AgentsPanel.logic";
 
 /**
  * In-flight states all present as Working (one steady state, per the
@@ -73,6 +74,7 @@ const STATUS_VISUALS: Record<
   },
 };
 
+/** Render the status marker used by compact workflow summaries and the fleet meter. */
 function StatusDot({ status }: { status: RuntimeSubagent["status"] }) {
   return (
     <span
@@ -82,6 +84,7 @@ function StatusDot({ status }: { status: RuntimeSubagent["status"] }) {
   );
 }
 
+/** Format an elapsed duration without sub-second churn. */
 function formatElapsedSeconds(totalSeconds: number): string {
   const seconds = Math.max(0, Math.floor(totalSeconds));
   const minutes = Math.floor(seconds / 60);
@@ -95,6 +98,7 @@ function formatElapsedSeconds(totalSeconds: number): string {
   return `${hours}h ${String(minutes % 60).padStart(2, "0")}m`;
 }
 
+/** Calculate an agent activation's elapsed display from persisted timestamps. */
 function elapsedBetween(startedAt: string, endIso: string | null): string {
   const start = Date.parse(startedAt);
   const end = endIso ? Date.parse(endIso) : Date.now();
@@ -204,10 +208,6 @@ function workflowIsLive(group: AgentPanelWorkflowGroup): boolean {
     status !== "cancelled" &&
     status !== "interrupted"
   );
-}
-
-function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
-  return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
 }
 
 /**
@@ -454,12 +454,15 @@ function WorkflowSection({
 /** Fixed-width fleet meter: one segment per agent without growing the header. */
 function FleetMeter({ agents }: { agents: ReadonlyArray<RuntimeSubagent> }) {
   return (
-    <span aria-hidden className="flex w-14 shrink-0 gap-0.5">
+    <span
+      aria-hidden
+      className={cn("flex w-14 shrink-0 overflow-hidden", agents.length <= 14 && "gap-0.5")}
+    >
       {agents.map((agent) => (
         <span
           key={agent.id}
           className={cn(
-            "h-[3px] min-w-0.5 flex-1 rounded-[1px]",
+            "h-[3px] min-w-0 flex-1 rounded-[1px]",
             agent.status === "completed"
               ? "bg-success"
               : isActiveSubagentStatus(agent.status)
@@ -472,6 +475,7 @@ function FleetMeter({ agents }: { agents: ReadonlyArray<RuntimeSubagent> }) {
   );
 }
 
+/** Render the complete source-neutral agent roster for one thread. */
 export function AgentsPanel({
   model,
   environmentId = null,
@@ -482,10 +486,7 @@ export function AgentsPanel({
   threadId?: ThreadId | null;
 }) {
   const [finishedOpen, setFinishedOpen] = useState(true);
-  const allAgents = [
-    ...model.workflows.flatMap((group) => workflowMembers(group)),
-    ...model.directAgents,
-  ];
+  const allAgents = allPanelAgents(model);
   const liveDirect = model.directAgents.filter((agent) => isActiveSubagentStatus(agent.status));
   const finished = allAgents.filter((agent) => !isActiveSubagentStatus(agent.status));
 
@@ -519,18 +520,14 @@ export function AgentsPanel({
       </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-3 p-2.5">
-          {model.workflows
-            .filter((group) =>
-              workflowMembers(group).some((agent) => isActiveSubagentStatus(agent.status)),
-            )
-            .map((group) => (
-              <WorkflowSection
-                key={group.workflow.id}
-                group={group}
-                environmentId={environmentId}
-                threadId={threadId}
-              />
-            ))}
+          {model.workflows.filter(workflowIsVisible).map((group) => (
+            <WorkflowSection
+              key={group.workflow.id}
+              group={group}
+              environmentId={environmentId}
+              threadId={threadId}
+            />
+          ))}
           {liveDirect.length > 0 ? (
             <section className="flex flex-col gap-2.5">
               <div className="px-1 pt-0.5 text-xs text-muted-foreground">

--- a/apps/web/src/components/AgentsPanel.tsx
+++ b/apps/web/src/components/AgentsPanel.tsx
@@ -5,11 +5,11 @@
  *
  * Visualization rules (from live-test feedback):
  * - Spawn order is stable. Activity and completion update rows in place.
- * - Agent rows reserve three fixed lines for identity, activity, and metrics;
+ * - Agent cards reserve one row for identity and one for activity + metrics;
  *   changing data must never change their height.
  * - Workflow expansion is presentation state. A live run stays expanded when
  *   it settles; older collapsed runs can still be opened at run granularity.
- * - Static status dots, DOM-write elapsed timers, plain token counters.
+ * - Static status chips, DOM-write elapsed timers, plain token counters.
  */
 import { useAtomValue } from "@effect/atom-react";
 import type {
@@ -20,9 +20,10 @@ import type {
 import {
   formatSubagentModelLabel,
   formatSubagentTokenCount,
+  isActiveSubagentStatus,
 } from "@t3tools/client-runtime/state/subagentRuntime";
 import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
-import { Bot, Braces, Check, ChevronDown, ChevronRight, X } from "lucide-react";
+import { Bot, Braces, ChevronDown, ChevronRight, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { cn } from "~/lib/utils";
@@ -36,17 +37,40 @@ import { Button } from "~/components/ui/button";
  * stalled/waiting/queued subagent is still the fleet doing its job, not a
  * user problem). Only settled states differentiate.
  */
-const STATUS_VISUALS: Record<RuntimeSubagent["status"], { dotClass: string; label: string }> = {
-  pending: { dotClass: "bg-info", label: "Working" },
-  running: { dotClass: "bg-info", label: "Working" },
-  waiting: { dotClass: "bg-info", label: "Working" },
+const STATUS_VISUALS: Record<
+  RuntimeSubagent["status"],
+  { dotClass: string; chipClass: string; label: string }
+> = {
+  pending: { dotClass: "bg-info", chipClass: "bg-info/12 text-info-foreground", label: "Working" },
+  running: { dotClass: "bg-info", chipClass: "bg-info/12 text-info-foreground", label: "Working" },
+  waiting: { dotClass: "bg-info", chipClass: "bg-info/12 text-info-foreground", label: "Working" },
   // Idle reads as settled (muted, not sky): a resting Codex child looks done
   // unless resumed — live-test: sky idle dots read as stuck in-progress.
-  idle: { dotClass: "bg-muted-foreground/50", label: "Idle · resumable" },
-  completed: { dotClass: "bg-success", label: "Completed" },
-  failed: { dotClass: "bg-destructive", label: "Failed" },
-  cancelled: { dotClass: "bg-muted-foreground/60", label: "Stopped" },
-  interrupted: { dotClass: "bg-muted-foreground/60", label: "Stopped" },
+  idle: {
+    dotClass: "bg-muted-foreground/50",
+    chipClass: "bg-muted text-muted-foreground",
+    label: "Idle",
+  },
+  completed: {
+    dotClass: "bg-success",
+    chipClass: "bg-success/14 text-success-foreground",
+    label: "Done",
+  },
+  failed: {
+    dotClass: "bg-destructive",
+    chipClass: "bg-destructive/12 text-destructive-foreground",
+    label: "Failed",
+  },
+  cancelled: {
+    dotClass: "bg-muted-foreground/60",
+    chipClass: "bg-muted text-muted-foreground",
+    label: "Stopped",
+  },
+  interrupted: {
+    dotClass: "bg-muted-foreground/60",
+    chipClass: "bg-muted text-muted-foreground",
+    label: "Stopped",
+  },
 };
 
 function StatusDot({ status }: { status: RuntimeSubagent["status"] }) {
@@ -137,57 +161,37 @@ function agentActivityText(agent: RuntimeSubagent): string | null {
   );
 }
 
-/** Flat, non-interactive agent status line. No unfold. */
+/** Compact card for one agent: identity above its latest activity and metrics. */
 function AgentRow({ agent }: { agent: RuntimeSubagent }) {
   const visuals = STATUS_VISUALS[agent.status];
-  const statusLabel =
-    agent.kind === "subagent_batch" && agent.status === "idle" ? "Idle" : visuals.label;
   const activity = agentActivityText(agent);
   const modelLabel = formatSubagentModelLabel(agent.model, agent.effort);
-  const role =
-    agent.role?.trim().toLocaleLowerCase() === agent.title.trim().toLocaleLowerCase()
-      ? null
-      : agent.role;
-  const metadata = [
-    modelLabel,
-    agent.usage ? `${formatSubagentTokenCount(agent.usage.totalTokens)} tok` : "— tok",
-    agent.usage?.toolUses !== undefined ? `${agent.usage.toolUses} tools` : null,
-    agent.activationCount > 1 ? `run ${agent.activationCount}` : null,
-  ].filter((value): value is string => value !== null);
 
   return (
-    <div className="grid h-[3.875rem] grid-cols-[0.375rem_minmax(0,1fr)_auto] grid-rows-[1.25rem_1.125rem_1rem] items-center gap-x-2 rounded-md px-1.5 py-1">
-      <span className="col-start-1 row-start-1 flex items-center">
-        <StatusDot status={agent.status} />
-      </span>
-      <span className="col-start-2 row-start-1 flex min-w-0 items-baseline gap-2">
-        <span className="min-w-0 truncate text-sm font-medium">{agent.title}</span>
-        {role ? (
-          <span className="max-w-28 shrink-0 truncate rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground">
-            {role}
-          </span>
-        ) : null}
-      </span>
-      <span className="col-start-3 row-start-1 min-w-14 text-right font-mono text-[.7rem] text-muted-foreground/80">
-        <span className="inline-flex items-center gap-1">
-          <AgentElapsed agent={agent} />
-          {agent.status === "completed" ? (
-            <Check aria-hidden className="size-3 text-success" />
-          ) : null}
+    <div className="overflow-hidden rounded-md border border-border bg-card">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2">
+        <span className="truncate text-[.8125rem] font-medium">{agent.title}</span>
+        <span className="truncate font-mono text-[.65rem] text-muted-foreground/75">
+          {modelLabel}
         </span>
-      </span>
-      <span
-        className={cn(
-          "col-start-2 col-end-4 row-start-2 block truncate text-xs",
-          agent.status === "failed" ? "text-destructive-foreground" : "text-muted-foreground",
-        )}
-      >
-        {activity ?? statusLabel}
-      </span>
-      <span className="col-start-2 col-end-4 row-start-3 truncate font-mono text-[.7rem] tabular-nums text-muted-foreground/70">
-        {metadata.join(" · ")}
-      </span>
-      <span className="sr-only">{statusLabel}</span>
+        <span className={cn("rounded-md px-1.5 py-0.5 text-[.6875rem]", visuals.chipClass)}>
+          {visuals.label}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 border-t border-border/70 px-3 py-1.5 text-[.6875rem] text-muted-foreground">
+        <span
+          className={cn(
+            "min-w-0 truncate",
+            isActiveSubagentStatus(agent.status) && "font-mono text-info-foreground",
+          )}
+        >
+          {activity ?? visuals.label}
+        </span>
+        <span className="ml-auto flex shrink-0 items-center gap-2 font-mono">
+          {agent.usage ? `${formatSubagentTokenCount(agent.usage.totalTokens)} tok` : null}
+          <AgentElapsed agent={agent} />
+        </span>
+      </div>
     </div>
   );
 }
@@ -204,60 +208,6 @@ function workflowIsLive(group: AgentPanelWorkflowGroup): boolean {
 
 function workflowMembers(group: AgentPanelWorkflowGroup): ReadonlyArray<RuntimeSubagent> {
   return [...group.phases.flatMap((phase) => phase.members), ...group.unphasedMembers];
-}
-
-/**
- * Phase rail: the run's shape at a glance. One segment per phase in order,
- * separated by chevrons; each segment shows title + one dot per member.
- * The whole arc (done → live → pending) is visible without scrolling the
- * member list.
- */
-function PhaseRail({ group }: { group: AgentPanelWorkflowGroup }) {
-  if (group.phases.length === 0) {
-    return null;
-  }
-  return (
-    <div className="flex flex-wrap items-center gap-x-1 gap-y-1 px-1.5 pb-1 pt-1.5">
-      {group.phases.map((phase, index) => (
-        <div key={phase.index} className="flex items-center gap-1">
-          {index > 0 ? (
-            <ChevronRight aria-hidden className="size-3 text-muted-foreground/40" />
-          ) : null}
-          <div
-            className={cn(
-              "flex items-center gap-1 rounded-sm border px-1.5 py-0.5",
-              phase.state === "running"
-                ? "border-info/40"
-                : phase.state === "done"
-                  ? "border-success/30"
-                  : "border-border/50",
-            )}
-          >
-            <span
-              className={cn(
-                "font-mono text-[.65rem]",
-                phase.state === "running"
-                  ? "text-info-foreground"
-                  : phase.state === "done"
-                    ? "text-success-foreground"
-                    : "text-muted-foreground/70",
-              )}
-            >
-              {phase.state === "done" ? "✓ " : ""}
-              {phase.title}
-            </span>
-            <span className="flex items-center gap-0.5">
-              {phase.members.length === 0 ? (
-                <span className="font-mono text-[.6rem] text-muted-foreground/50">–</span>
-              ) : (
-                phase.members.map((member) => <StatusDot key={member.id} status={member.status} />)
-              )}
-            </span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
 }
 
 /**
@@ -325,6 +275,7 @@ function PhaseSection({
 }) {
   const [open, setOpen] = useState(defaultOpen || phase.state === "running");
   const previousState = useRef(phase.state);
+  const members = phase.members.filter((member) => isActiveSubagentStatus(member.status));
 
   useEffect(() => {
     if (previousState.current !== "running" && phase.state === "running") {
@@ -333,44 +284,34 @@ function PhaseSection({
     previousState.current = phase.state;
   }, [phase.state]);
 
+  if (members.length === 0) {
+    return null;
+  }
+
   return (
-    <div>
+    <div className="flex flex-col gap-2.5">
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
         aria-expanded={open}
-        className={cn(
-          "mt-2 flex w-full items-center gap-1.5 rounded-sm px-1.5 text-left text-[.65rem] font-medium uppercase tracking-wider hover:bg-accent/40",
-          phase.state === "done"
-            ? "text-success-foreground"
-            : phase.state === "running"
-              ? "text-info-foreground"
-              : "text-muted-foreground/70",
-        )}
+        className="flex w-full items-center gap-1.5 rounded-sm px-1 text-left text-xs text-muted-foreground hover:text-foreground"
       >
         {open ? (
           <ChevronDown aria-hidden className="size-3 shrink-0" />
         ) : (
           <ChevronRight aria-hidden className="size-3 shrink-0" />
         )}
-        {phase.state === "done" ? <Check aria-hidden className="size-3" /> : null}
-        <span>{phase.title}</span>
-        <span className="font-normal normal-case text-muted-foreground/70">
-          {phase.state === "pending" && phase.members.length === 0
-            ? "pending"
-            : phase.state === "done"
-              ? `${phase.settledCount} done`
-              : `${phase.activeCount} active · ${phase.settledCount} done`}
-        </span>
-        {!open && phase.members.length > 0 ? (
+        <span className="font-medium text-foreground/75">{phase.title}</span>
+        <span>{members.length} working</span>
+        {!open ? (
           <span className="ml-auto flex items-center gap-0.5">
-            {phase.members.map((member) => (
+            {members.map((member) => (
               <StatusDot key={member.id} status={member.status} />
             ))}
           </span>
         ) : null}
       </button>
-      {open ? phase.members.map((member) => <AgentRow key={member.id} agent={member} />) : null}
+      {open ? members.map((member) => <AgentRow key={member.id} agent={member} />) : null}
     </div>
   );
 }
@@ -388,21 +329,15 @@ function ExpandedWorkflowSection({
   onCollapse: () => void;
 }) {
   const [scriptOpen, setScriptOpen] = useState(false);
-  const members = workflowMembers(group);
-  const settled = members.filter(
-    (member) =>
-      member.status === "completed" ||
-      member.status === "failed" ||
-      member.status === "cancelled" ||
-      member.status === "interrupted",
+  const members = workflowMembers(group).filter((member) =>
+    isActiveSubagentStatus(member.status),
   ).length;
   const scriptPath = group.workflow.runHandles?.scriptPath;
   const canShowScript = scriptPath !== undefined && environmentId !== null && threadId !== null;
   return (
-    <section className="rounded-lg border border-border/50 bg-card/30 p-1.5">
-      <div className="flex items-center gap-2 px-1.5 pt-0.5 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
-        <StatusDot status={group.workflow.status} />
-        <span className="min-w-0 truncate">
+    <section className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2 px-1 pt-0.5">
+        <span className="min-w-0 truncate text-[.8125rem] font-semibold">
           {group.workflow.workflowName ?? group.workflow.title}
         </span>
         {canShowScript ? (
@@ -410,7 +345,7 @@ function ExpandedWorkflowSection({
             type="button"
             onClick={() => setScriptOpen((value) => !value)}
             className={cn(
-              "rounded-sm border border-border/60 px-1 font-mono normal-case hover:text-foreground",
+              "ml-auto rounded-sm border border-border/60 px-1 font-mono text-[.65rem] text-muted-foreground hover:text-foreground",
               scriptOpen && "text-foreground",
             )}
             aria-expanded={scriptOpen}
@@ -418,9 +353,7 @@ function ExpandedWorkflowSection({
             {"{}"} script
           </button>
         ) : null}
-        <span className="ml-auto font-mono normal-case text-muted-foreground/80">
-          {settled}/{members.length} settled
-        </span>
+        <span className="font-mono text-[.6875rem] text-muted-foreground">{members} working</span>
         <Button
           size="icon-micro"
           variant="ghost-muted"
@@ -430,7 +363,6 @@ function ExpandedWorkflowSection({
           <ChevronDown aria-hidden className="size-3" />
         </Button>
       </div>
-      <PhaseRail group={group} />
       {scriptOpen && canShowScript ? (
         <WorkflowScriptView
           environmentId={environmentId}
@@ -440,14 +372,13 @@ function ExpandedWorkflowSection({
         />
       ) : null}
       {group.phases.map((phase) => (
-        <PhaseSection key={phase.index} phase={phase} defaultOpen={!workflowIsLive(group)} />
+        <PhaseSection key={phase.index} phase={phase} />
       ))}
-      {group.unphasedMembers.map((member) => (
-        <AgentRow key={member.id} agent={member} />
-      ))}
-      {group.phases.length === 0 && group.unphasedMembers.length === 0 ? (
-        <AgentRow agent={group.workflow} />
-      ) : null}
+      {group.unphasedMembers
+        .filter((member) => isActiveSubagentStatus(member.status))
+        .map((member) => (
+          <AgentRow key={member.id} agent={member} />
+        ))}
     </section>
   );
 }
@@ -463,8 +394,7 @@ function CollapsedWorkflowSection({
   group: AgentPanelWorkflowGroup;
   onExpand: () => void;
 }) {
-  const members = workflowMembers(group);
-  const failed = members.filter((member) => member.status === "failed").length;
+  const members = workflowMembers(group).filter((member) => isActiveSubagentStatus(member.status));
   // Coordinator usage may already aggregate members (panel-footer rule):
   // count it only when there are no member rows to sum.
   const totalTokens = members.reduce(
@@ -483,12 +413,11 @@ function CollapsedWorkflowSection({
         className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left hover:bg-accent/40"
         aria-expanded={false}
       >
-        <StatusDot status={failed > 0 ? "failed" : group.workflow.status} />
+        <StatusDot status={group.workflow.status} />
         <span className="truncate text-sm">
           {group.workflow.workflowName ?? group.workflow.title}
         </span>
         <span className="ml-auto flex items-center gap-1.5 font-mono text-[.7rem] text-muted-foreground/80">
-          {failed > 0 ? <span className="text-destructive-foreground">{failed} failed</span> : null}
           <span>{members.length} agents</span>
           <span className="tabular-nums">· {formatSubagentTokenCount(totalTokens)} tok</span>
           {elapsed ? <span className="tabular-nums">· {elapsed}</span> : null}
@@ -522,6 +451,27 @@ function WorkflowSection({
   );
 }
 
+/** Fixed-width fleet meter: one segment per agent without growing the header. */
+function FleetMeter({ agents }: { agents: ReadonlyArray<RuntimeSubagent> }) {
+  return (
+    <span aria-hidden className="flex w-14 shrink-0 gap-0.5">
+      {agents.map((agent) => (
+        <span
+          key={agent.id}
+          className={cn(
+            "h-[3px] min-w-0.5 flex-1 rounded-[1px]",
+            agent.status === "completed"
+              ? "bg-success"
+              : isActiveSubagentStatus(agent.status)
+                ? "bg-info"
+                : "bg-muted-foreground/25",
+          )}
+        />
+      ))}
+    </span>
+  );
+}
+
 export function AgentsPanel({
   model,
   environmentId = null,
@@ -531,6 +481,14 @@ export function AgentsPanel({
   environmentId?: EnvironmentId | null;
   threadId?: ThreadId | null;
 }) {
+  const [finishedOpen, setFinishedOpen] = useState(true);
+  const allAgents = [
+    ...model.workflows.flatMap((group) => workflowMembers(group)),
+    ...model.directAgents,
+  ];
+  const liveDirect = model.directAgents.filter((agent) => isActiveSubagentStatus(agent.status));
+  const finished = allAgents.filter((agent) => !isActiveSubagentStatus(agent.status));
+
   if (!model.hasAgents) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
@@ -546,40 +504,66 @@ export function AgentsPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-xs text-muted-foreground">
+        {model.liveCount > 0 ? (
+          <span className="text-info-foreground">{model.liveCount} working</span>
+        ) : (
+          <span>All agents finished</span>
+        )}
+        <FleetMeter agents={allAgents} />
+        {model.totalTokens > 0 ? (
+          <span className="ml-auto border-l border-border pl-2 font-mono text-[.6875rem] tabular-nums">
+            {formatSubagentTokenCount(model.totalTokens)} tok
+          </span>
+        ) : null}
+      </div>
       <ScrollArea className="min-h-0 flex-1">
-        <div className="flex flex-col gap-2 p-2">
-          {model.workflows.map((group) => (
-            <WorkflowSection
-              key={group.workflow.id}
-              group={group}
-              environmentId={environmentId}
-              threadId={threadId}
-            />
-          ))}
-          {model.directAgents.length > 0 ? (
-            <section>
-              <div className="px-1.5 pt-1 text-[.65rem] font-medium uppercase tracking-wider text-muted-foreground">
-                Direct spawns
+        <div className="flex flex-col gap-3 p-2.5">
+          {model.workflows
+            .filter((group) =>
+              workflowMembers(group).some((agent) => isActiveSubagentStatus(agent.status)),
+            )
+            .map((group) => (
+              <WorkflowSection
+                key={group.workflow.id}
+                group={group}
+                environmentId={environmentId}
+                threadId={threadId}
+              />
+            ))}
+          {liveDirect.length > 0 ? (
+            <section className="flex flex-col gap-2.5">
+              <div className="px-1 pt-0.5 text-xs text-muted-foreground">
+                Spawned directly{" "}
+                <span className="font-mono text-[.6875rem]">{liveDirect.length}</span>
               </div>
-              {model.directAgents.map((agent) => (
+              {liveDirect.map((agent) => (
                 <AgentRow key={agent.id} agent={agent} />
               ))}
             </section>
           ) : null}
+          {finished.length > 0 ? (
+            <section className="flex flex-col gap-2.5">
+              <button
+                type="button"
+                onClick={() => setFinishedOpen((open) => !open)}
+                aria-expanded={finishedOpen}
+                className="flex items-center gap-1.5 rounded-sm px-1 text-left text-xs text-muted-foreground hover:text-foreground"
+              >
+                <ChevronDown
+                  aria-hidden
+                  className={cn("size-3 transition-transform", !finishedOpen && "-rotate-90")}
+                />
+                <span className="font-medium text-foreground/75">Finished</span>
+                <span>{finished.length}</span>
+              </button>
+              {finishedOpen
+                ? finished.map((agent) => <AgentRow key={agent.id} agent={agent} />)
+                : null}
+            </section>
+          ) : null}
         </div>
       </ScrollArea>
-      <footer className="flex items-center justify-between border-t border-border/60 px-3 py-1.5 font-mono text-[.7rem] text-muted-foreground">
-        <span className="flex items-center gap-2">
-          {model.runningCount + model.waitingCount > 0 ? (
-            <span className="text-info-foreground">
-              ● {model.runningCount + model.waitingCount} working
-            </span>
-          ) : null}
-          {model.idleCount > 0 ? <span>{model.idleCount} idle</span> : null}
-          {model.settledCount > 0 ? <span>{model.settledCount} settled</span> : null}
-        </span>
-        <span className="tabular-nums">Σ {formatSubagentTokenCount(model.totalTokens)} tok</span>
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION
The Agents panel currently presents each child as a dense three-line status row, which makes active work, model details, and outcomes difficult to scan. This change turns the existing roster data into compact two-row cards and moves the fleet summary above the list.

Live workflow phases and direct spawns remain grouped in spawn order. Idle and terminal agents collect under a collapsible Finished section, keeping active work prominent while preserving access to completed results. The panel continues to use the existing source-neutral agent model and does not add provider-specific history loading.

Web and desktop share this panel. Mobile does not currently expose the Agents surface.

## Validation

- Web typecheck passes.
- Targeted formatting and lint pass.
- Verified the same five-agent thread in an isolated real web client in dark and light themes.
- Verified Finished collapse and reopen with no page errors.
- Effective non-test diff: 320 lines in one frontend file (`size:L`).

## UI evidence

| Before | After |
| --- | --- |
| <img width="400" alt="Original Agents roster" src="https://github.com/user-attachments/assets/b68ecfb9-46ac-46ab-b867-700a6a0386b7" /> | <img width="400" alt="Compact Agents overview" src="https://github.com/user-attachments/assets/1ea49810-82a5-48cf-8603-2eba5101c059" /> |

This extracts the roster presentation from #10881. Saved child history and provider adapters remain separate from this visual change.

Model: GPT-6 Astra. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the agents panel with compact two-row cards, status chips, activity, and metrics.
  * Prioritized active agents and filtered inactive members in workflow and phase views.
  * Grouped completed agents in a collapsible **Finished** section.
  * Added a fixed-width fleet meter and header summary with active-agent counts.
  * Improved workflow visibility between phases and before the first member starts.
  * Replaced the phase rail and settled/failed counts with active-agent counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->