### PR TITLE
docs: add TheosRules.md with the first rule

### DIFF
--- a/TheosRules.md
+++ b/TheosRules.md
@@ -1,0 +1,7 @@
+# Theo's rules
+
+Rules from Theo about how T3 Code should be built. They apply to every surface: web, desktop, and mobile.
+
+## 1. The interface should not move in ways the user doesn't expect
+
+No animation, transition, layout shift, or reflow unless the user asked for it or can predict it. Content the user is reading or targeting must not jump out from under them. If something must move, the user should be able to see why it moved.


### PR DESCRIPTION
## Problem

Theo's rules for building T3 Code live in conversation, AGENTS.md asides, and people's heads. There is no single file that captures them, so they are easy to miss when reviewing a change.

## Fix

Adds `TheosRules.md` at the repo root, starting with rule 1: **the interface should not move in ways the user doesn't expect.** More rules will stack on top in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added interface guidance recommending that web, desktop, and mobile experiences avoid unexpected animations, transitions, layout shifts, and reflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->