### PR TITLE
fix(desktop): render Markdown throughout question cards

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -5025,6 +5025,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   </ComposerBanner.Row>
                 ) : !isComposerCollapsedMobile && pendingUserInputs.length > 0 ? (
                   <ComposerPendingUserInputPanel
+                    cwd={gitCwd ?? undefined}
+                    threadRef={routeThreadRef}
                     pendingUserInputs={pendingUserInputs}
                     respondingRequestIds={
                       activePendingIsResponding && activePendingUserInput
@@ -5045,6 +5047,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                 ) : isComposerCollapsedMobile && pendingUserInputs.length > 0 ? (
                   <div data-chat-composer-collapsed-controls="true">
                     <ComposerPendingUserInputPanel
+                      cwd={gitCwd ?? undefined}
+                      threadRef={routeThreadRef}
                       pendingUserInputs={pendingUserInputs}
                       respondingRequestIds={
                         activePendingIsResponding && activePendingUserInput

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -8,6 +8,18 @@ import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import type { PendingUserInput } from "../../session-logic";
 import { Collapsible } from "../ui/collapsible";
 
+const linkActions = vi.hoisted(() => ({
+  openExternal: vi.fn(async (_url: string) => {}),
+  toast: vi.fn(),
+}));
+vi.mock("../../localApi", () => ({
+  readLocalApi: () => ({ shell: { openExternal: linkActions.openExternal } }),
+}));
+vi.mock("../ui/toast", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../ui/toast")>()),
+  toastManager: { add: linkActions.toast },
+}));
+
 vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
 vi.mock("../../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
 vi.mock("../../hooks/useSettings", async (importOriginal) => {
@@ -15,6 +27,7 @@ vi.mock("../../hooks/useSettings", async (importOriginal) => {
   const settings = actual.getClientSettings();
   return {
     ...actual,
+    ensureClientSettingsHydrated: async () => {},
     useClientSettings: (select?: (value: typeof settings) => unknown) =>
       select ? select(settings) : settings,
   };
@@ -76,11 +89,11 @@ const prompt: PendingUserInput = {
 };
 
 /** Renders a pending question without mounting client effects for Markdown output assertions. */
-function renderPanel(pendingUserInput: PendingUserInput = prompt, isResponding = false) {
+function renderPanel(pendingUserInput: PendingUserInput = prompt) {
   return renderToStaticMarkup(
     <ComposerPendingUserInputPanel
       pendingUserInputs={[pendingUserInput]}
-      respondingRequestIds={isResponding ? [pendingUserInput.requestId] : []}
+      respondingRequestIds={[]}
       answers={{}}
       questionIndex={0}
       onToggleOption={() => {}}
@@ -136,6 +149,9 @@ describe("ComposerPendingUserInputPanel", () => {
     renderer = undefined;
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    vi.restoreAllMocks();
+    linkActions.openExternal.mockClear();
+    linkActions.toast.mockClear();
   });
 
   it("renders the header as a disclosure control for the question body", () => {
@@ -225,7 +241,7 @@ describe("ComposerPendingUserInputPanel", () => {
           ...prompt.questions[0]!,
           options: [
             {
-              label: "**Bold option**",
+              label: "**Bold option** *emphasis* ~~old~~",
               description: "Use `inline code` and [help](https://example.com/help).",
               value: "provider-choice",
             },
@@ -243,13 +259,14 @@ describe("ComposerPendingUserInputPanel", () => {
 
     expect(markup).toContain("<strong>Bold option</strong>");
     expect(markup).toContain("<code>inline code</code>");
-    expect(markup).toContain('data-pending-user-input-link="true"');
+    expect(markup).toContain("<em>emphasis</em>");
+    expect(markup).toContain("<del>old</del>");
     expect(markup).toContain('href="https://example.com/help"');
     expect(markup).not.toContain('href="javascript:');
     expect(markup).toContain("bad link");
   });
 
-  it("keeps option links separate from selection and auto-advance", async () => {
+  it("submits the original option value and advances only after the selection delay", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("window", {
       setTimeout,
@@ -277,21 +294,6 @@ describe("ComposerPendingUserInputPanel", () => {
       onToggleOption,
       onAdvance,
     );
-
-    const link = renderer.root.findByProps({ "data-pending-user-input-link": true });
-    expect(link.type).toBe("a");
-    expect(link.props.href).toBe("https://example.com/help");
-    // A native link must not live inside a selection button or clickable row.
-    for (let parent = link.parent; parent; parent = parent.parent) {
-      expect(parent.type).not.toBe("button");
-      expect(parent.props.onClick).toBeUndefined();
-    }
-    const stopPropagation = vi.fn();
-    await act(() => link.props.onKeyDown({ key: "Enter", stopPropagation }));
-    expect(stopPropagation).toHaveBeenCalledOnce();
-    await act(() => vi.advanceTimersByTime(200));
-    expect(onToggleOption).not.toHaveBeenCalled();
-    expect(onAdvance).not.toHaveBeenCalled();
 
     const optionButton = renderer.root
       .findAllByType("button")
@@ -339,36 +341,65 @@ describe("ComposerPendingUserInputPanel", () => {
     ).toHaveLength(0);
   });
 
-  it("preserves inline formatting and accessible labels while responding", () => {
-    const markup = renderPanel(
-      {
-        ...prompt,
-        questions: [
-          {
-            ...prompt.questions[0]!,
-            options: [
-              {
-                label: "**Bold** *emphasis* ~~old~~",
-                description: "Read [help](https://example.com/help).",
-              },
-            ],
-          },
-        ],
-      },
-      true,
-    );
-    expect(markup).toContain("<strong>Bold</strong>");
-    expect(markup).toContain("<em>emphasis</em>");
-    expect(markup).toContain("<del>old</del>");
-    const button = markup.match(/<button[^>]*aria-pressed="false"[^>]*>/)?.[0];
-    expect(button).toContain('disabled=""');
-    const labelId = button?.match(/aria-labelledby="([^"]+)"/)?.[1];
-    const descriptionId = button?.match(/aria-describedby="([^"]+)"/)?.[1];
-    expect(labelId).toBeDefined();
-    expect(descriptionId).toBeDefined();
-    expect(markup).toContain(`id="${labelId}"`);
-    expect(markup).toContain(`id="${descriptionId}"`);
-  });
+  it.each([false, true])(
+    "opens option links without answering (opening fails=%s)",
+    async (fails) => {
+      vi.useFakeTimers();
+      vi.stubGlobal("window", { setTimeout, clearTimeout });
+      const onToggleOption = vi.fn();
+      const onAdvance = vi.fn();
+      const error = new Error("Browser unavailable");
+      const reportError = vi.spyOn(console, "error").mockImplementation(() => {});
+      if (fails) linkActions.openExternal.mockRejectedValueOnce(error);
+      const url = "https://example.com/help";
+      // ReactTestRenderer has no DOM. Only the event target's anchor lookup is needed here.
+      class LinkTarget {
+        closest() {
+          return { href: url };
+        }
+      }
+      vi.stubGlobal("Element", LinkTarget);
+      renderer = await renderInteractivePanel(
+        {
+          ...prompt,
+          questions: [
+            { ...prompt.questions[0]!, options: [{ label: `[Help](${url})`, description: "" }] },
+          ],
+        },
+        onToggleOption,
+        onAdvance,
+      );
+      const options = renderer.root.findAllByType("div").find((node) => node.props.onClick)!;
+      const event = {
+        target: new LinkTarget(),
+        defaultPrevented: false,
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        preventDefault: vi.fn(),
+      };
+      await act(async () => options.props.onClick(event));
+      expect(linkActions.openExternal).toHaveBeenCalledExactlyOnceWith(url);
+      await act(() => vi.advanceTimersByTime(200));
+      expect(onToggleOption).not.toHaveBeenCalled();
+      expect(onAdvance).not.toHaveBeenCalled();
+      if (fails) {
+        expect(reportError).toHaveBeenCalledWith(error);
+        expect(linkActions.toast).toHaveBeenCalledWith({
+          type: "error",
+          title: "Unable to open question link",
+        });
+      } else {
+        expect(linkActions.toast).not.toHaveBeenCalled();
+      }
+      // Modified clicks retain the anchor's native browser behavior.
+      event.preventDefault.mockClear();
+      await act(async () => options.props.onClick({ ...event, metaKey: true }));
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(linkActions.openExternal).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([false, true])(
     "keeps raw fallback labels and cleans up auto-advance (multiSelect=%s)",

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -75,6 +75,7 @@ const prompt: PendingUserInput = {
   dismissible: true,
 };
 
+/** Renders a pending question without mounting client effects for Markdown output assertions. */
 function renderPanel(pendingUserInput: PendingUserInput = prompt, isResponding = false) {
   return renderToStaticMarkup(
     <ComposerPendingUserInputPanel
@@ -89,6 +90,7 @@ function renderPanel(pendingUserInput: PendingUserInput = prompt, isResponding =
   );
 }
 
+/** Mounts the card inside act so selection and auto-advance tests observe committed effects. */
 async function renderInteractivePanel(
   pendingUserInput: PendingUserInput,
   onToggleOption: (questionId: string, optionValue: string) => void,
@@ -111,6 +113,7 @@ async function renderInteractivePanel(
   return renderer;
 }
 
+/** Reads rendered text across Markdown wrappers for readable-preview assertions. */
 function textContent(node: ReactTestInstance): string {
   return node.children
     .map((child) => (typeof child === "string" ? child : textContent(child)))

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -1,5 +1,5 @@
 import { ApprovalRequestId } from "@t3tools/contracts";
-import { act } from "react";
+import { act, type ComponentProps, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -7,6 +7,55 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import type { PendingUserInput } from "../../session-logic";
 import { Collapsible } from "../ui/collapsible";
+
+vi.mock("@effect/atom-react", () => ({ useAtomValue: () => null }));
+vi.mock("../../hooks/useTheme", () => ({ useTheme: () => ({ resolvedTheme: "dark" }) }));
+vi.mock("../../hooks/useSettings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/useSettings")>();
+  const settings = actual.getClientSettings();
+  return {
+    ...actual,
+    useClientSettings: (select?: (value: typeof settings) => unknown) =>
+      select ? select(settings) : settings,
+  };
+});
+vi.mock("../ui/tooltip", async () => {
+  const { cloneElement, isValidElement } = await import("react");
+  return {
+    Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+    TooltipTrigger({
+      render,
+      children,
+    }: ComponentProps<typeof import("../ui/tooltip").TooltipTrigger>) {
+      if (!isValidElement(render)) return <>{children}</>;
+      return children === undefined ? render : cloneElement(render, undefined, children);
+    },
+    TooltipPopup: () => null,
+  };
+});
+vi.mock("../../state/use-atom-query-runner", () => ({ useAtomQueryRunner: () => vi.fn() }));
+vi.mock("../../state/use-atom-command", () => ({ useAtomCommand: () => vi.fn() }));
+vi.mock("../../state/session", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../state/session")>()),
+  usePreparedConnection: () => ({ _tag: "Loading" }),
+}));
+vi.mock("../../state/entities", () => ({
+  readThreadShell: () => null,
+  useProjects: () => [],
+  useServerConfigs: () => new Map(),
+}));
+vi.mock("../../remoteOpen", () => ({
+  useRemoteOpenResolution: () => ({ state: { mode: "local-exec" }, isResolved: true }),
+}));
+vi.mock("../../editorPreferences", () => ({
+  useOpenInPreferredEditor: () => vi.fn(),
+  usePreferredEditor: () => [null, vi.fn()],
+}));
+vi.mock("~/lib/openPullRequestLink", () => ({
+  findProjectOnChangeRequestHost: () => undefined,
+  parseChangeRequestUrl: () => null,
+  useOpenChangeRequestLink: () => vi.fn(),
+}));
 
 const prompt: PendingUserInput = {
   requestId: ApprovalRequestId.make("request-1"),
@@ -114,6 +163,28 @@ describe("ComposerPendingUserInputPanel", () => {
     expect(markup).toContain("Which approach should the migration take?");
     expect(markup).toContain("Incremental");
     expect(markup).toContain("Big bang");
+  });
+
+  it("renders expanded questions as Markdown instead of exposing source syntax", () => {
+    const markup = renderPanel({
+      ...prompt,
+      questions: [
+        {
+          ...prompt.questions[0]!,
+          question:
+            "Open [AWS sign-in link](https://example.com/signin?state=example) and confirm **when ready**.\n\n### Checks\n\n- Run `tests`\n\n> Review first.\n\n| Check | Result |\n| --- | --- |\n| Build | Ready |\n\n```text\nready\n```",
+        },
+      ],
+    });
+    expect(markup).toContain('href="https://example.com/signin?state=example"');
+    expect(markup).toContain("<strong>when ready</strong>");
+    expect(markup).toContain("<h3");
+    expect(markup).toContain("<ul");
+    expect(markup).toContain("<blockquote");
+    expect(markup).toContain("<table");
+    expect(markup).toContain("<pre");
+    expect(markup).not.toContain("[AWS sign-in link](");
+    expect(markup).not.toContain("**when ready**");
   });
 
   it("uses readable plain text for the collapsed preview", async () => {

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.test.tsx
@@ -1,9 +1,12 @@
 import { ApprovalRequestId } from "@t3tools/contracts";
+import { act } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vite-plus/test";
+import { create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import type { PendingUserInput } from "../../session-logic";
+import { Collapsible } from "../ui/collapsible";
 
 const prompt: PendingUserInput = {
   requestId: ApprovalRequestId.make("request-1"),
@@ -23,11 +26,11 @@ const prompt: PendingUserInput = {
   dismissible: true,
 };
 
-function renderPanel(pendingUserInput: PendingUserInput = prompt) {
+function renderPanel(pendingUserInput: PendingUserInput = prompt, isResponding = false) {
   return renderToStaticMarkup(
     <ComposerPendingUserInputPanel
       pendingUserInputs={[pendingUserInput]}
-      respondingRequestIds={[]}
+      respondingRequestIds={isResponding ? [pendingUserInput.requestId] : []}
       answers={{}}
       questionIndex={0}
       onToggleOption={() => {}}
@@ -37,7 +40,52 @@ function renderPanel(pendingUserInput: PendingUserInput = prompt) {
   );
 }
 
+async function renderInteractivePanel(
+  pendingUserInput: PendingUserInput,
+  onToggleOption: (questionId: string, optionValue: string) => void,
+  onAdvance: () => void,
+) {
+  let renderer!: ReactTestRenderer;
+  await act(() => {
+    renderer = create(
+      <ComposerPendingUserInputPanel
+        pendingUserInputs={[pendingUserInput]}
+        respondingRequestIds={[]}
+        answers={{}}
+        questionIndex={0}
+        onToggleOption={onToggleOption}
+        onAdvance={onAdvance}
+        onDismiss={() => {}}
+      />,
+    );
+  });
+  return renderer;
+}
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
 describe("ComposerPendingUserInputPanel", () => {
+  let renderer: ReactTestRenderer | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(async () => {
+    await act(() => renderer?.unmount());
+    renderer = undefined;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
   it("renders the header as a disclosure control for the question body", () => {
     const markup = renderPanel();
 
@@ -67,4 +115,221 @@ describe("ComposerPendingUserInputPanel", () => {
     expect(markup).toContain("Incremental");
     expect(markup).toContain("Big bang");
   });
+
+  it("uses readable plain text for the collapsed preview", async () => {
+    const pendingUserInput = {
+      ...prompt,
+      questions: [
+        {
+          ...prompt.questions[0]!,
+          question:
+            "Please open [AWS sign-in link](https://example.com/signin?state=example) and confirm **when ready**.",
+        },
+      ],
+    } satisfies PendingUserInput;
+
+    renderer = await renderInteractivePanel(
+      pendingUserInput,
+      () => {},
+      () => {},
+    );
+    const collapsible = renderer.root.findByType(Collapsible);
+    await act(() => collapsible.props.onOpenChange(false));
+
+    const preview = renderer.root.findByProps({ "data-pending-user-input-preview": true });
+    const previewText = textContent(preview);
+    expect(previewText).toContain("Please open AWS sign-in link and confirm when ready.");
+    expect(previewText).not.toContain("https://example.com/signin");
+    expect(previewText).not.toContain("**");
+  });
+
+  it("renders inline formatting and removes unsafe option links", () => {
+    const pendingUserInput = {
+      ...prompt,
+      questions: [
+        {
+          ...prompt.questions[0]!,
+          options: [
+            {
+              label: "**Bold option**",
+              description: "Use `inline code` and [help](https://example.com/help).",
+              value: "provider-choice",
+            },
+            {
+              label: "Safe fallback",
+              description: "[bad link](javascript:alert(1))",
+              value: "fallback-choice",
+            },
+          ],
+        },
+      ],
+    } satisfies PendingUserInput;
+
+    const markup = renderPanel(pendingUserInput);
+
+    expect(markup).toContain("<strong>Bold option</strong>");
+    expect(markup).toContain("<code>inline code</code>");
+    expect(markup).toContain('data-pending-user-input-link="true"');
+    expect(markup).toContain('href="https://example.com/help"');
+    expect(markup).not.toContain('href="javascript:');
+    expect(markup).toContain("bad link");
+  });
+
+  it("keeps option links separate from selection and auto-advance", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", {
+      setTimeout,
+      clearTimeout,
+    });
+    const onToggleOption = vi.fn();
+    const onAdvance = vi.fn();
+
+    renderer = await renderInteractivePanel(
+      {
+        ...prompt,
+        questions: [
+          {
+            ...prompt.questions[0]!,
+            options: [
+              {
+                label: "Choose **this**",
+                description: "Read [the help](https://example.com/help).",
+                value: "raw-provider-value",
+              },
+            ],
+          },
+        ],
+      },
+      onToggleOption,
+      onAdvance,
+    );
+
+    const link = renderer.root.findByProps({ "data-pending-user-input-link": true });
+    expect(link.type).toBe("a");
+    expect(link.props.href).toBe("https://example.com/help");
+    // A native link must not live inside a selection button or clickable row.
+    for (let parent = link.parent; parent; parent = parent.parent) {
+      expect(parent.type).not.toBe("button");
+      expect(parent.props.onClick).toBeUndefined();
+    }
+    const stopPropagation = vi.fn();
+    await act(() => link.props.onKeyDown({ key: "Enter", stopPropagation }));
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    await act(() => vi.advanceTimersByTime(200));
+    expect(onToggleOption).not.toHaveBeenCalled();
+    expect(onAdvance).not.toHaveBeenCalled();
+
+    const optionButton = renderer.root
+      .findAllByType("button")
+      .find((button) => button.props["aria-pressed"] !== undefined);
+    expect(optionButton).toBeDefined();
+    await act(() => optionButton?.props.onClick());
+    expect(onToggleOption).toHaveBeenCalledWith("question-1", "raw-provider-value");
+    expect(onAdvance).not.toHaveBeenCalled();
+
+    await act(() => vi.advanceTimersByTime(200));
+    expect(onAdvance).toHaveBeenCalledOnce();
+  });
+
+  it("flattens block Markdown and resolves reference links in previews", async () => {
+    renderer = await renderInteractivePanel(
+      {
+        ...prompt,
+        questions: [
+          {
+            ...prompt.questions[0]!,
+            question: [
+              "# Heading",
+              "Read [the **guide**][guide] &amp; `a_b`.  \nNext line.",
+              "> A quote",
+              "- First\n- Second",
+              "| Name | Status |\n| --- | --- |\n| Build | Ready |",
+              "![Diagram](https://example.com/image.png)",
+              "[guide]: https://example.com/path_(nested)",
+            ].join("\n\n"),
+          },
+        ],
+      },
+      () => {},
+      () => {},
+    );
+    await act(() => renderer!.root.findByType(Collapsible).props.onOpenChange(false));
+    const preview = renderer.root.findByProps({ "data-pending-user-input-preview": true });
+    expect(textContent(preview).replace(/\s+/g, " ").trim()).toBe(
+      "Heading Read the guide & a_b. Next line. A quote First Second Name Status Build Ready Diagram",
+    );
+    expect(
+      preview.findAll((node) =>
+        ["a", "strong", "em", "code", "br", "img", "table"].includes(String(node.type)),
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("preserves inline formatting and accessible labels while responding", () => {
+    const markup = renderPanel(
+      {
+        ...prompt,
+        questions: [
+          {
+            ...prompt.questions[0]!,
+            options: [
+              {
+                label: "**Bold** *emphasis* ~~old~~",
+                description: "Read [help](https://example.com/help).",
+              },
+            ],
+          },
+        ],
+      },
+      true,
+    );
+    expect(markup).toContain("<strong>Bold</strong>");
+    expect(markup).toContain("<em>emphasis</em>");
+    expect(markup).toContain("<del>old</del>");
+    const button = markup.match(/<button[^>]*aria-pressed="false"[^>]*>/)?.[0];
+    expect(button).toContain('disabled=""');
+    const labelId = button?.match(/aria-labelledby="([^"]+)"/)?.[1];
+    const descriptionId = button?.match(/aria-describedby="([^"]+)"/)?.[1];
+    expect(labelId).toBeDefined();
+    expect(descriptionId).toBeDefined();
+    expect(markup).toContain(`id="${labelId}"`);
+    expect(markup).toContain(`id="${descriptionId}"`);
+  });
+
+  it.each([false, true])(
+    "keeps raw fallback labels and cleans up auto-advance (multiSelect=%s)",
+    async (multiSelect) => {
+      vi.useFakeTimers();
+      vi.stubGlobal("window", { setTimeout, clearTimeout });
+      const onToggleOption = vi.fn();
+      const onAdvance = vi.fn();
+      renderer = await renderInteractivePanel(
+        {
+          ...prompt,
+          questions: [
+            {
+              ...prompt.questions[0]!,
+              multiSelect,
+              options: [{ label: "**Raw label**", description: "" }],
+            },
+          ],
+        },
+        onToggleOption,
+        onAdvance,
+      );
+      const button = renderer.root
+        .findAllByType("button")
+        .find((node) => node.props["aria-pressed"] !== undefined)!;
+      await act(() => button.props.onClick());
+      expect(onToggleOption).toHaveBeenCalledWith("question-1", "**Raw label**");
+      if (multiSelect) {
+        await act(() => vi.advanceTimersByTime(200));
+        expect(onAdvance).not.toHaveBeenCalled();
+      }
+      await act(() => renderer!.unmount());
+      renderer = undefined;
+      await act(() => vi.advanceTimersByTime(200));
+      expect(onAdvance).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -14,15 +14,16 @@ import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
 import ChatMarkdown from "../ChatMarkdown";
 
+/** Removes inline formatting and link targets from the collapsed question preview. */
 function MarkdownText({ children }: { children?: ReactNode }) {
   return <>{children}</>;
 }
 
+/** Preserves word boundaries when block Markdown is flattened into inline card text. */
 function MarkdownBlockText({ children }: { children?: ReactNode }) {
   return <>{children} </>;
 }
 
-// Flatten block boundaries without joining words or adding layout to the card.
 const inlineMarkdownComponents = {
   p: MarkdownBlockText,
   h1: MarkdownBlockText,
@@ -69,6 +70,7 @@ const inlineMarkdownElements = [
 ];
 const remarkPlugins = [remarkGfm];
 
+/** Restricts option copy to inline Markdown; previews also remove inline styling and links. */
 const PendingUserInputMarkdown = memo(function PendingUserInputMarkdown({
   text,
   plainText = false,

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -1,5 +1,8 @@
 import { type ApprovalRequestId } from "@t3tools/contracts";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, type ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { type PendingUserInput } from "../../session-logic";
 import {
   derivePendingUserInputProgress,
@@ -9,6 +12,81 @@ import { CheckIcon } from "lucide-react";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
+
+function MarkdownText({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}
+
+function MarkdownBlockText({ children }: { children?: ReactNode }) {
+  return <>{children} </>;
+}
+
+// Flatten block boundaries without joining words or adding layout to the card.
+const inlineMarkdownComponents = {
+  p: MarkdownBlockText,
+  h1: MarkdownBlockText,
+  h2: MarkdownBlockText,
+  h3: MarkdownBlockText,
+  h4: MarkdownBlockText,
+  h5: MarkdownBlockText,
+  h6: MarkdownBlockText,
+  li: MarkdownBlockText,
+  th: MarkdownBlockText,
+  td: MarkdownBlockText,
+  br: () => " ",
+  img: ({ alt }) => alt,
+  a: ({ href, children }) =>
+    href ? (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="pointer-events-auto text-primary underline underline-offset-2"
+        data-pending-user-input-link
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        {children}
+      </a>
+    ) : (
+      children
+    ),
+} satisfies Components;
+const plainMarkdownComponents = {
+  ...inlineMarkdownComponents,
+  a: MarkdownText,
+  strong: MarkdownText,
+  em: MarkdownText,
+  del: MarkdownText,
+  code: MarkdownText,
+} satisfies Components;
+const inlineMarkdownElements = [
+  ...Object.keys(inlineMarkdownComponents),
+  "strong",
+  "em",
+  "del",
+  "code",
+];
+const remarkPlugins = [remarkGfm];
+
+const PendingUserInputMarkdown = memo(function PendingUserInputMarkdown({
+  text,
+  plainText = false,
+}: {
+  text: string;
+  plainText?: boolean;
+}) {
+  return (
+    <ReactMarkdown
+      allowedElements={inlineMarkdownElements}
+      unwrapDisallowed
+      remarkPlugins={remarkPlugins}
+      skipHtml
+      components={plainText ? plainMarkdownComponents : inlineMarkdownComponents}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+});
 
 interface PendingUserInputPanelProps {
   pendingUserInputs: PendingUserInput[];
@@ -66,6 +144,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
 }) {
   const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
   const activeQuestion = progress.activeQuestion;
+  const optionA11yIdPrefix = useId();
   const autoAdvanceTimerRef = useRef<number | null>(null);
   const onAdvanceRef = useRef(onAdvance);
   const [optimisticSingleSelect, setOptimisticSingleSelect] = useState<{
@@ -191,8 +270,11 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
             {activeQuestion.header}
           </span>
           {isCollapsed ? (
-            <span className="min-w-0 flex-1 truncate text-secondary-label">
-              {activeQuestion.question}
+            <span
+              className="min-w-0 flex-1 truncate text-secondary-label"
+              data-pending-user-input-preview
+            >
+              <PendingUserInputMarkdown text={activeQuestion.question} plainText />
             </span>
           ) : null}
         </ComposerBanner.Content>
@@ -243,8 +325,10 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                 isOptimisticallySelected ||
                 (!customAnswerActive && progress.selectedOptionValues.includes(optionValue));
               const shortcutKey = index < 9 ? index + 1 : null;
+              const labelId = `${optionA11yIdPrefix}-label-${index}`;
+              const descriptionId = `${optionA11yIdPrefix}-description-${index}`;
               const className = cn(
-                "group flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none transition-colors duration-150 focus-visible:ring-1 focus-visible:ring-primary/25",
+                "group relative flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none transition-colors duration-150",
                 isSelected
                   ? "bg-muted/55 text-foreground"
                   : "bg-transparent text-foreground/85 hover:bg-muted/30",
@@ -252,11 +336,15 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                 !isResponding && "cursor-pointer",
               );
               const content = (
-                <>
-                  <div className="min-w-0 flex-1 flex flex-col gap-0.5">
-                    <span className="text-sm font-medium">{option.label}</span>
+                <div className="relative z-10 flex min-w-0 flex-1 items-center gap-2 pointer-events-none">
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span id={labelId} className="text-sm font-medium">
+                      <PendingUserInputMarkdown text={option.label} />
+                    </span>
                     {option.description && option.description !== option.label ? (
-                      <span className="text-secondary-label text-[11px]">{option.description}</span>
+                      <span id={descriptionId} className="text-secondary-label text-[11px]">
+                        <PendingUserInputMarkdown text={option.description} />
+                      </span>
                     ) : null}
                   </div>
                   {isSelected ? (
@@ -270,20 +358,29 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                       {shortcutKey}
                     </kbd>
                   ) : null}
-                </>
+                </div>
               );
+              // The full-row button and links are siblings. Text clicks reach the
+              // button; links opt into pointer events without selecting an answer.
               return (
-                <button
-                  key={`${activeQuestion.id}:${optionValue}`}
-                  type="button"
-                  disabled={isResponding}
-                  onClick={() => {
-                    handleOptionSelection(activeQuestion.id, optionValue);
-                  }}
-                  className={className}
-                >
+                <div key={`${activeQuestion.id}:${optionValue}`} className={className}>
+                  <button
+                    type="button"
+                    disabled={isResponding}
+                    aria-pressed={isSelected}
+                    aria-labelledby={labelId}
+                    aria-describedby={
+                      option.description && option.description !== option.label
+                        ? descriptionId
+                        : undefined
+                    }
+                    onClick={() => {
+                      handleOptionSelection(activeQuestion.id, optionValue);
+                    }}
+                    className="absolute inset-0 z-0 rounded-md outline-none focus-visible:ring-1 focus-visible:ring-primary/25"
+                  />
                   {content}
-                </button>
+                </div>
               );
             })}
           </div>

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -13,6 +13,8 @@ import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collaps
 import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
 import ChatMarkdown from "../ChatMarkdown";
+import { useOpenLink } from "../../browser/useOpenLink";
+import { toastManager } from "../ui/toast";
 
 /** Removes inline formatting and link targets from the collapsed question preview. */
 function MarkdownText({ children }: { children?: ReactNode }) {
@@ -44,8 +46,6 @@ const inlineMarkdownComponents = {
         target="_blank"
         rel="noopener noreferrer"
         className="pointer-events-auto text-primary underline underline-offset-2"
-        data-pending-user-input-link
-        onKeyDown={(event) => event.stopPropagation()}
       >
         {children}
       </a>
@@ -158,6 +158,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
   const activeQuestion = progress.activeQuestion;
   const optionA11yIdPrefix = useId();
+  const openLink = useOpenLink(threadRef);
   const autoAdvanceTimerRef = useRef<number | null>(null);
   const onAdvanceRef = useRef(onAdvance);
   const [optimisticSingleSelect, setOptimisticSingleSelect] = useState<{
@@ -329,7 +330,20 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
             {activeQuestion.multiSelect ? (
               <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
             ) : null}
-            <div className="mt-2 space-y-0.5">
+            <div
+              className="mt-2 space-y-0.5"
+              onClick={(event) => {
+                if (!(event.target instanceof Element) || event.defaultPrevented) return;
+                const link = event.target.closest<HTMLAnchorElement>("a[href]");
+                if (!link || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+                  return;
+                event.preventDefault();
+                void openLink(link.href).catch((error: unknown) => {
+                  console.error(error);
+                  toastManager.add({ type: "error", title: "Unable to open question link" });
+                });
+              }}
+            >
               {activeQuestion.options.map((option, index) => {
                 const optionValue = option.value ?? option.label;
                 const isOptimisticallySelected =

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -1,4 +1,4 @@
-import { type ApprovalRequestId } from "@t3tools/contracts";
+import { type ApprovalRequestId, type ScopedThreadRef } from "@t3tools/contracts";
 import { memo, type ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
@@ -12,6 +12,7 @@ import { CheckIcon } from "lucide-react";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../ui/collapsible";
 import { cn } from "~/lib/utils";
 import { ComposerBanner } from "./ComposerBanner";
+import ChatMarkdown from "../ChatMarkdown";
 
 function MarkdownText({ children }: { children?: ReactNode }) {
   return <>{children}</>;
@@ -89,6 +90,8 @@ const PendingUserInputMarkdown = memo(function PendingUserInputMarkdown({
 });
 
 interface PendingUserInputPanelProps {
+  cwd?: string | undefined;
+  threadRef?: ScopedThreadRef | undefined;
   pendingUserInputs: PendingUserInput[];
   respondingRequestIds: ApprovalRequestId[];
   answers: Record<string, PendingUserInputDraftAnswer>;
@@ -99,6 +102,8 @@ interface PendingUserInputPanelProps {
 }
 
 export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserInputPanel({
+  cwd,
+  threadRef,
   pendingUserInputs,
   respondingRequestIds,
   answers,
@@ -115,6 +120,8 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
     <ComposerPendingUserInputCard
       key={activePrompt.requestId}
       prompt={activePrompt}
+      cwd={cwd}
+      threadRef={threadRef}
       isResponding={respondingRequestIds.includes(activePrompt.requestId)}
       answers={answers}
       questionIndex={questionIndex}
@@ -126,6 +133,8 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
 });
 
 const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard({
+  cwd,
+  threadRef,
   prompt,
   isResponding,
   answers,
@@ -134,6 +143,8 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   onAdvance,
   onDismiss,
 }: {
+  cwd: string | undefined;
+  threadRef: ScopedThreadRef | undefined;
   prompt: PendingUserInput;
   isResponding: boolean;
   answers: Record<string, PendingUserInputDraftAnswer>;
@@ -310,81 +321,83 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
         </ComposerBanner.Actions>
       </CollapsibleTrigger>
       <CollapsiblePanel>
-        <ComposerBanner.Body className="pe-1 pb-1">
-          <p className="text-sm text-foreground/85">{activeQuestion.question}</p>
-          {activeQuestion.multiSelect ? (
-            <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
-          ) : null}
-          <div className="mt-2 space-y-0.5">
-            {activeQuestion.options.map((option, index) => {
-              const optionValue = option.value ?? option.label;
-              const isOptimisticallySelected =
-                optimisticSingleSelect?.questionId === activeQuestion.id &&
-                optimisticSingleSelect.optionValue === optionValue;
-              const isSelected =
-                isOptimisticallySelected ||
-                (!customAnswerActive && progress.selectedOptionValues.includes(optionValue));
-              const shortcutKey = index < 9 ? index + 1 : null;
-              const labelId = `${optionA11yIdPrefix}-label-${index}`;
-              const descriptionId = `${optionA11yIdPrefix}-description-${index}`;
-              const className = cn(
-                "group relative flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none transition-colors duration-150",
-                isSelected
-                  ? "bg-muted/55 text-foreground"
-                  : "bg-transparent text-foreground/85 hover:bg-muted/30",
-                isResponding && "opacity-50 cursor-not-allowed",
-                !isResponding && "cursor-pointer",
-              );
-              const content = (
-                <div className="relative z-10 flex min-w-0 flex-1 items-center gap-2 pointer-events-none">
-                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span id={labelId} className="text-sm font-medium">
-                      <PendingUserInputMarkdown text={option.label} />
-                    </span>
-                    {option.description && option.description !== option.label ? (
-                      <span id={descriptionId} className="text-secondary-label text-[11px]">
-                        <PendingUserInputMarkdown text={option.description} />
+        <ComposerBanner.Scroll key={activeQuestion.id}>
+          <ComposerBanner.Body className="pe-1 pb-1">
+            <ChatMarkdown text={activeQuestion.question} cwd={cwd} threadRef={threadRef} />
+            {activeQuestion.multiSelect ? (
+              <p className="mt-1 text-secondary-label text-xs">Select one or more options.</p>
+            ) : null}
+            <div className="mt-2 space-y-0.5">
+              {activeQuestion.options.map((option, index) => {
+                const optionValue = option.value ?? option.label;
+                const isOptimisticallySelected =
+                  optimisticSingleSelect?.questionId === activeQuestion.id &&
+                  optimisticSingleSelect.optionValue === optionValue;
+                const isSelected =
+                  isOptimisticallySelected ||
+                  (!customAnswerActive && progress.selectedOptionValues.includes(optionValue));
+                const shortcutKey = index < 9 ? index + 1 : null;
+                const labelId = `${optionA11yIdPrefix}-label-${index}`;
+                const descriptionId = `${optionA11yIdPrefix}-description-${index}`;
+                const className = cn(
+                  "group relative flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left outline-none transition-colors duration-150",
+                  isSelected
+                    ? "bg-muted/55 text-foreground"
+                    : "bg-transparent text-foreground/85 hover:bg-muted/30",
+                  isResponding && "opacity-50 cursor-not-allowed",
+                  !isResponding && "cursor-pointer",
+                );
+                const content = (
+                  <div className="relative z-10 flex min-w-0 flex-1 items-center gap-2 pointer-events-none">
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5 [overflow-wrap:anywhere]">
+                      <span id={labelId} className="text-sm font-medium">
+                        <PendingUserInputMarkdown text={option.label} />
                       </span>
+                      {option.description && option.description !== option.label ? (
+                        <span id={descriptionId} className="text-secondary-label text-[11px]">
+                          <PendingUserInputMarkdown text={option.description} />
+                        </span>
+                      ) : null}
+                    </div>
+                    {isSelected ? (
+                      <CheckIcon className="size-3.5 shrink-0 text-primary" />
+                    ) : shortcutKey !== null ? (
+                      <kbd
+                        className={cn(
+                          "flex size-5 shrink-0 items-center justify-center text-[10px] font-medium text-muted-foreground tabular-nums",
+                        )}
+                      >
+                        {shortcutKey}
+                      </kbd>
                     ) : null}
                   </div>
-                  {isSelected ? (
-                    <CheckIcon className="size-3.5 shrink-0 text-primary" />
-                  ) : shortcutKey !== null ? (
-                    <kbd
-                      className={cn(
-                        "flex size-5 shrink-0 items-center justify-center text-[10px] font-medium text-muted-foreground tabular-nums",
-                      )}
-                    >
-                      {shortcutKey}
-                    </kbd>
-                  ) : null}
-                </div>
-              );
-              // The full-row button and links are siblings. Text clicks reach the
-              // button; links opt into pointer events without selecting an answer.
-              return (
-                <div key={`${activeQuestion.id}:${optionValue}`} className={className}>
-                  <button
-                    type="button"
-                    disabled={isResponding}
-                    aria-pressed={isSelected}
-                    aria-labelledby={labelId}
-                    aria-describedby={
-                      option.description && option.description !== option.label
-                        ? descriptionId
-                        : undefined
-                    }
-                    onClick={() => {
-                      handleOptionSelection(activeQuestion.id, optionValue);
-                    }}
-                    className="absolute inset-0 z-0 rounded-md outline-none focus-visible:ring-1 focus-visible:ring-primary/25"
-                  />
-                  {content}
-                </div>
-              );
-            })}
-          </div>
-        </ComposerBanner.Body>
+                );
+                // The full-row button and links are siblings. Text clicks reach the
+                // button; links opt into pointer events without selecting an answer.
+                return (
+                  <div key={`${activeQuestion.id}:${optionValue}`} className={className}>
+                    <button
+                      type="button"
+                      disabled={isResponding}
+                      aria-pressed={isSelected}
+                      aria-labelledby={labelId}
+                      aria-describedby={
+                        option.description && option.description !== option.label
+                          ? descriptionId
+                          : undefined
+                      }
+                      onClick={() => {
+                        handleOptionSelection(activeQuestion.id, optionValue);
+                      }}
+                      className="absolute inset-0 z-0 rounded-md outline-none focus-visible:ring-1 focus-visible:ring-primary/25"
+                    />
+                    {content}
+                  </div>
+                );
+              })}
+            </div>
+          </ComposerBanner.Body>
+        </ComposerBanner.Scroll>
       </CollapsiblePanel>
     </Collapsible>
   );

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -8,8 +8,10 @@ so you can shorten them or split them into several messages.
 
 ## Answer agent questions
 
-On web and desktop, collapse a question from its header to show a one-line text
-preview. Markdown links appear as their labels in the preview.
+On web and desktop, expanded questions render Markdown links, headings, lists,
+code blocks, and tables. Collapse a question from its header to show a one-line text
+preview. Markdown links appear as their labels in the preview. Long questions scroll
+inside the card so the header and answer controls remain visible.
 
 Answer options support inline Markdown, including emphasis, code, and links.
 Opening a link in an option does not select that option or advance the question.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -8,14 +8,9 @@ so you can shorten them or split them into several messages.
 
 ## Answer agent questions
 
-On web and desktop, expanded questions render Markdown links, headings, lists,
-code blocks, and tables. Collapse a question from its header to show a one-line text
-preview. Markdown links appear as their labels in the preview. Long questions scroll
-inside the card so the header and answer controls remain visible.
-
-Answer options support inline Markdown, including emphasis, code, and links.
-Opening a link in an option does not select that option or advance the question.
-Select the option itself when you are ready to answer.
+When an agent asks a question, choose an answer or type your own in the composer.
+On web and desktop, you can open links in an answer option to read more before
+deciding. Opening a link does not select the option or submit an answer.
 
 ## Attach files
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -6,6 +6,15 @@ include a skill when the task needs more context.
 Messages can contain up to 120,000 characters. Longer drafts stay in the composer
 so you can shorten them or split them into several messages.
 
+## Answer agent questions
+
+On web and desktop, collapse a question from its header to show a one-line text
+preview. Markdown links appear as their labels in the preview.
+
+Answer options support inline Markdown, including emphasis, code, and links.
+Opening a link in an option does not select that option or advance the question.
+Select the option itself when you are ready to answer.
+
 ## Attach files
 
 Attach up to eight files per message. Images can be up to 10 MB; other files can


### PR DESCRIPTION
## What Changed

Question cards show raw Markdown such as `[AWS sign-in link](https://example.com/...)` and `**when ready**`. This fix renders expanded questions and answer options, and shows readable plain text when collapsed.

- Reuse `ChatMarkdown` for expanded questions, including thread and workspace context for file links.
- Support inline formatting in option labels and descriptions. Links open independently of answer selection and follow the existing browser preference; modified clicks keep native behavior.
- Preserve original answer values, keyboard shortcuts, single- and multi-select behavior, and auto-advance cleanup.
- Use the existing banner scroll area and wrap long option text so large questions stay usable.

## Why

Closes #11132. The reporter expanded the issue to cover all three views after desktop testing showed that fixing previews and options alone left the original expanded-question bug visible.

Expanded-body rendering overlaps #9810 and needs coordination when either PR lands. This PR stays within question-card formatting; pending-question navigation, mobile's separate card, and work-log summaries are excluded. The updated issue records the requested scope change, not additional maintainer approval.

## Validation

On `2c4afc7c9`:

- **163 tests passed** across question-card, ChatMarkdown, pending-input, session-logic, and browser-link-target suites. Coverage includes formatting, original answer values, delayed advancement, cleanup, and link-opening success/failure without answering.
- Web typecheck, targeted lint, formatting, and `git diff --check` passed. Existing effect-related lint warnings and schema suggestions remain.

Earlier integrated web testing covered inline and block Markdown, file links, collapsed previews, option selection, and long content at desktop and 520px widths. The desktop build passed, and a real agent's formatted question was visually verified in Electron. Prompts and answers used the normal app command API because native input automation was unreliable.

**Remaining verification:** the latest link-handling changes still need a fresh native pointer/focus and in-app browser pass; the controlled browser was unavailable. Earlier desktop results do not cover that follow-up. Repository-wide checks are left to CI.

## UI Changes

Original desktop report:

![Before: expanded question exposes raw Markdown](https://github.com/user-attachments/assets/1ffde2ea-03c7-4fb3-9e30-aa7411e2540f)

After-image and interaction-video uploads remain pending. The recorded walkthrough uses sampled UI states, so it is not evidence of exact interaction timing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — after upload pending
- [ ] I included a video for animation/interaction changes — upload pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent questions now support Markdown formatting in expanded views, previews, and answer options.
  * Links in answer options can be opened without selecting or submitting an answer.
  * Improved accessibility for answer choices with clearer labels and selection states.

* **Documentation**
  * Updated composer guidance for answering agent questions by selecting an option or entering a custom response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Model and harness: OpenAI Codex, with GPT-5.6 Luna (xhigh) for the initial implementation and Astra for review and follow-up fixes.
