### PR TITLE
fix(server): request a new Explorer window when revealing files

### DIFF
--- a/apps/server/src/process/externalLauncher.test.ts
+++ b/apps/server/src/process/externalLauncher.test.ts
@@ -242,11 +242,11 @@ it.effect("reveals a file in File Explorer through PowerShell on Windows", () =>
     ]);
     const encodedCommand = spawned.args[spawned.args.length - 1] ?? "";
     const decodedCommand = Buffer.from(encodedCommand, "base64").toString("utf16le");
-    // explorer.exe expects `/select,"<path>"` with only the path quoted;
+    // Request a new window with `/n,/select,"<path>"`, quoting only the path;
     // PowerShell 5.1's Start-Process passes the argument string verbatim.
     assert.equal(
       decodedCommand,
-      "$ProgressPreference = 'SilentlyContinue'; Start-Process 'explorer.exe' -ArgumentList ('/select,\"' + 'C:\\workspace with spaces\\media\\author''s clip.mp4' + '\"')",
+      "$ProgressPreference = 'SilentlyContinue'; Start-Process 'explorer.exe' -ArgumentList ('/n,/select,\"' + 'C:\\workspace with spaces\\media\\author''s clip.mp4' + '\"')",
     );
     assert.equal(spawned.options.shell, false);
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
@@ -255,12 +255,12 @@ it.effect("reveals a file in File Explorer through PowerShell on Windows", () =>
 // Real-chain smoke check for the Explorer selection contract: runs the exact
 // PowerShell source the reveal launch encodes, against a stub that records
 // the raw argument tail it receives, and asserts a spaced path arrives as the
-// single `/select,"<path>"` switch. Mock argv assertions cannot prove this —
+// raw `/n,/select,"<path>"` switches. Mock argv assertions cannot prove this —
 // only Windows' own PowerShell -> CreateProcess quoting chain can, so the
 // test runs only where that chain exists.
 // oxlint-disable-next-line t3code/no-global-process-runtime -- the skip decision needs the real host platform, outside any Effect runtime.
 it.skipIf(process.platform !== "win32")(
-  "delivers the raw /select switch for spaced paths through real PowerShell",
+  "delivers the raw new-window reveal switches for spaced paths through real PowerShell",
   { timeout: 60_000 },
   async () => {
     const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-reveal-smoke-"));
@@ -302,7 +302,7 @@ it.skipIf(process.platform !== "win32")(
       }
       await sleep(200);
       const recorded = NodeFS.readFileSync(outputPath, "utf8").trim();
-      assert.equal(recorded, `/select,"${explorerTarget}"`);
+      assert.equal(recorded, `/n,/select,"${explorerTarget}"`);
     } finally {
       NodeFS.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -386,13 +386,13 @@ it.effect.skipIf(windowsHost)(
       assert.equal(result.editors.includes("file-manager"), true);
       assert.ok(spawned);
       // The reveal routes through interop PowerShell so Explorer receives its
-      // raw `/select,"<path>"` switch even for spaced paths.
+      // raw `/n,/select,"<path>"` switches even for spaced paths.
       assert.equal(spawned.command, "powershell.exe");
       const encodedCommand = spawned.args[spawned.args.length - 1] ?? "";
       const decodedCommand = Buffer.from(encodedCommand, "base64").toString("utf16le");
       assert.equal(
         decodedCommand,
-        "$ProgressPreference = 'SilentlyContinue'; Start-Process 'explorer.exe' -ArgumentList ('/select,\"' + '\\\\wsl.localhost\\Ubuntu-24.04\\home\\t3\\workspace\\media\\clip.mp4' + '\"')",
+        "$ProgressPreference = 'SilentlyContinue'; Start-Process 'explorer.exe' -ArgumentList ('/n,/select,\"' + '\\\\wsl.localhost\\Ubuntu-24.04\\home\\t3\\workspace\\media\\clip.mp4' + '\"')",
       );
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
 );

--- a/apps/server/src/process/externalLauncher.ts
+++ b/apps/server/src/process/externalLauncher.ts
@@ -575,8 +575,8 @@ const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
 });
 
 /**
- * PowerShell source that launches File Explorer with its raw selection
- * switch. Explorer's contract is the single argument `/select,"<path>"` with
+ * PowerShell source that requests a new File Explorer window with the target
+ * selected. `/n` requests a fresh window; `/select,"<path>"` must arrive with
  * only the path quoted; Node's default spawn quoting wraps the whole argument
  * when the path has spaces and Explorer misparses it, silently opening a
  * fallback folder. A single `-ArgumentList` string in Windows PowerShell 5.1
@@ -589,7 +589,7 @@ export function buildFileExplorerRevealPowerShellSource(
   explorerCommand: string,
   target: string,
 ): string {
-  return `$ProgressPreference = 'SilentlyContinue'; Start-Process ${escapePowerShellStringLiteral(explorerCommand)} -ArgumentList ('/select,"' + ${escapePowerShellStringLiteral(target)} + '"')`;
+  return `$ProgressPreference = 'SilentlyContinue'; Start-Process ${escapePowerShellStringLiteral(explorerCommand)} -ArgumentList ('/n,/select,"' + ${escapePowerShellStringLiteral(target)} + '"')`;
 }
 
 function fileExplorerRevealLaunch(


### PR DESCRIPTION
Windows "Reveal in File Explorer" can appear to do nothing even when the server successfully launches the reveal command. During investigation, Explorer windows for previously requested files were present but hidden. The original cause of those windows becoming hidden is still unknown.

This draft proposes adding `/n` to the existing PowerShell-launched `/select,"<path>"` command to request a new Explorer window. It preserves path normalization and raw argument quoting, and updates the Windows and WSL command expectations plus the real Windows PowerShell argument smoke test. A tradeoff is that repeated reveals request additional windows rather than reusing an existing one.

Validation:

- Updated command expectations failed before the implementation change and passed afterward. Focused launcher suite on Windows: 9 passed, 13 platform-specific tests skipped, including the WSL simulation tests. The real PowerShell quoting test passed.
- Targeted lint, formatting, and server typecheck passed (typecheck emitted existing suggestions).
- A separate Windows experiment opened an isolated fixture folder, hid only its test window, and launched the reveal command for a filename containing a space and an apostrophe. The proposed command produced a visible window with the correct file selected. **The original command also succeeded in this experiment**, so this is compatibility evidence, not a reproduction proving the mitigation resolves the reported intermittent failure.

Keeping this as a draft pending validation against a recurrence of the actual failure. The needed comparison is whether the old command leaves the requested folder invisible while `/n,/select` presents the correct file. Successful process creation or a passing argument test alone is insufficient. This PR does not establish an introducing commit or claim the issue is fixed.

Model: GPT-6. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * File Explorer now opens a new window when revealing a selected file.
  * The target file remains selected using the existing reveal action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->