### PR TITLE
fix(skills): distinguish skills with the same name

### DIFF
--- a/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import { ProviderDriverKind } from "@t3tools/contracts";
+import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
 
 vi.mock("../../state/queries", () => ({
   useComposerPathSearch: () => ({ entries: [], isPending: false }),
@@ -17,6 +18,30 @@ import {
 } from "./use-composer-command-menu";
 
 describe("mobile slash commands", () => {
+  it.each(["$code", "/skill:code"])(
+    "preserves the selected skill source from %s",
+    (draftMessage) => {
+      const skill = {
+        name: "code-review",
+        path: "/personal/My Skills/code-review/SKILL.md",
+        enabled: true,
+      };
+      const result = resolveComposerCommandSelection({
+        draftMessage,
+        trigger: { rangeStart: 0, rangeEnd: draftMessage.length },
+        allowInteractionMode: false,
+        item: {
+          id: "personal-review",
+          type: "skill",
+          skill,
+          label: "Code Review",
+          description: "Standards and spec",
+        },
+      });
+      expect(collectSkillReferences(result.text)).toEqual([{ name: skill.name, path: skill.path }]);
+      expect(result.cursor).toBe(result.text.length);
+    },
+  );
   const antigravity = {
     driver: ProviderDriverKind.make("antigravity"),
     showInteractionModeToggle: false,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -106,6 +106,10 @@ export function buildComposerSlashCommandItems(input: {
   return items;
 }
 
+/**
+ * Apply a command pick to the active draft range, preserving exact skill sources and returning
+ * any requested interaction mode.
+ */
 export function resolveComposerCommandSelection(input: {
   readonly draftMessage: string;
   readonly trigger: Pick<ComposerTrigger, "rangeStart" | "rangeEnd">;
@@ -144,7 +148,10 @@ export function resolveComposerCommandSelection(input: {
   };
 }
 
-/** Shared autocomplete for thread composers and unsent new-task drafts. */
+/**
+ * Provide workspace-aware command suggestions and selection handlers for the thread and new-task
+ * composers.
+ */
 export function useComposerCommandMenu({
   draftMessage,
   ownerKey,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -12,8 +12,10 @@ import {
   scoreQueryMatch,
 } from "@t3tools/shared/searchRanking";
 import {
-  dedupeProviderSkillsByName,
+  dedupeProviderSkillsBySource,
   getProviderSkillsForSlashMenu,
+  formatProviderSkillReference,
+  formatProviderSkillMenuDescription,
   isProviderSkillUserInvocable,
   resolveProviderSkillsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -130,7 +132,7 @@ export function resolveComposerCommandSelection(input: {
   if (item.type === "path") {
     replacement = `${serializeComposerFileLink(item.path)} `;
   } else if (item.type === "skill") {
-    replacement = `$${item.skill.name} `;
+    replacement = `${formatProviderSkillReference(item.skill)} `;
   } else if (item.type === "slash-command") {
     replacement = `/${item.command} `;
   } else if (item.type === "provider-slash-command") {
@@ -289,29 +291,31 @@ export function useComposerCommandMenu({
       const skillItems = getProviderSkillsForSlashMenu(skills, true)
         .filter((skill) => matchesSlashSkillQuery(skill, q))
         .map((skill) => ({
-          id: `skill:${skill.name}`,
+          id: `skill:${JSON.stringify([skill.name, skill.path])}`,
           type: "skill" as const,
           skill,
           label: `skill:${skill.name}`,
-          description: skill.shortDescription ?? skill.description ?? "",
+          description: formatProviderSkillMenuDescription(skill, skills),
         }));
 
       return [...commandItems, ...skillItems];
     }
 
     if (trigger.kind === "skill") {
-      const enabledSkills = dedupeProviderSkillsByName(skills.filter(isProviderSkillUserInvocable));
+      const enabledSkills = dedupeProviderSkillsBySource(
+        skills.filter(isProviderSkillUserInvocable),
+      );
       const normalizedQuery = normalizeSearchQuery(trigger.query, {
         trimLeadingPattern: /^\$+/,
       });
 
       if (!normalizedQuery) {
         return enabledSkills.slice(0, 20).map((skill) => ({
-          id: `skill:${skill.name}`,
+          id: `skill:${JSON.stringify([skill.name, skill.path])}`,
           type: "skill" as const,
           skill,
           label: skill.displayName ?? skill.name,
-          description: skill.shortDescription ?? skill.description ?? "",
+          description: formatProviderSkillMenuDescription(skill, skills),
         }));
       }
 
@@ -374,11 +378,11 @@ export function useComposerCommandMenu({
       }
 
       return ranked.map(({ item: skill }) => ({
-        id: `skill:${skill.name}`,
+        id: `skill:${JSON.stringify([skill.name, skill.path])}`,
         type: "skill" as const,
         skill,
         label: skill.displayName ?? skill.name,
-        description: skill.shortDescription ?? skill.description ?? "",
+        description: formatProviderSkillMenuDescription(skill, skills),
       }));
     }
 

--- a/apps/server/src/provider/Drivers/AntigravitySkills.test.ts
+++ b/apps/server/src/provider/Drivers/AntigravitySkills.test.ts
@@ -122,7 +122,7 @@ it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
     }),
   );
 
-  it.effect("uses native root order for duplicate names", () =>
+  it.effect("keeps distinct sources in native root order for duplicate names", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -143,7 +143,7 @@ it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
 
       for (const [index, root] of roots.entries()) {
         const skills = yield* discoverAntigravitySkills(input);
-        assert.equal(skills.length, 1);
+        assert.equal(skills.length, roots.length - index);
         assert.equal(skills[0]?.path, path.join(root, `copy-${index}`, "SKILL.md"));
         yield* fileSystem.remove(root, { recursive: true });
       }
@@ -263,15 +263,16 @@ it.layer(NodeServices.layer)("discoverAntigravitySkills", (it) => {
         yield* writeSkill(path.join(root, name), "---\nname: review\n---\n");
       }
 
-      for (const name of nativeOrder) {
-        assert.deepEqual(yield* discoverAntigravitySkills(input), [
-          {
+      for (const [index, name] of nativeOrder.entries()) {
+        assert.deepEqual(
+          yield* discoverAntigravitySkills(input),
+          nativeOrder.slice(index).map((remainingName) => ({
             name: "review",
-            path: path.join(root, name, "SKILL.md"),
+            path: path.join(root, remainingName, "SKILL.md"),
             scope: "project",
             enabled: true,
-          },
-        ]);
+          })),
+        );
         yield* fileSystem.remove(path.join(root, name), { recursive: true });
       }
     }),

--- a/apps/server/src/provider/Drivers/AntigravitySkills.ts
+++ b/apps/server/src/provider/Drivers/AntigravitySkills.ts
@@ -153,8 +153,8 @@ const readSkill = Effect.fn("readAntigravitySkill")(function* (
 });
 
 /**
- * Match the official ACP's explicit skill roots. The first valid same-name skill
- * wins. Each root loads its own SKILL.md or those in its immediate subdirectories.
+ * Match the official ACP's explicit skill roots, retaining distinct source files.
+ * Each root loads its own SKILL.md or those in its immediate subdirectories.
  * Read failures remain typed so workspace snapshots do not cache partial results.
  */
 export const discoverAntigravitySkills = Effect.fn("discoverAntigravitySkills")(function* (input: {
@@ -182,7 +182,7 @@ export const discoverAntigravitySkills = Effect.fn("discoverAntigravitySkills")(
     remainingBytes: MAX_SCAN_BYTES,
     remainingEntries: MAX_SCAN_ENTRIES,
   };
-  const skillsByName = new Map<string, ServerProviderSkill>();
+  const skillsByPath = new Map<string, ServerProviderSkill>();
 
   const scanDirectory = Effect.fn("scanAntigravitySkillDirectory")(function* (
     directory: string,
@@ -209,8 +209,8 @@ export const discoverAntigravitySkills = Effect.fn("discoverAntigravitySkills")(
       const contents = yield* readSkill(skillPath, budget);
       if (contents === undefined) return;
       const skill = parseSkillFrontmatter(contents, skillFileName);
-      if (!skill || skillsByName.has(skill.name)) return;
-      skillsByName.set(skill.name, {
+      if (!skill || skillsByPath.has(skillPath)) return;
+      skillsByPath.set(skillPath, {
         ...skill,
         path: skillPath,
         scope,
@@ -233,5 +233,5 @@ export const discoverAntigravitySkills = Effect.fn("discoverAntigravitySkills")(
   for (const root of roots) {
     yield* scanDirectory(root.directory, root.scope, true);
   }
-  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return [...skillsByPath.values()].sort((left, right) => left.name.localeCompare(right.name));
 });

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
@@ -5,6 +5,14 @@ import { planClaudeSkillDispatch } from "./ClaudeSkillDispatch.ts";
 const SKILLS = new Set(["2spec", "implement", "review", "re-release-version"]);
 
 describe("planClaudeSkillDispatch", () => {
+  it("does not re-resolve attached source instructions by name", () => {
+    expect(
+      planClaudeSkillDispatch(
+        "Use [$review](/personal/review/SKILL.md)\n\nInstructions: run $implement next",
+        SKILLS,
+      ),
+    ).toBeUndefined();
+  });
   it("leaves a prompt without a known skill untouched", () => {
     expect(planClaudeSkillDispatch("fix the build", SKILLS)).toBeUndefined();
     // Not a discovered skill, so it stays prose rather than becoming a command.

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.test.ts
@@ -5,12 +5,19 @@ import { planClaudeSkillDispatch } from "./ClaudeSkillDispatch.ts";
 const SKILLS = new Set(["2spec", "implement", "review", "re-release-version"]);
 
 describe("planClaudeSkillDispatch", () => {
-  it("does not re-resolve attached source instructions by name", () => {
+  it("preserves source references while dispatching an intentional bare invocation", () => {
     expect(
       planClaudeSkillDispatch(
-        "Use [$review](/personal/review/SKILL.md)\n\nInstructions: run $implement next",
+        "Use [$review](/personal/review/SKILL.md) then $implement next",
         SKILLS,
       ),
+    ).toEqual({
+      leadingText: "Use [$review](/personal/review/SKILL.md) then",
+      commandText: "/implement next",
+      skillName: "implement",
+    });
+    expect(
+      planClaudeSkillDispatch("Use [$review](/personal/review/SKILL.md)", SKILLS),
     ).toBeUndefined();
   });
   it("leaves a prompt without a known skill untouched", () => {

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
@@ -2,8 +2,9 @@
  * ClaudeSkillDispatch — turns `$skill` mentions in a composer prompt into the
  * slash invocation Claude Code actually runs.
  *
- * The composer inserts `$name` for every provider. Codex parses that natively;
- * Claude Code does not, and treats it as prose. Claude Code's only user-side
+ * Legacy drafts and manually typed `$name` mentions need native dispatch.
+ * Source-bound composer picks are expanded by ProviderService instead.
+ * Claude Code treats bare `$name` as prose. Claude Code's only user-side
  * invocation is a text block whose first character is `/`: the harness
  * expands `/name args` into the SKILL.md body, and every character after the
  * name (newlines included) arrives as `ARGUMENTS`. Verified against the CLI in
@@ -29,6 +30,8 @@
  * (`packages/shared/src/composerInlineTokens.ts`), so a rendered chip and a
  * dispatched skill are always the same set.
  */
+import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
+
 const SKILL_MENTION_PATTERN =
   /(^|\s)\$(?![0-9][0-9_]*(?:[kKmMbBtT]|[eE][0-9]+)?(?:\s|$))(?=[a-zA-Z0-9:_-]*[a-zA-Z])([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s|$)/g;
 
@@ -50,6 +53,9 @@ export function planClaudeSkillDispatch(
   prompt: string,
   skillNames: ReadonlySet<string>,
 ): ClaudeSkillDispatch | undefined {
+  // Explicit sources have already been attached by ProviderService. Their
+  // instruction bodies are not additional native slash invocations.
+  if (collectSkillReferences(prompt).length > 0) return undefined;
   const mentions = [...prompt.matchAll(SKILL_MENTION_PATTERN)].flatMap((match) => {
     const name = match[2] ?? "";
     if (!skillNames.has(name)) return [];

--- a/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkillDispatch.ts
@@ -30,7 +30,6 @@
  * (`packages/shared/src/composerInlineTokens.ts`), so a rendered chip and a
  * dispatched skill are always the same set.
  */
-import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
 
 const SKILL_MENTION_PATTERN =
   /(^|\s)\$(?![0-9][0-9_]*(?:[kKmMbBtT]|[eE][0-9]+)?(?:\s|$))(?=[a-zA-Z0-9:_-]*[a-zA-Z])([a-zA-Z0-9][a-zA-Z0-9:_-]*)(?=\s|$)/g;
@@ -44,7 +43,8 @@ export interface ClaudeSkillDispatch {
 }
 
 /**
- * Split `prompt` around the last `$skill` mention that names a known skill.
+ * Split the pre-fallback `prompt` around the last known `$skill` mention.
+ * Generated exact-file instructions must remain separate from this input.
  * Returns `undefined` when there is nothing to dispatch, in which case the
  * prompt should go out unchanged. Mentions that do not match a discovered
  * skill stay literal: a `$HOME` in prose must not become a command.
@@ -53,9 +53,6 @@ export function planClaudeSkillDispatch(
   prompt: string,
   skillNames: ReadonlySet<string>,
 ): ClaudeSkillDispatch | undefined {
-  // Explicit sources have already been attached by ProviderService. Their
-  // instruction bodies are not additional native slash invocations.
-  if (collectSkillReferences(prompt).length > 0) return undefined;
   const mentions = [...prompt.matchAll(SKILL_MENTION_PATTERN)].flatMap((match) => {
     const name = match[2] ?? "";
     if (!skillNames.has(name)) return [];

--- a/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.test.ts
@@ -89,7 +89,7 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
     }),
   );
 
-  it.effect("prefers user skills on name collisions even with a stray .agents copy", () =>
+  it.effect("keeps user and project sources while ignoring a stray .agents copy", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -123,11 +123,18 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
           scope: "user",
           description: "User deploy.",
         },
+        {
+          name: "deploy",
+          path: path.join(workspace, ".claude", "skills", "deploy", "SKILL.md"),
+          enabled: true,
+          scope: "project",
+          description: "Claude deploy.",
+        },
       ]);
     }),
   );
 
-  it.effect("prefers user skills over project skills on name collisions", () =>
+  it.effect("keeps user and project sources on name collisions", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
@@ -148,7 +155,8 @@ it.layer(NodeServices.layer)("discoverClaudeSkills", (it) => {
 
       const skills = yield* discoverClaudeSkills({ homePath: configDir }, workspace);
 
-      assert.equal(skills.length, 1);
+      assert.equal(skills.length, 2);
+      assert.equal(skills[1]?.scope, "project");
       assert.equal(skills[0]?.scope, "user");
       assert.equal(skills[0]?.description, "User deploy.");
     }),

--- a/apps/server/src/provider/Drivers/ClaudeSkills.ts
+++ b/apps/server/src/provider/Drivers/ClaudeSkills.ts
@@ -299,11 +299,8 @@ const resolveClaudeConfigDirPath = Effect.fn("resolveClaudeConfigDirPath")(funct
  * Enumerate Claude Code skills from the user config dir and the workspace
  * `.claude/skills`. Discovery is best-effort: unreadable roots and malformed
  * skill entries are skipped so a broken skill never degrades the provider
- * snapshot. Roots are listed highest precedence first and the first hit for a
- * name wins, matching Claude Code: verified against the CLI with the same
- * skill name in both scopes, the user copy is the one that runs. Reporting the
- * project copy instead would attach its invocation metadata to a command
- * Claude Code resolves elsewhere.
+ * snapshot. Keep distinct files so explicit picks can bind a source, even
+ * when native name-based invocation would shadow it.
  */
 export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* (
   config: Pick<ClaudeSettings, "homePath">,
@@ -320,7 +317,7 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
     ...(cwd ? [{ directory: path.join(cwd, ".claude", "skills"), scope: "project" as const }] : []),
   ];
 
-  const skillsByName = new Map<string, ServerProviderSkill>();
+  const skillsByPath = new Map<string, ServerProviderSkill>();
   for (const root of roots) {
     const entries = yield* fileSystem
       .readDirectory(root.directory)
@@ -354,9 +351,8 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
         continue;
       }
 
-      // First root wins, so a later root never displaces a higher-precedence
-      // skill of the same name.
-      if (skillsByName.has(name)) {
+      // Repeated roots can report the same file more than once.
+      if (skillsByPath.has(skillPath)) {
         continue;
       }
 
@@ -364,7 +360,7 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
       const userInvocationOnly =
         (frontmatter.kind === "parsed" && frontmatter.userInvocationOnly === true) ||
         override?.userInvocationOnly === true;
-      skillsByName.set(name, {
+      skillsByPath.set(skillPath, {
         name,
         path: skillPath,
         enabled: override?.enabled ?? true,
@@ -380,5 +376,5 @@ export const discoverClaudeSkills = Effect.fn("discoverClaudeSkills")(function* 
     }
   }
 
-  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return [...skillsByPath.values()].sort((left, right) => left.name.localeCompare(right.name));
 });

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,3 +1,4 @@
+import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
 /**
  * CursorSkills — workspace-aware discovery and native invocation for Cursor.
  *
@@ -229,7 +230,7 @@ const inspectCursorSkills = Effect.fn("inspectCursorSkills")(function* (
   ];
   const roots = [...(cwd ? rootsBelow(cwd, "project") : []), ...rootsBelow(userHome, "user")];
 
-  const skillsByName = new Map<string, ServerProviderSkill>();
+  const skillsByPath = new Map<string, ServerProviderSkill>();
   const budget: CursorSkillScanBudget = {
     remainingEntries: MAX_SKILL_SCAN_ENTRIES,
     remainingBytes: MAX_SKILL_SCAN_BYTES,
@@ -240,11 +241,11 @@ const inspectCursorSkills = Effect.fn("inspectCursorSkills")(function* (
     if (budget.exhausted) break;
     const skills = yield* discoverSkillsInRoot({ ...root, budget });
     for (const skill of skills) {
-      if (!skillsByName.has(skill.name)) skillsByName.set(skill.name, skill);
+      if (!skillsByPath.has(skill.path)) skillsByPath.set(skill.path, skill);
     }
   }
   return {
-    skills: [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name)),
+    skills: [...skillsByPath.values()].sort((left, right) => left.name.localeCompare(right.name)),
     failureReason: budget.exhausted
       ? ("scan-budget-exhausted" as const)
       : budget.incomplete
@@ -274,8 +275,9 @@ export const probeCursorSkills = Effect.fn("probeCursorSkills")(function* (
   return inspection.skills;
 });
 
-/** Cursor invokes Agent Skills with `/name`; T3 composers insert `$name`. */
+/** Preserve native invocation for legacy drafts and manually typed `$name` mentions. */
 export function hasCursorSkillMention(prompt: string): boolean {
+  if (collectSkillReferences(prompt).length > 0) return false;
   return HAS_SKILL_MENTION_PATTERN.test(prompt);
 }
 
@@ -283,6 +285,7 @@ export function rewriteCursorSkillMentions(
   prompt: string,
   skillNames: ReadonlySet<string>,
 ): string {
+  if (collectSkillReferences(prompt).length > 0) return prompt;
   return prompt.replace(SKILL_MENTION_PATTERN, (match, prefix: string, name: string) =>
     skillNames.has(name) ? `${prefix}/${name}` : match,
   );

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -1,4 +1,3 @@
-import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
 /**
  * CursorSkills — workspace-aware discovery and native invocation for Cursor.
  *
@@ -277,7 +276,6 @@ export const probeCursorSkills = Effect.fn("probeCursorSkills")(function* (
 
 /** Preserve native invocation for legacy drafts and manually typed `$name` mentions. */
 export function hasCursorSkillMention(prompt: string): boolean {
-  if (collectSkillReferences(prompt).length > 0) return false;
   return HAS_SKILL_MENTION_PATTERN.test(prompt);
 }
 
@@ -285,7 +283,6 @@ export function rewriteCursorSkillMentions(
   prompt: string,
   skillNames: ReadonlySet<string>,
 ): string {
-  if (collectSkillReferences(prompt).length > 0) return prompt;
   return prompt.replace(SKILL_MENTION_PATTERN, (match, prefix: string, name: string) =>
     skillNames.has(name) ? `${prefix}/${name}` : match,
   );

--- a/apps/server/src/provider/Drivers/CursorSkills.ts
+++ b/apps/server/src/provider/Drivers/CursorSkills.ts
@@ -215,6 +215,10 @@ const discoverSkillsInRoot = Effect.fn("discoverCursorSkillsInRoot")(function* (
   return skills;
 });
 
+/**
+ * Inspect project and user skill roots by source path, returning partial results with a failure
+ * reason when scanning is incomplete.
+ */
 const inspectCursorSkills = Effect.fn("inspectCursorSkills")(function* (
   cwd?: string,
   environment: NodeJS.ProcessEnv = process.env,
@@ -260,6 +264,10 @@ export const discoverCursorSkills = Effect.fn("discoverCursorSkills")(function* 
   return (yield* inspectCursorSkills(cwd, environment)).skills;
 });
 
+/**
+ * Discover Cursor skill sources for provider snapshots, failing when the scan cannot establish a
+ * complete inventory.
+ */
 export const probeCursorSkills = Effect.fn("probeCursorSkills")(function* (
   cwd?: string,
   environment: NodeJS.ProcessEnv = process.env,

--- a/apps/server/src/provider/Drivers/GrokSkills.test.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.test.ts
@@ -75,6 +75,26 @@ describe("discoverGrokSkills", () => {
     ),
   );
 
+  it.effect("keeps distinct same-name sources from the CLI inventory", () =>
+    Effect.gen(function* () {
+      const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {});
+      expect(skills.map((skill) => skill.path)).toEqual([
+        "/plugins/review/SKILL.md",
+        "/personal/review/SKILL.md",
+      ]);
+    }).pipe(
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        makeInspectSpawner(
+          inspectPayload([
+            { name: "review", source: { type: "bundled", path: "/plugins/review/SKILL.md" } },
+            { name: "review", source: { type: "user", path: "/personal/review/SKILL.md" } },
+          ]),
+        ),
+      ),
+    ),
+  );
+
   it.effect("disables skills the CLI marks as not user-invocable", () =>
     Effect.gen(function* () {
       const skills = yield* discoverGrokSkills({ binaryPath: "grok" }, {});

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -45,7 +45,8 @@ class GrokSkillsProbeError extends Schema.TaggedError<GrokSkillsProbeError>()(
 /**
  * Map `grok inspect --json` output onto provider skills. Entries without a
  * name or a filesystem path are skipped; `userInvocable: false` skills are
- * kept but disabled so pickers that filter on `enabled` hide them.
+ * kept but disabled so pickers that filter on `enabled` hide them. Distinct
+ * paths remain separate even when they share a name.
  */
 function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSkill> | undefined {
   let parsed: unknown;

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -62,7 +62,7 @@ function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSk
     return undefined;
   }
 
-  const skillsByName = new Map<string, ServerProviderSkill>();
+  const skillsByPath = new Map<string, ServerProviderSkill>();
   for (const entry of entries) {
     if (typeof entry !== "object" || entry === null) {
       continue;
@@ -79,7 +79,7 @@ function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSk
     }
     const scope = typeof source?.type === "string" ? source.type.trim() : "";
     const description = typeof record.description === "string" ? record.description.trim() : "";
-    skillsByName.set(name, {
+    skillsByPath.set(path, {
       name,
       path,
       enabled: record.userInvocable !== false,
@@ -88,7 +88,7 @@ function decodeGrokInspectSkills(stdout: string): ReadonlyArray<ServerProviderSk
     });
   }
 
-  return [...skillsByName.values()].sort((left, right) => left.name.localeCompare(right.name));
+  return [...skillsByPath.values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
 /**

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -990,15 +990,29 @@ describe("ClaudeAdapterLive", () => {
 
       yield* adapter.sendTurn({
         threadId: session.threadId,
-        input: "ok, now $implement all the tickets\nstart with auth",
+        input:
+          "Use [$review](/personal/review/SKILL.md), now $implement all the tickets\nstart with auth\n\nInstructions: $implement remains literal",
+        skillContext: "\n\nInstructions: $implement remains literal",
         attachments: [],
       });
 
-      const promptMessage = yield* Effect.promise(() =>
-        readFirstPromptMessage(harness.getLastCreateQueryInput()),
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input:
+          "Use [$review](/personal/review/SKILL.md)\n\nInstructions: $implement remains literal",
+        skillContext: "\n\nInstructions: $implement remains literal",
+      });
+      const messages = yield* Effect.promise(() =>
+        readPromptMessages(harness.getLastCreateQueryInput(), 2),
       );
+      assert.deepEqual(messages[1]?.message.content, [
+        { type: "text", text: "Instructions: $implement remains literal" },
+        { type: "text", text: "Use [$review](/personal/review/SKILL.md)" },
+      ]);
+      const promptMessage = messages[0];
       assert.deepEqual(promptMessage?.message.content, [
-        { type: "text", text: "ok, now" },
+        { type: "text", text: "Instructions: $implement remains literal" },
+        { type: "text", text: "Use [$review](/personal/review/SKILL.md), now" },
         { type: "text", text: "/implement all the tickets\nstart with auth" },
       ]);
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1475,7 +1475,13 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
     readonly skillNames: ReadonlySet<string>;
   },
 ) {
-  const text = buildPromptText(input, dependencies.boundInstanceId, dependencies.modelCatalog);
+  const skillContext = input.skillContext ?? "";
+  const originalInput = skillContext ? input.input?.slice(0, -skillContext.length) : input.input;
+  const text = buildPromptText(
+    { ...input, input: originalInput },
+    dependencies.boundInstanceId,
+    dependencies.modelCatalog,
+  );
   const sdkContent: Array<Record<string, unknown>> = [];
 
   // Claude Code expands a skill only from the LAST text block, and only when
@@ -1483,6 +1489,7 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   // therefore split into [leading text, "/name trailing text"] so the CLI
   // runs it natively and the prose around it survives. See ClaudeSkillDispatch.
   const dispatch = planClaudeSkillDispatch(text, dependencies.skillNames);
+  if (skillContext) sdkContent.push({ type: "text", text: skillContext.trimStart() });
   if (dispatch?.leadingText !== undefined) {
     sdkContent.push({ type: "text", text: dispatch.leadingText });
   }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1464,6 +1464,10 @@ function buildClaudeImageContentBlock(input: {
   };
 }
 
+/**
+ * Build SDK content with native skill dispatch planned only from user text. Keep exact-file
+ * fallback instructions in a separate block so they cannot trigger name-based dispatch.
+ */
 const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
   input: ProviderSendTurnInput,
   dependencies: {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -415,37 +415,45 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
     }),
   );
 
-  it.effect("maps codex model options before sending a turn", () =>
-    Effect.gen(function* () {
-      const adapter = yield* CodexAdapter;
-      yield* adapter.startSession({
-        provider: ProviderDriverKind.make("codex"),
-        threadId: asThreadId("sess-missing"),
-        runtimeMode: "full-access",
-      });
-      const runtime = sessionRuntimeFactory.lastRuntime;
-      NodeAssert.ok(runtime);
-      runtime.sendTurnImpl.mockClear();
-
-      yield* Effect.ignore(
-        adapter.sendTurn({
+  it.effect(
+    "forwards exact skill selections and maps codex model options before sending a turn",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* CodexAdapter;
+        yield* adapter.startSession({
+          provider: ProviderDriverKind.make("codex"),
           threadId: asThreadId("sess-missing"),
-          input: "hello",
-          modelSelection: createModelSelection(ProviderInstanceId.make("codex"), "gpt-5.3-codex", [
-            { id: "reasoningEffort", value: "high" },
-            { id: "serviceTier", value: "priority" },
-          ]),
-          attachments: [],
-        }),
-      );
+          runtimeMode: "full-access",
+        });
+        const runtime = sessionRuntimeFactory.lastRuntime;
+        NodeAssert.ok(runtime);
+        runtime.sendTurnImpl.mockClear();
 
-      NodeAssert.deepStrictEqual(runtime.sendTurnImpl.mock.calls[0]?.[0], {
-        input: "hello",
-        model: "gpt-5.3-codex",
-        effort: "high",
-        serviceTier: "priority",
-      });
-    }),
+        yield* Effect.ignore(
+          adapter.sendTurn({
+            threadId: asThreadId("sess-missing"),
+            input: "hello",
+            skills: [{ name: "code-review", path: "/personal/code-review/SKILL.md" }],
+            modelSelection: createModelSelection(
+              ProviderInstanceId.make("codex"),
+              "gpt-5.3-codex",
+              [
+                { id: "reasoningEffort", value: "high" },
+                { id: "serviceTier", value: "priority" },
+              ],
+            ),
+            attachments: [],
+          }),
+        );
+
+        NodeAssert.deepStrictEqual(runtime.sendTurnImpl.mock.calls[0]?.[0], {
+          input: "hello",
+          skills: [{ name: "code-review", path: "/personal/code-review/SKILL.md" }],
+          model: "gpt-5.3-codex",
+          effort: "high",
+          serviceTier: "priority",
+        });
+      }),
   );
 
   it.effect("passes configured launch args into the session runtime", () => {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2530,6 +2530,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     return yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),
+        ...(input.skills ? { skills: input.skills } : {}),
         ...(input.modelSelection?.instanceId === boundInstanceId
           ? { model: input.modelSelection.model }
           : {}),
@@ -2715,6 +2716,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     capabilities: {
       sessionModelSwitch: "in-session",
       promptlessTurnContinuation: true,
+      nativeSkillInput: true,
     },
     startSession,
     sendTurn,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -63,6 +63,28 @@ function makeThreadOpenResponse(
 }
 
 describe("buildTurnStartParams", () => {
+  it.effect(
+    "preserves same-name selections as native exact-path skill inputs alongside text and images",
+    () =>
+      Effect.gen(function* () {
+        const skills = [
+          { name: "code-review", path: "/personal/code-review/SKILL.md" },
+          { name: "code-review", path: "C:\\plugins\\code-review\\SKILL.md" },
+        ];
+        const params = yield* buildTurnStartParams({
+          threadId: "provider-thread-1",
+          runtimeMode: "full-access",
+          prompt: "Review these changes",
+          skills,
+          attachments: [{ type: "image", url: "https://example.com/image.png" }],
+        });
+        NodeAssert.deepStrictEqual(params.input, [
+          { type: "text", text: "Review these changes" },
+          ...skills.map((skill) => ({ type: "skill", ...skill })),
+          { type: "image", url: "https://example.com/image.png" },
+        ]);
+      }),
+  );
   it("keeps invalid turn values only in the schema cause", () => {
     const secret = "codex-turn-input-secret-sentinel";
     const error = Effect.runSync(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -606,6 +606,10 @@ function buildCodexCollaborationMode(input: {
   };
 }
 
+/**
+ * Build Codex turn parameters, carrying authorized skill selections as native path-bound inputs
+ * alongside text and images.
+ */
 export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -184,6 +184,7 @@ export interface CodexSessionRuntimeOptions {
 }
 
 export interface CodexSessionRuntimeSendTurnInput {
+  readonly skills?: ReadonlyArray<{ readonly name: string; readonly path: string }>;
   readonly input?: string;
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
@@ -609,6 +610,7 @@ export function buildTurnStartParams(input: {
   readonly threadId: string;
   readonly runtimeMode: RuntimeMode;
   readonly prompt?: string;
+  readonly skills?: CodexSessionRuntimeSendTurnInput["skills"];
   readonly attachments?: ReadonlyArray<{
     readonly type: "image";
     readonly url: string;
@@ -629,6 +631,9 @@ export function buildTurnStartParams(input: {
       type: "text",
       text: input.prompt,
     });
+  }
+  for (const skill of input.skills ?? []) {
+    turnInput.push({ type: "skill", name: skill.name, path: skill.path });
   }
   for (const attachment of input.attachments ?? []) {
     turnInput.push(attachment);
@@ -2359,6 +2364,7 @@ export const makeCodexSessionRuntime = (
             threadId: providerThreadId,
             runtimeMode: options.runtimeMode,
             ...(input.input ? { prompt: input.input } : {}),
+            ...(input.skills ? { skills: input.skills } : {}),
             ...(input.attachments ? { attachments: input.attachments } : {}),
             ...(normalizedModel ? { model: normalizedModel } : {}),
             ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -310,7 +310,9 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
       });
       yield* adapter.sendTurn({
         threadId,
-        input: "please $review this",
+        input:
+          "Use [$review](/personal/review/SKILL.md) then $review this\n\nInstructions: $review stays literal",
+        skillContext: "\n\nInstructions: $review stays literal",
         attachments: [],
       });
       const snapshot = yield* adapter.readThread(threadId);
@@ -319,7 +321,12 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         [
           [
             {
-              prompt: [{ type: "text", text: "please /review this" }],
+              prompt: [
+                {
+                  type: "text",
+                  text: "Use [$review](/personal/review/SKILL.md) then /review this\n\nInstructions: $review stays literal",
+                },
+              ],
               result: { stopReason: "end_turn" },
             },
           ],
@@ -335,7 +342,10 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         ),
         [
           [
-            { type: "text", text: "please /review this" },
+            {
+              type: "text",
+              text: "Use [$review](/personal/review/SKILL.md) then /review this\n\nInstructions: $review stays literal",
+            },
             { type: "text", text: buildRuntimeInstructions({ harness: "Cursor" }) },
           ],
         ],

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -989,7 +989,10 @@ export function makeCursorAdapter(
           }
 
           const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
-          const rawPrompt = input.input?.trim() ?? "";
+          const skillContext = input.skillContext ?? "";
+          const rawPrompt =
+            (skillContext ? input.input?.slice(0, -skillContext.length) : input.input)?.trim() ??
+            "";
           if (rawPrompt) {
             let cursorSkillNames = ctx.cursorSkillNames;
             if (hasCursorSkillMention(rawPrompt) && cursorSkillNames === undefined) {
@@ -1010,7 +1013,7 @@ export function makeCursorAdapter(
             const prompt = cursorSkillNames
               ? rewriteCursorSkillMentions(rawPrompt, cursorSkillNames)
               : rawPrompt;
-            promptParts.push({ type: "text", text: prompt });
+            promptParts.push({ type: "text", text: prompt + skillContext });
           }
           if (input.attachments && input.attachments.length > 0) {
             for (const attachment of input.attachments) {

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -453,9 +453,11 @@ describe("Cursor skills", () => {
     ));
 
   it("rewrites only discovered skill mentions into Cursor slash invocations", () => {
-    const explicit = "Use [$review](/personal/review/SKILL.md)\n\nInstructions: use $review next";
-    expect(hasCursorSkillMention(explicit)).toBe(false);
-    expect(rewriteCursorSkillMentions(explicit, new Set(["review"]))).toBe(explicit);
+    const explicit = "Use [$review](/personal/review/SKILL.md) then use $review next";
+    expect(hasCursorSkillMention(explicit)).toBe(true);
+    expect(rewriteCursorSkillMentions(explicit, new Set(["review"]))).toBe(
+      explicit.replace("use $review next", "use /review next"),
+    );
     expect(hasCursorSkillMention("use $Review_Pr:V2 here")).toBe(true);
     expect(hasCursorSkillMention("please $review this")).toBe(true);
     expect(

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -388,6 +388,13 @@ describe("Cursor skills", () => {
             scope: "project",
             enabled: true,
           },
+          {
+            name: "review",
+            description: "user review",
+            path: path.join(userHome, ".cursor", "skills", "review", "SKILL.md"),
+            scope: "user",
+            enabled: true,
+          },
         ]);
         expect(
           (yield* probeCursorSkills(workspace, { HOME: userHome }).pipe(Effect.result))._tag,
@@ -446,6 +453,9 @@ describe("Cursor skills", () => {
     ));
 
   it("rewrites only discovered skill mentions into Cursor slash invocations", () => {
+    const explicit = "Use [$review](/personal/review/SKILL.md)\n\nInstructions: use $review next";
+    expect(hasCursorSkillMention(explicit)).toBe(false);
+    expect(rewriteCursorSkillMentions(explicit, new Set(["review"]))).toBe(explicit);
     expect(hasCursorSkillMention("use $Review_Pr:V2 here")).toBe(true);
     expect(hasCursorSkillMention("please $review this")).toBe(true);
     expect(

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -123,6 +123,10 @@ const makeFakeInstance = (
       streamChanges: Stream.empty,
       applyUsageLimits: () => Effect.void,
     },
+    snapshotForCwd: (cwd) =>
+      Effect.succeed({
+        skills: [{ name: driverKind, path: `${cwd}/SKILL.md`, enabled: true }],
+      } as unknown as ServerProvider),
     adapter,
     textGeneration: {} as unknown as TextGeneration.TextGeneration["Service"],
   };
@@ -155,6 +159,17 @@ const layer = Layer.mergeAll(
 );
 
 it.layer(layer)("ProviderAdapterRegistryLive", (it) => {
+  it.effect("discovers skills through the selected instance's workspace snapshot", () =>
+    Effect.gen(function* () {
+      const registry = yield* ProviderAdapterRegistry.ProviderAdapterRegistry;
+      for (const instance of fakeInstances) {
+        assert.deepEqual(yield* registry.getSkills(instance.instanceId, "/selected-workspace"), [
+          { name: instance.driverKind, path: "/selected-workspace/SKILL.md", enabled: true },
+        ]);
+      }
+    }),
+  );
+
   it("resolves adapters and routing metadata from provider instances", () =>
     Effect.gen(function* () {
       const registry = yield* ProviderAdapterRegistry.ProviderAdapterRegistry;

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -19,7 +19,7 @@ import { ProviderInstanceId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { ProviderUnsupportedError } from "../Errors.ts";
+import { ProviderUnsupportedError, ProviderValidationError } from "../Errors.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import {
   ProviderAdapterRegistry,
@@ -62,6 +62,32 @@ const makeProviderAdapterRegistry = Effect.fn("makeProviderAdapterRegistry")(fun
       ),
     );
 
+  const getSkills: ProviderAdapterRegistryShape["getSkills"] = Effect.fn("getSkills")(
+    function* (instanceId, cwd) {
+      const instance = yield* registry.getInstance(instanceId);
+      if (!instance || !instance.enabled)
+        return yield* new ProviderUnsupportedError({ provider: instanceId });
+      const snapshot = yield* (
+        cwd !== undefined && instance.snapshotForCwd
+          ? instance.snapshotForCwd(cwd)
+          : instance.snapshot.refresh
+      ).pipe(
+        Effect.mapError(
+          () =>
+            new ProviderValidationError({
+              operation: "ProviderService.sendTurn",
+              issue: "Cannot discover the selected provider's skills. Refresh skills and retry.",
+            }),
+        ),
+      );
+      if (snapshot.status === "error")
+        return yield* new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: "Cannot discover the selected provider's skills. Refresh skills and retry.",
+        });
+      return snapshot.skills;
+    },
+  );
   const listInstances: ProviderAdapterRegistryShape["listInstances"] = () =>
     registry.listInstances.pipe(
       Effect.map((instances) => instances.map((instance) => instance.instanceId)),
@@ -69,6 +95,7 @@ const makeProviderAdapterRegistry = Effect.fn("makeProviderAdapterRegistry")(fun
 
   return {
     getByInstance,
+    getSkills,
     getInstanceInfo,
     listInstances,
     subscribeChanges: registry.subscribeChanges,

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -62,6 +62,10 @@ const makeProviderAdapterRegistry = Effect.fn("makeProviderAdapterRegistry")(fun
       ),
     );
 
+  /**
+   * Refresh the selected instance's workspace inventory for source authorization; disabled
+   * instances and failed discovery must not authorize a turn.
+   */
   const getSkills: ProviderAdapterRegistryShape["getSkills"] = Effect.fn("getSkills")(
     function* (instanceId, cwd) {
       const instance = yield* registry.getInstance(instanceId);

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1,3 +1,4 @@
+import { serializeSkillReference } from "@t3tools/shared/composerInlineTokens";
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
@@ -985,6 +986,44 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
     assert.equal(codex.startSession.mock.calls.length, 0);
   }).pipe(Effect.provide(NodeServices.layer)),
 );
+
+for (const driver of ["codex", "claudeAgent", "cursor", "grok", "opencode", "antigravity"]) {
+  const driverKind = ProviderDriverKind.make(driver);
+  const instanceId = ProviderInstanceId.make(`skill-test-${driver}`);
+  const fake = makeFakeCodexAdapter(driverKind);
+  const setup = makeProviderServiceLayer({
+    registry: makeStaticInstanceRegistry([[instanceId, fake.adapter]]),
+  });
+  setup.layer(`explicit skill dispatch: ${driver}`, (it) => {
+    it.effect("delivers the chosen source's instructions to the adapter", () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const directory = fixtureCwd(`skill-${driver}`);
+        const skillPath = NodePath.join(directory, "SKILL.md");
+        NodeFS.writeFileSync(
+          skillPath,
+          "MATT_STANDARDS_AND_SPEC: review the diff against the spec.",
+        );
+        const threadId = asThreadId(`skill-${driver}`);
+        yield* provider.startSession(threadId, {
+          provider: driverKind,
+          providerInstanceId: instanceId,
+          threadId,
+          runtimeMode: "full-access",
+          cwd: directory,
+        });
+        yield* provider.sendTurn({
+          threadId,
+          input: `Use ${serializeSkillReference({ name: "code-review", path: skillPath })} now.`,
+        });
+        const sent = fake.sendTurn.mock.calls.at(-1)?.[0].input ?? "";
+        assert.include(sent, "MATT_STANDARDS_AND_SPEC");
+        assert.include(sent, encodeJson(skillPath));
+        assert.include(sent, encodeJson(directory));
+      }),
+    );
+  });
+}
 
 const routing = makeProviderServiceLayer();
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -380,6 +380,7 @@ function makeStaticInstanceRegistry(
       const adapter = adapters.get(instanceId);
       return adapter ? Effect.succeed(adapter) : Effect.fail(unsupported(instanceId));
     },
+    getSkills: () => Effect.succeed([]),
     getInstanceInfo: (instanceId) => {
       const adapter = adapters.get(instanceId);
       return adapter
@@ -851,6 +852,7 @@ it.effect(
           requestedInstanceId === instanceId
             ? Effect.succeed(codex.adapter)
             : Effect.fail(unsupported()),
+        getSkills: () => Effect.succeed([]),
         getInstanceInfo: (requestedInstanceId) =>
           requestedInstanceId === instanceId
             ? Effect.succeed({
@@ -930,6 +932,7 @@ it.effect("ProviderServiceLive rejects new sessions for disabled custom instance
         requestedInstanceId === instanceId
           ? Effect.succeed(codex.adapter)
           : Effect.fail(unsupported()),
+      getSkills: () => Effect.succeed([]),
       getInstanceInfo: (requestedInstanceId) =>
         requestedInstanceId === instanceId
           ? Effect.succeed({
@@ -993,15 +996,22 @@ for (const driver of ["codex", "claudeAgent", "cursor", "grok", "opencode", "ant
   const driverKind = ProviderDriverKind.make(driver);
   const instanceId = ProviderInstanceId.make(`skill-test-${driver}`);
   const fake = makeFakeCodexAdapter(driverKind);
+  const directory = fixtureCwd(`skill-${driver}`);
+  const skillPath = NodePath.join(directory, "SKILL.md");
   const setup = makeProviderServiceLayer({
-    registry: makeStaticInstanceRegistry([[instanceId, fake.adapter]]),
+    registry: {
+      ...makeStaticInstanceRegistry([[instanceId, fake.adapter]]),
+      getSkills: (requestedInstance, cwd) => {
+        assert.equal(requestedInstance, instanceId);
+        assert.equal(cwd, directory);
+        return Effect.succeed([{ name: "code-review", path: skillPath, enabled: true }]);
+      },
+    },
   });
   setup.layer(`explicit skill dispatch: ${driver}`, (it) => {
     it.effect("delivers the chosen source's instructions to the adapter", () =>
       Effect.gen(function* () {
         const provider = yield* ProviderService.ProviderService;
-        const directory = fixtureCwd(`skill-${driver}`);
-        const skillPath = NodePath.join(directory, "SKILL.md");
         NodeFS.writeFileSync(
           skillPath,
           "MATT_STANDARDS_AND_SPEC: review the diff against the spec.",
@@ -1014,8 +1024,6 @@ for (const driver of ["codex", "claudeAgent", "cursor", "grok", "opencode", "ant
           runtimeMode: "full-access",
           cwd: directory,
         });
-        // Native invocation delegates source loading to the provider, not this server fallback.
-        if (driver === "codex") NodeFS.unlinkSync(skillPath);
         yield* provider.sendTurn({
           threadId,
           input: `Use ${serializeSkillReference({ name: "code-review", path: skillPath })} now.`,
@@ -1035,7 +1043,23 @@ for (const driver of ["codex", "claudeAgent", "cursor", "grok", "opencode", "ant
           assert.include(sent, encodeJson(skillPath));
           assert.include(sent, encodeJson(directory));
           assert.isUndefined(fake.sendTurn.mock.calls.at(-1)?.[0].skills);
+          const context = fake.sendTurn.mock.calls.at(-1)?.[0].skillContext;
+          assert.isString(context);
+          assert.isTrue(sent.endsWith(context!));
+          assert.include(context!, "MATT_STANDARDS_AND_SPEC");
         }
+        const undiscoveredPath = NodePath.join(directory, "undiscovered", "SKILL.md");
+        NodeFS.mkdirSync(NodePath.dirname(undiscoveredPath), { recursive: true });
+        NodeFS.writeFileSync(undiscoveredPath, "DO_NOT_SEND");
+        const calls = fake.sendTurn.mock.calls.length;
+        const failure = yield* provider
+          .sendTurn({
+            threadId,
+            input: serializeSkillReference({ name: "code-review", path: undiscoveredPath }),
+          })
+          .pipe(Effect.flip);
+        assert.instanceOf(failure, ProviderValidationError);
+        assert.equal(fake.sendTurn.mock.calls.length, calls);
       }),
     );
   });

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -276,7 +276,9 @@ function makeFakeCodexAdapter(
     capabilities: {
       sessionModelSwitch: "in-session",
       ...(supportsConversationRollback !== undefined ? { supportsConversationRollback } : {}),
-      ...(provider === CODEX_DRIVER ? { promptlessTurnContinuation: true } : {}),
+      ...(provider === CODEX_DRIVER
+        ? { promptlessTurnContinuation: true, nativeSkillInput: true }
+        : {}),
     },
     startSession,
     sendTurn,
@@ -1012,14 +1014,28 @@ for (const driver of ["codex", "claudeAgent", "cursor", "grok", "opencode", "ant
           runtimeMode: "full-access",
           cwd: directory,
         });
+        // Native invocation delegates source loading to the provider, not this server fallback.
+        if (driver === "codex") NodeFS.unlinkSync(skillPath);
         yield* provider.sendTurn({
           threadId,
           input: `Use ${serializeSkillReference({ name: "code-review", path: skillPath })} now.`,
         });
         const sent = fake.sendTurn.mock.calls.at(-1)?.[0].input ?? "";
-        assert.include(sent, "MATT_STANDARDS_AND_SPEC");
-        assert.include(sent, encodeJson(skillPath));
-        assert.include(sent, encodeJson(directory));
+        if (driver === "codex") {
+          assert.equal(
+            sent,
+            `Use ${serializeSkillReference({ name: "code-review", path: skillPath })} now.`,
+          );
+          assert.deepEqual(fake.sendTurn.mock.calls.at(-1)?.[0].skills, [
+            { name: "code-review", path: skillPath },
+          ]);
+          assert.notInclude(sent, "MATT_STANDARDS_AND_SPEC");
+        } else {
+          assert.include(sent, "MATT_STANDARDS_AND_SPEC");
+          assert.include(sent, encodeJson(skillPath));
+          assert.include(sent, encodeJson(directory));
+          assert.isUndefined(fake.sendTurn.mock.calls.at(-1)?.[0].skills);
+        }
       }),
     );
   });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -34,6 +34,7 @@ import {
   type ProviderSession,
 } from "@t3tools/contracts";
 import { expandAssistantCitationsForProvider } from "@t3tools/shared/assistantCitations";
+import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
 import { expandSkillReferencesForProvider } from "../skillReferences.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { causeErrorTag } from "@t3tools/shared/observability";
@@ -1546,18 +1547,11 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 
     const inputTextWithCitations =
       parsed.input === undefined ? undefined : expandAssistantCitationsForProvider(parsed.input);
-    const inputTextWithSkills =
-      inputTextWithCitations === undefined
-        ? undefined
-        : yield* expandSkillReferencesForProvider(inputTextWithCitations).pipe(
-            Effect.provideService(FileSystem.FileSystem, fileSystem),
-            Effect.provideService(Path.Path, pathService),
-          );
-    if (inputTextWithSkills !== parsed.input) {
+    if (inputTextWithCitations !== parsed.input) {
       yield* decodeInputOrValidationError({
         operation: "ProviderService.sendTurn",
         schema: ProviderSendTurnInput.fields.input,
-        payload: inputTextWithSkills,
+        payload: inputTextWithCitations,
       });
     }
 
@@ -1567,7 +1561,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     // sends generic files as file parts, the others send images only and rely
     // on the path line for everything else. Unresolvable ids are skipped here
     // and surface as adapter errors when the file is read.
-    let inputTextWithAttachmentContext = inputTextWithSkills;
+    let inputTextWithAttachmentContext = inputTextWithCitations;
     const appendAttachmentContext = (context: string | undefined) => {
       if (context === undefined) return;
       const candidate = inputTextWithAttachmentContext
@@ -1662,6 +1656,27 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           allowRecovery: true,
         });
       }
+      const skills = collectSkillReferences(parsed.input ?? "");
+      const providerPrompt =
+        input.input === undefined || routed.adapter.capabilities.nativeSkillInput === true
+          ? input.input
+          : yield* expandSkillReferencesForProvider(input.input, skills).pipe(
+              Effect.provideService(FileSystem.FileSystem, fileSystem),
+              Effect.provideService(Path.Path, pathService),
+            );
+      yield* decodeInputOrValidationError({
+        operation: "ProviderService.sendTurn",
+        schema: ProviderSendTurnInput.fields.input,
+        payload: providerPrompt,
+      });
+      const { skills: _ignoredSkills, ...baseInput } = input;
+      const providerInput = {
+        ...baseInput,
+        ...(providerPrompt !== undefined ? { input: providerPrompt } : {}),
+        ...(routed.adapter.capabilities.nativeSkillInput === true && skills.length > 0
+          ? { skills }
+          : {}),
+      };
       metricProvider = routed.adapter.provider;
       metricModel = input.modelSelection?.model;
       yield* Effect.annotateCurrentSpan({
@@ -1687,7 +1702,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }),
         (turnMetadata) =>
           Effect.gen(function* () {
-            const turn = yield* routed.adapter.sendTurn(input);
+            const turn = yield* routed.adapter.sendTurn(providerInput);
             yield* associateTurnAnalytics({
               providerInstanceId: routed.instanceId,
               threadId: input.threadId,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -35,7 +35,7 @@ import {
 } from "@t3tools/contracts";
 import { expandAssistantCitationsForProvider } from "@t3tools/shared/assistantCitations";
 import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
-import { expandSkillReferencesForProvider } from "../skillReferences.ts";
+import { authorizeSkillReferences, expandSkillReferencesForProvider } from "../skillReferences.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
@@ -1657,6 +1657,14 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         });
       }
       const skills = collectSkillReferences(parsed.input ?? "");
+      if (skills.length > 0) {
+        const sessions = yield* routed.adapter.listSessions();
+        const session = sessions.find((candidate) => candidate.threadId === input.threadId);
+        const inventory = yield* registry.getSkills(routed.instanceId, session?.cwd);
+        yield* authorizeSkillReferences(skills, inventory).pipe(
+          Effect.provideService(FileSystem.FileSystem, fileSystem),
+        );
+      }
       const providerPrompt =
         input.input === undefined || routed.adapter.capabilities.nativeSkillInput === true
           ? input.input
@@ -1669,9 +1677,12 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         schema: ProviderSendTurnInput.fields.input,
         payload: providerPrompt,
       });
-      const { skills: _ignoredSkills, ...baseInput } = input;
+      const { skills: _ignoredSkills, skillContext: _ignoredSkillContext, ...baseInput } = input;
       const providerInput = {
         ...baseInput,
+        ...(providerPrompt !== input.input && input.input !== undefined
+          ? { skillContext: providerPrompt?.slice(input.input.length) }
+          : {}),
         ...(providerPrompt !== undefined ? { input: providerPrompt } : {}),
         ...(routed.adapter.capabilities.nativeSkillInput === true && skills.length > 0
           ? { skills }

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -34,6 +34,7 @@ import {
   type ProviderSession,
 } from "@t3tools/contracts";
 import { expandAssistantCitationsForProvider } from "@t3tools/shared/assistantCitations";
+import { expandSkillReferencesForProvider } from "../skillReferences.ts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { causeErrorTag } from "@t3tools/shared/observability";
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
@@ -1545,11 +1546,18 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 
     const inputTextWithCitations =
       parsed.input === undefined ? undefined : expandAssistantCitationsForProvider(parsed.input);
-    if (inputTextWithCitations !== parsed.input) {
+    const inputTextWithSkills =
+      inputTextWithCitations === undefined
+        ? undefined
+        : yield* expandSkillReferencesForProvider(inputTextWithCitations).pipe(
+            Effect.provideService(FileSystem.FileSystem, fileSystem),
+            Effect.provideService(Path.Path, pathService),
+          );
+    if (inputTextWithSkills !== parsed.input) {
       yield* decodeInputOrValidationError({
         operation: "ProviderService.sendTurn",
         schema: ProviderSendTurnInput.fields.input,
-        payload: inputTextWithCitations,
+        payload: inputTextWithSkills,
       });
     }
 
@@ -1559,7 +1567,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     // sends generic files as file parts, the others send images only and rely
     // on the path line for everything else. Unresolvable ids are skipped here
     // and surface as adapter errors when the file is read.
-    let inputTextWithAttachmentContext = inputTextWithCitations;
+    let inputTextWithAttachmentContext = inputTextWithSkills;
     const appendAttachmentContext = (context: string | undefined) => {
       if (context === undefined) return;
       const candidate = inputTextWithAttachmentContext

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -47,6 +47,8 @@ export interface ProviderAdapterCapabilities {
    * Declares whether changing the model on an existing session is supported.
    */
   readonly sessionModelSwitch: ProviderSessionModelSwitchMode;
+  /** Accepts native skill invocation bound to an exact file path. */
+  readonly nativeSkillInput?: boolean;
   /** Starts a resumed turn with no synthetic user prompt. Omitted means the
       adapter needs an explicit continuation instruction. */
   readonly promptlessTurnContinuation?: boolean;

--- a/apps/server/src/provider/Services/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderAdapterRegistry.ts
@@ -7,13 +7,17 @@
  *
  * @module ProviderAdapterRegistry
  */
-import type { ProviderDriverKind, ProviderInstanceId } from "@t3tools/contracts";
+import type { ProviderDriverKind, ProviderInstanceId, ServerProvider } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as PubSub from "effect/PubSub";
 import type * as Scope from "effect/Scope";
 
-import type { ProviderAdapterError, ProviderUnsupportedError } from "../Errors.ts";
+import type {
+  ProviderAdapterError,
+  ProviderUnsupportedError,
+  ProviderValidationError,
+} from "../Errors.ts";
 import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
 import type { ProviderContinuationIdentity } from "../ProviderDriver.ts";
 
@@ -41,6 +45,11 @@ export interface ProviderAdapterRegistryShape {
     instanceId: ProviderInstanceId,
   ) => Effect.Effect<ProviderAdapterShape<ProviderAdapterError>, ProviderUnsupportedError>;
 
+  /** Discover skills for this instance and the active session workspace. */
+  readonly getSkills: (
+    instanceId: ProviderInstanceId,
+    cwd: string | undefined,
+  ) => Effect.Effect<ServerProvider["skills"], ProviderUnsupportedError | ProviderValidationError>;
   readonly getInstanceInfo: (
     instanceId: ProviderInstanceId,
   ) => Effect.Effect<ProviderInstanceRoutingInfo, ProviderUnsupportedError>;

--- a/apps/server/src/provider/skillReferences.test.ts
+++ b/apps/server/src/provider/skillReferences.test.ts
@@ -1,0 +1,62 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  collectSkillReferences,
+  serializeSkillReference,
+} from "@t3tools/shared/composerInlineTokens";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { expandSkillReferencesForProvider } from "./skillReferences.ts";
+import { ProviderValidationError } from "./Errors.ts";
+
+const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
+
+it.layer(NodeServices.layer)("selected skill sources", (it) => {
+  it.effect("loads only the selected file, even when another source has the same name", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped();
+      const skills = ["plugin", "personal"].map((source) => ({
+        name: "code-review",
+        path: path.join(root, source, "SKILL.md"),
+      }));
+      for (const skill of skills) {
+        yield* fs.makeDirectory(path.dirname(skill.path), { recursive: true });
+        yield* fs.writeFileString(
+          skill.path,
+          skill === skills[0] ? "OFFICIAL_INSTRUCTIONS" : "MATT_STANDARDS_AND_SPEC",
+        );
+      }
+      for (const skill of skills) {
+        const prompt = `Use ${serializeSkillReference(skill)} now.`;
+        const expanded = yield* expandSkillReferencesForProvider(prompt);
+        assert.include(
+          expanded,
+          skill === skills[0] ? "OFFICIAL_INSTRUCTIONS" : "MATT_STANDARDS_AND_SPEC",
+        );
+        assert.notInclude(
+          expanded,
+          skill === skills[0] ? "MATT_STANDARDS_AND_SPEC" : "OFFICIAL_INSTRUCTIONS",
+        );
+        assert.deepEqual(collectSkillReferences(expanded), [skill]);
+        assert.include(expanded, encodeString(path.dirname(skill.path)));
+      }
+    }),
+  );
+  it.effect("fails before dispatch when the selected source disappeared", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped();
+      const prompt = serializeSkillReference({
+        name: "code-review",
+        path: path.join(root, "SKILL.md"),
+      });
+      const error = yield* expandSkillReferencesForProvider(prompt).pipe(Effect.flip);
+      assert.instanceOf(error, ProviderValidationError);
+    }),
+  );
+});

--- a/apps/server/src/provider/skillReferences.test.ts
+++ b/apps/server/src/provider/skillReferences.test.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import {
   collectSkillReferences,
@@ -8,12 +9,125 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
-import { expandSkillReferencesForProvider } from "./skillReferences.ts";
+import { authorizeSkillReferences, expandSkillReferencesForProvider } from "./skillReferences.ts";
 import { ProviderValidationError } from "./Errors.ts";
 
 const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
 
 it.layer(NodeServices.layer)("selected skill sources", (it) => {
+  it.effect(
+    "authorizes canonical inventory members and rejects disabled, hidden, renamed, and undiscovered files",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped();
+        const allowed = {
+          name: "review",
+          path: path.join(root, "allowed", "SKILL.md"),
+          enabled: true,
+        };
+        const other = { name: "review", path: path.join(root, "other", "SKILL.md"), enabled: true };
+        for (const skill of [allowed, other]) {
+          yield* fs.makeDirectory(path.dirname(skill.path), { recursive: true });
+          yield* fs.writeFileString(skill.path, "instructions");
+        }
+        yield* authorizeSkillReferences(
+          [
+            {
+              ...allowed,
+              path: `${root}${path.sep}other${path.sep}..${path.sep}allowed${path.sep}SKILL.md`,
+            },
+          ],
+          [allowed],
+        );
+        for (const [reference, inventory] of [
+          [other, [allowed]],
+          [allowed, [{ ...allowed, enabled: false }]],
+          [allowed, [{ ...allowed, userInvocable: false }]],
+          [{ ...allowed, name: "invented" }, [allowed]],
+          [allowed, []],
+        ] as const) {
+          let reads = 0;
+          const failure = yield* authorizeSkillReferences([reference], inventory).pipe(
+            Effect.andThen(expandSkillReferencesForProvider(serializeSkillReference(reference))),
+            Effect.provideService(FileSystem.FileSystem, {
+              ...fs,
+              readFileString: (...args) => {
+                reads++;
+                return fs.readFileString(...args);
+              },
+            }),
+            Effect.flip,
+          );
+          assert.instanceOf(failure, ProviderValidationError);
+          assert.equal(reads, 0);
+        }
+      }),
+  );
+
+  it.effect("stops before reading a file that exceeds the remaining aggregate budget", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped();
+      const references = ["first", "second", "third"].map((name) => ({
+        name,
+        path: path.join(root, name, "SKILL.md"),
+      }));
+      for (const reference of references) {
+        yield* fs.makeDirectory(path.dirname(reference.path), { recursive: true });
+        yield* fs.writeFileString(reference.path, "x".repeat(65_000));
+      }
+      const reads: string[] = [];
+      const error = yield* expandSkillReferencesForProvider(
+        references.map(serializeSkillReference).join(" "),
+      ).pipe(
+        Effect.provideService(FileSystem.FileSystem, {
+          ...fs,
+          readFileString: (file, ...args) => {
+            reads.push(file);
+            return fs.readFileString(file, ...args);
+          },
+        }),
+        Effect.flip,
+      );
+      assert.instanceOf(error, ProviderValidationError);
+      assert.deepEqual(reads, [references[0]!.path]);
+    }),
+  );
+
+  it.effect(
+    "accepts the exact aggregate limit and rejects one extra character before reading",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const root = yield* fs.makeTempDirectoryScoped();
+        const reference = { name: "review", path: path.join(root, "SKILL.md") };
+        yield* fs.writeFileString(reference.path, "instructions");
+        const prompt = serializeSkillReference(reference);
+        const expanded = yield* expandSkillReferencesForProvider(prompt);
+        const padding = " ".repeat(PROVIDER_SEND_TURN_MAX_INPUT_CHARS - expanded.length);
+        assert.equal(
+          (yield* expandSkillReferencesForProvider(prompt + padding)).length,
+          PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
+        );
+        let reads = 0;
+        yield* expandSkillReferencesForProvider(prompt + padding + " ").pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fs,
+            readFileString: (...args) => {
+              reads++;
+              return fs.readFileString(...args);
+            },
+          }),
+          Effect.flip,
+        );
+        assert.equal(reads, 0);
+      }),
+  );
+
   it.effect("loads only the selected file, even when another source has the same name", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/skillReferences.ts
+++ b/apps/server/src/provider/skillReferences.ts
@@ -1,0 +1,57 @@
+import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { ProviderValidationError } from "./Errors.ts";
+
+const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
+
+/** Bind explicit picks before provider routing, including providers without native skill inputs. */
+export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferencesForProvider")(
+  function* (prompt: string) {
+    const references = collectSkillReferences(prompt);
+    if (references.length === 0) return prompt;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const blocks: string[] = [];
+    for (const reference of references) {
+      const info = yield* fileSystem.stat(reference.path).pipe(
+        Effect.mapError(
+          () =>
+            new ProviderValidationError({
+              operation: "ProviderService.sendTurn",
+              issue: `Cannot read selected skill: ${reference.path}. Select an available skill and retry.`,
+            }),
+        ),
+      );
+      if (info.type !== "File" || info.size > BigInt(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)) {
+        return yield* new ProviderValidationError({
+          operation: "ProviderService.sendTurn",
+          issue: `Selected skill is not a readable file within the prompt size limit: ${reference.path}`,
+        });
+      }
+      const contents = yield* fileSystem.readFileString(reference.path).pipe(
+        Effect.mapError(
+          () =>
+            new ProviderValidationError({
+              operation: "ProviderService.sendTurn",
+              issue: `Cannot read selected skill: ${reference.path}. Select an available skill and retry.`,
+            }),
+        ),
+      );
+      blocks.push(
+        [
+          "The user explicitly selected this skill file. This source is authoritative for this invocation; follow its instructions rather than resolving the name again.",
+          `Skill name: ${encodeString(reference.name)}`,
+          `Skill file: ${encodeString(reference.path)}`,
+          `Resolve relative skill resources from: ${encodeString(path.dirname(reference.path))}`,
+          "Selected skill instructions:",
+          contents,
+        ].join("\n"),
+      );
+    }
+    return `${prompt}\n\n${blocks.join("\n\n")}`;
+  },
+);

--- a/apps/server/src/provider/skillReferences.ts
+++ b/apps/server/src/provider/skillReferences.ts
@@ -8,10 +8,9 @@ import { ProviderValidationError } from "./Errors.ts";
 
 const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
 
-/** Bind explicit picks before provider routing, including providers without native skill inputs. */
+/** Exact-file fallback for providers without native path-bound skill inputs. */
 export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferencesForProvider")(
-  function* (prompt: string) {
-    const references = collectSkillReferences(prompt);
+  function* (prompt: string, references = collectSkillReferences(prompt)) {
     if (references.length === 0) return prompt;
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;

--- a/apps/server/src/provider/skillReferences.ts
+++ b/apps/server/src/provider/skillReferences.ts
@@ -1,5 +1,5 @@
 import { collectSkillReferences } from "@t3tools/shared/composerInlineTokens";
-import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS } from "@t3tools/contracts";
+import { PROVIDER_SEND_TURN_MAX_INPUT_CHARS, type ServerProvider } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -8,6 +8,37 @@ import { ProviderValidationError } from "./Errors.ts";
 
 const encodeString = Schema.encodeSync(Schema.fromJsonString(Schema.String));
 
+/** Only enabled, user-invocable sources discovered by this provider may be dispatched. */
+export const authorizeSkillReferences = Effect.fn("authorizeSkillReferences")(function* (
+  references: ReturnType<typeof collectSkillReferences>,
+  inventory: ServerProvider["skills"],
+) {
+  const fs = yield* FileSystem.FileSystem;
+  for (const reference of references) {
+    const candidates = (inventory ?? []).filter(
+      (skill) => skill.enabled && skill.userInvocable !== false && skill.name === reference.name,
+    );
+    const reject = () =>
+      new ProviderValidationError({
+        operation: "ProviderService.sendTurn",
+        issue: `Selected skill is not an available, user-invocable source: ${reference.path}. Refresh skills and retry.`,
+      });
+    if (candidates.length === 0) return yield* reject();
+    const canonical = yield* fs.realPath(reference.path).pipe(Effect.mapError(reject));
+    let authorized = false;
+    for (const candidate of candidates) {
+      const candidatePath = yield* fs
+        .realPath(candidate.path)
+        .pipe(Effect.catch(() => Effect.succeed(undefined)));
+      if (candidatePath === canonical) {
+        authorized = true;
+        break;
+      }
+    }
+    if (!authorized) return yield* reject();
+  }
+});
+
 /** Exact-file fallback for providers without native path-bound skill inputs. */
 export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferencesForProvider")(
   function* (prompt: string, references = collectSkillReferences(prompt)) {
@@ -15,6 +46,13 @@ export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferences
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     const blocks: string[] = [];
+    let size = prompt.length;
+    const overflow = () =>
+      new ProviderValidationError({
+        operation: "ProviderService.sendTurn",
+        issue: `Selected skill instructions exceed the ${PROVIDER_SEND_TURN_MAX_INPUT_CHARS} character prompt limit.`,
+      });
+    if (size > PROVIDER_SEND_TURN_MAX_INPUT_CHARS) return yield* overflow();
     for (const reference of references) {
       const info = yield* fileSystem.stat(reference.path).pipe(
         Effect.mapError(
@@ -31,6 +69,17 @@ export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferences
           issue: `Selected skill is not a readable file within the prompt size limit: ${reference.path}`,
         });
       }
+      const header =
+        [
+          "The user explicitly selected this skill file. This source is authoritative for this invocation; follow its instructions rather than resolving the name again.",
+          `Skill name: ${encodeString(reference.name)}`,
+          `Skill file: ${encodeString(reference.path)}`,
+          `Resolve relative skill resources from: ${encodeString(path.dirname(reference.path))}`,
+          "Selected skill instructions:",
+        ].join("\n") + "\n";
+      // Conservatively budget UTF-8 bytes before reading, then check the decoded character count.
+      const remaining = PROVIDER_SEND_TURN_MAX_INPUT_CHARS - size - 2 - header.length;
+      if (remaining < 0 || info.size > BigInt(remaining)) return yield* overflow();
       const contents = yield* fileSystem.readFileString(reference.path).pipe(
         Effect.mapError(
           () =>
@@ -40,16 +89,9 @@ export const expandSkillReferencesForProvider = Effect.fn("expandSkillReferences
             }),
         ),
       );
-      blocks.push(
-        [
-          "The user explicitly selected this skill file. This source is authoritative for this invocation; follow its instructions rather than resolving the name again.",
-          `Skill name: ${encodeString(reference.name)}`,
-          `Skill file: ${encodeString(reference.path)}`,
-          `Resolve relative skill resources from: ${encodeString(path.dirname(reference.path))}`,
-          "Selected skill instructions:",
-          contents,
-        ].join("\n"),
-      );
+      if (contents.length > remaining) return yield* overflow();
+      size += 2 + header.length + contents.length;
+      blocks.push(header + contents);
     }
     return `${prompt}\n\n${blocks.join("\n\n")}`;
   },

--- a/apps/server/src/provider/testUtils/providerAdapterRegistryMock.ts
+++ b/apps/server/src/provider/testUtils/providerAdapterRegistryMock.ts
@@ -46,6 +46,7 @@ export const makeAdapterRegistryMock = (adapters: KindAdapterMap): ProviderAdapt
 
   return {
     getByInstance,
+    getSkills: () => Effect.succeed([]),
     getInstanceInfo: (instanceId) => {
       const adapter = byInstanceId.get(instanceId);
       if (!adapter) {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -129,6 +129,7 @@ type SerializedComposerSkillNode = Spread<
     skillName: string;
     skillLabel?: string;
     skillDescription?: string;
+    skillSource?: string;
     type: "composer-skill";
     version: 1;
   },
@@ -253,15 +254,16 @@ type ComposerSkillMetadata = {
 function skillMetadataByName(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ReadonlyMap<string, ComposerSkillMetadata> {
-  return new Map(
-    skills.map((skill) => [
-      skill.name,
-      {
-        label: formatProviderSkillDisplayName(skill),
-        description: resolveSkillDescription(skill),
-      },
-    ]),
-  );
+  const metadata = new Map<string, ComposerSkillMetadata>();
+  for (const skill of skills) {
+    const value = {
+      label: formatProviderSkillDisplayName(skill),
+      description: resolveSkillDescription(skill),
+    };
+    if (!metadata.has(skill.name)) metadata.set(skill.name, value);
+    metadata.set(skill.path, value);
+  }
+  return metadata;
 }
 
 function ComposerSkillDecorator(props: { skillLabel: string; skillDescription: string | null }) {
@@ -299,6 +301,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
   __skillName: string;
   __skillLabel: string;
   __skillDescription: string | null;
+  __skillSource: string;
 
   static override getType(): string {
     return "composer-skill";
@@ -309,6 +312,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
       node.__skillName,
       node.__skillLabel,
       node.__skillDescription,
+      node.__skillSource,
       node.__key,
     );
   }
@@ -318,6 +322,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
       serializedNode.skillName,
       serializedNode.skillLabel ?? serializedNode.skillName,
       serializedNode.skillDescription ?? null,
+      serializedNode.skillSource,
     ).updateFromJSON(serializedNode);
   }
 
@@ -325,6 +330,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     skillName: string,
     skillLabel: string,
     skillDescription: string | null,
+    skillSource?: string,
     key?: NodeKey,
   ) {
     super(key);
@@ -332,6 +338,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     this.__skillName = normalizedSkillName;
     this.__skillLabel = skillLabel;
     this.__skillDescription = skillDescription;
+    this.__skillSource = skillSource ?? `$${normalizedSkillName}`;
   }
 
   override exportJSON(): SerializedComposerSkillNode {
@@ -339,6 +346,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
       ...super.exportJSON(),
       skillName: this.__skillName,
       skillLabel: this.__skillLabel,
+      skillSource: this.__skillSource,
       ...(this.__skillDescription ? { skillDescription: this.__skillDescription } : {}),
       type: "composer-skill",
       version: 1,
@@ -356,7 +364,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
   }
 
   override getTextContent(): string {
-    return `$${this.__skillName}`;
+    return this.__skillSource;
   }
 
   override isInline(): true {
@@ -377,8 +385,11 @@ function $createComposerSkillNode(
   skillName: string,
   skillLabel: string,
   skillDescription: string | null,
+  skillSource?: string,
 ): ComposerSkillNode {
-  return $applyNodeReplacement(new ComposerSkillNode(skillName, skillLabel, skillDescription));
+  return $applyNodeReplacement(
+    new ComposerSkillNode(skillName, skillLabel, skillDescription, skillSource),
+  );
 }
 
 function ComposerTerminalContextDecorator(props: { context: TerminalContextDraft }) {
@@ -861,12 +872,13 @@ function $setComposerEditorPrompt(
       continue;
     }
     if (segment.type === "skill") {
-      const metadata = skillMetadata.get(segment.name);
+      const metadata = skillMetadata.get(segment.path ?? segment.name);
       paragraph.append(
         $createComposerSkillNode(
           segment.name,
           metadata?.label ?? formatProviderSkillDisplayName({ name: segment.name }),
           metadata?.description ?? null,
+          segment.source,
         ),
       );
       continue;

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -251,6 +251,7 @@ type ComposerSkillMetadata = {
   description: string | null;
 };
 
+/** Index chip metadata by exact path, with first-by-name lookup retained for legacy drafts. */
 function skillMetadataByName(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ReadonlyMap<string, ComposerSkillMetadata> {
@@ -307,6 +308,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     return "composer-skill";
   }
 
+  /** Preserve the selected source when Lexical clones a skill chip during editor updates. */
   static override clone(node: ComposerSkillNode): ComposerSkillNode {
     return new ComposerSkillNode(
       node.__skillName,
@@ -317,6 +319,7 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     );
   }
 
+  /** Restore persisted chips, accepting older drafts that stored only a skill name. */
   static override importJSON(serializedNode: SerializedComposerSkillNode): ComposerSkillNode {
     return $createComposerSkillNode(
       serializedNode.skillName,
@@ -326,6 +329,10 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     ).updateFromJSON(serializedNode);
   }
 
+  /**
+   * Create a chip from a serialized skill reference, falling back to a bare name for legacy
+   * callers.
+   */
   constructor(
     skillName: string,
     skillLabel: string,
@@ -341,6 +348,10 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     this.__skillSource = skillSource ?? `$${normalizedSkillName}`;
   }
 
+  /**
+   * Persist the selected source with the display metadata so draft reloads retain skill
+   * identity.
+   */
   override exportJSON(): SerializedComposerSkillNode {
     return {
       ...super.exportJSON(),
@@ -363,6 +374,10 @@ class ComposerSkillNode extends DecoratorNode<React.ReactElement> {
     return false;
   }
 
+  /**
+   * Return the invocation source for copy and prompt submission, independent of the visible
+   * label.
+   */
   override getTextContent(): string {
     return this.__skillSource;
   }
@@ -851,6 +866,7 @@ function $appendTextWithLineBreaks(parent: ElementNode, text: string): void {
   }
 }
 
+/** Rebuild the editor from serialized draft text, resolving source-bound skill metadata by path. */
 function $setComposerEditorPrompt(
   prompt: string,
   terminalContexts: ReadonlyArray<TerminalContextDraft>,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -887,6 +887,8 @@ import {
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
+  formatProviderSkillReference,
+  formatProviderSkillMenuDescription,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -2106,15 +2108,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       }));
       const query = composerTrigger.query.trim().toLowerCase();
       const skillItems = slashMenuSkills.map((skill) => ({
-        id: `skill:${selectedProvider}:${skill.name}`,
+        id: `skill:${selectedProvider}:${JSON.stringify([skill.name, skill.path])}`,
         type: "skill" as const,
         provider: selectedProvider,
         skill,
         label: `/skill:${skill.name}`,
-        description:
-          skill.shortDescription ??
-          skill.description ??
-          (skill.scope ? `${skill.scope} skill` : ""),
+        description: formatProviderSkillMenuDescription(skill, selectedProviderSkills),
       }));
       const visibleProviderSlashCommandItems = providerSlashCommandItems.filter(
         (item) => item.command.name !== "compact" || compactSlashCommandAvailable,
@@ -2127,15 +2126,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
     if (composerTrigger.kind === "skill") {
       return searchProviderSkills(selectedProviderSkills, composerTrigger.query).map((skill) => ({
-        id: `skill:${selectedProvider}:${skill.name}`,
+        id: `skill:${selectedProvider}:${JSON.stringify([skill.name, skill.path])}`,
         type: "skill" as const,
         provider: selectedProvider,
         skill,
         label: formatProviderSkillDisplayName(skill),
-        description:
-          skill.shortDescription ??
-          skill.description ??
-          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+        description: formatProviderSkillMenuDescription(skill, selectedProviderSkills),
       }));
     }
     return [];
@@ -2930,7 +2926,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return;
       }
       if (item.type === "skill") {
-        const replacement = `$${item.skill.name} `;
+        const replacement = `${formatProviderSkillReference(item.skill)} `;
         const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
           snapshot.value,
           trigger.rangeEnd,

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -21,6 +21,19 @@ const citation: AssistantCitation = {
 };
 
 describe("splitPromptIntoComposerSegments", () => {
+  it("preserves the exact skill source in an inline chip", () => {
+    const source = "[$code-review](/personal/My%20Skills/code-review/SKILL.md)";
+    expect(splitPromptIntoComposerSegments(`Use ${source} now`)).toEqual([
+      { type: "text", text: "Use " },
+      {
+        type: "skill",
+        name: "code-review",
+        source,
+        path: "/personal/My Skills/code-review/SKILL.md",
+      },
+      { type: "text", text: " now" },
+    ]);
+  });
   it("splits mention tokens followed by whitespace into mention segments", () => {
     expect(splitPromptIntoComposerSegments("Inspect @AGENTS.md please")).toEqual([
       { type: "text", text: "Inspect " },

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -148,6 +148,10 @@ export function collectComposerPromptInlineTokens(text: string) {
   ].sort((left, right) => left.start - right.start);
 }
 
+/**
+ * Split draft text into editor segments while retaining each chip's original source for lossless
+ * serialization.
+ */
 function splitPromptTextIntoComposerSegments(text: string): ComposerPromptSegment[] {
   const segments: ComposerPromptSegment[] = [];
   if (!text) {

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -22,6 +22,8 @@ export type ComposerPromptSegment =
   | {
       type: "skill";
       name: string;
+      source?: string;
+      path?: string;
     }
   | {
       type: "citation";
@@ -172,7 +174,11 @@ function splitPromptTextIntoComposerSegments(text: string): ComposerPromptSegmen
         source: match.source,
       });
     } else {
-      segments.push({ type: "skill", name: match.value });
+      segments.push({
+        type: "skill",
+        name: match.value,
+        ...(match.path ? { source: match.source, path: match.path } : {}),
+      });
     }
 
     cursor = match.end;

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -33,6 +33,12 @@ const citation: AssistantCitation = {
 const citationSource = serializeAssistantCitation(citation).replaceAll("+", "%20");
 
 describe("formatAssistantCitationForComposer", () => {
+  it("maps cursor positions across a source-bound skill chip without losing its path", () => {
+    const source = "[$code-review](/personal/My%20Skills/code-review/SKILL.md)";
+    const prompt = `Use ${source} now`;
+    expect(expandCollapsedComposerCursor(prompt, 5)).toBe(4 + source.length);
+    expect(collapseExpandedComposerCursor(prompt, 4 + source.length)).toBe(5);
+  });
   it.each([undefined, "", " \n\t "])(
     "keeps citation-only insertion for a blank comment %j",
     (comment) => {

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -61,6 +61,10 @@ function tokenStartForCursor(text: string, cursor: number): number {
   return index + 1;
 }
 
+/**
+ * Map a visible editor cursor to serialized prompt offsets, treating each inline chip as one
+ * position.
+ */
 export function expandCollapsedComposerCursor(text: string, cursorInput: number): number {
   const collapsedCursor = clampCursor(text, cursorInput);
   const segments = splitPromptIntoComposerSegments(text);
@@ -138,6 +142,10 @@ export function clampCollapsedComposerCursor(text: string, cursorInput: number):
   );
 }
 
+/**
+ * Map serialized prompt offsets back to editor positions, collapsing each inline chip to one
+ * position.
+ */
 export function collapseExpandedComposerCursor(text: string, cursorInput: number): number {
   const expandedCursor = clampCursor(text, cursorInput);
   const segments = splitPromptIntoComposerSegments(text);

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -82,7 +82,7 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
       continue;
     }
     if (segment.type === "skill") {
-      const expandedLength = segment.name.length + 1;
+      const expandedLength = segment.source?.length ?? segment.name.length + 1;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
       }
@@ -162,7 +162,7 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
       continue;
     }
     if (segment.type === "skill") {
-      const expandedLength = segment.name.length + 1;
+      const expandedLength = segment.source?.length ?? segment.name.length + 1;
       if (remaining === 0) {
         return collapsedCursor;
       }

--- a/apps/web/src/providerSkillSearch.test.ts
+++ b/apps/web/src/providerSkillSearch.test.ts
@@ -13,6 +13,20 @@ function makeSkill(input: Partial<ServerProviderSkill> & Pick<ServerProviderSkil
 }
 
 describe("searchProviderSkills", () => {
+  it("lets users find either same-name skill by its own description", () => {
+    const plugin = makeSkill({
+      name: "code-review",
+      path: "/plugins/review/SKILL.md",
+      description: "Official review",
+    });
+    const personal = makeSkill({
+      name: "code-review",
+      path: "/personal/review/SKILL.md",
+      description: "Standards and spec",
+    });
+    expect(searchProviderSkills([plugin, personal], "standards", Infinity)).toEqual([personal]);
+    expect(searchProviderSkills([plugin, personal], "code-review", Infinity)).toHaveLength(2);
+  });
   it("moves exact ui matches ahead of broader ui matches", () => {
     const skills = [
       makeSkill({
@@ -83,7 +97,7 @@ describe("searchProviderSkills", () => {
     ]);
   });
 
-  it("returns the first enabled definition for each skill name", () => {
+  it("returns distinct sources for the same skill name", () => {
     const skills = [
       makeSkill({ name: "branch-audit", path: "/Users/matt/.codex/skills/branch-audit/SKILL.md" }),
       makeSkill({ name: "browser" }),
@@ -93,6 +107,7 @@ describe("searchProviderSkills", () => {
     expect(searchProviderSkills(skills, "").map((skill) => skill.path)).toEqual([
       "/Users/matt/.codex/skills/branch-audit/SKILL.md",
       "/tmp/browser/SKILL.md",
+      "/Users/matt/.agents/skills/branch-audit/SKILL.md",
     ]);
   });
 });

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -1,6 +1,6 @@
 import type { ServerProviderSkill } from "@t3tools/contracts";
 import {
-  dedupeProviderSkillsByName,
+  dedupeProviderSkillsBySource,
   formatProviderSkillDisplayName,
   isProviderSkillUserInvocable,
 } from "@t3tools/client-runtime/providerSkills";
@@ -74,7 +74,7 @@ export function searchProviderSkills(
   query: string,
   limit = Number.POSITIVE_INFINITY,
 ): ServerProviderSkill[] {
-  const enabledSkills = dedupeProviderSkillsByName(skills.filter(isProviderSkillUserInvocable));
+  const enabledSkills = dedupeProviderSkillsBySource(skills.filter(isProviderSkillUserInvocable));
   const normalizedQuery = normalizeSearchQuery(query, { trimLeadingPattern: /^\$+/ });
 
   if (!normalizedQuery) {

--- a/apps/web/src/providerSkillSearch.ts
+++ b/apps/web/src/providerSkillSearch.ts
@@ -69,6 +69,10 @@ export function scoreProviderSkill(skill: ServerProviderSkill, query: string): n
   return Math.min(...scores);
 }
 
+/**
+ * Rank invocable skill sources for autocomplete without collapsing same-name choices from
+ * different files.
+ */
 export function searchProviderSkills(
   skills: ReadonlyArray<ServerProviderSkill>,
   query: string,

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -102,6 +102,9 @@ provider. On mobile, both are also available before starting a thread on
 
 The slash menu also includes skills unless you turn off **Settings → General →
 Show skills in slash menu**. Only skills enabled for the provider are listed.
+Skills with the same name show their source paths so you can choose the intended
+copy. A selected skill keeps that source when you save or send the draft. If the
+file is no longer available, select it again before retrying.
 
 Provider commands must start the message to run. T3 Code commands such as
 `/model` and `/plan`, and skill mentions, work on any line.

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -2,7 +2,7 @@ import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  dedupeProviderSkillsByName,
+  dedupeProviderSkillsBySource,
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
@@ -52,7 +52,17 @@ describe("formatProviderSkillDisplayName", () => {
   });
 });
 
-describe("dedupeProviderSkillsByName", () => {
+describe("dedupeProviderSkillsBySource", () => {
+  it("keeps distinct skill sources but collapses repeated entries for the same source", () => {
+    const plugin = { name: "code-review", path: "/plugins/code-review/SKILL.md", enabled: true };
+    const personal = {
+      name: "code-review",
+      path: "/.agents/skills/code-review/SKILL.md",
+      enabled: true,
+    };
+    expect(dedupeProviderSkillsBySource([plugin, personal, plugin])).toEqual([plugin, personal]);
+    expect(dedupeProviderSkillsBySource([personal, plugin])).toEqual([personal, plugin]);
+  });
   it("keeps the first resolved skill and preserves unrelated skill order", () => {
     const firstSkill = {
       name: "branch-audit",
@@ -66,11 +76,11 @@ describe("dedupeProviderSkillsByName", () => {
     };
     const duplicateSkill = {
       name: "Branch-Audit",
-      path: "/Users/matt/.agents/skills/branch-audit/SKILL.md",
+      path: "/Users/matt/.codex/skills/branch-audit/SKILL.md",
       enabled: true,
     };
 
-    expect(dedupeProviderSkillsByName([firstSkill, otherSkill, duplicateSkill])).toEqual([
+    expect(dedupeProviderSkillsBySource([firstSkill, otherSkill, duplicateSkill])).toEqual([
       firstSkill,
       otherSkill,
     ]);
@@ -89,7 +99,7 @@ describe("getProviderSkillsForSlashMenu", () => {
     ]);
   });
 
-  it("shows one row when enabled skills share a name", () => {
+  it("shows distinct sources when enabled skills share a name", () => {
     const skills = [
       {
         name: "babysit-pr",
@@ -111,6 +121,7 @@ describe("getProviderSkillsForSlashMenu", () => {
     expect(getProviderSkillsForSlashMenu(skills, true).map((skill) => skill.name)).toEqual([
       "babysit-pr",
       "browser",
+      "babysit-pr",
     ]);
   });
 

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -30,6 +30,10 @@ export function formatProviderSkillDisplayName(
   return titleCaseWords(skill.name);
 }
 
+/**
+ * Keep the first entry for each name and normalized path so same-name skills from distinct files
+ * remain selectable.
+ */
 export function dedupeProviderSkillsBySource(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ServerProviderSkill[] {
@@ -60,6 +64,10 @@ export function isProviderSkillUserInvocable(
   return skill.enabled && skill.userInvocable !== false;
 }
 
+/**
+ * Return user-invocable sources when skill suggestions are enabled, retaining distinct files
+ * with the same name.
+ */
 export function getProviderSkillsForSlashMenu(
   skills: ReadonlyArray<ServerProviderSkill>,
   showSkillsInSlashMenu: boolean,
@@ -69,10 +77,18 @@ export function getProviderSkillsForSlashMenu(
     : [];
 }
 
+/**
+ * Serialize a menu selection with its exact source instead of relying on provider name
+ * resolution.
+ */
 export function formatProviderSkillReference(skill: ServerProviderSkill): string {
   return serializeSkillReference(skill);
 }
 
+/**
+ * Include the source path when another invocable skill shares this name so users can distinguish
+ * menu choices.
+ */
 export function formatProviderSkillMenuDescription(
   skill: ServerProviderSkill,
   skills: ReadonlyArray<ServerProviderSkill>,

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -3,6 +3,7 @@ import type {
   ServerProviderSkill,
   ServerProviderSlashCommand,
 } from "@t3tools/contracts";
+import { serializeSkillReference } from "@t3tools/shared/composerInlineTokens";
 
 export type ProviderSkillSourceKind = "app" | "repo" | "project" | "personal" | "system" | "other";
 
@@ -29,16 +30,19 @@ export function formatProviderSkillDisplayName(
   return titleCaseWords(skill.name);
 }
 
-export function dedupeProviderSkillsByName(
+export function dedupeProviderSkillsBySource(
   skills: ReadonlyArray<ServerProviderSkill>,
 ): ServerProviderSkill[] {
-  const seenNames = new Set<string>();
+  const seenSources = new Set<string>();
   return skills.filter((skill) => {
-    const normalizedName = skill.name.trim().toLowerCase();
-    if (seenNames.has(normalizedName)) {
+    const sourceKey = JSON.stringify([
+      skill.name.trim().toLowerCase(),
+      normalizePathSeparators(skill.path),
+    ]);
+    if (seenSources.has(sourceKey)) {
       return false;
     }
-    seenNames.add(normalizedName);
+    seenSources.add(sourceKey);
     return true;
   });
 }
@@ -48,7 +52,7 @@ export function dedupeProviderSkillsByName(
  * provider's settings will not run, and one the provider reserves for the
  * agent (Claude Code's `user-invocable: false`) rejects a user invocation.
  * Everything else, including skills the agent may not start on its own, is
- * fair game: the server dispatches the pick in the provider's native form.
+ * fair game: the server attaches the explicitly selected file before dispatch.
  */
 export function isProviderSkillUserInvocable(
   skill: Pick<ServerProviderSkill, "enabled" | "userInvocable">,
@@ -61,8 +65,27 @@ export function getProviderSkillsForSlashMenu(
   showSkillsInSlashMenu: boolean,
 ): ServerProviderSkill[] {
   return showSkillsInSlashMenu
-    ? dedupeProviderSkillsByName(skills.filter(isProviderSkillUserInvocable))
+    ? dedupeProviderSkillsBySource(skills.filter(isProviderSkillUserInvocable))
     : [];
+}
+
+export function formatProviderSkillReference(skill: ServerProviderSkill): string {
+  return serializeSkillReference(skill);
+}
+
+export function formatProviderSkillMenuDescription(
+  skill: ServerProviderSkill,
+  skills: ReadonlyArray<ServerProviderSkill>,
+): string {
+  const description = skill.shortDescription ?? skill.description ?? "";
+  const hasCollision = skills.some(
+    (other) =>
+      other.enabled &&
+      other.userInvocable !== false &&
+      other.name.trim().toLowerCase() === skill.name.trim().toLowerCase() &&
+      other.path !== skill.path,
+  );
+  return hasCollision ? `${skill.path}${description ? ` · ${description}` : ""}` : description;
 }
 
 export function getProviderSlashCommandsForSlashMenu(

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -71,6 +71,10 @@ export const ProviderSendTurnInput = Schema.Struct({
   /** Internal recovery signal. Allows an empty turn only for adapters that
       explicitly support promptless continuation. */
   continuation: Schema.optional(Schema.Boolean),
+  /** Generated exact-file fallback suffix, excluded from native name-based dispatch planning. */
+  skillContext: Schema.optional(
+    Schema.String.check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)),
+  ),
   /** Exact sources selected in the composer, supplied internally by ProviderService. */
   skills: Schema.optional(
     Schema.Array(Schema.Struct({ name: TrimmedNonEmptyString, path: TrimmedNonEmptyString })),

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -71,6 +71,10 @@ export const ProviderSendTurnInput = Schema.Struct({
   /** Internal recovery signal. Allows an empty turn only for adapters that
       explicitly support promptless continuation. */
   continuation: Schema.optional(Schema.Boolean),
+  /** Exact sources selected in the composer, supplied internally by ProviderService. */
+  skills: Schema.optional(
+    Schema.Array(Schema.Struct({ name: TrimmedNonEmptyString, path: TrimmedNonEmptyString })),
+  ),
   input: Schema.optional(
     TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)),
   ),

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -12,6 +12,28 @@ describe("explicit skill references", () => {
     expect(collectSkillReferences(`Example: \`${ref}\`\n\n\`\`\`md\n${ref}\n\`\`\``)).toEqual([]);
   });
   it.each([
+    "`` [$review](/private/SKILL.md) ``",
+    "`` literal ` [$review](/private/SKILL.md) ``",
+    "`` multi\n [$review](/private/SKILL.md) \nline ``",
+    "```md\n[$review](/private/SKILL.md)",
+    "~~~md\n[$review](/private/SKILL.md)",
+    "````md\n```\n[$review](/private/SKILL.md)\n````",
+    "~~~~md\n~~~\n[$review](/private/SKILL.md)\n~~~~",
+    "```md\n~~~\n[$review](/private/SKILL.md)",
+  ])("ignores references in Markdown code: %s", (text) => {
+    expect(collectSkillReferences(text)).toEqual([]);
+  });
+
+  it("collects references after matching fences and unmatched inline delimiters", () => {
+    const ref = "[$review](/personal/review/SKILL.md)";
+    expect(collectSkillReferences("````md\nignored\n`````\n" + ref)).toEqual([
+      { name: "review", path: "/personal/review/SKILL.md" },
+    ]);
+    expect(collectSkillReferences("`` unmatched " + ref)).toEqual([
+      { name: "review", path: "/personal/review/SKILL.md" },
+    ]);
+  });
+  it.each([
     "/home/Matt/My Skills (personal)/review?#雪/SKILL.md",
     "C:\\Users\\Matt\\My Skills (personal)\\review\\SKILL.md",
     "\\\\server\\skills\\review\\SKILL.md",

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { collectComposerInlineTokens } from "./composerInlineTokens.ts";
+import {
+  collectComposerInlineTokens,
+  collectSkillReferences,
+  serializeSkillReference,
+} from "./composerInlineTokens.ts";
+
+describe("explicit skill references", () => {
+  it("does not invoke references quoted as code examples", () => {
+    const ref = "[$review](/personal/review/SKILL.md)";
+    expect(collectSkillReferences(`Example: \`${ref}\`\n\n\`\`\`md\n${ref}\n\`\`\``)).toEqual([]);
+  });
+  it.each([
+    "/home/Matt/My Skills (personal)/review?#雪/SKILL.md",
+    "C:\\Users\\Matt\\My Skills (personal)\\review\\SKILL.md",
+    "\\\\server\\skills\\review\\SKILL.md",
+  ])("preserves the selected source through serialization: %s", (path) => {
+    const skill = { name: "code-review", path };
+    const reference = serializeSkillReference(skill);
+    expect(collectSkillReferences(`Use ${reference}, then ${reference}.`)).toEqual([skill]);
+  });
+
+  it("keeps different same-name sources in the same prompt", () => {
+    const skills = [
+      { name: "code-review", path: "/plugins/review/SKILL.md" },
+      { name: "code-review", path: "/personal/review/SKILL.md" },
+    ];
+    expect(collectSkillReferences(skills.map(serializeSkillReference).join(" and "))).toEqual(
+      skills,
+    );
+  });
+
+  it("leaves bare names, external links, and malformed references as text", () => {
+    expect(
+      collectSkillReferences(
+        "$code-review [$review](https://example.com/SKILL.md) [$review](%zz) [$review](relative/SKILL.md)",
+      ),
+    ).toEqual([]);
+  });
+});
 
 describe("collectComposerInlineTokens", () => {
   it("collects file links, mentions, and skills with source ranges", () => {

--- a/packages/shared/src/composerInlineTokens.test.ts
+++ b/packages/shared/src/composerInlineTokens.test.ts
@@ -24,6 +24,20 @@ describe("explicit skill references", () => {
     expect(collectSkillReferences(text)).toEqual([]);
   });
 
+  it.each([
+    ["\\` REF \\`", true],
+    ["\\` REF `", true],
+    ["\\\\` REF `", false],
+    ["` REF \\`", false],
+    ["\\`` REF `", false],
+    ["\\`` REF ``", true],
+  ])("handles escaped backticks outside, but not inside, code spans: %s", (text, detected) => {
+    const skill = { name: "review", path: "/personal/review/SKILL.md" };
+    expect(collectSkillReferences(text.replace("REF", serializeSkillReference(skill)))).toEqual(
+      detected ? [skill] : [],
+    );
+  });
+
   it("collects references after matching fences and unmatched inline delimiters", () => {
     const ref = "[$review](/personal/review/SKILL.md)";
     expect(collectSkillReferences("````md\nignored\n`````\n" + ref)).toEqual([

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -19,6 +19,10 @@ export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
 }
 
+/**
+ * Encode a selected skill as a Markdown reference that preserves its exact file through storage
+ * and transport.
+ */
 export function serializeSkillReference(skill: { name: string; path: string }): string {
   const path = encodeURI(skill.path).replace(
     /[()?#]/g,
@@ -96,6 +100,10 @@ function collectMarkdownCodeRanges(text: string): Array<{ start: number; end: nu
   return ranges.sort((left, right) => left.start - right.start);
 }
 
+/**
+ * Parse absolute SKILL.md references outside Markdown code, retaining source offsets for
+ * composer chips. Malformed references remain prose.
+ */
 function collectSkillReferenceTokens(
   text: string,
 ): Extract<ComposerInlineToken, { type: "skill" }>[] {
@@ -209,6 +217,10 @@ function collectMentionTokens(text: string): ComposerInlineToken[] {
   return matches;
 }
 
+/**
+ * Collect file and skill chips in source order. Pass prior tokens to preserve an existing chip
+ * at the end of an edited draft.
+ */
 export function collectComposerInlineTokens(
   text: string,
   options: CollectComposerInlineTokensOptions = {},

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -9,6 +9,7 @@ export type ComposerInlineToken =
   | {
       readonly type: "skill";
       readonly value: string;
+      readonly path?: string;
       readonly source: string;
       readonly start: number;
       readonly end: number;
@@ -16,6 +17,56 @@ export type ComposerInlineToken =
 
 export interface CollectComposerInlineTokensOptions {
   readonly preserveTrailingFrom?: ReadonlyArray<ComposerInlineToken>;
+}
+
+export function serializeSkillReference(skill: { name: string; path: string }): string {
+  const path = encodeURI(skill.path).replace(
+    /[()?#]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `[$${skill.name}](${path})`;
+}
+
+/** Explicit source references survive draft storage and transport as Markdown. */
+export function collectSkillReferences(
+  text: string,
+): ReadonlyArray<{ name: string; path: string }> {
+  const references = new Map<string, { name: string; path: string }>();
+  for (const token of collectSkillReferenceTokens(text)) {
+    if (token.path)
+      references.set(JSON.stringify([token.value, token.path]), {
+        name: token.value,
+        path: token.path,
+      });
+  }
+  return [...references.values()];
+}
+
+function collectSkillReferenceTokens(
+  text: string,
+): Extract<ComposerInlineToken, { type: "skill" }>[] {
+  if (!text.includes("[$")) return [];
+  const tokens: Extract<ComposerInlineToken, { type: "skill" }>[] = [];
+  const codeRanges = [...text.matchAll(/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/g)];
+  const pattern = /(^|\s)\[\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)\]\(([^\s)]+)\)/g;
+  for (const match of text.matchAll(pattern)) {
+    const start = (match.index ?? 0) + (match[1]?.length ?? 0);
+    if (codeRanges.some((range) => start >= range.index && start < range.index + range[0].length))
+      continue;
+    const name = match[2];
+    const encodedPath = match[3];
+    if (!name || !encodedPath) continue;
+    let path: string;
+    try {
+      path = decodeURIComponent(encodedPath);
+    } catch {
+      continue;
+    }
+    if (!/^(?:\/|[a-zA-Z]:[\\/]|\\\\)/.test(path) || !/[\\/]SKILL\.md$/i.test(path)) continue;
+    const end = (match.index ?? 0) + match[0].length;
+    tokens.push({ type: "skill", value: name, path, source: text.slice(start, end), start, end });
+  }
+  return tokens;
 }
 
 /**
@@ -106,7 +157,7 @@ export function collectComposerInlineTokens(
   text: string,
   options: CollectComposerInlineTokensOptions = {},
 ): ReadonlyArray<ComposerInlineToken> {
-  const matches = collectMentionTokens(text);
+  const matches = [...collectMentionTokens(text), ...collectSkillReferenceTokens(text)];
 
   for (const match of text.matchAll(SKILL_TOKEN_REGEX)) {
     const fullMatch = match[0];

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -42,17 +42,64 @@ export function collectSkillReferences(
   return [...references.values()];
 }
 
+/** Markdown fences and exact-length backtick spans are literal, including unclosed fences. */
+function collectMarkdownCodeRanges(text: string): Array<{ start: number; end: number }> {
+  const fences: Array<{ start: number; end: number }> = [];
+  let open: { start: number; character: string; length: number } | undefined;
+  for (const line of text.matchAll(/^.*(?:\n|$)/gm)) {
+    const delimiter = /^ {0,3}(`{3,}|~{3,})(.*)\r?\n?$/.exec(line[0]);
+    if (!delimiter) continue;
+    const run = delimiter[1]!;
+    const rest = delimiter[2]!;
+    if (open) {
+      if (run[0] === open.character && run.length >= open.length && rest.trim() === "") {
+        fences.push({ start: open.start, end: line.index + line[0].length });
+        open = undefined;
+      }
+    } else if (run[0] !== "`" || !rest.includes("`")) {
+      open = { start: line.index, character: run[0]!, length: run.length };
+    }
+  }
+  if (open) fences.push({ start: open.start, end: text.length });
+  const ranges = [...fences];
+  let offset = 0;
+  for (const fence of [...fences, { start: text.length, end: text.length }]) {
+    const runs = [...text.slice(offset, fence.start).matchAll(/`+/g)];
+    const nextByLength = new Map<number, number>();
+    const closing = new Map<number, number>();
+    for (let index = runs.length - 1; index >= 0; index--) {
+      const length = runs[index]![0].length;
+      const next = nextByLength.get(length);
+      if (next !== undefined) closing.set(index, next);
+      nextByLength.set(length, index);
+    }
+    for (let index = 0; index < runs.length; index++) {
+      const end = closing.get(index);
+      if (end === undefined) continue;
+      ranges.push({
+        start: offset + runs[index]!.index,
+        end: offset + runs[end]!.index + runs[end]![0].length,
+      });
+      index = end;
+    }
+    offset = fence.end;
+  }
+  return ranges.sort((left, right) => left.start - right.start);
+}
+
 function collectSkillReferenceTokens(
   text: string,
 ): Extract<ComposerInlineToken, { type: "skill" }>[] {
   if (!text.includes("[$")) return [];
   const tokens: Extract<ComposerInlineToken, { type: "skill" }>[] = [];
-  const codeRanges = [...text.matchAll(/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/g)];
+  const codeRanges = collectMarkdownCodeRanges(text);
+  let codeRangeIndex = 0;
   const pattern = /(^|\s)\[\$([a-zA-Z0-9][a-zA-Z0-9:_-]*)\]\(([^\s)]+)\)/g;
   for (const match of text.matchAll(pattern)) {
     const start = (match.index ?? 0) + (match[1]?.length ?? 0);
-    if (codeRanges.some((range) => start >= range.index && start < range.index + range[0].length))
-      continue;
+    while (codeRanges[codeRangeIndex] && codeRanges[codeRangeIndex]!.end <= start) codeRangeIndex++;
+    const codeRange = codeRanges[codeRangeIndex];
+    if (codeRange && start >= codeRange.start && start < codeRange.end) continue;
     const name = match[2];
     const encodedPath = match[3];
     if (!name || !encodedPath) continue;

--- a/packages/shared/src/composerInlineTokens.ts
+++ b/packages/shared/src/composerInlineTokens.ts
@@ -64,21 +64,30 @@ function collectMarkdownCodeRanges(text: string): Array<{ start: number; end: nu
   const ranges = [...fences];
   let offset = 0;
   for (const fence of [...fences, { start: text.length, end: text.length }]) {
-    const runs = [...text.slice(offset, fence.start).matchAll(/`+/g)];
+    const runs = [...text.slice(offset, fence.start).matchAll(/`+/g)].map((run) => {
+      const start = offset + run.index;
+      let backslashes = 0;
+      for (let cursor = start - 1; cursor >= offset && text[cursor] === "\\"; cursor--) {
+        backslashes++;
+      }
+      return { start, length: run[0].length, escaped: backslashes % 2 };
+    });
     const nextByLength = new Map<number, number>();
     const closing = new Map<number, number>();
     for (let index = runs.length - 1; index >= 0; index--) {
-      const length = runs[index]![0].length;
-      const next = nextByLength.get(length);
+      const run = runs[index]!;
+      // Outside a span, an escape consumes only the first backtick in a run.
+      // Inside a span, backslashes are literal, so closing runs keep their full length.
+      const next = nextByLength.get(run.length - run.escaped);
       if (next !== undefined) closing.set(index, next);
-      nextByLength.set(length, index);
+      nextByLength.set(run.length, index);
     }
     for (let index = 0; index < runs.length; index++) {
       const end = closing.get(index);
       if (end === undefined) continue;
       ranges.push({
-        start: offset + runs[index]!.index,
-        end: offset + runs[end]!.index + runs[end]![0].length,
+        start: runs[index]!.start + runs[index]!.escaped,
+        end: runs[end]!.start + runs[end]!.length,
       });
       index = end;
     }


### PR DESCRIPTION
## What Changed

Show skills with the same name as separate choices, each with its file path. Keep the selected file when saving drafts and sending prompts across web, desktop, and mobile. Codex now receives the selected path directly; other providers receive instructions from that file.

Fixes #11161.

Validation: 284 focused tests passed; mobile typecheck and formatting passed.

## Why

The picker used to hide one of two skills with the same name and run the wrong file. 

## UI Changes

| Before: one skill shown | After: both files selectable |
| --- | --- |
| ![One skill shown](https://github.com/user-attachments/assets/def1bebf-8f3d-4c10-82fa-1be5774ac3a3) | ![Both skill files shown](https://github.com/user-attachments/assets/68677d11-2ddc-444f-acba-2c63edc8dcd8) |
| | _(Paths are only shown for skills sharing the same name)_ |

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Model: GPT-6. Harness: Codex.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills with identical names can now coexist; source paths help distinguish and select the intended skill.
  * Selected skill sources remain attached when drafts are saved or sent.
  * Skill references are passed to supported providers using their exact source files.
  * Markdown links and encoded paths are preserved in composer skill chips.

* **Bug Fixes**
  * Improved skill discovery, search, cursor handling, and command dispatch for duplicate-name skills.
  * Unauthorized, unavailable, or oversized skill references are rejected safely.

* **Documentation**
  * Added guidance on selecting and restoring source-specific skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->