### PR TITLE
feat(server): read Codex and Claude agent history

### DIFF
--- a/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
+++ b/apps/server/integration/orphanedProviderSessionStartup.integration.test.ts
@@ -123,6 +123,7 @@ const startupDependencies = Layer.mergeAll(
     assertConversationRollbackSupported: () => Effect.die("unused"),
     getInstanceInfo: () => Effect.die("unused"),
     rollbackConversation: () => Effect.die("unused"),
+    getAgentHistory: () => Effect.die("unused"),
     uploadFeedback: () => Effect.die("unused"),
     streamEvents: Stream.empty,
   }),

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -23,6 +23,7 @@ type WsRpcMethod = RpcGroup.Rpcs<typeof WsRpcGroup>["_tag"];
 export const RPC_REQUIRED_SCOPES = {
   [ORCHESTRATION_WS_METHODS.dispatchCommand]: AuthOrchestrationOperateScope,
   [ORCHESTRATION_WS_METHODS.getWorkflowScript]: AuthOrchestrationReadScope,
+  [ORCHESTRATION_WS_METHODS.getAgentHistory]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getTurnDiff]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.getFullThreadDiff]: AuthOrchestrationReadScope,
   [ORCHESTRATION_WS_METHODS.searchThreads]: AuthOrchestrationReadScope,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -137,6 +137,7 @@ function createProviderServiceHarness(
         },
       }),
     rollbackConversation,
+    getAgentHistory: () => unsupported(),
     uploadFeedback: () => unsupported(),
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -390,6 +390,7 @@ describe("ProviderCommandReactor", () => {
         });
       },
       rollbackConversation: () => unsupported(),
+      getAgentHistory: () => unsupported(),
       uploadFeedback: () => unsupported(),
       get streamEvents() {
         return Stream.fromPubSub(runtimeEventPubSub);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -141,6 +141,7 @@ function createProviderServiceHarness() {
       });
     },
     rollbackConversation: () => unsupported(),
+    getAgentHistory: () => unsupported(),
     uploadFeedback: () => unsupported(),
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -7279,3 +7279,48 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 });
+
+for (const source of ["configured", "inherited"] as const) {
+  it.effect(`reads child history from the ${source} Claude home without starting a session`, () => {
+    const home = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-history-adapter-"));
+    const sessionId = "0945fcd9-8a8d-450a-b8cf-4ebd0ef17468";
+    const directory = NodePath.join(home, "projects", "-workspace", sessionId, "subagents");
+    NodeFS.mkdirSync(directory, { recursive: true });
+    NodeFS.writeFileSync(
+      NodePath.join(directory, "agent-child.jsonl"),
+      JSON.stringify({
+        type: "user",
+        uuid: "9eb84969-819b-4d5b-854f-327474810b34",
+        parentUuid: null,
+        isSidechain: true,
+        sessionId,
+        agentId: "child",
+        message: { role: "user", content: "Saved task" },
+      }) + "\n",
+    );
+    const harness = makeHarness({
+      claudeConfig: { homePath: source === "configured" ? home : "" },
+      environment: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: source === "configured" ? "/unused-claude-home" : home,
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      assert.isDefined(adapter.getAgentHistory);
+      const result = yield* adapter.getAgentHistory!({
+        threadId: ThreadId.make("stopped-history-thread"),
+        agentId: "child",
+        offset: 0,
+        resumeCursor: { resume: sessionId },
+      });
+      assert.equal(result.status, "ready");
+      assert.equal(result.entries[0]?.detail, "Saved task");
+      assert.isUndefined(harness.getLastCreateQueryInput());
+      assert.deepStrictEqual(yield* adapter.listSessions(), []);
+    }).pipe(
+      Effect.provide(harness.layer),
+      Effect.ensuring(Effect.sync(() => NodeFS.rmSync(home, { recursive: true, force: true }))),
+    );
+  });
+}

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -7280,9 +7280,17 @@ describe("ClaudeAdapterLive", () => {
   });
 });
 
-for (const source of ["configured", "inherited"] as const) {
+for (const source of ["configured", "inherited", "relative", "literal-tilde"] as const) {
   it.effect(`reads child history from the ${source} Claude home without starting a session`, () => {
-    const home = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "claude-history-adapter-"));
+    const workspace = NodeFS.mkdtempSync(
+      NodePath.join(NodeOS.tmpdir(), "claude-history-workspace-"),
+    );
+    const relativeHome =
+      source === "literal-tilde" ? NodePath.join("~", ".claude") : "relative-home";
+    const home =
+      source === "relative" || source === "literal-tilde"
+        ? NodePath.join(workspace, relativeHome)
+        : NodePath.join(workspace, "home");
     const sessionId = "0945fcd9-8a8d-450a-b8cf-4ebd0ef17468";
     const directory = NodePath.join(home, "projects", "-workspace", sessionId, "subagents");
     NodeFS.mkdirSync(directory, { recursive: true });
@@ -7302,7 +7310,12 @@ for (const source of ["configured", "inherited"] as const) {
       claudeConfig: { homePath: source === "configured" ? home : "" },
       environment: {
         ...process.env,
-        CLAUDE_CONFIG_DIR: source === "configured" ? "/unused-claude-home" : home,
+        CLAUDE_CONFIG_DIR:
+          source === "configured"
+            ? "/unused-claude-home"
+            : source === "relative" || source === "literal-tilde"
+              ? relativeHome
+              : home,
       },
     });
     return Effect.gen(function* () {
@@ -7313,6 +7326,7 @@ for (const source of ["configured", "inherited"] as const) {
         agentId: "child",
         offset: 0,
         resumeCursor: { resume: sessionId },
+        cwd: workspace,
       });
       assert.equal(result.status, "ready");
       assert.equal(result.entries[0]?.detail, "Saved task");
@@ -7320,7 +7334,9 @@ for (const source of ["configured", "inherited"] as const) {
       assert.deepStrictEqual(yield* adapter.listSessions(), []);
     }).pipe(
       Effect.provide(harness.layer),
-      Effect.ensuring(Effect.sync(() => NodeFS.rmSync(home, { recursive: true, force: true }))),
+      Effect.ensuring(
+        Effect.sync(() => NodeFS.rmSync(workspace, { recursive: true, force: true })),
+      ),
     );
   });
 }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -8,7 +8,6 @@
  */
 import * as NodeOS from "node:os";
 import { readClaudeAgentHistory } from "./claudeAgentHistory.ts";
-import { expandHomePath } from "../../pathExpansion.ts";
 import {
   type CanUseTool,
   query,
@@ -5050,13 +5049,13 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             offset: input.offset,
             view: input.view,
             configDir: claudeEnvironment.CLAUDE_CONFIG_DIR
-              ? expandHomePath(claudeEnvironment.CLAUDE_CONFIG_DIR)
+              ? path.resolve(input.cwd ?? process.cwd(), claudeEnvironment.CLAUDE_CONFIG_DIR)
               : path.join(NodeOS.homedir(), ".claude"),
           }),
         catch: (cause) =>
           new ProviderAdapterRequestError({
             provider: PROVIDER,
-            method: "getSubagentMessages",
+            method: "getAgentHistory",
             detail: "Could not read saved Claude agent history.",
             cause,
           }),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -6,6 +6,9 @@
  *
  * @module ClaudeAdapterLive
  */
+import * as NodeOS from "node:os";
+import { readClaudeAgentHistory } from "./claudeAgentHistory.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
 import {
   type CanUseTool,
   query,
@@ -5028,6 +5031,39 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     },
   );
 
