### PR TITLE
fix(web): close menus when clicking into the browser tab

### DIFF
--- a/apps/web/src/browser/HostedBrowserWebview.tsx
+++ b/apps/web/src/browser/HostedBrowserWebview.tsx
@@ -156,9 +156,18 @@ export function HostedBrowserWebview(props: {
         }
       }, recovery.delayMs);
     };
+    // A click inside the guest only reaches this document as a webview focus
+    // event, so open menus and popovers never see the outside press that
+    // would dismiss them. Replay it as a pointerdown on the webview itself.
+    const dismissHostPopups = () => {
+      webview.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, pointerType: "mouse" }),
+      );
+    };
     webview.addEventListener("did-attach", register);
     webview.addEventListener("dom-ready", register);
     webview.addEventListener("render-process-gone", recoverGuest);
+    webview.addEventListener("focus", dismissHostPopups);
     register();
     return () => {
       disposed = true;
@@ -166,6 +175,7 @@ export function HostedBrowserWebview(props: {
       webview.removeEventListener("did-attach", register);
       webview.removeEventListener("dom-ready", register);
       webview.removeEventListener("render-process-gone", recoverGuest);
+      webview.removeEventListener("focus", dismissHostPopups);
     };
   }, [clientSettingsHydrated, config, initialSrc, runtimeTabId, webviewGeneration]);
 


### PR DESCRIPTION
In the desktop app, opening the right panel's "+" surface menu and then clicking the page inside the browser tab left the menu open. Electron delivers that click to the guest `<webview>`, so the host document only sees a webview `focus` event and never the `pointerdown` that Base UI's outside-press dismissal listens for. The browser toolbar's "Preview menu" had the same problem.

The hosted webview now replays a `pointerdown` on itself whenever it gains focus. Every menu and popover already dismisses on an outside press, so no per-menu wiring is needed.

Reproduced and verified in the dev desktop app over CDP: with the surface menu open, clicking inside the loaded page previously kept it open (active element `WEBVIEW`, no pointer events on the host). After the change the same click closes the surface menu and the toolbar menu. The `HostedBrowserWebview` test, web typecheck, and scoped lint and format checks pass; Codex review of the commit found no regressions.

| Before | After |
| --- | --- |
| ![before: menu stays open after clicking the page](https://raw.githubusercontent.com/Gigioxx/t3code/e9f64f5073a904ca4d023a5cc66d0166cbb8d766/11137/before-menu-stays-open.png) | ![after: menu closes after clicking the page](https://raw.githubusercontent.com/Gigioxx/t3code/e9f64f5073a904ca4d023a5cc66d0166cbb8d766/11137/after-menu-closes.png) |

Fixes #11137.

Built with Claude Fable 5.1 in Claude Code through T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host popups and menus now dismiss correctly when focus moves into the hosted webview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->