### PR TITLE
fix(server): retry a failed provider version lookup on the next probe

### DIFF
--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -8,10 +8,12 @@ import * as NodePath from "node:path";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
-import { HttpClient } from "effect/unstable/http";
+import * as TestClock from "effect/testing/TestClock";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import {
   createProviderVersionAdvisory,
@@ -145,6 +147,44 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         expect(version).toBe("9.9.9");
       }),
     ),
+  );
+
+  it.effect(
+    "retries a failed registry lookup on the next probe instead of caching it for an hour",
+    () =>
+      Effect.gen(function* () {
+        const cache = new Map<string, { expiresAt: number; version: string | null }>();
+        const registry = (status: number, body: string) =>
+          HttpClient.make(() =>
+            Effect.succeed(
+              HttpClientResponse.fromWeb(
+                HttpClientRequest.get("https://registry.npmjs.org/"),
+                new Response(body, { status }),
+              ),
+            ),
+          );
+        const failing = registry(503, "");
+        const serving = registry(200, '{"version":"2.0.0"}');
+        const resolve = (client: HttpClient.HttpClient) =>
+          resolveLatestProviderVersion(manualPackageTool).pipe(
+            Effect.provideService(ProviderVersionCache, cache),
+            Effect.provideService(HttpClient.HttpClient, client),
+          );
+
+        expect(yield* resolve(failing)).toBeNull();
+        const failed = cache.get("@example/package-tool");
+        expect(failed?.version).toBeNull();
+        expect(failed!.expiresAt - DateTime.toEpochMillis(yield* DateTime.now)).toBe(60_000);
+
+        // Still within the retry window: the failure is served from cache.
+        expect(yield* resolve(serving)).toBeNull();
+        yield* TestClock.adjust("61 seconds");
+        expect(yield* resolve(serving)).toBe("2.0.0");
+        expect(
+          cache.get("@example/package-tool")!.expiresAt -
+            DateTime.toEpochMillis(yield* DateTime.now),
+        ).toBe(60 * 60 * 1_000);
+      }),
   );
 
   it.effect("prefers the installer's own latest version over the npm registry", () =>

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -23,6 +23,9 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 
 const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
+// A lookup that timed out or failed retries on the next probe instead of
+// silencing the update prompt for the whole cache window.
+const LATEST_VERSION_RETRY_TTL_MS = 60 * 1_000;
 const LATEST_VERSION_TIMEOUT_MS = 4_000;
 const HOMEBREW_INFO_TIMEOUT_MS = 10_000;
 const HOMEBREW_INFO_MAX_BYTES = 256 * 1_024;
@@ -675,7 +678,7 @@ export const resolveLatestProviderVersion = Effect.fn("resolveLatestProviderVers
 
   const version = yield* fetchNpmLatestVersion(packageName);
   latestVersionCache.set(packageName, {
-    expiresAt: now + LATEST_VERSION_CACHE_TTL_MS,
+    expiresAt: now + (version === null ? LATEST_VERSION_RETRY_TTL_MS : LATEST_VERSION_CACHE_TTL_MS),
     version,
   });
   return version;


### PR DESCRIPTION
The provider update prompt depends on `resolveLatestProviderVersion`, which asks the npm registry for the latest version under a 4 s timeout. When that single request times out (a cold DNS lookup on a filtering resolver can take over 10 s) or fails, the `null` result is cached for the full one-hour TTL, so `deriveVersionAdvisory` stays `unknown` and the "update available" toast never appears, even though the next lookup would take well under a second.

A failed or timed-out lookup is now cached for one minute instead of an hour, so the next provider probe retries it. Successful lookups keep the hour-long cache, and the request timeout is unchanged.

## Verification

- New test in `providerMaintenance.test.ts`: a 503 from the registry yields `null` with a 60 s cache entry, the failure is still served from cache inside that minute, and after the test clock passes it a 200 response resolves `2.0.0` with the hour-long entry.
- `vp test run apps/server/src/provider/providerMaintenance.test.ts`: the new test and the existing cache tests pass. Two npm-ownership tests in that file fail identically on an untouched `main` checkout on this machine (they depend on the local npm prefix), so they are unrelated.
- Server typecheck and lint on the touched files are clean.

Fixes #11163. Implemented with Claude Code (Claude Fable 5.1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed npm registry lookups are retried after one minute instead of being cached for the full hour.
  - Successful version lookups continue to be cached for one hour, ensuring update notifications remain timely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->