+  /** Read the configured instance’s saved child transcript without creating a live SDK query. */
+  const getAgentHistory: ClaudeAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
+    function* (input) {
+      const sessionId = readClaudeResumeState(input.resumeCursor)?.resume;
+      if (!sessionId)
+        return {
+          status: "unavailable",
+          entries: [],
+          nextOffset: null,
+          message: "No saved Claude session is available for this thread.",
+        };
+      return yield* Effect.tryPromise({
+        try: () =>
+          readClaudeAgentHistory({
+            sessionId,
+            agentId: input.agentId,
+            offset: input.offset,
+            view: input.view,
+            configDir: claudeEnvironment.CLAUDE_CONFIG_DIR
+              ? expandHomePath(claudeEnvironment.CLAUDE_CONFIG_DIR)
+              : path.join(NodeOS.homedir(), ".claude"),
+          }),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "getSubagentMessages",
+            detail: "Could not read saved Claude agent history.",
+            cause,
+          }),
+      });
+    },
+  );
+
   const readThread: ClaudeAdapterShape["readThread"] = Effect.fn("readThread")(
     function* (threadId) {
       const context = yield* requireSession(threadId);
@@ -5135,6 +5171,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     sendTurn,
     interruptTurn,
     readThread,
+    getAgentHistory,
     rollbackThread,
     respondToRequest,
     respondToUserInput,

--- a/apps/server/src/provider/Layers/CodexAdapter.history.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.history.test.ts
@@ -1,0 +1,74 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { it, expect } from "@effect/vitest";
+import { CodexSettings, ThreadId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import { ServerConfig } from "../../config.ts";
+import { writeFakeCli } from "../../testUtils/fakeCli.ts";
+import { makeCodexAdapter } from "./CodexAdapter.ts";
+
+const decodeCodexSettings = Schema.decodeEffect(CodexSettings);
+
+it.effect(
+  "reuses one initialize-only Codex transport across concurrent and repeated history reads",
+  () =>
+    Effect.gen(function* () {
+      const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "codex-history-client-"));
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => NodeFS.rmSync(dir, { recursive: true, force: true })),
+      );
+      const log = NodePath.join(dir, "methods.txt");
+      const binaryPath = writeFakeCli({
+        directory: dir,
+        name: "codex-history",
+        env: { HISTORY_TEST_LOG: log },
+        source: `
+      import { appendFileSync } from "node:fs";
+      import { createInterface } from "node:readline";
+      createInterface({ input: process.stdin }).on("line", (line) => {
+        const request = JSON.parse(line);
+        appendFileSync(process.env.HISTORY_TEST_LOG, request.method + "\\n");
+        if (request.id === undefined) return;
+        const result = request.method === "initialize" ? { userAgent: "codex/1.0", codexHome: process.cwd(), platformFamily: "unix", platformOs: "linux" }
+          : { thread: { id: request.params.threadId, cliVersion: "test", createdAt: 0, updatedAt: 0,
+              cwd: process.cwd(), ephemeral: false, modelProvider: "openai", preview: "", sessionId: "session",
+              status: { type: "idle" }, source: { subAgent: { thread_spawn: { parent_thread_id: "parent", depth: 1 } } },
+              turns: [{ id: "turn", status: "completed", error: null, items: [{ id: "message", type: "agentMessage", text: "Saved answer" }] }] } };
+        process.stdout.write(JSON.stringify({ id: request.id, result }) + "\\n");
+      });
+    `,
+      });
+      const adapter = yield* makeCodexAdapter(yield* decodeCodexSettings({ binaryPath }));
+      const input = {
+        threadId: ThreadId.make("stopped"),
+        agentId: "child",
+        cwd: dir,
+        offset: 0,
+        resumeCursor: { threadId: "parent" },
+      };
+      const results = yield* Effect.all(
+        [adapter.getAgentHistory!(input), adapter.getAgentHistory!(input)],
+        { concurrency: "unbounded" },
+      );
+      expect(results.every((result) => result.entries[0]?.detail === "Saved answer")).toBe(true);
+      yield* adapter.getAgentHistory!(input);
+      const methods = NodeFS.readFileSync(log, "utf8").trim().split("\n");
+      expect(methods.filter((method) => method === "initialize")).toHaveLength(1);
+      expect(methods.filter((method) => method === "thread/read")).toHaveLength(6);
+      expect(
+        methods.every((method) => ["initialize", "initialized", "thread/read"].includes(method)),
+      ).toBe(true);
+      expect(yield* adapter.listSessions()).toEqual([]);
+    }).pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), process.cwd()).pipe(
+          Layer.provideMerge(NodeServices.layer),
+        ),
+      ),
+    ),
+);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1,3 +1,6 @@
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
+import { withCodexAppServerClient } from "./CodexProvider.ts";
+import { readCodexAgentHistory } from "./codexAgentHistory.ts";
 /**
  * CodexAdapterLive - Scoped live implementation for the Codex provider adapter.
  *
@@ -2234,6 +2237,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
 
+  const withHistoryClient = yield* makeAgentHistoryClient((cwd) =>
+    withCodexAppServerClient({
+      binaryPath: codexConfig.binaryPath,
+      homePath: codexConfig.homePath,
+      launchArgs: resolveCodexLaunchArgs(codexConfig.launchArgs, options?.environment),
+      environment: options?.environment,
+      cwd,
+    }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner)),
+  );
+
   const startSession: CodexAdapterShape["startSession"] = (input) =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -2573,6 +2586,41 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     );
   });
 
+  /** Read saved descendants through the shared read-only transport without resuming a coding session. */
+  const getAgentHistory: CodexAdapterShape["getAgentHistory"] = Effect.fn("getAgentHistory")(
+    function* (input) {
+      if (!isCodexResumeCursorSchema(input.resumeCursor)) {
+        return {
+          status: "unavailable",
+          entries: [],
+          nextOffset: null,
+          message: "No saved Codex session is available for this thread.",
+        };
+      }
+      const parentThreadId = input.resumeCursor.threadId;
+      return yield* withHistoryClient(input.cwd ?? process.cwd(), ({ client }) =>
+        readCodexAgentHistory({
+          parentThreadId,
+          agentId: input.agentId,
+          offset: input.offset,
+          view: input.view,
+          readThread: (threadId, includeTurns) =>
+            client.request("thread/read", { threadId, includeTurns }),
+        }),
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "thread/read",
+              detail: "Could not read saved agent history.",
+              cause,
+            }),
+        ),
+      );
+    },
+  );
+
   const readThread: CodexAdapterShape["readThread"] = (threadId) =>
     requireSession(threadId).pipe(
       Effect.flatMap((session) => session.runtime.readThread),
@@ -2721,6 +2769,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     compaction: { type: "native", start: compactThread },
     interruptTurn,
     readThread,
+    getAgentHistory,
     rollbackThread,
     uploadFeedback,
     respondToRequest,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2237,6 +2237,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, CodexAdapterSessionContext>();
 
+  /** Reuse one read-only app-server per workspace across short history refreshes. */
   const withHistoryClient = yield* makeAgentHistoryClient((cwd) =>
     withCodexAppServerClient({
       binaryPath: codexConfig.binaryPath,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -257,6 +257,14 @@ function makeFakeCodexAdapter(
       Effect.succeed({ threadId, turns: [] }),
   );
 
+  const getAgentHistory = vi.fn(
+    (
+      _input: Parameters<
+        NonNullable<ProviderAdapterShape<ProviderAdapterError>["getAgentHistory"]>
+      >[0],
+    ) => Effect.succeed({ status: "ready" as const, entries: [], nextOffset: null, message: null }),
+  );
+
   const uploadFeedback = vi.fn(
     (
       input: ProviderUploadFeedbackInput,
@@ -295,6 +303,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     ...(provider === CODEX_DRIVER ? { uploadFeedback } : {}),
+    ...(provider === CODEX_DRIVER || provider === CLAUDE_AGENT_DRIVER ? { getAgentHistory } : {}),
     stopAll,
     get streamEvents() {
       return Stream.fromPubSub(runtimeEventPubSub);
@@ -332,6 +341,7 @@ function makeFakeCodexAdapter(
     readThread,
     rollbackThread,
     uploadFeedback,
+    getAgentHistory,
     stopAll,
   };
 }
@@ -1971,6 +1981,63 @@ routing.layer("ProviderServiceLive routing", (it) => {
       });
       yield* Fiber.join(retryFiber);
       yield* provider.stopSession({ threadId });
+    }),
+  );
+
+  it.effect("reads saved agent history without recovering a stopped session", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-agent-history-stopped");
+      const cwd = fixtureCwd("agent-history");
+      yield* provider.startSession(threadId, {
+        provider: CODEX_DRIVER,
+        providerInstanceId: codexInstanceId,
+        threadId,
+        cwd,
+        resumeCursor: { threadId: "native-parent" },
+        runtimeMode: "full-access",
+      });
+      yield* routing.codex.stopSession(threadId);
+      routing.codex.startSession.mockClear();
+      routing.codex.sendTurn.mockClear();
+      routing.codex.getAgentHistory.mockClear();
+      const result = yield* provider.getAgentHistory({
+        threadId,
+        agentId: "native-child",
+        offset: 50,
+      });
+      assert.equal(result.status, "ready");
+      assert.equal(routing.codex.startSession.mock.calls.length, 0);
+      assert.equal(routing.codex.sendTurn.mock.calls.length, 0);
+      assert.deepStrictEqual(routing.codex.getAgentHistory.mock.calls, [
+        [
+          {
+            threadId,
+            agentId: "native-child",
+            offset: 50,
+            cwd,
+            resumeCursor: { threadId: "native-parent" },
+          },
+        ],
+      ]);
+    }),
+  );
+
+  it.effect("reports unsupported history without restarting the provider", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService.ProviderService;
+      const threadId = asThreadId("thread-agent-history-unsupported");
+      yield* provider.startSession(threadId, {
+        provider: CURSOR_DRIVER,
+        providerInstanceId: ProviderInstanceId.make("cursor"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* routing.cursor.stopSession(threadId);
+      routing.cursor.startSession.mockClear();
+      const result = yield* provider.getAgentHistory({ threadId, agentId: "child", offset: 0 });
+      assert.equal(result.status, "unsupported");
+      assert.equal(routing.cursor.startSession.mock.calls.length, 0);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -2182,6 +2182,37 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     );
   });
 
+  /** Route history to the persisted provider instance without recovering or starting its session. */
+  const getAgentHistory: ProviderServiceMethod<"getAgentHistory"> = Effect.fn("getAgentHistory")(
+    function* (input) {
+      const binding = Option.getOrUndefined(yield* directory.getBinding(input.threadId));
+      if (!binding) {
+        return yield* toValidationError(
+          "ProviderService.getAgentHistory",
+          "No saved provider session exists for this thread.",
+        );
+      }
+      const instanceId = yield* requireBindingInstanceId(
+        "ProviderService.getAgentHistory",
+        binding,
+      );
+      const adapter = yield* registry.getByInstance(instanceId);
+      if (!adapter.getAgentHistory) {
+        return {
+          status: "unsupported",
+          entries: [],
+          nextOffset: null,
+          message: "Agent history is not supported by this provider yet.",
+        };
+      }
+      return yield* adapter.getAgentHistory({
+        ...input,
+        resumeCursor: binding.resumeCursor,
+        cwd: readPersistedCwd(binding.runtimePayload),
+      });
+    },
+  );
+
   const uploadFeedback: ProviderServiceMethod<"uploadFeedback"> = Effect.fn("uploadFeedback")(
     function* (rawInput) {
       const input = yield* decodeInputOrValidationError({
@@ -2316,6 +2347,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     assertConversationRollbackSupported,
     rollbackConversation,
     uploadFeedback,
+    getAgentHistory,
     // Each access creates a fresh PubSub subscription so that multiple
     // consumers (ProviderRuntimeIngestion, CheckpointReactor, etc.) each
     // independently receive all runtime events.

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -214,6 +214,7 @@ describe("ProviderSessionReaper", () => {
         });
       },
       rollbackConversation: () => unsupported(),
+      getAgentHistory: () => unsupported(),
       uploadFeedback: () => unsupported(),
       streamEvents: Stream.empty,
     };

--- a/apps/server/src/provider/Layers/agentHistory.test.ts
+++ b/apps/server/src/provider/Layers/agentHistory.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "@effect/vitest";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+describe("agent history selection", () => {
+  it("keeps file edits in recent tools", () => {
+    const page = collectAgentHistory({ offset: 0, view: "recent-tools" });
+    page.add(agentHistoryEntry("edit", "file-edit", "Edit X.jsx", "patch"));
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(["edit"]);
+  });
+  const entries = Array.from({ length: 130 }, (_, index) =>
+    agentHistoryEntry(
+      String(index),
+      index % 2 ? "assistant" : "tool",
+      `Entry ${index}`,
+      "x".repeat(1000),
+    ),
+  );
+  it("returns the newest five tools beyond the first page with compact details", () => {
+    const page = collectAgentHistory({ offset: 0, view: "recent-tools" });
+    for (const entry of entries) page.add(entry);
+    expect(page.result().entries.map((entry) => entry.id)).toEqual([
+      "120",
+      "122",
+      "124",
+      "126",
+      "128",
+    ]);
+    expect(
+      page.result().entries.every((entry) => entry.detail.length === 240 && entry.truncated),
+    ).toBe(true);
+    expect(page.result().nextOffset).toBeNull();
+  });
+  it("opens on the latest page and supplies its position for previous navigation", () => {
+    const page = collectAgentHistory({ offset: 0, view: "latest" });
+    for (const entry of entries) page.add(entry);
+    expect(page.result().startOffset).toBe(80);
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(
+      entries.slice(-50).map((entry) => entry.id),
+    );
+    expect(page.result().nextOffset).toBeNull();
+  });
+  it("keeps forward pagination unchanged", () => {
+    const page = collectAgentHistory({ offset: 50 });
+    for (const entry of entries) if (page.add(entry)) break;
+    expect(page.result().entries.map((entry) => entry.id)).toEqual(
+      entries.slice(50, 100).map((entry) => entry.id),
+    );
+    expect(page.result().nextOffset).toBe(100);
+  });
+});

--- a/apps/server/src/provider/Layers/agentHistory.test.ts
+++ b/apps/server/src/provider/Layers/agentHistory.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect } from "@effect/vitest";
-import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+import {
+  agentHistoryEntry,
+  boundedHistoryJson,
+  boundedHistoryText,
+  collectAgentHistory,
+} from "./agentHistory.ts";
 
 describe("agent history selection", () => {
+  it("bounds text before advancing through later provider values", () => {
+    function* values() {
+      yield "x".repeat(9000);
+      throw new Error("iterator advanced past the detail limit");
+    }
+    expect(boundedHistoryText(values())).toEqual({ text: "x".repeat(8000), truncated: true });
+  });
+  it("bounds nested JSON before serialization", () => {
+    const value = {
+      longValue: "x".repeat(2000),
+      rows: Array.from({ length: 1000 }, (_, index) => index),
+    };
+    const result = boundedHistoryJson(value);
+    expect(result.text.length).toBeLessThanOrEqual(8000);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toContain("more items");
+  });
   it("keeps file edits in recent tools", () => {
     const page = collectAgentHistory({ offset: 0, view: "recent-tools" });
     page.add(agentHistoryEntry("edit", "file-edit", "Edit X.jsx", "patch"));

--- a/apps/server/src/provider/Layers/agentHistory.ts
+++ b/apps/server/src/provider/Layers/agentHistory.ts
@@ -1,0 +1,66 @@
+import type {
+  AgentHistoryEntry,
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
+} from "@t3tools/contracts";
+
+/** Keep history payloads bounded; omitted detail is explicitly marked in the UI. */
+export function agentHistoryEntry(
+  id: string,
+  kind: AgentHistoryEntry["kind"],
+  title: string,
+  detail = "",
+): AgentHistoryEntry {
+  return {
+    id,
+    kind,
+    title: title.slice(0, 500),
+    detail: detail.slice(0, 8000),
+    truncated: title.length > 500 || detail.length > 8000,
+  };
+}
+
+/** Full history pages forward; previews retain only the latest five tools, oldest first. */
+export function collectAgentHistory(
+  input: Pick<OrchestrationGetAgentHistoryInput, "offset" | "view">,
+) {
+  const entries: AgentHistoryEntry[] = [];
+  let index = 0;
+  let nextOffset: number | null = null;
+  return {
+    add(entry: AgentHistoryEntry): boolean {
+      if (input.view === "latest") {
+        index++;
+        entries.push(entry);
+        if (entries.length > 50) entries.shift();
+        return false;
+      }
+      if (input.view === "recent-tools") {
+        if (entry.kind !== "tool" && entry.kind !== "file-edit") return false;
+        entries.push({
+          ...entry,
+          detail: entry.detail.slice(0, 240),
+          truncated: entry.truncated || entry.detail.length > 240,
+        });
+        if (entries.length > 5) entries.shift();
+        return false;
+      }
+      if (index++ < input.offset) return false;
+      if (entries.length === 50) {
+        nextOffset = input.offset + entries.length;
+        return true;
+      }
+      entries.push(entry);
+      return false;
+    },
+    result(): OrchestrationGetAgentHistoryResult {
+      return {
+        status: "ready",
+        entries,
+        nextOffset,
+        message: null,
+        ...(input.view === "latest" ? { startOffset: Math.max(0, index - entries.length) } : {}),
+      };
+    },
+  };
+}

--- a/apps/server/src/provider/Layers/agentHistory.ts
+++ b/apps/server/src/provider/Layers/agentHistory.ts
@@ -60,6 +60,7 @@ export function boundedHistoryJson(value: unknown): BoundedHistoryText {
   let truncated = false;
   const seen = new WeakSet<object>();
 
+  /** Copy one provider value while enforcing the shared traversal budget. */
   const project = (current: unknown, depth: number): unknown => {
     if (remainingNodes-- <= 0) {
       truncated = true;

--- a/apps/server/src/provider/Layers/agentHistory.ts
+++ b/apps/server/src/provider/Layers/agentHistory.ts
@@ -4,28 +4,126 @@ import type {
   OrchestrationGetAgentHistoryResult,
 } from "@t3tools/contracts";
 
+const MAX_DETAIL_LENGTH = 8000;
+const MAX_JSON_DEPTH = 5;
+const MAX_JSON_ITEMS = 25;
+const MAX_JSON_NODES = 100;
+const MAX_JSON_STRING_LENGTH = 1000;
+
+export interface BoundedHistoryText {
+  readonly text: string;
+  readonly truncated: boolean;
+}
+
 /** Keep history payloads bounded; omitted detail is explicitly marked in the UI. */
 export function agentHistoryEntry(
   id: string,
   kind: AgentHistoryEntry["kind"],
   title: string,
   detail = "",
+  truncated = false,
 ): AgentHistoryEntry {
   return {
     id,
     kind,
     title: title.slice(0, 500),
-    detail: detail.slice(0, 8000),
-    truncated: title.length > 500 || detail.length > 8000,
+    detail: detail.slice(0, MAX_DETAIL_LENGTH),
+    truncated: truncated || title.length > 500 || detail.length > MAX_DETAIL_LENGTH,
+  };
+}
+
+/** Join text without first materializing an unbounded provider payload. */
+export function boundedHistoryText(parts: Iterable<string>, separator = "\n"): BoundedHistoryText {
+  let text = "";
+  let truncated = false;
+  for (const part of parts) {
+    const prefix = text.length === 0 ? "" : separator;
+    const available = MAX_DETAIL_LENGTH - text.length;
+    if (available <= prefix.length) {
+      truncated = true;
+      break;
+    }
+    text += prefix;
+    if (part.length > available - prefix.length) {
+      text += part.slice(0, available - prefix.length);
+      truncated = true;
+      break;
+    }
+    text += part;
+  }
+  return { text, truncated };
+}
+
+/** Serialize a shallow, bounded projection instead of walking arbitrary provider payloads. */
+export function boundedHistoryJson(value: unknown): BoundedHistoryText {
+  let remainingNodes = MAX_JSON_NODES;
+  let truncated = false;
+  const seen = new WeakSet<object>();
+
+  const project = (current: unknown, depth: number): unknown => {
+    if (remainingNodes-- <= 0) {
+      truncated = true;
+      return "[content omitted]";
+    }
+    if (typeof current === "string") {
+      if (current.length > MAX_JSON_STRING_LENGTH) truncated = true;
+      return current.slice(0, MAX_JSON_STRING_LENGTH);
+    }
+    if (
+      current === null ||
+      typeof current === "boolean" ||
+      typeof current === "number" ||
+      typeof current === "undefined"
+    )
+      return current;
+    if (typeof current !== "object") return String(current);
+    if (depth >= MAX_JSON_DEPTH) {
+      truncated = true;
+      return "[content omitted]";
+    }
+    if (seen.has(current)) {
+      truncated = true;
+      return "[circular]";
+    }
+    seen.add(current);
+    if (Array.isArray(current)) {
+      const result = current.slice(0, MAX_JSON_ITEMS).map((entry) => project(entry, depth + 1));
+      if (current.length > MAX_JSON_ITEMS) {
+        truncated = true;
+        result.push(`[${current.length - MAX_JSON_ITEMS} more items]`);
+      }
+      return result;
+    }
+    const result: Record<string, unknown> = {};
+    let count = 0;
+    for (const key in current) {
+      if (!Object.hasOwn(current, key)) continue;
+      if (count++ === MAX_JSON_ITEMS) {
+        truncated = true;
+        result["…"] = "Additional properties omitted";
+        break;
+      }
+      const boundedKey = key.slice(0, 200);
+      if (boundedKey.length !== key.length) truncated = true;
+      result[boundedKey] = project((current as Record<string, unknown>)[key], depth + 1);
+    }
+    return result;
+  };
+
+  const serialized = JSON.stringify(project(value, 0), null, 2) ?? "";
+  return {
+    text: serialized.slice(0, MAX_DETAIL_LENGTH),
+    truncated: truncated || serialized.length > MAX_DETAIL_LENGTH,
   };
 }
 
 /** Full history pages forward; previews retain only the latest five tools, oldest first. */
 export function collectAgentHistory(
   input: Pick<OrchestrationGetAgentHistoryInput, "offset" | "view">,
+  initialIndex = 0,
 ) {
   const entries: AgentHistoryEntry[] = [];
-  let index = 0;
+  let index = initialIndex;
   let nextOffset: number | null = null;
   return {
     add(entry: AgentHistoryEntry): boolean {

--- a/apps/server/src/provider/Layers/agentHistoryClient.test.ts
+++ b/apps/server/src/provider/Layers/agentHistoryClient.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+import { makeAgentHistoryClient } from "./agentHistoryClient.ts";
+
+describe("saved history transport lifetime", () => {
+  it.effect(
+    "shares concurrent and repeated reads, isolates directories, and releases idle clients",
+    () =>
+      Effect.gen(function* () {
+        const opened: string[] = [];
+        const closed: string[] = [];
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const use = yield* makeAgentHistoryClient((cwd) =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  opened.push(cwd);
+                  return cwd;
+                }),
+                (cwd) =>
+                  Effect.sync(() => {
+                    closed.push(cwd);
+                  }),
+              ),
+            );
+            yield* Effect.all([use("a", Effect.succeed), use("a", Effect.succeed)], {
+              concurrency: "unbounded",
+            });
+            yield* use("a", Effect.succeed);
+            yield* use("b", Effect.succeed);
+            expect(opened).toEqual(["a", "b"]);
+            expect(closed).toEqual([]);
+            yield* TestClock.adjust("31 seconds");
+            expect(closed.sort()).toEqual(["a", "b"]);
+            yield* use("a", Effect.succeed);
+            expect(opened).toEqual(["a", "b", "a"]);
+          }),
+        );
+        expect(closed).toEqual(["a", "b", "a"]);
+      }),
+  );
+
+  it.effect("invalidates failed reads and retries on a fresh client", () =>
+    Effect.gen(function* () {
+      let opened = 0;
+      let closed = 0;
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.acquireRelease(
+          Effect.sync(() => ++opened),
+          () =>
+            Effect.sync(() => {
+              closed++;
+            }),
+        ),
+      );
+      yield* use("a", () => Effect.fail("disconnected")).pipe(Effect.flip);
+      expect(closed).toBe(1);
+      expect(yield* use("a", Effect.succeed)).toBe(2);
+    }),
+  );
+
+  it.effect("cleans up a transport whose initialization never completes", () =>
+    Effect.gen(function* () {
+      let closed = 0;
+      const started = yield* Deferred.make<void>();
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.gen(function* () {
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              closed++;
+            }),
+          );
+          yield* Deferred.succeed(started, undefined);
+          return yield* Effect.never;
+        }),
+      );
+      const pending = yield* use("a", Effect.succeed).pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("21 seconds");
+      expect((yield* Fiber.await(pending))._tag).toBe("Failure");
+      expect(closed).toBe(1);
+    }),
+  );
+  it.effect("releases a timed-out read before returning and permits a fresh lookup", () =>
+    Effect.gen(function* () {
+      let closed = 0;
+      const started = yield* Deferred.make<void>();
+      const use = yield* makeAgentHistoryClient(() =>
+        Effect.acquireRelease(Effect.succeed("client"), () =>
+          Effect.sync(() => {
+            closed++;
+          }),
+        ),
+      );
+      const pending = yield* use("a", () =>
+        Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+      ).pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("21 seconds");
+      const result = yield* Fiber.await(pending);
+      expect(result._tag).toBe("Failure");
+      expect(closed).toBe(1);
+      expect(yield* use("a", Effect.succeed)).toBe("client");
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/agentHistoryClient.ts
+++ b/apps/server/src/provider/Layers/agentHistoryClient.ts
@@ -1,0 +1,19 @@
+import * as Effect from "effect/Effect";
+import * as RcMap from "effect/RcMap";
+import type * as Scope from "effect/Scope";
+
+/** Share read-only transports across cards without retaining idle processes or session state. */
+export const makeAgentHistoryClient = Effect.fn("makeAgentHistoryClient")(function* <A, E, R>(
+  lookup: (cwd: string) => Effect.Effect<A, E, R | Scope.Scope>,
+) {
+  const clients = yield* RcMap.make({
+    lookup: (cwd: string) => lookup(cwd).pipe(Effect.timeout("20 seconds")),
+    idleTimeToLive: "30 seconds",
+    capacity: 8,
+  });
+  return <B, E2>(cwd: string, read: (client: A) => Effect.Effect<B, E2>) =>
+    Effect.scoped(RcMap.get(clients, cwd).pipe(Effect.flatMap(read))).pipe(
+      Effect.timeout("20 seconds"),
+      Effect.onError(() => RcMap.invalidate(clients, cwd)),
+    );
+});

--- a/apps/server/src/provider/Layers/agentHistoryClient.ts
+++ b/apps/server/src/provider/Layers/agentHistoryClient.ts
@@ -11,9 +11,11 @@ export const makeAgentHistoryClient = Effect.fn("makeAgentHistoryClient")(functi
     idleTimeToLive: "30 seconds",
     capacity: 8,
   });
-  return <B, E2>(cwd: string, read: (client: A) => Effect.Effect<B, E2>) =>
+  /** Borrow a workspace client for one bounded read and evict it after failures. */
+  const useClient = <B, E2>(cwd: string, read: (client: A) => Effect.Effect<B, E2>) =>
     Effect.scoped(RcMap.get(clients, cwd).pipe(Effect.flatMap(read))).pipe(
       Effect.timeout("20 seconds"),
       Effect.onError(() => RcMap.invalidate(clients, cwd)),
     );
+  return useClient;
 });

--- a/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
@@ -1,0 +1,169 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeCrypto from "node:crypto";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import * as DateTime from "effect/DateTime";
+import { readClaudeAgentHistory } from "./claudeAgentHistory.ts";
+
+const sessionId = "0945fcd9-8a8d-450a-b8cf-4ebd0ef17468";
+let configDir: string;
+beforeEach(async () => {
+  configDir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "claude-agent-history-"));
+});
+afterEach(async () => {
+  await NodeFSP.rm(configDir, { recursive: true, force: true });
+});
+
+/** Write a linked SDK transcript so reader tests exercise real chain reconstruction. */
+async function save(agentId: string, contents: ReadonlyArray<unknown>, nested = false) {
+  const directory = NodePath.join(
+    configDir,
+    "projects",
+    "-workspace",
+    sessionId,
+    "subagents",
+    ...(nested ? ["workflow", "review"] : []),
+  );
+  await NodeFSP.mkdir(directory, { recursive: true });
+  let parentUuid: string | null = null;
+  const lines = contents.map((content, index) => {
+    const uuid = NodeCrypto.randomUUID();
+    const type =
+      index === 0 ||
+      (Array.isArray(content) && content.some((block) => block.type === "tool_result"))
+        ? "user"
+        : "assistant";
+    const row = {
+      type,
+      uuid,
+      parentUuid,
+      isSidechain: true,
+      sessionId,
+      agentId,
+      timestamp: DateTime.formatIso(DateTime.makeUnsafe(index * 1000)),
+      message: { role: type, content },
+    };
+    parentUuid = uuid;
+    return JSON.stringify(row);
+  });
+  const file = NodePath.join(directory, `agent-${agentId}.jsonl`);
+  await NodeFSP.writeFile(file, lines.join("\n") + "\n");
+  return file;
+}
+
+const read = (agentId = "child", offset = 0) =>
+  readClaudeAgentHistory({ configDir, sessionId, agentId, offset });
+
+describe("Claude saved agent history", () => {
+  it("skips malformed messages without losing subsequent valid history", async () => {
+    await save("child", [
+      "prompt",
+      null,
+      [{ type: "text", text: 42 }],
+      [{ type: "text", text: "Valid answer" }],
+    ]);
+    const result = await read();
+    expect(result.entries.map((entry) => entry.detail)).toEqual(["prompt", "Valid answer"]);
+  });
+  it("identifies file edits without putting patch content in the title", async () => {
+    await save("child", [
+      "prompt",
+      [
+        {
+          type: "tool_use",
+          id: "edit",
+          name: "Edit",
+          input: { file_path: "src/X.jsx", old_string: "old", new_string: "new" },
+        },
+      ],
+    ]);
+    const result = await read();
+    expect(result.entries[1]).toMatchObject({ kind: "file-edit", title: "Edit src/X.jsx" });
+    expect(result.entries[1]?.detail).toContain("new_string");
+  });
+  it("reads nested transcripts, preserves calls and results, and bounds entry detail", async () => {
+    await save(
+      "child",
+      [
+        "Review the changes",
+        [
+          { type: "text", text: "Checking the file" },
+          { type: "tool_use", id: "tool1", name: "Read", input: { file_path: "index.ts" } },
+        ],
+        [
+          {
+            type: "tool_result",
+            tool_use_id: "tool1",
+            content: [{ type: "text", text: "x".repeat(9000) }],
+          },
+        ],
+      ],
+      true,
+    );
+    const result = await read();
+    expect(result.status).toBe("ready");
+    expect(result.entries.map((entry) => entry.title)).toEqual([
+      "Prompt",
+      "Agent",
+      "Read",
+      "Tool result",
+    ]);
+    expect(result.entries[2]?.detail).toContain("index.ts");
+    expect(result.entries[3]?.detail).toHaveLength(8000);
+    expect(result.entries[3]?.truncated).toBe(true);
+  });
+
+  it("paginates by visible entries without losing or repeating blocks", async () => {
+    await save("child", [
+      "Prompt",
+      Array.from({ length: 55 }, (_, index) => ({ type: "text", text: `entry ${index}` })),
+    ]);
+    const first = await read();
+    const second = await read("child", first.nextOffset!);
+    expect(first.entries).toHaveLength(50);
+    expect(second.entries).toHaveLength(6);
+    expect(second.nextOffset).toBeNull();
+    expect(new Set([...first.entries, ...second.entries].map((entry) => entry.id)).size).toBe(56);
+    expect(second.entries.at(-1)?.detail).toBe("entry 54");
+  });
+
+  it("does not cross parent sessions, provider homes, or follow child symlinks", async () => {
+    const file = await save("child", ["private"]);
+    expect(
+      (
+        await readClaudeAgentHistory({
+          configDir,
+          sessionId: NodeCrypto.randomUUID(),
+          agentId: "child",
+          offset: 0,
+        })
+      ).status,
+    ).toBe("unavailable");
+    expect(
+      (
+        await readClaudeAgentHistory({
+          configDir: NodePath.join(configDir, "other-home"),
+          sessionId,
+          agentId: "child",
+          offset: 0,
+        })
+      ).status,
+    ).toBe("unavailable");
+    expect((await read("../../child")).status).toBe("unavailable");
+    if (HostProcessPlatform.defaultValue() !== "win32") {
+      await NodeFSP.symlink(file, NodePath.join(NodePath.dirname(file), "agent-alias.jsonl"));
+      expect((await read("alias")).status).toBe("unavailable");
+    }
+  });
+
+  it("tolerates a record still being written but reports corruption in completed records", async () => {
+    const file = await save("child", ["Prompt", [{ type: "text", text: "Done" }]]);
+    await NodeFSP.appendFile(file, '{"type":');
+    expect((await read()).entries).toHaveLength(2);
+    await NodeFSP.appendFile(file, "\n");
+    await expect(read()).rejects.toThrow();
+  });
+});

--- a/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
   await NodeFSP.rm(configDir, { recursive: true, force: true });
 });
 
