### PR TITLE
fix(codex): pick up a new login without restarting T3

### DIFF
--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -21,11 +21,12 @@
  *
  * @module provider/Drivers/CodexDriver
  */
-import { CodexSettings, ProviderDriverKind } from "@t3tools/contracts";
+import { CodexSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -43,6 +44,7 @@ import {
 } from "../Layers/codexResetCredit.ts";
 import {
   checkCodexProviderStatus,
+  hasCodexAccountChanged,
   makePendingCodexProvider,
   probeCodexSkillsForCwd,
   withCodexAppServerClient,
@@ -195,6 +197,12 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // Kick the TTL-gated manifest refresh in the background and classify
       // with the in-memory manifest, so a slow or hung fetch never delays the
       // provider check. A refresh that lands mid-probe applies on the next one.
+      // Live sessions keep the account they spawned with. When a probe shows a
+      // different login, stop them so the next send respawns app-server with
+      // the current credentials (the same path as Stop or the idle reaper).
+      // Only signed-in probes move the baseline, so a logout or failed probe
+      // in between does not hide the switch.
+      const lastProbedAuth = yield* Ref.make<ServerProvider["auth"] | null>(null);
       const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
           Effect.zipWith(
@@ -204,6 +212,28 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
               stampIdentity(ModelManifest.applyModelManifest(draft, manifest, DRIVER_KIND)),
             { concurrent: true },
           ),
+        ),
+        Effect.tap((probed) =>
+          probed.auth.status !== "authenticated"
+            ? Effect.void
+            : Ref.getAndSet(lastProbedAuth, probed.auth).pipe(
+                Effect.flatMap((previous) =>
+                  hasCodexAccountChanged(previous, probed.auth)
+                    ? Effect.logInfo("Codex account changed; stopping live sessions.", {
+                        instanceId,
+                        email: probed.auth.email,
+                      }).pipe(
+                        Effect.andThen(adapter.stopAll()),
+                        Effect.catchCause((cause) =>
+                          Effect.logWarning("Failed to stop Codex sessions after account change.", {
+                            instanceId,
+                            cause,
+                          }),
+                        ),
+                      )
+                    : Effect.void,
+                ),
+              ),
         ),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       );

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -200,8 +200,9 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // Live sessions keep the account they spawned with. When a probe shows a
       // different login, stop them so the next send respawns app-server with
       // the current credentials (the same path as Stop or the idle reaper).
-      // Only signed-in probes move the baseline, so a logout or failed probe
-      // in between does not hide the switch.
+      // Only signed-in probes move the baseline, and a switch moves it only
+      // after the stop succeeds, so a logout, failed probe, or failed stop in
+      // between does not hide the switch from the next probe.
       const lastProbedAuth = yield* Ref.make<ServerProvider["auth"] | null>(null);
       const checkProvider = modelManifest.refreshInBackground.pipe(
         Effect.andThen(
@@ -216,14 +217,14 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         Effect.tap((probed) =>
           probed.auth.status !== "authenticated"
             ? Effect.void
-            : Ref.getAndSet(lastProbedAuth, probed.auth).pipe(
+            : Ref.get(lastProbedAuth).pipe(
                 Effect.flatMap((previous) =>
                   hasCodexAccountChanged(previous, probed.auth)
                     ? Effect.logInfo("Codex account changed; stopping live sessions.", {
                         instanceId,
-                        email: probed.auth.email,
                       }).pipe(
                         Effect.andThen(adapter.stopAll()),
+                        Effect.andThen(Ref.set(lastProbedAuth, probed.auth)),
                         Effect.catchCause((cause) =>
                           Effect.logWarning("Failed to stop Codex sessions after account change.", {
                             instanceId,
@@ -231,7 +232,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
                           }),
                         ),
                       )
-                    : Effect.void,
+                    : Ref.set(lastProbedAuth, probed.auth),
                 ),
               ),
         ),

--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,6 +1,10 @@
 import { assert, it } from "@effect/vitest";
 
-import { applyPreferredCodexDefaultModel, mapCodexModelCapabilities } from "./CodexProvider.ts";
+import {
+  applyPreferredCodexDefaultModel,
+  hasCodexAccountChanged,
+  mapCodexModelCapabilities,
+} from "./CodexProvider.ts";
 
 it("maps current Codex model capability fields", () => {
   const capabilities = mapCodexModelCapabilities({
@@ -143,4 +147,16 @@ it("ignores custom models that shadow a preferred slug", () => {
   ]);
 
   assert.deepStrictEqual(models.find((model) => model.isDefault)?.slug, "gpt-5.4");
+});
+
+it("detects a switch between two signed-in Codex accounts and nothing else", () => {
+  const alice = { status: "authenticated", type: "chatgpt", email: "alice@example.com" } as const;
+  const bob = { status: "authenticated", type: "chatgpt", email: "bob@example.com" } as const;
+  assert.isTrue(hasCodexAccountChanged(alice, bob));
+  assert.isFalse(
+    hasCodexAccountChanged(alice, { ...alice, label: "ChatGPT Pro 20x Subscription" }),
+  );
+  assert.isFalse(hasCodexAccountChanged(null, alice));
+  assert.isFalse(hasCodexAccountChanged(alice, { status: "unauthenticated" }));
+  assert.isFalse(hasCodexAccountChanged({ status: "unknown" }, alice));
 });

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -524,6 +524,23 @@ const makePendingCodexProvider = (
     });
   });
 
+/**
+ * A live app-server keeps the credentials it loaded at spawn, so after
+ * `codex login` to another account, threads with a live process keep using
+ * the old one. Only a change between two signed-in accounts counts; a
+ * signed-out or failed probe is not a switch, and neither is a plan change
+ * (`label`) on the same account.
+ */
+export function hasCodexAccountChanged(
+  previous: ServerProvider["auth"] | null,
+  next: ServerProvider["auth"],
+): boolean {
+  if (!previous || previous.status !== "authenticated" || next.status !== "authenticated") {
+    return false;
+  }
+  return previous.type !== next.type || previous.email !== next.email;
+}
+
 function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]): {
   readonly status: Exclude<ServerProviderState, "disabled">;
   readonly auth: ServerProvider["auth"];


### PR DESCRIPTION
After signing into another Codex account, Settings shows the new account but threads with a live `codex app-server` keep using the old credentials until Stop, the idle reaper, or a T3 restart. The process loads `auth.json` once at spawn and never rereads it. Fixes #11136.

The Codex driver now compares the signed-in account across status probes and stops that instance's live sessions when it changes. The next send finds no live session and respawns app-server with the current credentials through the existing resume path. A plan change on the same account, a signed-out probe, or a failed probe does not count as a switch, and a failed probe does not lose the baseline.

Reproduced against a real `codex app-server`: swapping the account under a live process left `account/read` on the old account while a fresh process reported the new one.

Verified with the focused CodexProvider tests, server typecheck, and lint on the touched files. The three pre-existing updater-detection failures in `CodexDriver.test.ts` fail identically on `main` on this machine.

Built with Claude Fable 5.1 in Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Codex sessions now automatically restart when a different signed-in account is detected.
  * Authentication changes are handled more reliably without treating sign-outs or failed checks as account switches.
  * Account details are no longer included in account-change logs.

* **Tests**
  * Added coverage for detecting account changes while ignoring plan-label-only updates and unauthenticated states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->