### PR TITLE
perf(web): huge-thread switch no longer blanks the chat pane

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -648,6 +648,17 @@ describe("resolveThreadSwitchTimeline", () => {
     ).toEqual({ entries: ["fresh-b"], displayThreadKey: "env-1:thread-b" });
   });
 
+  it("does not keep a remembered snapshot on a resolved empty thread", () => {
+    rememberReadyThreadTimeline(held);
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: false,
+        activeThreadKey: "env-1:thread-a",
+        nextEntries: [],
+      }),
+    ).toEqual({ entries: [], displayThreadKey: "env-1:thread-a" });
+  });
+
   it("does not hold another environment's timeline across a jump", () => {
     expect(threadKeysShareEnvironment("env-1:thread-a", "env-2:thread-b")).toBe(false);
     expect(

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -59,11 +59,13 @@ import {
   resolveSendEnvMode,
   threadShellHasStarted,
   resolveDraftHeroState,
+  isPaintOnlyThreadTimeline,
   peekHeldThreadTimeline,
   peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resetHeldThreadTimeline,
   resolveThreadSwitchTimeline,
+  threadKeysShareEnvironment,
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
   codexArtifactTemplatePromptToAppend,
@@ -575,39 +577,39 @@ describe("resolveThreadSwitchTimeline", () => {
     resetHeldThreadTimeline();
   });
 
-  const held = { threadKey: "thread-a", entries: ["a1", "a2"] };
+  const held = { threadKey: "env-1:thread-a", entries: ["a1", "a2"] };
 
   it("keeps the previous thread's entries while the next thread is loading", () => {
     expect(
       resolveThreadSwitchTimeline({
         loading: true,
-        activeThreadKey: "thread-b",
+        activeThreadKey: "env-1:thread-b",
         nextEntries: [],
         lastReady: held,
       }),
-    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "env-1:thread-a" });
   });
 
   it("shows the new thread once its detail is ready", () => {
     expect(
       resolveThreadSwitchTimeline({
         loading: false,
-        activeThreadKey: "thread-b",
+        activeThreadKey: "env-1:thread-b",
         nextEntries: ["b1"],
         lastReady: held,
       }),
-    ).toEqual({ entries: ["b1"], displayThreadKey: "thread-b" });
+    ).toEqual({ entries: ["b1"], displayThreadKey: "env-1:thread-b" });
   });
 
   it("does not invent a timeline on the first open of a thread", () => {
     expect(
       resolveThreadSwitchTimeline({
         loading: true,
-        activeThreadKey: "thread-a",
+        activeThreadKey: "env-1:thread-a",
         nextEntries: [],
         lastReady: null,
       }),
-    ).toEqual({ entries: [], displayThreadKey: "thread-a" });
+    ).toEqual({ entries: [], displayThreadKey: "env-1:thread-a" });
   });
 
   it("survives a ChatView remount by remembering the last ready timeline", () => {
@@ -616,34 +618,51 @@ describe("resolveThreadSwitchTimeline", () => {
     expect(
       resolveThreadSwitchTimeline({
         loading: true,
-        activeThreadKey: "thread-b",
+        activeThreadKey: "env-1:thread-b",
         nextEntries: [],
       }),
-    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "env-1:thread-a" });
   });
 
   it("paints a remembered destination instead of the last-viewed thread", () => {
     rememberReadyThreadTimeline(held);
-    rememberReadyThreadTimeline({ threadKey: "thread-b", entries: ["b1", "b2"] });
-    expect(peekRememberedThreadTimeline<string[]>("thread-a")).toEqual(["a1", "a2"]);
+    rememberReadyThreadTimeline({ threadKey: "env-1:thread-b", entries: ["b1", "b2"] });
+    expect(peekRememberedThreadTimeline<string[]>("env-1:thread-a")).toEqual(["a1", "a2"]);
     expect(
       resolveThreadSwitchTimeline({
         loading: true,
-        activeThreadKey: "thread-a",
+        activeThreadKey: "env-1:thread-a",
         nextEntries: [],
       }),
-    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "env-1:thread-a" });
   });
 
   it("prefers live entries over a remembered snapshot", () => {
-    rememberReadyThreadTimeline({ threadKey: "thread-b", entries: ["stale-b"] });
+    rememberReadyThreadTimeline({ threadKey: "env-1:thread-b", entries: ["stale-b"] });
     expect(
       resolveThreadSwitchTimeline({
         loading: false,
-        activeThreadKey: "thread-b",
+        activeThreadKey: "env-1:thread-b",
         nextEntries: ["fresh-b"],
       }),
-    ).toEqual({ entries: ["fresh-b"], displayThreadKey: "thread-b" });
+    ).toEqual({ entries: ["fresh-b"], displayThreadKey: "env-1:thread-b" });
+  });
+
+  it("does not hold another environment's timeline across a jump", () => {
+    expect(threadKeysShareEnvironment("env-1:thread-a", "env-2:thread-b")).toBe(false);
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: true,
+        activeThreadKey: "env-2:thread-b",
+        nextEntries: [],
+        lastReady: held,
+      }),
+    ).toEqual({ entries: [], displayThreadKey: "env-2:thread-b" });
+  });
+
+  it("treats a foreign held timeline as paint-only", () => {
+    expect(isPaintOnlyThreadTimeline("env-1:thread-a", "env-1:thread-b")).toBe(true);
+    expect(isPaintOnlyThreadTimeline("env-1:thread-b", "env-1:thread-b")).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -59,6 +59,9 @@ import {
   resolveSendEnvMode,
   threadShellHasStarted,
   resolveDraftHeroState,
+  peekHeldThreadTimeline,
+  rememberReadyThreadTimeline,
+  resetHeldThreadTimeline,
   resolveThreadSwitchTimeline,
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
@@ -567,6 +570,10 @@ describe("draft hero submission transition", () => {
 });
 
 describe("resolveThreadSwitchTimeline", () => {
+  afterEach(() => {
+    resetHeldThreadTimeline();
+  });
+
   const held = { threadKey: "thread-a", entries: ["a1", "a2"] };
 
   it("keeps the previous thread's entries while the next thread is loading", () => {
@@ -600,6 +607,19 @@ describe("resolveThreadSwitchTimeline", () => {
         held: null,
       }),
     ).toEqual({ entries: [], displayThreadKey: "thread-a" });
+  });
+
+  it("survives a ChatView remount by remembering the last ready timeline", () => {
+    rememberReadyThreadTimeline(held);
+    expect(peekHeldThreadTimeline<string[]>()).toEqual(held);
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: true,
+        activeThreadKey: "thread-b",
+        nextEntries: [],
+        held: peekHeldThreadTimeline<string[]>(),
+      }),
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -66,6 +66,7 @@ import {
   resetHeldThreadTimeline,
   resolveThreadSwitchTimeline,
   threadKeysShareEnvironment,
+  timelineHasEphemeralPreviewUrls,
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
   codexArtifactTemplatePromptToAppend,
@@ -687,6 +688,31 @@ describe("resolveThreadSwitchTimeline", () => {
   it("treats a foreign held timeline as paint-only", () => {
     expect(isPaintOnlyThreadTimeline("env-1:thread-a", "env-1:thread-b")).toBe(true);
     expect(isPaintOnlyThreadTimeline("env-1:thread-b", "env-1:thread-b")).toBe(false);
+  });
+
+  it("does not remember a timeline that still has handoff blob previews", () => {
+    expect(
+      timelineHasEphemeralPreviewUrls([
+        {
+          kind: "message",
+          message: {
+            role: "user",
+            attachments: [{ type: "image", previewUrl: "blob:handoff" }],
+          },
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      timelineHasEphemeralPreviewUrls([
+        {
+          kind: "message",
+          message: {
+            role: "user",
+            attachments: [{ type: "image", previewUrl: "https://cdn.example/a.png" }],
+          },
+        },
+      ]),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -612,6 +612,19 @@ describe("resolveThreadSwitchTimeline", () => {
     ).toEqual({ entries: [], displayThreadKey: "env-1:thread-a" });
   });
 
+  it("keeps the held thread workspace cwd with the snapshot", () => {
+    rememberReadyThreadTimeline({
+      ...held,
+      markdownCwd: "/repo/a",
+      workspaceRoot: "/repo/a",
+    });
+    expect(peekHeldThreadTimeline<string[]>()).toEqual({
+      ...held,
+      markdownCwd: "/repo/a",
+      workspaceRoot: "/repo/a",
+    });
+  });
+
   it("survives a ChatView remount by remembering the last ready timeline", () => {
     rememberReadyThreadTimeline(held);
     expect(peekHeldThreadTimeline<string[]>()).toEqual(held);

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -697,7 +697,16 @@ describe("resolveThreadSwitchTimeline", () => {
           kind: "message",
           message: {
             role: "user",
-            attachments: [{ type: "image", previewUrl: "blob:handoff" }],
+            attachments: [
+              {
+                type: "image",
+                id: "preview",
+                name: "preview.png",
+                mimeType: "image/png",
+                sizeBytes: 1,
+                previewUrl: "blob:handoff",
+              },
+            ],
           },
         },
       ]),
@@ -708,7 +717,16 @@ describe("resolveThreadSwitchTimeline", () => {
           kind: "message",
           message: {
             role: "user",
-            attachments: [{ type: "image", previewUrl: "https://cdn.example/a.png" }],
+            attachments: [
+              {
+                type: "image",
+                id: "preview",
+                name: "preview.png",
+                mimeType: "image/png",
+                sizeBytes: 1,
+                previewUrl: "https://cdn.example/a.png",
+              },
+            ],
           },
         },
       ]),

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -59,6 +59,7 @@ import {
   resolveSendEnvMode,
   threadShellHasStarted,
   resolveDraftHeroState,
+  resolveThreadSwitchTimeline,
   scheduleEnvironmentReconnectWarning,
   startNewThreadForProject,
   codexArtifactTemplatePromptToAppend,
@@ -562,6 +563,43 @@ describe("draft hero submission transition", () => {
         backgroundSubmissionPending: true,
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveThreadSwitchTimeline", () => {
+  const held = { threadKey: "thread-a", entries: ["a1", "a2"] };
+
+  it("keeps the previous thread's entries while the next thread is loading", () => {
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: true,
+        activeThreadKey: "thread-b",
+        nextEntries: [],
+        held,
+      }),
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+  });
+
+  it("shows the new thread once its detail is ready", () => {
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: false,
+        activeThreadKey: "thread-b",
+        nextEntries: ["b1"],
+        held,
+      }),
+    ).toEqual({ entries: ["b1"], displayThreadKey: "thread-b" });
+  });
+
+  it("does not invent a timeline on the first open of a thread", () => {
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: true,
+        activeThreadKey: "thread-a",
+        nextEntries: [],
+        held: null,
+      }),
+    ).toEqual({ entries: [], displayThreadKey: "thread-a" });
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -696,7 +696,13 @@ describe("resolveThreadSwitchTimeline", () => {
         {
           kind: "message",
           message: {
+            id: MessageId.make("preview-message"),
             role: "user",
+            text: "Preview",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-09-10T12:00:00.000Z",
+            updatedAt: "2026-09-10T12:00:00.000Z",
             attachments: [
               {
                 type: "image",
@@ -716,7 +722,13 @@ describe("resolveThreadSwitchTimeline", () => {
         {
           kind: "message",
           message: {
+            id: MessageId.make("preview-message"),
             role: "user",
+            text: "Preview",
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-09-10T12:00:00.000Z",
+            updatedAt: "2026-09-10T12:00:00.000Z",
             attachments: [
               {
                 type: "image",

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -60,6 +60,7 @@ import {
   threadShellHasStarted,
   resolveDraftHeroState,
   peekHeldThreadTimeline,
+  peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resetHeldThreadTimeline,
   resolveThreadSwitchTimeline,
@@ -582,7 +583,7 @@ describe("resolveThreadSwitchTimeline", () => {
         loading: true,
         activeThreadKey: "thread-b",
         nextEntries: [],
-        held,
+        lastReady: held,
       }),
     ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
   });
@@ -593,7 +594,7 @@ describe("resolveThreadSwitchTimeline", () => {
         loading: false,
         activeThreadKey: "thread-b",
         nextEntries: ["b1"],
-        held,
+        lastReady: held,
       }),
     ).toEqual({ entries: ["b1"], displayThreadKey: "thread-b" });
   });
@@ -604,7 +605,7 @@ describe("resolveThreadSwitchTimeline", () => {
         loading: true,
         activeThreadKey: "thread-a",
         nextEntries: [],
-        held: null,
+        lastReady: null,
       }),
     ).toEqual({ entries: [], displayThreadKey: "thread-a" });
   });
@@ -617,9 +618,32 @@ describe("resolveThreadSwitchTimeline", () => {
         loading: true,
         activeThreadKey: "thread-b",
         nextEntries: [],
-        held: peekHeldThreadTimeline<string[]>(),
       }),
     ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+  });
+
+  it("paints a remembered destination instead of the last-viewed thread", () => {
+    rememberReadyThreadTimeline(held);
+    rememberReadyThreadTimeline({ threadKey: "thread-b", entries: ["b1", "b2"] });
+    expect(peekRememberedThreadTimeline<string[]>("thread-a")).toEqual(["a1", "a2"]);
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: true,
+        activeThreadKey: "thread-a",
+        nextEntries: [],
+      }),
+    ).toEqual({ entries: ["a1", "a2"], displayThreadKey: "thread-a" });
+  });
+
+  it("prefers live entries over a remembered snapshot", () => {
+    rememberReadyThreadTimeline({ threadKey: "thread-b", entries: ["stale-b"] });
+    expect(
+      resolveThreadSwitchTimeline({
+        loading: false,
+        activeThreadKey: "thread-b",
+        nextEntries: ["fresh-b"],
+      }),
+    ).toEqual({ entries: ["fresh-b"], displayThreadKey: "thread-b" });
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -263,51 +263,105 @@ export function resolveDraftHeroState(input: {
 }
 
 /**
- * Keep the last ready timeline on screen while the next thread's detail is
- * still loading. Remounting to an empty list punches a hole through the chat
- * pane (white in light mode, blank in dark) for the whole snapshot wait.
+ * Keep painted timelines on screen across thread jumps. Remounting LegendList
+ * (or handing it an empty first paint) punches a hole through the chat pane —
+ * white in light mode — so cmd+1/2/3 spam flashes even when the destination
+ * is already cached.
  *
  * Stored at module scope because ChatView remounts when the thread route
  * changes (same pattern as the thread-error banner session dismissals).
+ * Remember more than the last thread so jumping back to cmd+1 does not show
+ * cmd+3's messages, and so a cached destination can paint on the first frame.
  */
 export type HeldThreadTimeline<T extends readonly unknown[]> = {
   threadKey: string | null;
   entries: T;
 };
 
-let heldThreadTimeline: HeldThreadTimeline<readonly unknown[]> | null = null;
+const MAX_REMEMBERED_THREAD_TIMELINES = 16;
+
+let rememberedThreadTimelines = new Map<string, readonly unknown[]>();
+let rememberedThreadTimelineOrder: string[] = [];
+let lastReadyThreadKey: string | null = null;
+
+function rememberThreadTimelineEntries(threadKey: string, entries: readonly unknown[]): void {
+  rememberedThreadTimelines.set(threadKey, entries);
+  rememberedThreadTimelineOrder = [
+    ...rememberedThreadTimelineOrder.filter((key) => key !== threadKey),
+    threadKey,
+  ];
+  while (rememberedThreadTimelineOrder.length > MAX_REMEMBERED_THREAD_TIMELINES) {
+    const evicted = rememberedThreadTimelineOrder.shift();
+    if (evicted !== undefined) {
+      rememberedThreadTimelines.delete(evicted);
+    }
+  }
+  lastReadyThreadKey = threadKey;
+}
 
 export function rememberReadyThreadTimeline<T extends readonly unknown[]>(
   held: HeldThreadTimeline<T>,
 ): void {
-  heldThreadTimeline = held;
+  if (held.threadKey === null || held.entries.length === 0) {
+    return;
+  }
+  rememberThreadTimelineEntries(held.threadKey, held.entries);
+}
+
+export function peekRememberedThreadTimeline<T extends readonly unknown[]>(
+  threadKey: string | null,
+): T | null {
+  if (threadKey === null) {
+    return null;
+  }
+  return (rememberedThreadTimelines.get(threadKey) as T | undefined) ?? null;
 }
 
 export function peekHeldThreadTimeline<
   T extends readonly unknown[],
 >(): HeldThreadTimeline<T> | null {
-  return heldThreadTimeline as HeldThreadTimeline<T> | null;
+  if (lastReadyThreadKey === null) {
+    return null;
+  }
+  const entries = rememberedThreadTimelines.get(lastReadyThreadKey);
+  if (entries === undefined || entries.length === 0) {
+    return null;
+  }
+  return { threadKey: lastReadyThreadKey, entries: entries as T };
 }
 
 export function resetHeldThreadTimeline(): void {
-  heldThreadTimeline = null;
+  rememberedThreadTimelines = new Map();
+  rememberedThreadTimelineOrder = [];
+  lastReadyThreadKey = null;
 }
 
 export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input: {
   loading: boolean;
   activeThreadKey: string | null;
   nextEntries: T;
-  held: HeldThreadTimeline<T> | null;
+  rememberedForActive?: T | null;
+  lastReady?: HeldThreadTimeline<T> | null;
 }): { entries: T; displayThreadKey: string | null } {
-  const held = input.held;
+  if (input.nextEntries.length > 0) {
+    return { entries: input.nextEntries, displayThreadKey: input.activeThreadKey };
+  }
+
+  const rememberedForActive =
+    input.rememberedForActive ?? peekRememberedThreadTimeline<T>(input.activeThreadKey);
+  if (rememberedForActive !== null && rememberedForActive.length > 0) {
+    return { entries: rememberedForActive, displayThreadKey: input.activeThreadKey };
+  }
+
+  const lastReady = input.lastReady ?? peekHeldThreadTimeline<T>();
   if (
     input.loading &&
-    held !== null &&
-    held.threadKey !== null &&
-    held.threadKey !== input.activeThreadKey &&
-    held.entries.length > 0
+    lastReady !== null &&
+    lastReady.threadKey !== null &&
+    lastReady.threadKey !== input.activeThreadKey &&
+    lastReady.entries.length > 0
   ) {
-    return { entries: held.entries, displayThreadKey: held.threadKey };
+    return { entries: lastReady.entries, displayThreadKey: lastReady.threadKey };
   }
   return { entries: input.nextEntries, displayThreadKey: input.activeThreadKey };
 }

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -18,6 +18,7 @@ import {
   type ThreadLinkedPullRequest,
   type TurnId,
 } from "@t3tools/contracts";
+import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import { resolveAssetUrl } from "@t3tools/client-runtime/state/assets";
 import {
   squashAtomCommandFailure,
@@ -336,6 +337,25 @@ export function resetHeldThreadTimeline(): void {
   lastReadyThreadKey = null;
 }
 
+export function threadKeysShareEnvironment(left: string | null, right: string | null): boolean {
+  if (left === null || right === null) {
+    return false;
+  }
+  const leftRef = parseScopedThreadKey(left);
+  const rightRef = parseScopedThreadKey(right);
+  return leftRef !== null && rightRef !== null && leftRef.environmentId === rightRef.environmentId;
+}
+
+/** True while we still paint another thread's last snapshot. */
+export function isPaintOnlyThreadTimeline(
+  displayThreadKey: string | null,
+  activeThreadKey: string | null,
+): boolean {
+  return (
+    displayThreadKey !== null && activeThreadKey !== null && displayThreadKey !== activeThreadKey
+  );
+}
+
 export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input: {
   loading: boolean;
   activeThreadKey: string | null;
@@ -359,7 +379,8 @@ export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input:
     lastReady !== null &&
     lastReady.threadKey !== null &&
     lastReady.threadKey !== input.activeThreadKey &&
-    lastReady.entries.length > 0
+    lastReady.entries.length > 0 &&
+    threadKeysShareEnvironment(lastReady.threadKey, input.activeThreadKey)
   ) {
     return { entries: lastReady.entries, displayThreadKey: lastReady.threadKey };
   }

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -742,6 +742,17 @@ export function revokeUserMessagePreviewUrls(message: ChatMessage): void {
   }
 }
 
+export function timelineHasEphemeralPreviewUrls(
+  entries: ReadonlyArray<Pick<TimelineEntry, "kind"> & { message?: ChatMessage }>,
+): boolean {
+  return entries.some(
+    (entry) =>
+      entry.kind === "message" &&
+      entry.message !== undefined &&
+      collectUserMessageBlobPreviewUrls(entry.message).length > 0,
+  );
+}
+
 export function collectUserMessageBlobPreviewUrls(message: ChatMessage): string[] {
   if (message.role !== "user" || !message.attachments) {
     return [];

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -266,12 +266,36 @@ export function resolveDraftHeroState(input: {
  * Keep the last ready timeline on screen while the next thread's detail is
  * still loading. Remounting to an empty list punches a hole through the chat
  * pane (white in light mode, blank in dark) for the whole snapshot wait.
+ *
+ * Stored at module scope because ChatView remounts when the thread route
+ * changes (same pattern as the thread-error banner session dismissals).
  */
+export type HeldThreadTimeline<T extends readonly unknown[]> = {
+  threadKey: string | null;
+  entries: T;
+};
+
+let heldThreadTimeline: HeldThreadTimeline<readonly unknown[]> | null = null;
+
+export function rememberReadyThreadTimeline<T extends readonly unknown[]>(
+  held: HeldThreadTimeline<T>,
+): void {
+  heldThreadTimeline = held;
+}
+
+export function peekHeldThreadTimeline<T extends readonly unknown[]>(): HeldThreadTimeline<T> | null {
+  return heldThreadTimeline as HeldThreadTimeline<T> | null;
+}
+
+export function resetHeldThreadTimeline(): void {
+  heldThreadTimeline = null;
+}
+
 export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input: {
   loading: boolean;
   activeThreadKey: string | null;
   nextEntries: T;
-  held: { threadKey: string | null; entries: T } | null;
+  held: HeldThreadTimeline<T> | null;
 }): { entries: T; displayThreadKey: string | null } {
   const held = input.held;
   if (

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -262,6 +262,30 @@ export function resolveDraftHeroState(input: {
   );
 }
 
+/**
+ * Keep the last ready timeline on screen while the next thread's detail is
+ * still loading. Remounting to an empty list punches a hole through the chat
+ * pane (white in light mode, blank in dark) for the whole snapshot wait.
+ */
+export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input: {
+  loading: boolean;
+  activeThreadKey: string | null;
+  nextEntries: T;
+  held: { threadKey: string | null; entries: T } | null;
+}): { entries: T; displayThreadKey: string | null } {
+  const held = input.held;
+  if (
+    input.loading &&
+    held !== null &&
+    held.threadKey !== null &&
+    held.threadKey !== input.activeThreadKey &&
+    held.entries.length > 0
+  ) {
+    return { entries: held.entries, displayThreadKey: held.threadKey };
+  }
+  return { entries: input.nextEntries, displayThreadKey: input.activeThreadKey };
+}
+
 export function resolveDraftPromotionNavigationTarget(input: {
   serverThreadRef: ScopedThreadRef | null;
   serverThread: Pick<Thread, "latestTurn" | "session"> | null | undefined;

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -283,7 +283,9 @@ export function rememberReadyThreadTimeline<T extends readonly unknown[]>(
   heldThreadTimeline = held;
 }
 
-export function peekHeldThreadTimeline<T extends readonly unknown[]>(): HeldThreadTimeline<T> | null {
+export function peekHeldThreadTimeline<
+  T extends readonly unknown[],
+>(): HeldThreadTimeline<T> | null {
   return heldThreadTimeline as HeldThreadTimeline<T> | null;
 }
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -277,19 +277,24 @@ export function resolveDraftHeroState(input: {
 export type HeldThreadTimeline<T extends readonly unknown[]> = {
   threadKey: string | null;
   entries: T;
+  markdownCwd?: string | null;
+  workspaceRoot?: string | null;
 };
 
 const MAX_REMEMBERED_THREAD_TIMELINES = 16;
 
-let rememberedThreadTimelines = new Map<string, readonly unknown[]>();
+let rememberedThreadTimelines = new Map<string, HeldThreadTimeline<readonly unknown[]>>();
 let rememberedThreadTimelineOrder: string[] = [];
 let lastReadyThreadKey: string | null = null;
 
-function rememberThreadTimelineEntries(threadKey: string, entries: readonly unknown[]): void {
-  rememberedThreadTimelines.set(threadKey, entries);
+function rememberThreadTimelineEntries(held: HeldThreadTimeline<readonly unknown[]>): void {
+  if (held.threadKey === null) {
+    return;
+  }
+  rememberedThreadTimelines.set(held.threadKey, held);
   rememberedThreadTimelineOrder = [
-    ...rememberedThreadTimelineOrder.filter((key) => key !== threadKey),
-    threadKey,
+    ...rememberedThreadTimelineOrder.filter((key) => key !== held.threadKey),
+    held.threadKey,
   ];
   while (rememberedThreadTimelineOrder.length > MAX_REMEMBERED_THREAD_TIMELINES) {
     const evicted = rememberedThreadTimelineOrder.shift();
@@ -297,7 +302,7 @@ function rememberThreadTimelineEntries(threadKey: string, entries: readonly unkn
       rememberedThreadTimelines.delete(evicted);
     }
   }
-  lastReadyThreadKey = threadKey;
+  lastReadyThreadKey = held.threadKey;
 }
 
 export function rememberReadyThreadTimeline<T extends readonly unknown[]>(
@@ -306,7 +311,7 @@ export function rememberReadyThreadTimeline<T extends readonly unknown[]>(
   if (held.threadKey === null || held.entries.length === 0) {
     return;
   }
-  rememberThreadTimelineEntries(held.threadKey, held.entries);
+  rememberThreadTimelineEntries(held);
 }
 
 export function peekRememberedThreadTimeline<T extends readonly unknown[]>(
@@ -315,7 +320,7 @@ export function peekRememberedThreadTimeline<T extends readonly unknown[]>(
   if (threadKey === null) {
     return null;
   }
-  return (rememberedThreadTimelines.get(threadKey) as T | undefined) ?? null;
+  return (rememberedThreadTimelines.get(threadKey)?.entries as T | undefined) ?? null;
 }
 
 export function peekHeldThreadTimeline<
@@ -324,11 +329,11 @@ export function peekHeldThreadTimeline<
   if (lastReadyThreadKey === null) {
     return null;
   }
-  const entries = rememberedThreadTimelines.get(lastReadyThreadKey);
-  if (entries === undefined || entries.length === 0) {
+  const held = rememberedThreadTimelines.get(lastReadyThreadKey);
+  if (held === undefined || held.entries.length === 0) {
     return null;
   }
-  return { threadKey: lastReadyThreadKey, entries: entries as T };
+  return held as HeldThreadTimeline<T>;
 }
 
 export function resetHeldThreadTimeline(): void {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -369,7 +369,7 @@ export function resolveThreadSwitchTimeline<T extends readonly unknown[]>(input:
 
   const rememberedForActive =
     input.rememberedForActive ?? peekRememberedThreadTimeline<T>(input.activeThreadKey);
-  if (rememberedForActive !== null && rememberedForActive.length > 0) {
+  if (input.loading && rememberedForActive !== null && rememberedForActive.length > 0) {
     return { entries: rememberedForActive, displayThreadKey: input.activeThreadKey };
   }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -415,7 +415,7 @@ import {
   resolveComposerInteractionMode,
   resolveComposerProviderSelection,
   resolveDraftHeroState,
-  peekHeldThreadTimeline,
+  peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resolveThreadSwitchTimeline,
   observeProactivePanelUserChoice,
@@ -3249,7 +3249,7 @@ export default function ChatView(props: ChatViewProps) {
     loading: timelineEntries.length === 0 && threadSyncPhase !== null,
     activeThreadKey,
     nextEntries: timelineEntries,
-    held: peekHeldThreadTimeline<typeof timelineEntries>(),
+    rememberedForActive: peekRememberedThreadTimeline<typeof timelineEntries>(activeThreadKey),
   });
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
@@ -4922,6 +4922,21 @@ export default function ChatView(props: ChatViewProps) {
       void legendListRef.current?.scrollToEnd?.({ animated });
     });
   }, []);
+  const displayedTimelineKeyRef = useRef(displayedTimeline.displayThreadKey);
+  useLayoutEffect(() => {
+    const displayKey = displayedTimeline.displayThreadKey;
+    if (displayKey === null || displayKey !== activeThreadKey) {
+      displayedTimelineKeyRef.current = displayKey;
+      return;
+    }
+    if (displayedTimelineKeyRef.current === displayKey) {
+      return;
+    }
+    displayedTimelineKeyRef.current = displayKey;
+    // Keep the list mounted across jumps; pin the newly displayed thread to
+    // its end the way a remount used to via initialScrollAtEnd.
+    scrollToEnd();
+  }, [activeThreadKey, displayedTimeline.displayThreadKey, scrollToEnd]);
   useLayoutEffect(() => {
     if (timelineScrollModeRef.current !== "anchoring-new-turn") {
       return;
@@ -8455,7 +8470,6 @@ export default function ChatView(props: ChatViewProps) {
                 onCiteAssistantText={citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                key={displayedTimeline.displayThreadKey ?? activeThread.id}
                 isWorking={isWorking}
                 isPreparingWorktree={isPreparingWorktree}
                 isCompacting={isCompacting}
@@ -8467,6 +8481,7 @@ export default function ChatView(props: ChatViewProps) {
                 turnDiffSummaries={activeThread.checkpoints}
                 activeThreadEnvironmentId={activeThread.environmentId}
                 routeThreadKey={routeThreadKey}
+                displayThreadKey={displayedTimeline.displayThreadKey ?? routeThreadKey}
                 onOpenTurnDiff={onOpenTurnDiff}
                 supportsConversationRollback={supportsConversationRollback}
                 onRevertToTurnCount={onRevertTimelineTurn}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -415,6 +415,7 @@ import {
   resolveComposerInteractionMode,
   resolveComposerProviderSelection,
   resolveDraftHeroState,
+  isPaintOnlyThreadTimeline,
   peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resolveThreadSwitchTimeline,
@@ -1382,6 +1383,10 @@ function chatActionErrorMessage(error: unknown): string {
 }
 
 const ENVIRONMENT_UNAVAILABLE_SEND_TOAST_TRAIL_SIZE = 3;
+const EMPTY_HELD_TURN_DIFF_SUMMARIES: readonly never[] = [];
+const noopHeldTurnDiff = (_turnId: TurnId, _filePath?: string) => {};
+const noopHeldRevert = (_targetTurnCount: number) => {};
+const noopHeldAttachment = (_attachment: ChatFileAttachment) => {};
 
 /**
  * Drops the send-time anchored end space. That space is what holds a sent
@@ -3251,6 +3256,12 @@ export default function ChatView(props: ChatViewProps) {
     nextEntries: timelineEntries,
     rememberedForActive: peekRememberedThreadTimeline<typeof timelineEntries>(activeThreadKey),
   });
+  const displayedTimelineKey = displayedTimeline.displayThreadKey ?? routeThreadKey;
+  const paintOnlyDisplayedTimeline = isPaintOnlyThreadTimeline(
+    displayedTimeline.displayThreadKey,
+    activeThreadKey,
+  );
+  const displayedThreadRef = parseScopedThreadKey(displayedTimelineKey);
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
     activeThreadKey !== null && dockedDraftHeroThreadKey === activeThreadKey;
@@ -8465,31 +8476,43 @@ export default function ChatView(props: ChatViewProps) {
             <div className="relative flex min-h-0 flex-1 flex-col bg-background">
               {/* Messages — LegendList handles virtualization and scrolling internally */}
               <MessagesTimeline
-                citationRequest={citationRequest}
+                citationRequest={paintOnlyDisplayedTimeline ? null : citationRequest}
                 citationHistoryLoading={threadDetailLoading}
-                onCiteAssistantText={citeAssistantText}
+                onCiteAssistantText={paintOnlyDisplayedTimeline ? undefined : citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                isWorking={isWorking}
-                isPreparingWorktree={isPreparingWorktree}
-                isCompacting={isCompacting}
-                activeTurnStartedAt={activeWorkStartedAt}
+                isWorking={!paintOnlyDisplayedTimeline && isWorking}
+                isPreparingWorktree={!paintOnlyDisplayedTimeline && isPreparingWorktree}
+                isCompacting={!paintOnlyDisplayedTimeline && isCompacting}
+                activeTurnStartedAt={paintOnlyDisplayedTimeline ? null : activeWorkStartedAt}
                 listRef={legendListRef}
                 timelineEntries={displayedTimeline.entries}
-                latestTurn={activeLatestTurn}
-                runningTurnId={activeRunningTurnId}
-                turnDiffSummaries={activeThread.checkpoints}
-                activeThreadEnvironmentId={activeThread.environmentId}
-                routeThreadKey={routeThreadKey}
-                displayThreadKey={displayedTimeline.displayThreadKey ?? routeThreadKey}
-                onOpenTurnDiff={onOpenTurnDiff}
-                supportsConversationRollback={supportsConversationRollback}
-                onRevertToTurnCount={onRevertTimelineTurn}
-                onUseArtifactTemplate={useArtifactTemplate}
-                isRevertingCheckpoint={isRevertingCheckpoint}
+                latestTurn={paintOnlyDisplayedTimeline ? null : activeLatestTurn}
+                runningTurnId={paintOnlyDisplayedTimeline ? null : activeRunningTurnId}
+                turnDiffSummaries={
+                  paintOnlyDisplayedTimeline
+                    ? EMPTY_HELD_TURN_DIFF_SUMMARIES
+                    : activeThread.checkpoints
+                }
+                activeThreadEnvironmentId={
+                  displayedThreadRef?.environmentId ?? activeThread.environmentId
+                }
+                routeThreadKey={displayedTimelineKey}
+                displayThreadKey={displayedTimelineKey}
+                onOpenTurnDiff={paintOnlyDisplayedTimeline ? noopHeldTurnDiff : onOpenTurnDiff}
+                supportsConversationRollback={
+                  !paintOnlyDisplayedTimeline && supportsConversationRollback
+                }
+                onRevertToTurnCount={
+                  paintOnlyDisplayedTimeline ? noopHeldRevert : onRevertTimelineTurn
+                }
+                onUseArtifactTemplate={paintOnlyDisplayedTimeline ? undefined : useArtifactTemplate}
+                isRevertingCheckpoint={!paintOnlyDisplayedTimeline && isRevertingCheckpoint}
                 onImageExpand={onExpandTimelineImage}
-                onFileOpen={openFileAttachment}
-                onFileDownload={downloadFileAttachment}
+                onFileOpen={paintOnlyDisplayedTimeline ? noopHeldAttachment : openFileAttachment}
+                onFileDownload={
+                  paintOnlyDisplayedTimeline ? noopHeldAttachment : downloadFileAttachment
+                }
                 markdownCwd={gitCwd ?? undefined}
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
@@ -8499,17 +8522,17 @@ export default function ChatView(props: ChatViewProps) {
                     ? resolveProviderSkillsForCwd(activeProviderStatus, gitCwd)
                     : EMPTY_PROVIDER_SKILLS
                 }
-                anchorMessageId={timelineAnchorMessageId}
+                anchorMessageId={paintOnlyDisplayedTimeline ? null : timelineAnchorMessageId}
                 onAnchorReady={onTimelineAnchorReady}
                 contentInsetEndAdjustment={composerTimelineInset}
-                liveFollowEnabled={timelineLiveFollowEnabled}
+                liveFollowEnabled={!paintOnlyDisplayedTimeline && timelineLiveFollowEnabled}
                 onIsAtEndChange={onIsAtEndChange}
                 onContentOverflowChange={setTimelineOverflows}
                 onToolOutputCollapsedAtEnd={onToolOutputCollapsedAtEnd}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
                 hideEmptyPlaceholder={isDraftHeroState || threadDetailLoading}
                 topFadeEnabled={!hasTimelineTopBanner}
-                loadEarlier={loadEarlierTurns}
+                loadEarlier={paintOnlyDisplayedTimeline ? null : loadEarlierTurns}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3359,18 +3359,21 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
-  if (
-    !threadDetailLoading &&
-    timelineEntries.length > 0 &&
-    !timelineHasEphemeralPreviewUrls(timelineEntries)
-  ) {
+  useLayoutEffect(() => {
+    if (
+      threadDetailLoading ||
+      timelineEntries.length === 0 ||
+      timelineHasEphemeralPreviewUrls(timelineEntries)
+    ) {
+      return;
+    }
     rememberReadyThreadTimeline({
       threadKey: activeThreadKey,
       entries: timelineEntries,
       markdownCwd: gitCwd,
       workspaceRoot: activeWorkspaceRoot ?? null,
     });
-  }
+  }, [activeThreadKey, activeWorkspaceRoot, gitCwd, threadDetailLoading, timelineEntries]);
   const heldPaintContext = paintOnlyDisplayedTimeline
     ? peekHeldThreadTimeline<typeof timelineEntries>()
     : null;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8455,7 +8455,6 @@ export default function ChatView(props: ChatViewProps) {
                 onCiteAssistantText={citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                key={displayedTimeline.displayThreadKey ?? activeThread.id}
                 isWorking={isWorking}
                 isPreparingWorktree={isPreparingWorktree}
                 isCompacting={isCompacting}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -415,6 +415,7 @@ import {
   resolveComposerInteractionMode,
   resolveComposerProviderSelection,
   resolveDraftHeroState,
+  resolveThreadSwitchTimeline,
   observeProactivePanelUserChoice,
   resolveProactiveTurnDiffAction,
   resolveThreadMetadataUpdateForNextTurn,
@@ -3239,6 +3240,19 @@ export default function ChatView(props: ChatViewProps) {
     timelineMessages,
     workLogEntries,
   ]);
+  const lastReadyTimelineRef = useRef<{
+    threadKey: string | null;
+    entries: typeof timelineEntries;
+  } | null>(null);
+  if (!threadDetailLoading && timelineEntries.length > 0) {
+    lastReadyTimelineRef.current = { threadKey: activeThreadKey, entries: timelineEntries };
+  }
+  const displayedTimeline = resolveThreadSwitchTimeline({
+    loading: threadDetailLoading,
+    activeThreadKey,
+    nextEntries: timelineEntries,
+    held: lastReadyTimelineRef.current,
+  });
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =
     activeThreadKey !== null && dockedDraftHeroThreadKey === activeThreadKey;
@@ -8435,7 +8449,7 @@ export default function ChatView(props: ChatViewProps) {
               />
             </div>
             {/* Messages Wrapper */}
-            <div className="relative flex min-h-0 flex-1 flex-col">
+            <div className="relative flex min-h-0 flex-1 flex-col bg-background">
               {/* Messages — LegendList handles virtualization and scrolling internally */}
               <MessagesTimeline
                 citationRequest={citationRequest}
@@ -8443,13 +8457,13 @@ export default function ChatView(props: ChatViewProps) {
                 onCiteAssistantText={citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
-                key={activeThread.id}
+                key={displayedTimeline.displayThreadKey ?? activeThread.id}
                 isWorking={isWorking}
                 isPreparingWorktree={isPreparingWorktree}
                 isCompacting={isCompacting}
                 activeTurnStartedAt={activeWorkStartedAt}
                 listRef={legendListRef}
-                timelineEntries={timelineEntries}
+                timelineEntries={displayedTimeline.entries}
                 latestTurn={activeLatestTurn}
                 runningTurnId={activeRunningTurnId}
                 turnDiffSummaries={activeThread.checkpoints}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8495,9 +8495,14 @@ export default function ChatView(props: ChatViewProps) {
               <MessagesTimeline
                 citationRequest={paintOnlyDisplayedTimeline ? null : citationRequest}
                 citationHistoryLoading={threadDetailLoading}
-                onCiteAssistantText={paintOnlyDisplayedTimeline ? undefined : citeAssistantText}
-                agentPanelModel={paintOnlyDisplayedTimeline ? undefined : agentPanelModel}
-                onOpenAgents={paintOnlyDisplayedTimeline ? undefined : addAgentsSurface}
+                {...(!paintOnlyDisplayedTimeline
+                  ? {
+                      onCiteAssistantText: citeAssistantText,
+                      agentPanelModel,
+                      onOpenAgents: addAgentsSurface,
+                      onUseArtifactTemplate: useArtifactTemplate,
+                    }
+                  : {})}
                 isWorking={!paintOnlyDisplayedTimeline && isWorking}
                 isPreparingWorktree={!paintOnlyDisplayedTimeline && isPreparingWorktree}
                 isCompacting={!paintOnlyDisplayedTimeline && isCompacting}
@@ -8523,7 +8528,6 @@ export default function ChatView(props: ChatViewProps) {
                 onRevertToTurnCount={
                   paintOnlyDisplayedTimeline ? noopHeldRevert : onRevertTimelineTurn
                 }
-                onUseArtifactTemplate={paintOnlyDisplayedTimeline ? undefined : useArtifactTemplate}
                 isRevertingCheckpoint={!paintOnlyDisplayedTimeline && isRevertingCheckpoint}
                 onImageExpand={onExpandTimelineImage}
                 onFileOpen={paintOnlyDisplayedTimeline ? noopHeldAttachment : openFileAttachment}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8455,6 +8455,7 @@ export default function ChatView(props: ChatViewProps) {
                 onCiteAssistantText={citeAssistantText}
                 agentPanelModel={agentPanelModel}
                 onOpenAgents={addAgentsSurface}
+                key={displayedTimeline.displayThreadKey ?? activeThread.id}
                 isWorking={isWorking}
                 isPreparingWorktree={isPreparingWorktree}
                 isCompacting={isCompacting}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -420,6 +420,7 @@ import {
   peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resolveThreadSwitchTimeline,
+  timelineHasEphemeralPreviewUrls,
   observeProactivePanelUserChoice,
   resolveProactiveTurnDiffAction,
   resolveThreadMetadataUpdateForNextTurn,
@@ -3358,7 +3359,11 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
-  if (!threadDetailLoading && timelineEntries.length > 0) {
+  if (
+    !threadDetailLoading &&
+    timelineEntries.length > 0 &&
+    !timelineHasEphemeralPreviewUrls(timelineEntries)
+  ) {
     rememberReadyThreadTimeline({
       threadKey: activeThreadKey,
       entries: timelineEntries,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -416,6 +416,7 @@ import {
   resolveComposerProviderSelection,
   resolveDraftHeroState,
   isPaintOnlyThreadTimeline,
+  peekHeldThreadTimeline,
   peekRememberedThreadTimeline,
   rememberReadyThreadTimeline,
   resolveThreadSwitchTimeline,
@@ -3247,9 +3248,6 @@ export default function ChatView(props: ChatViewProps) {
     timelineMessages,
     workLogEntries,
   ]);
-  if (!threadDetailLoading && timelineEntries.length > 0) {
-    rememberReadyThreadTimeline({ threadKey: activeThreadKey, entries: timelineEntries });
-  }
   const displayedTimeline = resolveThreadSwitchTimeline({
     loading: timelineEntries.length === 0 && threadSyncPhase !== null,
     activeThreadKey,
@@ -3360,6 +3358,17 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  if (!threadDetailLoading && timelineEntries.length > 0) {
+    rememberReadyThreadTimeline({
+      threadKey: activeThreadKey,
+      entries: timelineEntries,
+      markdownCwd: gitCwd,
+      workspaceRoot: activeWorkspaceRoot ?? null,
+    });
+  }
+  const heldPaintContext = paintOnlyDisplayedTimeline
+    ? peekHeldThreadTimeline<typeof timelineEntries>()
+    : null;
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Git status arrives after the composer paints. A checkout seen earlier in
@@ -8513,10 +8522,18 @@ export default function ChatView(props: ChatViewProps) {
                 onFileDownload={
                   paintOnlyDisplayedTimeline ? noopHeldAttachment : downloadFileAttachment
                 }
-                markdownCwd={gitCwd ?? undefined}
+                markdownCwd={
+                  paintOnlyDisplayedTimeline
+                    ? (heldPaintContext?.markdownCwd ?? undefined)
+                    : (gitCwd ?? undefined)
+                }
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
-                workspaceRoot={activeWorkspaceRoot}
+                workspaceRoot={
+                  paintOnlyDisplayedTimeline
+                    ? (heldPaintContext?.workspaceRoot ?? undefined)
+                    : activeWorkspaceRoot
+                }
                 skills={
                   activeProviderStatus
                     ? resolveProviderSkillsForCwd(activeProviderStatus, gitCwd)

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -8493,8 +8493,8 @@ export default function ChatView(props: ChatViewProps) {
                 citationRequest={paintOnlyDisplayedTimeline ? null : citationRequest}
                 citationHistoryLoading={threadDetailLoading}
                 onCiteAssistantText={paintOnlyDisplayedTimeline ? undefined : citeAssistantText}
-                agentPanelModel={agentPanelModel}
-                onOpenAgents={addAgentsSurface}
+                agentPanelModel={paintOnlyDisplayedTimeline ? undefined : agentPanelModel}
+                onOpenAgents={paintOnlyDisplayedTimeline ? undefined : addAgentsSurface}
                 isWorking={!paintOnlyDisplayedTimeline && isWorking}
                 isPreparingWorktree={!paintOnlyDisplayedTimeline && isPreparingWorktree}
                 isCompacting={!paintOnlyDisplayedTimeline && isCompacting}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -415,6 +415,8 @@ import {
   resolveComposerInteractionMode,
   resolveComposerProviderSelection,
   resolveDraftHeroState,
+  peekHeldThreadTimeline,
+  rememberReadyThreadTimeline,
   resolveThreadSwitchTimeline,
   observeProactivePanelUserChoice,
   resolveProactiveTurnDiffAction,
@@ -3240,18 +3242,14 @@ export default function ChatView(props: ChatViewProps) {
     timelineMessages,
     workLogEntries,
   ]);
-  const lastReadyTimelineRef = useRef<{
-    threadKey: string | null;
-    entries: typeof timelineEntries;
-  } | null>(null);
   if (!threadDetailLoading && timelineEntries.length > 0) {
-    lastReadyTimelineRef.current = { threadKey: activeThreadKey, entries: timelineEntries };
+    rememberReadyThreadTimeline({ threadKey: activeThreadKey, entries: timelineEntries });
   }
   const displayedTimeline = resolveThreadSwitchTimeline({
-    loading: threadDetailLoading,
+    loading: timelineEntries.length === 0 && threadSyncPhase !== null,
     activeThreadKey,
     nextEntries: timelineEntries,
-    held: lastReadyTimelineRef.current,
+    held: peekHeldThreadTimeline<typeof timelineEntries>(),
   });
   const [dockedDraftHeroThreadKey, setDockedDraftHeroThreadKey] = useState<string | null>(null);
   const draftHeroDockRequested =

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -331,6 +331,12 @@ interface MessagesTimelineProps {
   runningTurnId: TurnId | null;
   turnDiffSummaries: ReadonlyArray<TurnDiffSummary>;
   routeThreadKey: string;
+  /**
+   * Thread whose entries are currently painted. Differs from `routeThreadKey`
+   * while a jump is still holding the previous list. Identity for row
+   * projection and list extraData — do not remount on this value.
+   */
+  displayThreadKey?: string;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   supportsConversationRollback: boolean;
   onRevertToTurnCount: (targetTurnCount: number) => void;
@@ -389,6 +395,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   runningTurnId,
   turnDiffSummaries,
   routeThreadKey,
+  displayThreadKey,
   onOpenTurnDiff,
   supportsConversationRollback,
   onRevertToTurnCount,
@@ -416,17 +423,30 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   loadEarlier = null,
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
+  const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
+  const listIdentityKey = displayThreadKey ?? routeThreadKey;
+  const listIdentityRef = useRef(listIdentityKey);
+  const previousLatestTurnRef = useRef(latestTurn);
+  let paintedExpandedTurnIds = expandedTurnIds;
+  let paintedExpandedWorkGroupIds = expandedWorkGroupIds;
+  if (listIdentityRef.current !== listIdentityKey) {
+    listIdentityRef.current = listIdentityKey;
+    previousLatestTurnRef.current = latestTurn;
+    paintedExpandedTurnIds = new Set();
+    paintedExpandedWorkGroupIds = new Set();
+    setExpandedTurnIds(paintedExpandedTurnIds);
+    setExpandedWorkGroupIds(paintedExpandedWorkGroupIds);
+  }
   const citationThreadRef = useMemo(() => parseScopedThreadKey(routeThreadKey), [routeThreadKey]);
   const expandCitedTurn = useCallback((turnId: TurnId) => {
     setExpandedTurnIds((current) =>
       current.has(turnId) ? current : new Set([...current, turnId]),
     );
   }, []);
-  const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
   // Scroll/disclosure state outlives virtualized rows, but never the current thread.
   const workGroupViewState = useMemo<WorkGroupViewState>(
     () => ({ scrollPositions: new Map(), expandedEntries: new Set() }),
-    [routeThreadKey],
+    [listIdentityKey],
   );
   const [disclosureToggleSettling, setDisclosureToggleSettling] = useState(false);
   const [minimapStripMap] = useState(() => new Map<string, HTMLSpanElement>());
@@ -518,7 +538,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   // An in-session interrupt leaves its turn expanded so the user keeps their
   // place; the next turn (or a reload, since this is local state) folds it.
-  const previousLatestTurnRef = useRef(latestTurn);
   useEffect(() => {
     const previous = previousLatestTurnRef.current;
     previousLatestTurnRef.current = latestTurn;
@@ -557,34 +576,34 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         timelineEntries,
         latestTurn,
         runningTurnId,
-        expandedTurnIds,
-        expandedWorkGroupIds,
+        expandedTurnIds: paintedExpandedTurnIds,
+        expandedWorkGroupIds: paintedExpandedWorkGroupIds,
         isWorking,
         activeTurnStartedAt,
         turnDiffSummaries,
         supportsConversationRollback,
       },
-      previous?.threadKey === routeThreadKey && previous.workspaceRoot === workspaceRoot
+      previous?.threadKey === listIdentityKey && previous.workspaceRoot === workspaceRoot
         ? previous.projection
         : null,
     );
-    rowsProjectionRef.current = { threadKey: routeThreadKey, workspaceRoot, projection };
+    rowsProjectionRef.current = { threadKey: listIdentityKey, workspaceRoot, projection };
     return projection.rows;
   }, [
     rowsProjectionRef,
-    routeThreadKey,
+    listIdentityKey,
     workspaceRoot,
     timelineEntries,
     latestTurn,
     runningTurnId,
-    expandedTurnIds,
-    expandedWorkGroupIds,
+    paintedExpandedTurnIds,
+    paintedExpandedWorkGroupIds,
     isWorking,
     activeTurnStartedAt,
     turnDiffSummaries,
     supportsConversationRollback,
   ]);
-  const rows = useStableRows(rawRows);
+  const rows = useStableRows(rawRows, listIdentityKey);
   const minimapItems = useMemo(() => deriveTimelineMinimapItems(rows), [rows]);
   const [timelineViewportElement, setTimelineViewportElement] = useState<HTMLDivElement | null>(
     null,
@@ -851,7 +870,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           <LegendList<MessagesTimelineRow>
             ref={listRef}
             data={rows}
-            extraData={rows.length}
+            extraData={`${listIdentityKey}:${rows.length}`}
             keyExtractor={keyExtractor}
             getItemType={getItemType}
             renderItem={renderItem}
@@ -2744,17 +2763,23 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
 
 /** Returns a structurally-shared copy of `rows`: for each row whose content
  *  hasn't changed since last call, the previous object reference is reused. */
-function useStableRows(rows: MessagesTimelineRow[]): MessagesTimelineRow[] {
+function useStableRows(rows: MessagesTimelineRow[], identity: string): MessagesTimelineRow[] {
   const prevState = useRef<StableMessagesTimelineRowsState>({
     byId: new Map<string, MessagesTimelineRow>(),
     result: [],
   });
+  const prevIdentity = useRef(identity);
 
   return useMemo(() => {
-    const nextState = computeStableMessagesTimelineRows(rows, prevState.current);
+    const previous =
+      prevIdentity.current === identity
+        ? prevState.current
+        : { byId: new Map<string, MessagesTimelineRow>(), result: [] };
+    prevIdentity.current = identity;
+    const nextState = computeStableMessagesTimelineRows(rows, previous);
     prevState.current = nextState;
     return nextState.result;
-  }, [rows]);
+  }, [identity, rows]);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -822,7 +822,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
   if (rows.length === 0 && !isWorking) {
     if (hideEmptyPlaceholder) {
-      return null;
+      // Occupy the pane with the theme surface so a thread switch cannot
+      // punch a hole through to the window chrome (white in light mode).
+      return <div className="h-full min-h-0 bg-background" data-timeline-loading="true" />;
     }
     return (
       <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
Switching between large conversations briefly cleared the chat pane. This keeps the timeline mounted, remembers the latest painted content for up to 16 threads, and refreshes the list and scroll position when its displayed thread changes. Remembered content from another thread is paint-only until the requested thread is ready.

Rebased all 12 original commits onto [#11198](https://github.com/pingdotgg/t3code/pull/11198), the fourth layer of the performance stack. Two compatibility commits correct optional callback props and complete test fixtures for current types.

## Direct production-browser comparison

Six counterbalanced rounds per build, identical isolated data and browser. Streaming values are median synchronous update milliseconds; navigation is the median time to the correct visible final message.

| Metric | Main | Four-PR stack | Stack + this PR |
| --- | ---: | ---: | ---: |
| Prose after completed code | 18.575 ms | 14.700 ms | 14.800 ms |
| Growing code block | 174.425 ms | 114.775 ms | 111.775 ms |
| Cached thread switch | 252.625 ms | 252.475 ms | 178.500 ms |
| Switches with blank frames | 48/48 | 48/48 | 0/48 |

This PR reduces cached switch latency **29.3%** versus its parent and removes the observed blank pane. All 144 measured switches reached the correct destination. Separate rapid navigation checks in light and dark themes also passed with no sampled blank frames.

Across the fixed 960-update streaming mix, the four-PR stack takes **32.0% less** synchronous update time than main; adding this PR makes that **33.2% less**. Its incremental streaming difference varies across rounds and is not a reliable additional streaming win. These are local web measurements, not provider throughput or cold/remote/mobile timings.

[Full methods, exact revisions and results](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/374d95b05acb63ee/total-comparison.md) · [Raw samples and scripts](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4b8408024537dd14/total-comparison-samples.zip)

## Browser evidence

Recordings were captured separately from timing and preserve screenshot timestamps.

Before: four-PR stack

[Before recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/0c05a5aafbe20e5c/switch-before-realtime.webm)

![Before: repeated blank conversation panes during thread switches](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/53aa6296a4b60b90/switch-before-contact.jpg)

After: stack plus this PR

[After recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/77aa4dff2fd5a931/switch-after-realtime.webm)

![After: conversation remains visible during thread switches](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/b8cffc474a8a735f/switch-after-contact.jpg)

## Validation

- Three focused timeline/scroll test files passed after rebase: 192 tests. After compatibility fixes, affected suites passed (184 tests), followed by 137 passing ChatView logic tests after the final fixture-only correction.
- Final web typecheck and production build passed.
- Browser verification used two 400-message synthetic threads, normal app pagination, six rounds and 48 cached switches per build, plus rapid interrupted navigation in both themes.
- Web verified. Desktop shares the web implementation, but Electron keybindings were not exercised; mobile is unchanged and was not tested.

Original implementation: cursor-grok-4.6-high-fast / Cursor. Rebase, compatibility fixes and measurements: GPT-6 / Codex with agent-browser.

<div><a href="https://cursor.com/agents/bc-240e940b-c369-402a-892d-36ec3e6e2a67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-240e940b-c369-402a-892d-36ec3e6e2a67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