-/** Write a linked SDK transcript so reader tests exercise real chain reconstruction. */
+/** Write a linked JSONL transcript in Claude's persisted child-agent layout. */
 async function save(agentId: string, contents: ReadonlyArray<unknown>, nested = false) {
   const directory = NodePath.join(
     configDir,
@@ -165,5 +165,23 @@ describe("Claude saved agent history", () => {
     expect((await read()).entries).toHaveLength(2);
     await NodeFSP.appendFile(file, "\n");
     await expect(read()).rejects.toThrow();
+  });
+
+  it("stops reading once the requested page is complete", async () => {
+    const file = await save("child", [
+      Array.from({ length: 51 }, (_, index) => ({ type: "text", text: `entry ${index}` })),
+    ]);
+    await NodeFSP.appendFile(file, '{"type":\n');
+    const result = await read();
+    expect(result.entries).toHaveLength(50);
+    expect(result.nextOffset).toBe(50);
+  });
+
+  it("rejects transcripts with more than the bounded record count", async () => {
+    const file = await save("child", ["Prompt"]);
+    await NodeFSP.appendFile(file, `${'{"type":"progress"}\n'.repeat(50_000)}`);
+    const result = await read();
+    expect(result.status).toBe("unavailable");
+    expect(result.message).toContain("too many records");
   });
 });

