### PR TITLE
fix(server): survive a failed stderr write

### DIFF
--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -16,6 +16,7 @@ import { sharedServerCommandFlags } from "./cli/config.ts";
 import { isEntrypoint } from "./entrypoint.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
+import { guardStderr } from "./stderrGuard.ts";
 import { serviceCommand } from "./cli/service.ts";
 import { servicePreflightCommand } from "./cli/servicePreflight.ts";
 import { themeCommand } from "./cli/theme.ts";
@@ -75,6 +76,7 @@ if (
     runtimeMain: import.meta.main,
   })
 ) {
+  guardStderr(process.stderr);
   Command.run(cli, { version: packageJson.version }).pipe(
     Effect.scoped,
     Effect.provide(CliRuntimeLayer),

--- a/apps/server/src/stderrGuard.test.ts
+++ b/apps/server/src/stderrGuard.test.ts
@@ -1,0 +1,42 @@
+// @effect-diagnostics nodeBuiltinImport:off - the guard exists for a real Node stream.
+import * as NodeStream from "node:stream";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { guardStderr } from "./stderrGuard.ts";
+
+const makeStream = (write: (chunk: unknown) => boolean) => {
+  const emitter = new NodeStream.EventEmitter();
+  return Object.assign(emitter, { write }) as unknown as Parameters<typeof guardStderr>[0] & {
+    emit: (event: string, payload: unknown) => boolean;
+  };
+};
+
+describe("guardStderr", () => {
+  it("passes the chunk through and reports what the stream reported", () => {
+    const written: unknown[] = [];
+    const stream = makeStream((chunk) => {
+      written.push(chunk);
+      return false;
+    });
+    guardStderr(stream);
+    expect(stream.write("first\n" as never)).toBe(false);
+    expect(written).toEqual(["first\n"]);
+  });
+
+  it("survives a write that throws, which is what kills an unguarded process", () => {
+    const stream = makeStream(() => {
+      throw Object.assign(new Error("write EIO"), { code: "EIO" });
+    });
+    guardStderr(stream);
+    // `true` rather than `false`: a caller told the write was buffered waits for
+    // a `drain` event that a broken pipe never emits.
+    expect(stream.write("warning\n" as never)).toBe(true);
+  });
+
+  it("survives an error event the stream raises on its own", () => {
+    const stream = makeStream(() => true);
+    guardStderr(stream);
+    expect(() => stream.emit("error", new Error("write EIO"))).not.toThrow();
+  });
+});

--- a/apps/server/src/stderrGuard.ts
+++ b/apps/server/src/stderrGuard.ts
@@ -1,0 +1,33 @@
+type StreamWrite = (...args: readonly never[]) => boolean;
+
+interface GuardableStream {
+  write: StreamWrite;
+  readonly on: (event: "error", listener: () => void) => unknown;
+}
+
+/**
+ * Stop a failed write on this process's stderr from killing the process.
+ *
+ * The desktop app runs the server as a child with piped stdio, so its stderr
+ * can start failing with `EIO` while the process is otherwise healthy. The
+ * server's own output goes through the logger and survives that, but Node
+ * prints process warnings itself from `node:internal/process/warning`, whose
+ * `writeOut` calls `console.error` with no error handling. That makes any
+ * warning, including one Node raises on its own, a fatal uncaught exception
+ * once stderr is unwritable.
+ *
+ * Wrapping the write leaves Node's warning formatting and `--trace-warnings`
+ * alone and only removes the ability to crash. A swallowed write reports
+ * success so callers do not wait on a `drain` event that will never arrive.
+ */
+export const guardStderr = (stream: GuardableStream): void => {
+  const write = stream.write.bind(stream);
+  stream.write = (...args) => {
+    try {
+      return write(...args);
+    } catch {
+      return true;
+    }
+  };
+  stream.on("error", () => {});
+};


### PR DESCRIPTION
## What changed

`apps/server/src/stderrGuard.ts` wraps the entrypoint's stderr so a failed write cannot end the process. `bin.ts` calls it inside the existing `isEntrypoint` block, so importing the module for tests still has no side effects.

## Why

The desktop app runs the server as a child process with piped stdio. `DesktopBackendManager` spawns it with `stdout`/`stderr` set to `"pipe"` and drains both. While that pipe is healthy everything is fine, but when a write starts failing with `EIO` the server dies for a reason that has nothing to do with its own work.

Node prints process warnings itself, from `node:internal/process/warning`. Its `writeOut` calls `console.error` with no error handling of any kind, so a single failed write there becomes an uncaught exception. The warning is incidental. `ExperimentalWarning: SQLite is an experimental feature` is enough, and this package emits that one on every run. Observed as an Electron uncaught-exception dialog with this stack:

```
Error: write EIO
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    ...
    at Writable.write (node:internal/streams/writable:508:10)
    at console.value (node:internal/console/constructor:310:16)
    at console.error (node:internal/console/constructor:441:26)
    at writeOut (node:internal/process/warning:56:3)
```

Guarding the stream rather than replacing the `warning` listener is deliberate. Owning the listener would mean reimplementing Node's warning formatting and would silently drop `--trace-warnings`. Wrapping the write leaves both alone and removes only the ability to crash.

A swallowed write reports success rather than failure. A caller told the write was buffered waits for a `drain` event that a broken pipe never emits.

## Validation

- `vp test run src/stderrGuard.test.ts`, 3 passed.
- Red first. With the guard body replaced by a no-op, 2 of the 3 fail, and the pass-through case still passes because it does not depend on the guard.
- `tsc --noEmit` in `apps/server`, exit 0, no diagnostics on the changed files.
- `vp lint` on the three changed files, exit 0.
- `vp test run src/bin.test.ts`, 23 passed.

`src/entrypoint.test.ts > matches through a symlinked entrypoint` fails both with and without this change when the checkout lives under `/tmp` on macOS, since `/tmp` is itself a symlink to `/private/tmp`. Pre-existing and unrelated.

## One related thing I did not change

`drainBackendOutput` in `apps/desktop/src/backend/DesktopBackendManager.ts` catches `BackendProcessOutputReadError` outside `Stream.runForEach`, so a read error ends the drain permanently instead of resuming it. Nothing would read that pipe again for the rest of the backend's life, which is one way to reach the state above. I found no evidence in local traces that it actually fired, so I left it to whoever owns that code rather than encode an unproven theory in a fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when writing diagnostic output fails, helping prevent unexpected process termination.
  * Stderr write errors are now handled gracefully while preserving normal output behavior.

* **Tests**
  * Added coverage for successful writes, write failures, and emitted stream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->