--- a/apps/server/src/provider/Layers/claudeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.ts
@@ -1,0 +1,239 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+import {
+  getSubagentMessages,
+  type SessionMessage,
+  type SessionStoreEntry,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+const isAgentId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9_-]+$/)));
+const isSessionId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9-]+$/)));
+
+const decodeTranscriptEntry = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Struct({ type: Schema.String })),
+  { onExcessProperty: "preserve" },
+);
+const ContentBlock = Schema.Struct({
+  type: Schema.String,
+  text: Schema.optionalKey(Schema.String),
+  thinking: Schema.optionalKey(Schema.String),
+  name: Schema.optionalKey(Schema.String),
+  input: Schema.optionalKey(Schema.Unknown),
+  content: Schema.optionalKey(Schema.Unknown),
+  is_error: Schema.optionalKey(Schema.Boolean),
+});
+const decodeMessage = Schema.decodeUnknownOption(
+  Schema.Struct({
+    content: Schema.Union([Schema.String, Schema.Array(ContentBlock)]),
+  }),
+);
+const decodeTextContent = Schema.decodeUnknownOption(
+  Schema.Array(
+    Schema.Struct({
+      type: Schema.String,
+      text: Schema.optionalKey(Schema.String),
+    }),
+  ),
+);
+
+/** Return an empty history response with a recoverable explanation for the client. */
+const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
+  status: "unavailable",
+  entries: [],
+  nextOffset: null,
+  message,
+});
+
+/** Missing transcript directories mean no saved history; other filesystem errors remain visible. */
+async function directoryEntries(path: string) {
+  try {
+    return await NodeFSP.readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+/** Use lstat so a symlink cannot redirect traversal outside the configured transcript store. */
+async function isDirectory(path: string) {
+  try {
+    return (await NodeFSP.lstat(path)).isDirectory();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/** Find only regular child transcripts inside the persisted parent's directory. */
+async function findTranscript(
+  directory: string,
+  filename: string,
+  depth = 0,
+): Promise<string | null> {
+  if (depth > 16) return null;
+  const entries = await directoryEntries(directory);
+  if (entries.some((entry) => entry.name === filename && entry.isFile()))
+    return NodePath.join(directory, filename);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const found = await findTranscript(NodePath.join(directory, entry.name), filename, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Extract only textual tool results; image and other binary blocks are not activity text. */
+function resultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  const blocks = decodeTextContent(content);
+  return blocks._tag === "Some"
+    ? blocks.value.flatMap((block) => (block.text ? [block.text] : [])).join("\n")
+    : "";
+}
+
+/** Skip unsupported transcript records while retaining the rest of the saved conversation. */
+export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry[] {
+  const decoded = decodeMessage(message.message);
+  if (decoded._tag === "None") return [];
+  const { content } = decoded.value;
+  if (typeof content === "string")
+    return content
+      ? [
+          agentHistoryEntry(
+            message.uuid,
+            message.type === "user" ? "user" : "assistant",
+            message.type === "user" ? "Prompt" : "Agent",
+            content,
+          ),
+        ]
+      : [];
+  return content.flatMap((block, index): AgentHistoryEntry[] => {
+    const id = `${message.uuid}:${index}`;
+    switch (block.type) {
+      case "text":
+        return block.text
+          ? [
+              agentHistoryEntry(
+                id,
+                message.type === "user" ? "user" : "assistant",
+                message.type === "user" ? "Prompt" : "Agent",
+                block.text,
+              ),
+            ]
+          : [];
+      case "thinking":
+        return block.thinking
+          ? [agentHistoryEntry(id, "reasoning", "Reasoning", block.thinking)]
+          : [];
+      case "tool_use": {
+        const fileEdit =
+          block.name === "Edit" || block.name === "Write" || block.name === "MultiEdit";
+        const path =
+          block.input &&
+          typeof block.input === "object" &&
+          "file_path" in block.input &&
+          typeof block.input.file_path === "string"
+            ? block.input.file_path
+            : null;
+        return [
+          agentHistoryEntry(
+            id,
+            fileEdit ? "file-edit" : "tool",
+            fileEdit && path ? `Edit ${path}` : (block.name ?? "Tool"),
+            JSON.stringify(block.input ?? {}, null, 2),
+          ),
+        ];
+      }
+      case "tool_result":
+        return [
+          agentHistoryEntry(
+            id,
+            "tool",
+            block.is_error ? "Tool error" : "Tool result",
+            resultText(block.content),
+          ),
+        ];
+      default:
+        return [];
+    }
+  });
+}
+
+/** The SDK rebuilds the conversation chain. A read-only store keeps its reads instance-local. */
+export async function readClaudeAgentHistory(input: {
+  configDir: string;
+  sessionId: string;
+  agentId: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+}): Promise<OrchestrationGetAgentHistoryResult> {
+  if (!isAgentId(input.agentId) || !isSessionId(input.sessionId)) {
+    return unavailable("No saved transcript is available for this agent.");
+  }
+  const projectsDir = NodePath.join(input.configDir, "projects");
+  let transcript: string | null = null;
+  for (const project of await directoryEntries(projectsDir)) {
+    if (!project.isDirectory()) continue;
+    const projectDir = NodePath.join(projectsDir, project.name);
+    const sessionDir = NodePath.join(projectDir, input.sessionId);
+    if (
+      !(await isDirectory(sessionDir)) ||
+      !(await isDirectory(NodePath.join(sessionDir, "subagents")))
+    )
+      continue;
+    transcript = await findTranscript(
+      NodePath.join(sessionDir, "subagents"),
+      `agent-${input.agentId}.jsonl`,
+    );
+    if (transcript) break;
+  }
+  if (!transcript)
+    return unavailable("Claude has no saved transcript for this agent in this session.");
+  const handle = await NodeFSP.open(
+    transcript,
+    NodeFS.constants.O_RDONLY | NodeFS.constants.O_NOFOLLOW,
+  );
+  let contents: string;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) return unavailable("The agent transcript is not a regular file.");
+    if (stat.size > 64 * 1024 * 1024)
+      return unavailable("This agent transcript is too large to load.");
+    contents = await handle.readFile("utf8");
+  } finally {
+    await handle.close();
+  }
+  const lines = contents.split("\n");
+  const entries: SessionStoreEntry[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]!;
+    if (!line.trim()) continue;
+    try {
+      entries.push(decodeTranscriptEntry(line));
+    } catch (error) {
+      // A running Claude process may still be writing the last JSONL record.
+      if (index === lines.length - 1 && !contents.endsWith("\n")) break;
+      throw error;
+    }
+  }
+  const messages = await getSubagentMessages(input.sessionId, input.agentId, {
+    sessionStore: {
+      append: async () => {
+        throw new Error("Agent history is read-only.");
+      },
+      load: async () => entries,
+    },
+  });
+  const page = collectAgentHistory(input);
+  for (const message of messages) {
+    for (const entry of claudeHistoryEntries(message)) {
+      if (page.add(entry)) return page.result();
+    }
+  }
+  return page.result();
+}

--- a/apps/server/src/provider/Layers/claudeAgentHistory.ts
+++ b/apps/server/src/provider/Layers/claudeAgentHistory.ts
@@ -2,14 +2,20 @@
 import * as NodeFSP from "node:fs/promises";
 import * as NodeFS from "node:fs";
 import * as NodePath from "node:path";
-import {
-  getSubagentMessages,
-  type SessionMessage,
-  type SessionStoreEntry,
-} from "@anthropic-ai/claude-agent-sdk";
 import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
-import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+import {
+  agentHistoryEntry,
+  boundedHistoryJson,
+  boundedHistoryText,
+  collectAgentHistory,
+  type BoundedHistoryText,
+} from "./agentHistory.ts";
+
+const MAX_TRANSCRIPT_BYTES = 8 * 1024 * 1024;
+const MAX_TRANSCRIPT_RECORDS = 50_000;
+const MAX_TRANSCRIPT_LINE_BYTES = 1024 * 1024;
+const TRANSCRIPT_READ_CHUNK_BYTES = 64 * 1024;
 
 const isAgentId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9_-]+$/)));
 const isSessionId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9-]+$/)));
@@ -17,6 +23,13 @@ const isSessionId = Schema.is(Schema.String.check(Schema.isPattern(/^[a-zA-Z0-9-
 const decodeTranscriptEntry = Schema.decodeUnknownSync(
   Schema.fromJsonString(Schema.Struct({ type: Schema.String })),
   { onExcessProperty: "preserve" },
+);
+const decodeHistoryMessage = Schema.decodeUnknownOption(
+  Schema.Struct({
+    type: Schema.Literals(["user", "assistant"]),
+    uuid: Schema.String,
+    message: Schema.Unknown,
+  }),
 );
 const ContentBlock = Schema.Struct({
   type: Schema.String,
@@ -69,6 +82,48 @@ async function isDirectory(path: string) {
   }
 }
 
+/** Stream only complete bounded JSONL records and never read bytes appended after the initial stat. */
+async function* transcriptLines(
+  handle: NodeFSP.FileHandle,
+  size: number,
+): AsyncGenerator<{ readonly text: string; readonly complete: boolean }> {
+  const buffer = Buffer.allocUnsafe(TRANSCRIPT_READ_CHUNK_BYTES);
+  let pending = Buffer.alloc(0);
+  let droppingOversizedLine = false;
+  let position = 0;
+  while (position < size) {
+    const length = Math.min(buffer.length, size - position);
+    const { bytesRead } = await handle.read(buffer, 0, length, position);
+    if (bytesRead === 0) break;
+    position += bytesRead;
+    let start = 0;
+    for (let index = 0; index < bytesRead; index++) {
+      if (buffer[index] !== 10) continue;
+      const fragment = buffer.subarray(start, index);
+      if (!droppingOversizedLine && pending.length + fragment.length <= MAX_TRANSCRIPT_LINE_BYTES) {
+        const line =
+          pending.length === 0
+            ? fragment.toString("utf8")
+            : Buffer.concat([pending, fragment]).toString("utf8");
+        if (line.trim()) yield { text: line, complete: true };
+      }
+      pending = Buffer.alloc(0);
+      droppingOversizedLine = false;
+      start = index + 1;
+    }
+    const tail = buffer.subarray(start, bytesRead);
+    if (droppingOversizedLine) continue;
+    if (pending.length + tail.length > MAX_TRANSCRIPT_LINE_BYTES) {
+      pending = Buffer.alloc(0);
+      droppingOversizedLine = true;
+    } else if (tail.length > 0) {
+      pending = pending.length === 0 ? Buffer.from(tail) : Buffer.concat([pending, tail]);
+    }
+  }
+  if (!droppingOversizedLine && pending.length > 0)
+    yield { text: pending.toString("utf8"), complete: false };
+}
+
 /** Find only regular child transcripts inside the persisted parent's directory. */
 async function findTranscript(
   directory: string,
@@ -88,16 +143,20 @@ async function findTranscript(
 }
 
 /** Extract only textual tool results; image and other binary blocks are not activity text. */
-function resultText(content: unknown): string {
-  if (typeof content === "string") return content;
+function resultText(content: unknown): BoundedHistoryText {
+  if (typeof content === "string") return boundedHistoryText([content]);
   const blocks = decodeTextContent(content);
   return blocks._tag === "Some"
-    ? blocks.value.flatMap((block) => (block.text ? [block.text] : [])).join("\n")
-    : "";
+    ? boundedHistoryText(blocks.value.flatMap((block) => (block.text ? [block.text] : [])))
+    : { text: "", truncated: false };
 }
 
 /** Skip unsupported transcript records while retaining the rest of the saved conversation. */
-export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry[] {
+export function claudeHistoryEntries(message: {
+  readonly type: "user" | "assistant";
+  readonly uuid: string;
+  readonly message: unknown;
+}): AgentHistoryEntry[] {
   const decoded = decodeMessage(message.message);
   if (decoded._tag === "None") return [];
   const { content } = decoded.value;
@@ -140,31 +199,36 @@ export function claudeHistoryEntries(message: SessionMessage): AgentHistoryEntry
           typeof block.input.file_path === "string"
             ? block.input.file_path
             : null;
+        const detail = boundedHistoryJson(block.input ?? {});
         return [
           agentHistoryEntry(
             id,
             fileEdit ? "file-edit" : "tool",
             fileEdit && path ? `Edit ${path}` : (block.name ?? "Tool"),
-            JSON.stringify(block.input ?? {}, null, 2),
+            detail.text,
+            detail.truncated,
           ),
         ];
       }
-      case "tool_result":
+      case "tool_result": {
+        const detail = resultText(block.content);
         return [
           agentHistoryEntry(
             id,
             "tool",
             block.is_error ? "Tool error" : "Tool result",
-            resultText(block.content),
+            detail.text,
+            detail.truncated,
           ),
         ];
+      }
       default:
         return [];
     }
   });
 }
 
-/** The SDK rebuilds the conversation chain. A read-only store keeps its reads instance-local. */
+/** Stream a bounded child transcript and stop as soon as the requested page is complete. */
 export async function readClaudeAgentHistory(input: {
   configDir: string;
   sessionId: string;
@@ -198,42 +262,32 @@ export async function readClaudeAgentHistory(input: {
     transcript,
     NodeFS.constants.O_RDONLY | NodeFS.constants.O_NOFOLLOW,
   );
-  let contents: string;
   try {
     const stat = await handle.stat();
     if (!stat.isFile()) return unavailable("The agent transcript is not a regular file.");
-    if (stat.size > 64 * 1024 * 1024)
+    if (stat.size > MAX_TRANSCRIPT_BYTES)
       return unavailable("This agent transcript is too large to load.");
-    contents = await handle.readFile("utf8");
+    const page = collectAgentHistory(input);
+    let decodedRecords = 0;
+    for await (const line of transcriptLines(handle, stat.size)) {
+      let entry: ReturnType<typeof decodeTranscriptEntry>;
+      try {
+        entry = decodeTranscriptEntry(line.text);
+      } catch (error) {
+        // A running Claude process may still be writing the final JSONL record.
+        if (!line.complete) break;
+        throw error;
+      }
+      if (++decodedRecords > MAX_TRANSCRIPT_RECORDS)
+        return unavailable("This agent transcript has too many records to load.");
+      const message = decodeHistoryMessage(entry);
+      if (message._tag === "None") continue;
+      for (const historyEntry of claudeHistoryEntries(message.value)) {
+        if (page.add(historyEntry)) return page.result();
+      }
+    }
+    return page.result();
   } finally {
     await handle.close();
   }
-  const lines = contents.split("\n");
-  const entries: SessionStoreEntry[] = [];
-  for (let index = 0; index < lines.length; index++) {
-    const line = lines[index]!;
-    if (!line.trim()) continue;
-    try {
-      entries.push(decodeTranscriptEntry(line));
-    } catch (error) {
-      // A running Claude process may still be writing the last JSONL record.
-      if (index === lines.length - 1 && !contents.endsWith("\n")) break;
-      throw error;
-    }
-  }
-  const messages = await getSubagentMessages(input.sessionId, input.agentId, {
-    sessionStore: {
-      append: async () => {
-        throw new Error("Agent history is read-only.");
-      },
-      load: async () => entries,
-    },
-  });
-  const page = collectAgentHistory(input);
-  for (const message of messages) {
-    for (const entry of claudeHistoryEntries(message)) {
-      if (page.add(entry)) return page.result();
-    }
-  }
-  return page.result();
 }

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import type { V2ThreadReadResponse } from "effect-codex-app-server/schema";
+import { OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { codexHistoryEntry, readCodexAgentHistory } from "./codexAgentHistory.ts";
+
+const isAgentHistoryResult = Schema.is(OrchestrationGetAgentHistoryResult);
+
+/** Build native snapshots with explicit ancestry and enough items to exercise page boundaries. */
+function thread(id: string, parent: string | null, count = 1): V2ThreadReadResponse {
+  return {
+    thread: {
+      id,
+      cliVersion: "test",
+      createdAt: 0,
+      updatedAt: 0,
+      cwd: "/workspace",
+      ephemeral: false,
+      modelProvider: "openai",
+      preview: "",
+      sessionId: "session",
+      status: { type: "idle" },
+      source: parent
+        ? { subAgent: { thread_spawn: { parent_thread_id: parent, depth: 1 } } }
+        : "appServer",
+      turns: [
+        {
+          id: "turn",
+          status: "completed",
+          error: null,
+          items: Array.from({ length: count }, (_, index) => ({
+            id: `item-${index}`,
+            type: "commandExecution" as const,
+            command: `read file ${index}`,
+            cwd: "/workspace",
+            commandActions: [],
+            status: "completed" as const,
+            exitCode: 0,
+            aggregatedOutput: "x".repeat(9000),
+          })),
+        },
+      ],
+    },
+  };
+}
+
+describe("saved Codex agent history", () => {
+  it("labels file edits with their paths while preserving the patch for expansion", () => {
+    expect(
+      codexHistoryEntry({
+        type: "fileChange",
+        id: "edit",
+        status: "completed",
+        changes: [
+          { path: "src/X.jsx", kind: { type: "update", move_path: null }, diff: "-old\n+new" },
+        ],
+      }),
+    ).toMatchObject({
+      kind: "file-edit",
+      title: "Edit src/X.jsx",
+      detail: "src/X.jsx\n-old\n+new",
+    });
+  });
+  it("uses native reasoning text when no summary is supplied and omits empty markers", () => {
+    expect(
+      codexHistoryEntry({
+        type: "reasoning",
+        id: "r",
+        summary: [],
+        content: ["Checking the schema."],
+      }),
+    ).toMatchObject({ title: "Reasoning", detail: "Checking the schema." });
+    expect(
+      codexHistoryEntry({
+        type: "reasoning",
+        id: "r",
+        summary: ["Reviewing validation."],
+        content: ["Other text"],
+      }),
+    ).toMatchObject({ title: "Reasoning summary", detail: "Reviewing validation." });
+    expect(
+      codexHistoryEntry({ type: "reasoning", id: "r", summary: [" "], content: [] }),
+    ).toBeNull();
+  });
+  it.effect("reads a stopped nested child's history with bounded, nonoverlapping pages", () =>
+    Effect.gen(function* () {
+      const calls: Array<[string, boolean]> = [];
+      const readThread = (id: string, includeTurns: boolean) => {
+        calls.push([id, includeTurns]);
+        return Effect.succeed(thread(id, id === "child" ? "coordinator" : "parent", 53));
+      };
+      const first = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 0,
+        readThread,
+      });
+      expect(calls).toEqual([
+        ["child", false],
+        ["coordinator", false],
+        ["child", true],
+      ]);
+      expect(first.entries).toHaveLength(50);
+      expect(first.nextOffset).toBe(50);
+      expect(first.entries[0]?.truncated).toBe(true);
+      expect(first.entries[0]?.detail).toHaveLength(8000);
+      expect(isAgentHistoryResult(first)).toBe(true);
+      const next = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: first.nextOffset!,
+        readThread,
+      });
+      expect(next.entries.map((entry) => entry.id)).toEqual([
+        "turn:item-50",
+        "turn:item-51",
+        "turn:item-52",
+      ]);
+      expect(next.nextOffset).toBeNull();
+    }),
+  );
+
+  for (const scenario of ["unrelated", "cycle", "parent"] as const) {
+    it.effect(`rejects ${scenario} without loading conversation content`, () =>
+      Effect.gen(function* () {
+        const calls: boolean[] = [];
+        const result = yield* readCodexAgentHistory({
+          parentThreadId: "parent",
+          agentId: scenario === "parent" ? "parent" : "child",
+          offset: 0,
+          readThread: (id, includeTurns) => {
+            calls.push(includeTurns);
+            return Effect.succeed(thread(id, scenario === "cycle" ? "child" : null));
+          },
+        });
+        expect(result.status).toBe("unavailable");
+        expect(result.entries).toEqual([]);
+        expect(calls).not.toContain(true);
+      }),
+    );
+  }
+
+  it.effect("surfaces provider read failures instead of claiming there is no activity", () =>
+    Effect.gen(function* () {
+      const error = new Error("history missing");
+      const result = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 0,
+        readThread: () => Effect.fail(error),
+      }).pipe(Effect.flip);
+      expect(result).toBe(error);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -98,6 +98,18 @@ describe("saved Codex agent history", () => {
     expect(entry?.detail.length).toBeLessThanOrEqual(8000);
     expect(entry?.truncated).toBe(true);
   });
+  it("keeps command history readable when Codex omits aggregated output", () => {
+    expect(
+      codexHistoryEntry({
+        type: "commandExecution",
+        id: "command",
+        command: "pwd",
+        cwd: "/workspace",
+        commandActions: [],
+        status: "inProgress",
+      }),
+    ).toMatchObject({ kind: "tool", title: "pwd", detail: "" });
+  });
   it.effect("reads a stopped nested child's history with bounded, nonoverlapping pages", () =>
     Effect.gen(function* () {
       const calls: Array<[string, boolean]> = [];

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -156,6 +156,29 @@ describe("saved Codex agent history", () => {
     );
   }
 
+  it.effect("rejects a descendant of an unrelated parent thread", () =>
+    Effect.gen(function* () {
+      const parents: Record<string, string | null> = {
+        child: "other-coordinator",
+        "other-coordinator": "other-parent",
+        "other-parent": null,
+      };
+      const calls: boolean[] = [];
+      const result = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 0,
+        readThread: (id, includeTurns) => {
+          calls.push(includeTurns);
+          return Effect.succeed(thread(id, parents[id] ?? null));
+        },
+      });
+      expect(result.status).toBe("unavailable");
+      expect(result.entries).toEqual([]);
+      expect(calls).not.toContain(true);
+    }),
+  );
+
   it.effect("surfaces provider read failures instead of claiming there is no activity", () =>
     Effect.gen(function* () {
       const error = new Error("history missing");

--- a/apps/server/src/provider/Layers/codexAgentHistory.test.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.test.ts
@@ -83,6 +83,21 @@ describe("saved Codex agent history", () => {
       codexHistoryEntry({ type: "reasoning", id: "r", summary: [" "], content: [] }),
     ).toBeNull();
   });
+  it("bounds MCP payloads before serializing them", () => {
+    const entry = codexHistoryEntry({
+      type: "mcpToolCall",
+      id: "mcp",
+      server: "test",
+      tool: "large-result",
+      arguments: { rows: Array.from({ length: 1000 }, () => "x".repeat(2000)) },
+      durationMs: 1,
+      error: null,
+      result: null,
+      status: "completed",
+    });
+    expect(entry?.detail.length).toBeLessThanOrEqual(8000);
+    expect(entry?.truncated).toBe(true);
+  });
   it.effect("reads a stopped nested child's history with bounded, nonoverlapping pages", () =>
     Effect.gen(function* () {
       const calls: Array<[string, boolean]> = [];
@@ -151,6 +166,48 @@ describe("saved Codex agent history", () => {
         readThread: () => Effect.fail(error),
       }).pipe(Effect.flip);
       expect(result).toBe(error);
+    }),
+  );
+
+  it.effect("does not normalize entries before a requested offset", () =>
+    Effect.gen(function* () {
+      const snapshot = thread("child", "parent", 0);
+      const argumentsWithThrowingGetter = Object.defineProperty({}, "payload", {
+        enumerable: true,
+        get() {
+          throw new Error("skipped payload was read");
+        },
+      });
+      snapshot.thread.turns[0]!.items = [
+        {
+          type: "mcpToolCall",
+          id: "skipped",
+          server: "test",
+          tool: "skipped",
+          arguments: argumentsWithThrowingGetter,
+          durationMs: 1,
+          error: null,
+          result: null,
+          status: "completed",
+        },
+        {
+          id: "visible",
+          type: "commandExecution",
+          command: "read visible",
+          cwd: "/workspace",
+          commandActions: [],
+          status: "completed",
+          exitCode: 0,
+          aggregatedOutput: "visible output",
+        },
+      ];
+      const result = yield* readCodexAgentHistory({
+        parentThreadId: "parent",
+        agentId: "child",
+        offset: 1,
+        readThread: () => Effect.succeed(snapshot),
+      });
+      expect(result.entries.map((entry) => entry.id)).toEqual(["turn:visible"]);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -1,0 +1,140 @@
+import type { AgentHistoryEntry, OrchestrationGetAgentHistoryResult } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import type {
+  V2ThreadReadResponse,
+  V2ThreadReadResponse__ThreadItem,
+} from "effect-codex-app-server/schema";
+
+import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+
+/** Normalize native items for all history views, preserving displayable reasoning and bounded tool detail. */
+export function codexHistoryEntry(
+  item: V2ThreadReadResponse__ThreadItem,
+): AgentHistoryEntry | null {
+  switch (item.type) {
+    case "userMessage":
+      return agentHistoryEntry(
+        item.id,
+        "user",
+        "Prompt",
+        item.content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n"),
+      );
+    case "agentMessage":
+      return agentHistoryEntry(item.id, "assistant", "Agent", item.text);
+    case "reasoning": {
+      const summary = (item.summary ?? []).join("\n").trim();
+      const content = (item.content ?? []).join("\n").trim();
+      if (!summary && !content) return null;
+      return agentHistoryEntry(
+        item.id,
+        "reasoning",
+        summary ? "Reasoning summary" : "Reasoning",
+        summary || content,
+      );
+    }
+    case "plan":
+      return agentHistoryEntry(item.id, "assistant", "Plan", item.text);
+    case "commandExecution":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        item.command,
+        [
+          item.aggregatedOutput,
+          item.exitCode === null || item.exitCode === undefined
+            ? null
+            : `Exit code: ${item.exitCode}`,
+        ]
+          .filter((value) => value !== null && value !== undefined)
+          .join("\n"),
+      );
+    case "fileChange":
+      return agentHistoryEntry(
+        item.id,
+        "file-edit",
+        `Edit ${item.changes.map((change) => change.path).join(", ")}`,
+        item.changes.map((change) => `${change.path}\n${change.diff}`).join("\n\n"),
+      );
+    case "mcpToolCall":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        `${item.server}: ${item.tool}`,
+        JSON.stringify(
+          { arguments: item.arguments, result: item.result, error: item.error },
+          null,
+          2,
+        ),
+      );
+    case "dynamicToolCall":
+      return agentHistoryEntry(
+        item.id,
+        "tool",
+        item.tool,
+        JSON.stringify({ arguments: item.arguments, result: item.contentItems }, null, 2),
+      );
+    case "webSearch":
+      return agentHistoryEntry(item.id, "tool", `Search: ${item.query}`);
+    case "collabAgentToolCall":
+      return agentHistoryEntry(item.id, "tool", item.tool, item.prompt ?? item.status);
+    case "imageView":
+      return agentHistoryEntry(item.id, "tool", `View image: ${item.path}`);
+    case "imageGeneration":
+      return agentHistoryEntry(item.id, "tool", "Generate image", item.savedPath ?? item.status);
+    case "enteredReviewMode":
+    case "exitedReviewMode":
+      return agentHistoryEntry(item.id, "assistant", "Review", item.review);
+    default:
+      return null;
+  }
+}
+
+/** Report an unverified child without returning any of its saved content. */
+const unavailable = (message: string): OrchestrationGetAgentHistoryResult => ({
+  status: "unavailable",
+  entries: [],
+  nextOffset: null,
+  message,
+});
+
+/** Verify native ancestry before reading content, including nested children. No resume/start calls. */
+export const readCodexAgentHistory = Effect.fn("readCodexAgentHistory")(function* <E>(input: {
+  parentThreadId: string;
+  agentId: string;
+  offset: number;
+  view?: "recent-tools" | "latest" | undefined;
+  readThread: (threadId: string, includeTurns: boolean) => Effect.Effect<V2ThreadReadResponse, E>;
+}) {
+  const seen = new Set<string>([input.parentThreadId]);
+  let currentId = input.agentId;
+  let belongsToParent = false;
+  for (let depth = 0; depth < 32; depth++) {
+    if (seen.has(currentId)) break;
+    seen.add(currentId);
+    const { thread } = yield* input.readThread(currentId, false);
+    const source = thread.source;
+    if (
+      typeof source !== "object" ||
+      !("subAgent" in source) ||
+      typeof source.subAgent !== "object" ||
+      !("thread_spawn" in source.subAgent)
+    )
+      break;
+    currentId = source.subAgent.thread_spawn.parent_thread_id;
+    if (currentId === input.parentThreadId) {
+      belongsToParent = true;
+      break;
+    }
+  }
+  if (!belongsToParent)
+    return unavailable("This agent does not belong to the saved provider session.");
+  const { thread } = yield* input.readThread(input.agentId, true);
+  const page = collectAgentHistory(input);
+  for (const turn of thread.turns) {
+    for (const item of turn.items) {
+      const entry = codexHistoryEntry(item);
+      if (entry && page.add({ ...entry, id: `${turn.id}:${entry.id}` })) return page.result();
+    }
+  }
+  return page.result();
+});

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -5,74 +5,119 @@ import type {
   V2ThreadReadResponse__ThreadItem,
 } from "effect-codex-app-server/schema";
 
-import { agentHistoryEntry, collectAgentHistory } from "./agentHistory.ts";
+import {
+  agentHistoryEntry,
+  boundedHistoryJson,
+  boundedHistoryText,
+  collectAgentHistory,
+} from "./agentHistory.ts";
+
+/** Identify entries that count toward pagination without serializing their payloads. */
+function hasCodexHistoryEntry(item: V2ThreadReadResponse__ThreadItem): boolean {
+  if (item.type === "reasoning")
+    return (
+      (item.summary ?? []).some((part) => part.trim()) ||
+      (item.content ?? []).some((part) => part.trim())
+    );
+  return (
+    item.type === "userMessage" ||
+    item.type === "agentMessage" ||
+    item.type === "plan" ||
+    item.type === "commandExecution" ||
+    item.type === "fileChange" ||
+    item.type === "mcpToolCall" ||
+    item.type === "dynamicToolCall" ||
+    item.type === "webSearch" ||
+    item.type === "collabAgentToolCall" ||
+    item.type === "imageView" ||
+    item.type === "imageGeneration" ||
+    item.type === "enteredReviewMode" ||
+    item.type === "exitedReviewMode"
+  );
+}
+
+/** Yield file edits lazily so a large change list cannot create an unbounded intermediate string. */
+function* fileChangeDetails(
+  item: Extract<V2ThreadReadResponse__ThreadItem, { type: "fileChange" }>,
+) {
+  for (const change of item.changes) yield `${change.path}\n${change.diff}`;
+}
+
+/** Yield file paths lazily so history titles remain bounded for large change lists. */
+function* fileChangePaths(item: Extract<V2ThreadReadResponse__ThreadItem, { type: "fileChange" }>) {
+  for (const change of item.changes) yield change.path;
+}
 
 /** Normalize native items for all history views, preserving displayable reasoning and bounded tool detail. */
 export function codexHistoryEntry(
   item: V2ThreadReadResponse__ThreadItem,
 ): AgentHistoryEntry | null {
   switch (item.type) {
-    case "userMessage":
-      return agentHistoryEntry(
-        item.id,
-        "user",
-        "Prompt",
-        item.content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n"),
+    case "userMessage": {
+      const detail = boundedHistoryText(
+        item.content.flatMap((part) => (part.type === "text" ? [part.text] : [])),
       );
+      return agentHistoryEntry(item.id, "user", "Prompt", detail.text, detail.truncated);
+    }
     case "agentMessage":
       return agentHistoryEntry(item.id, "assistant", "Agent", item.text);
     case "reasoning": {
-      const summary = (item.summary ?? []).join("\n").trim();
-      const content = (item.content ?? []).join("\n").trim();
-      if (!summary && !content) return null;
+      const summary = boundedHistoryText(item.summary ?? []);
+      const detail = summary.text.trim() ? summary : boundedHistoryText(item.content ?? []);
+      if (!detail.text.trim()) return null;
       return agentHistoryEntry(
         item.id,
         "reasoning",
-        summary ? "Reasoning summary" : "Reasoning",
-        summary || content,
+        summary.text.trim() ? "Reasoning summary" : "Reasoning",
+        detail.text.trim(),
+        detail.truncated,
       );
     }
     case "plan":
       return agentHistoryEntry(item.id, "assistant", "Plan", item.text);
-    case "commandExecution":
-      return agentHistoryEntry(
-        item.id,
-        "tool",
-        item.command,
+    case "commandExecution": {
+      const detail = boundedHistoryText(
         [
           item.aggregatedOutput,
           item.exitCode === null || item.exitCode === undefined
             ? null
             : `Exit code: ${item.exitCode}`,
-        ]
-          .filter((value) => value !== null && value !== undefined)
-          .join("\n"),
+        ].filter((value): value is string => value !== null),
       );
-    case "fileChange":
+      return agentHistoryEntry(item.id, "tool", item.command, detail.text, detail.truncated);
+    }
+    case "fileChange": {
+      const paths = boundedHistoryText(fileChangePaths(item), ", ");
+      const detail = boundedHistoryText(fileChangeDetails(item), "\n\n");
       return agentHistoryEntry(
         item.id,
         "file-edit",
-        `Edit ${item.changes.map((change) => change.path).join(", ")}`,
-        item.changes.map((change) => `${change.path}\n${change.diff}`).join("\n\n"),
+        `Edit ${paths.text}`,
+        detail.text,
+        paths.truncated || detail.truncated,
       );
-    case "mcpToolCall":
+    }
+    case "mcpToolCall": {
+      const detail = boundedHistoryJson({
+        arguments: item.arguments,
+        result: item.result,
+        error: item.error,
+      });
       return agentHistoryEntry(
         item.id,
         "tool",
         `${item.server}: ${item.tool}`,
-        JSON.stringify(
-          { arguments: item.arguments, result: item.result, error: item.error },
-          null,
-          2,
-        ),
+        detail.text,
+        detail.truncated,
       );
-    case "dynamicToolCall":
-      return agentHistoryEntry(
-        item.id,
-        "tool",
-        item.tool,
-        JSON.stringify({ arguments: item.arguments, result: item.contentItems }, null, 2),
-      );
+    }
+    case "dynamicToolCall": {
+      const detail = boundedHistoryJson({
+        arguments: item.arguments,
+        result: item.contentItems,
+      });
+      return agentHistoryEntry(item.id, "tool", item.tool, detail.text, detail.truncated);
+    }
     case "webSearch":
       return agentHistoryEntry(item.id, "tool", `Search: ${item.query}`);
     case "collabAgentToolCall":
@@ -129,9 +174,14 @@ export const readCodexAgentHistory = Effect.fn("readCodexAgentHistory")(function
   if (!belongsToParent)
     return unavailable("This agent does not belong to the saved provider session.");
   const { thread } = yield* input.readThread(input.agentId, true);
-  const page = collectAgentHistory(input);
+  let skippedEntries = 0;
+  const page = collectAgentHistory(input, input.view === undefined ? input.offset : 0);
   for (const turn of thread.turns) {
     for (const item of turn.items) {
+      if (input.view === undefined && skippedEntries < input.offset && hasCodexHistoryEntry(item)) {
+        skippedEntries++;
+        continue;
+      }
       const entry = codexHistoryEntry(item);
       if (entry && page.add({ ...entry, id: `${turn.id}:${entry.id}` })) return page.result();
     }

--- a/apps/server/src/provider/Layers/codexAgentHistory.ts
+++ b/apps/server/src/provider/Layers/codexAgentHistory.ts
@@ -82,7 +82,7 @@ export function codexHistoryEntry(
           item.exitCode === null || item.exitCode === undefined
             ? null
             : `Exit code: ${item.exitCode}`,
-        ].filter((value): value is string => value !== null),
+        ].filter((value): value is string => typeof value === "string"),
       );
       return agentHistoryEntry(item.id, "tool", item.command, detail.text, detail.truncated);
     }

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -8,6 +8,8 @@
  * @module ProviderAdapter
  */
 import type {
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
   ApprovalRequestId,
   ProviderApprovalDecision,
   ProviderDriverKind,
@@ -126,9 +128,15 @@ export interface ProviderAdapterShape<TError> {
    */
   readonly hasSession: (threadId: ThreadId) => Effect.Effect<boolean>;
 
-  /**
-   * Read a provider thread snapshot.
-   */
+  /** Omitted when this provider cannot retrieve saved child history. Never resumes a session. */
+  readonly getAgentHistory?: (
+    input: OrchestrationGetAgentHistoryInput & {
+      readonly resumeCursor: unknown;
+      readonly cwd?: string | undefined;
+    },
+  ) => Effect.Effect<OrchestrationGetAgentHistoryResult, TError>;
+
+  /** Read a provider thread snapshot. */
   readonly readThread: (threadId: ThreadId) => Effect.Effect<ProviderThreadSnapshot, TError>;
 
   /**

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -12,6 +12,8 @@
  * @module ProviderService
  */
 import type {
+  OrchestrationGetAgentHistoryInput,
+  OrchestrationGetAgentHistoryResult,
   ProviderInterruptTurnInput,
   ProviderInstanceId,
   ProviderRespondToRequestInput,
@@ -121,9 +123,12 @@ export interface ProviderServiceShape {
     readonly numTurns: number;
   }) => Effect.Effect<void, ProviderServiceError>;
 
-  /**
-   * Upload a thread and return the provider's shareable feedback identifier.
-   */
+  /** Read saved child history without recovering or resuming the parent session. */
+  readonly getAgentHistory: (
+    input: OrchestrationGetAgentHistoryInput,
+  ) => Effect.Effect<OrchestrationGetAgentHistoryResult, ProviderServiceError>;
+
+  /** Upload a thread and return the provider's shareable feedback identifier. */
   readonly uploadFeedback: (
     input: ProviderUploadFeedbackInput,
   ) => Effect.Effect<ProviderUploadFeedbackResult, ProviderServiceError>;

--- a/apps/server/src/serverRuntimeStartup.reconcile.test.ts
+++ b/apps/server/src/serverRuntimeStartup.reconcile.test.ts
@@ -68,6 +68,7 @@ const makeProviderService = (liveThreadIds: ReadonlyArray<ThreadId> = []) =>
     assertConversationRollbackSupported: () => Effect.die("unused"),
     getInstanceInfo: () => Effect.die("unused"),
     rollbackConversation: () => Effect.die("unused"),
+    getAgentHistory: () => Effect.die("unused"),
     uploadFeedback: () => Effect.die("unused"),
     streamEvents: Stream.empty,
   }) satisfies ProviderService.ProviderService["Service"];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -43,6 +43,7 @@ import {
   OrchestrationSearchThreadsError,
   OrchestrationGetTurnDiffError,
   ORCHESTRATION_WS_METHODS,
+  OrchestrationGetAgentHistoryError,
   ProjectId,
   type ProjectEntriesFailure,
   type ProjectFileFailure,
@@ -1394,6 +1395,19 @@ const makeWsRpcLayer = (
                       message: "Failed to dispatch orchestration command",
                       cause,
                     }),
+              ),
+            ),
+            { "rpc.aggregate": "orchestration" },
+          ),
+        [ORCHESTRATION_WS_METHODS.getAgentHistory]: (input) =>
+          observeRpcEffect(
+            ORCHESTRATION_WS_METHODS.getAgentHistory,
+            providerService.getAgentHistory(input).pipe(
+              Effect.mapError(
+                () =>
+                  new OrchestrationGetAgentHistoryError({
+                    message: "Could not load agent history from this environment.",
+                  }),
               ),
             ),
             { "rpc.aggregate": "orchestration" },

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -34,6 +34,7 @@ import {
 export const ORCHESTRATION_WS_METHODS = {
   dispatchCommand: "orchestration.dispatchCommand",
   getWorkflowScript: "orchestration.getWorkflowScript",
+  getAgentHistory: "orchestration.getAgentHistory",
   getTurnDiff: "orchestration.getTurnDiff",
   getFullThreadDiff: "orchestration.getFullThreadDiff",
   searchThreads: "orchestration.searchThreads",
@@ -2126,6 +2127,38 @@ export const OrchestrationSearchThreadsResult = Schema.Struct({
 });
 export type OrchestrationSearchThreadsResult = typeof OrchestrationSearchThreadsResult.Type;
 
+/** Provider history is read on demand, independently of retained thread activities. */
+export const OrchestrationGetAgentHistoryInput = Schema.Struct({
+  threadId: ThreadId,
+  agentId: TrimmedNonEmptyString.check(Schema.isMaxLength(256)),
+  offset: NonNegativeInt,
+  view: Schema.optional(Schema.Literals(["recent-tools", "latest"])),
+});
+export type OrchestrationGetAgentHistoryInput = typeof OrchestrationGetAgentHistoryInput.Type;
+
+export const AgentHistoryEntry = Schema.Struct({
+  id: Schema.String,
+  kind: Schema.Literals(["tool", "file-edit", "assistant", "user", "reasoning"]),
+  title: Schema.String.check(Schema.isMaxLength(500)),
+  detail: Schema.String.check(Schema.isMaxLength(8000)),
+  truncated: Schema.Boolean,
+});
+export type AgentHistoryEntry = typeof AgentHistoryEntry.Type;
+
+export const OrchestrationGetAgentHistoryResult = Schema.Struct({
+  status: Schema.Literals(["ready", "unavailable", "unsupported"]),
+  entries: Schema.Array(AgentHistoryEntry).check(Schema.isMaxLength(50)),
+  nextOffset: Schema.NullOr(NonNegativeInt),
+  startOffset: Schema.optional(NonNegativeInt),
+  message: Schema.NullOr(Schema.String),
+});
+export type OrchestrationGetAgentHistoryResult = typeof OrchestrationGetAgentHistoryResult.Type;
+
+export class OrchestrationGetAgentHistoryError extends Schema.TaggedError<OrchestrationGetAgentHistoryError>()(
+  "OrchestrationGetAgentHistoryError",
+  { message: Schema.String },
+) {}
+
 export const OrchestrationGetWorkflowScriptInput = Schema.Struct({
   threadId: ThreadId,
   /** Absolute path from the workflow's runHandles.scriptPath. The server
@@ -2178,6 +2211,10 @@ export const OrchestrationRpcSchemas = {
   dispatchCommand: {
     input: ClientOrchestrationCommand,
     output: DispatchResult,
+  },
+  getAgentHistory: {
+    input: OrchestrationGetAgentHistoryInput,
+    output: OrchestrationGetAgentHistoryResult,
   },
   getWorkflowScript: {
     input: OrchestrationGetWorkflowScriptInput,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -92,6 +92,7 @@ import {
   OrchestrationGetTurnDiffInput,
   OrchestrationRpcSchemas,
   OrchestrationGetWorkflowScriptError,
+  OrchestrationGetAgentHistoryError,
 } from "./orchestration.ts";
 import {
   ProviderUploadFeedbackError,
@@ -1163,6 +1164,12 @@ const WsOrchestrationDispatchCommandRpc = Rpc.make(ORCHESTRATION_WS_METHODS.disp
   error: Schema.Union([OrchestrationDispatchCommandError, EnvironmentAuthorizationError]),
 });
 
+const WsOrchestrationGetAgentHistoryRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getAgentHistory, {
+  payload: OrchestrationRpcSchemas.getAgentHistory.input,
+  success: OrchestrationRpcSchemas.getAgentHistory.output,
+  error: Schema.Union([OrchestrationGetAgentHistoryError, EnvironmentAuthorizationError]),
+});
+
 const WsOrchestrationGetWorkflowScriptRpc = Rpc.make(ORCHESTRATION_WS_METHODS.getWorkflowScript, {
   payload: OrchestrationRpcSchemas.getWorkflowScript.input,
   success: OrchestrationRpcSchemas.getWorkflowScript.output,
@@ -1403,6 +1410,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscribeResourceTelemetryRpc,
   WsOrchestrationDispatchCommandRpc,
   WsOrchestrationGetWorkflowScriptRpc,
+  WsOrchestrationGetAgentHistoryRpc,
   WsOrchestrationGetTurnDiffRpc,
   WsOrchestrationGetFullThreadDiffRpc,
   WsOrchestrationSearchThreadsRpc,


### PR DESCRIPTION
Agent cards can identify provider child agents, but retained parent-thread activities do not contain their complete saved history. That leaves the client with no reliable way to inspect a Codex or Claude child after activity has been summarized or dropped.

This adds an authenticated, read-only `orchestration.getAgentHistory` RPC routed through the thread's persisted provider binding without recovering or resuming the parent session. Codex reads the native child thread with `thread/read` after verifying its ancestry. Claude reads the SDK's saved subagent transcript through a bounded, read-only session store. Both normalize messages, reasoning, tools, and file edits into one paginated contract.

History reads reuse bounded short-lived transports, cap entries and payload sizes, reject unrelated Codex descendants, and constrain Claude transcript traversal to regular files under the configured store. Providers without an implementation return `unsupported` through the same contract.

This is the Codex/Claude server foundation extracted from #10881. The roster redesign is isolated in #11135; client presentation and additional provider adapters can build on this endpoint separately.

Validation: 235 focused tests passed across shared history paging, transport reuse, provider parsing, adapter routing, and provider service behavior. Contracts and server typechecks pass; changed files pass formatting and lint with no errors.

Model: GPT-6 Astra  
Harness: Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent history retrieval for supported Claude and Codex sessions.
  * View recent tools, latest entries, or paginated history with bounded details and truncation indicators.
  * History can be read without restarting sessions or sending new turns.
  * Added authorization and error handling for orchestration requests.
* **Bug Fixes**
  * Improved handling of missing, invalid, incomplete, or unsupported history data.
  * Added validation to prevent unrelated or unsafe nested histories from being accessed.
  * Improved history pagination and formatting for file edits and tool activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->