### PR TITLE
feat(server): report Z.ai coding quota through OpenCode

### DIFF
--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -155,6 +155,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         Effect.map(stampIdentity),
         Effect.provideService(OpenCodeServerOwner.OpenCodeServerOwner, serverOwner),
         Effect.provideService(OpenCodeRuntime, openCodeRuntime),
+        Effect.provideService(HttpClient.HttpClient, httpClient),
       );
       // NOTE: the local branch intentionally uses the shared SDK server
       // instead of `opencode debug skill` (loadSkillsFromCli). The CLI writes

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -7,6 +7,7 @@ import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
 import { beforeEach } from "vite-plus/test";
 
 import { OpenCodeSettings } from "@t3tools/contracts";
@@ -21,6 +22,7 @@ import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
 import { checkOpenCodeProviderStatus } from "./OpenCodeProvider.ts";
 import type { OpenCodeInventory } from "../opencodeRuntime.ts";
 const decodeOpenCodeSettings = Schema.decodeSync(OpenCodeSettings);
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 const DEFAULT_VERSION_STDOUT = "opencode 1.14.19\n";
 
@@ -164,6 +166,23 @@ beforeEach(() => {
 });
 
 const testLayer = Layer.succeed(OpenCodeRuntime, OpenCodeRuntimeTestDouble).pipe(
+  Layer.provideMerge(
+    Layer.succeed(
+      HttpClient.HttpClient,
+      HttpClient.make((request) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              code: 200,
+              success: true,
+              data: { limits: [{ type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 42 }] },
+            }),
+          ),
+        ),
+      ),
+    ),
+  ),
   Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
   Layer.provideMerge(NodeServices.layer),
 );
@@ -199,6 +218,44 @@ const checkProvider = Effect.fn("checkProvider")(function* (
 });
 
 it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
+  it.effect("publishes connected Z.ai quota through the existing provider snapshot", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["zai-coding-plan"],
+          default: {},
+          all: [
+            {
+              id: "zai-coding-plan",
+              name: "Z.ai",
+              source: "api",
+              env: [],
+              key: "test-key",
+              options: {},
+              models: {},
+            },
+          ],
+        },
+        agents: [],
+        skills: [],
+      };
+      const snapshot = yield* checkProvider(makeOpenCodeSettings());
+      NodeAssert.equal(snapshot.status, "ready");
+      NodeAssert.equal(snapshot.usageLimits?.windows[0]?.usedPercent, 42);
+      NodeAssert.equal(encodeJson(snapshot).includes("test-key"), false);
+      const failedQuota = yield* checkProvider(makeOpenCodeSettings()).pipe(
+        Effect.provideService(
+          HttpClient.HttpClient,
+          HttpClient.make((request) =>
+            Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({}, { status: 503 }))),
+          ),
+        ),
+      );
+      NodeAssert.equal(failedQuota.status, "ready");
+      NodeAssert.equal(failedQuota.auth.status, "authenticated");
+      NodeAssert.equal(failedQuota.usageLimits?.unavailable?.reason, "probeFailed");
+    }),
+  );
   it.effect("shows a codex-style missing binary message", () =>
     Effect.gen(function* () {
       runtimeMock.state.runVersionError = new Error("spawn opencode ENOENT");

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -8,6 +8,7 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import { HttpClient } from "effect/unstable/http";
 
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { compareSemverVersions } from "@t3tools/shared/semver";
@@ -27,6 +28,7 @@ import {
 } from "../opencodeRuntime.ts";
 import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
 import * as OpenCodeServerOwner from "../OpenCodeServerOwner.ts";
+import { readOpenCodeZaiUsageLimits } from "./zaiUsageLimits.ts";
 
 const OPENCODE_PRESENTATION = {
   displayName: "OpenCode",
@@ -367,7 +369,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
 ): Effect.fn.Return<
   ServerProviderDraft,
   never,
-  OpenCodeRuntime | OpenCodeServerOwner.OpenCodeServerOwner
+  OpenCodeRuntime | OpenCodeServerOwner.OpenCodeServerOwner | HttpClient.HttpClient
 > {
   const openCodeRuntime = yield* OpenCodeRuntime;
   const serverOwner = yield* OpenCodeServerOwner.OpenCodeServerOwner;
@@ -520,6 +522,10 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   );
   const skills = openCodeSkillsToServerProviderSkills(inventoryExit.value.inventory.skills);
   const connectedCount = inventoryExit.value.inventory.providerList.connected.length;
+  const usageLimits = yield* readOpenCodeZaiUsageLimits(
+    inventoryExit.value.inventory.providerList,
+    checkedAt,
+  );
   return buildServerProvider({
     presentation: OPENCODE_PRESENTATION,
     enabled: true,
@@ -531,6 +537,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
       installed: true,
       version,
       status: connectedCount > 0 ? "ready" : "warning",
+      ...(usageLimits ? { usageLimits } : {}),
       auth: {
         status: connectedCount > 0 ? "authenticated" : "unknown",
         type: "opencode",

--- a/apps/server/src/provider/Layers/zaiUsageLimits.test.ts
+++ b/apps/server/src/provider/Layers/zaiUsageLimits.test.ts
@@ -1,0 +1,198 @@
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+
+import { resolveUsageLimitsAfterProbe } from "../providerUsageLimits.ts";
+import { readOpenCodeZaiUsageLimits } from "./zaiUsageLimits.ts";
+
+const checkedAt = "2026-09-10T12:00:00.000Z";
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+const reset = Date.parse("2026-09-10T17:00:00.000Z");
+const providers: ProviderListResponse = {
+  connected: ["zai-coding-plan"],
+  default: {},
+  all: [
+    {
+      id: "zai-coding-plan",
+      name: "Z.AI Coding Plan",
+      source: "api",
+      env: [],
+      key: "test-key",
+      options: {},
+      models: {},
+    },
+  ],
+};
+const limits = [
+  { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 25, nextResetTime: reset },
+  { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 60, nextResetTime: reset + 604800000 },
+  { type: "TIME_LIMIT", unit: 5, number: 1, percentage: 10, nextResetTime: reset },
+];
+const response = (items: ReadonlyArray<unknown> = limits) => ({
+  code: 200,
+  success: true,
+  data: { limits: items },
+});
+
+function fixture(body: unknown = response(), status = 200) {
+  const requests: string[] = [];
+  const client = HttpClient.make((request) =>
+    Effect.sync(() => {
+      requests.push(request.url);
+      return HttpClientResponse.fromWeb(request, Response.json(body, { status }));
+    }),
+  );
+  return {
+    requests,
+    read: (inventory = providers) =>
+      readOpenCodeZaiUsageLimits(inventory, checkedAt).pipe(
+        Effect.provideService(HttpClient.HttpClient, client),
+      ),
+  };
+}
+
+describe("OpenCode Z.ai quota", () => {
+  it.effect(
+    "maps the five-hour, weekly and separate MCP windows without inventing a month duration",
+    () =>
+      Effect.gen(function* () {
+        const test = fixture();
+        const result = yield* test.read();
+        expect(test.requests).toEqual(["https://api.z.ai/api/monitor/usage/quota/limit"]);
+        expect(result).toEqual({
+          checkedAt,
+          windows: [
+            {
+              id: "zai_tokens_limit_3_5",
+              kind: "session",
+              label: "Z.ai Coding · 5h",
+              usedPercent: 25,
+              windowDurationMins: 300,
+              resetsAt: "2026-09-10T17:00:00.000Z",
+            },
+            {
+              id: "zai_tokens_limit_6_1",
+              kind: "weekly",
+              label: "Z.ai Coding · 1w",
+              usedPercent: 60,
+              windowDurationMins: 10080,
+              resetsAt: "2026-09-17T17:00:00.000Z",
+            },
+            {
+              id: "zai_time_limit_5_1",
+              kind: "other",
+              label: "Z.ai MCP · 1mo",
+              usedPercent: 10,
+              resetsAt: "2026-09-10T17:00:00.000Z",
+            },
+          ],
+        });
+      }),
+  );
+
+  it.effect("uses OpenCode's config credential before its resolved account key", () =>
+    Effect.gen(function* () {
+      const client = HttpClient.make((request) =>
+        Effect.sync(() => {
+          expect(request.headers.authorization).toBe("Bearer config-key");
+          return HttpClientResponse.fromWeb(request, Response.json(response()));
+        }),
+      );
+      const result = yield* readOpenCodeZaiUsageLimits(
+        {
+          ...providers,
+          all: [{ ...providers.all[0]!, source: "config", options: { apiKey: "config-key" } }],
+        },
+        checkedAt,
+      ).pipe(Effect.provideService(HttpClient.HttpClient, client));
+      expect(encodeJson(result)).not.toContain("config-key");
+      expect(result?.windows).toHaveLength(3);
+    }),
+  );
+
+  it.effect("does not request quota for disconnected or other upstream providers", () =>
+    Effect.gen(function* () {
+      const test = fixture();
+      expect(yield* test.read({ ...providers, connected: [] })).toBeUndefined();
+      expect(yield* test.read({ ...providers, connected: ["zai"] })).toBeUndefined();
+      expect(test.requests).toEqual([]);
+    }),
+  );
+
+  it.effect("does not guess credentials for custom endpoints, plugin auth or missing keys", () =>
+    Effect.gen(function* () {
+      const test = fixture();
+      for (const provider of [
+        { ...providers.all[0]!, key: "" },
+        { ...providers.all[0]!, source: "custom" as const },
+        { ...providers.all[0]!, options: { baseURL: "https://proxy.example.test/v1" } },
+        { ...providers.all[0]!, options: { apiKey: "" } },
+      ]) {
+        expect((yield* test.read({ ...providers, all: [provider] }))?.unavailable?.reason).toBe(
+          "unsupported",
+        );
+      }
+      expect(test.requests).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "clamps percentages, omits invalid resets, and ignores unknown limit kinds and units",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* fixture(
+          response([
+            { ...limits[0]!, percentage: 120, nextResetTime: -1 },
+            { ...limits[1]!, percentage: -5, nextResetTime: 1e30 },
+            { ...limits[0]!, type: "FUTURE_LIMIT" },
+            { ...limits[0]!, unit: 99 },
+          ]),
+        ).read();
+        expect(result?.windows.map((window) => window.usedPercent)).toEqual([100, 0]);
+        expect(result?.windows.every((window) => window.resetsAt === undefined)).toBe(true);
+      }),
+  );
+
+  it.effect("does not represent an empty quota response as zero usage", () =>
+    Effect.gen(function* () {
+      expect((yield* fixture(response([])).read())?.unavailable?.reason).toBe("unsupported");
+    }),
+  );
+
+  it.effect(
+    "sanitizes HTTP and application errors and preserves the last good quota after a failed refresh",
+    () =>
+      Effect.gen(function* () {
+        const published = yield* fixture().read();
+        for (const [body, status] of [
+          [{ secret: "test-key" }, 401],
+          [response(), 429],
+          [{ code: 500, success: false, msg: "test-key" }, 200],
+          [response([{ ...limits[0]!, percentage: "bad" }]), 200],
+        ] as const) {
+          const probed = yield* fixture(body, status).read();
+          expect(probed?.unavailable?.reason).toBe("probeFailed");
+          expect(encodeJson(probed)).not.toContain("test-key");
+          expect(resolveUsageLimitsAfterProbe({ published, probed })).toBe(published);
+        }
+      }),
+  );
+
+  it.effect("bounds a stalled quota read", () =>
+    Effect.gen(function* () {
+      const fiber = yield* readOpenCodeZaiUsageLimits(providers, checkedAt).pipe(
+        Effect.provideService(
+          HttpClient.HttpClient,
+          HttpClient.make(() => Effect.never),
+        ),
+        Effect.forkChild,
+      );
+      yield* TestClock.adjust("5 seconds");
+      expect((yield* Fiber.join(fiber))?.unavailable?.reason).toBe("probeFailed");
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/zaiUsageLimits.ts
+++ b/apps/server/src/provider/Layers/zaiUsageLimits.ts
@@ -1,0 +1,120 @@
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2";
+import type { ServerProviderUsageLimits, ServerProviderUsageWindow } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import {
+  clampPercent,
+  makeUnavailableUsageLimits,
+  makeUsageLimits,
+} from "../providerUsageLimits.ts";
+
+const PROVIDER_ID = "zai-coding-plan";
+const CODING_URL = "https://api.z.ai/api/coding/paas/v4";
+const QUOTA_URL = "https://api.z.ai/api/monitor/usage/quota/limit";
+const Limit = Schema.Struct({
+  type: Schema.String,
+  unit: Schema.Int,
+  number: Schema.Int.check(Schema.isGreaterThan(0)),
+  percentage: Schema.Number.check(Schema.isFinite()),
+  nextResetTime: Schema.optional(Schema.NullOr(Schema.Number.check(Schema.isFinite()))),
+});
+const QuotaResponse = Schema.Struct({
+  code: Schema.Literal(200),
+  success: Schema.Literal(true),
+  data: Schema.Struct({ limits: Schema.Array(Limit) }),
+});
+
+function quotaWindow(limit: typeof Limit.Type): ServerProviderUsageWindow | undefined {
+  if (limit.type !== "TOKENS_LIMIT" && limit.type !== "TIME_LIMIT") return undefined;
+  // Z.ai uses 3 = hours, 4 = days, 5 = calendar months, 6 = weeks.
+  // Calendar months have no fixed duration; retain their reset timestamp instead.
+  const minutesPerUnit =
+    limit.unit === 3 ? 60 : limit.unit === 4 ? 1440 : limit.unit === 6 ? 10080 : undefined;
+  if (minutesPerUnit === undefined && limit.unit !== 5) return undefined;
+  const duration = minutesPerUnit === undefined ? undefined : minutesPerUnit * limit.number;
+  const isToolLimit = limit.type === "TIME_LIMIT";
+  const kind = isToolLimit
+    ? "other"
+    : limit.unit === 5
+      ? "monthly"
+      : duration === 10080
+        ? "weekly"
+        : "session";
+  const period = `${limit.number}${limit.unit === 3 ? "h" : limit.unit === 4 ? "d" : limit.unit === 6 ? "w" : "mo"}`;
+  const reset =
+    limit.nextResetTime && limit.nextResetTime > 0
+      ? DateTime.make(limit.nextResetTime)
+      : Option.none();
+  return {
+    id: `zai_${limit.type.toLowerCase()}_${limit.unit}_${limit.number}`,
+    kind,
+    label: `Z.ai ${isToolLimit ? "MCP" : "Coding"} · ${period}`,
+    usedPercent: clampPercent(limit.percentage),
+    ...(duration !== undefined ? { windowDurationMins: duration } : {}),
+    ...(Option.isSome(reset) ? { resetsAt: DateTime.formatIso(reset.value) } : {}),
+  };
+}
+
+/** Uses the credentials OpenCode resolved for this server, including remote instances.
+ * Never falls back to the T3 host's auth file, which may belong to another account.
+ */
+export const readOpenCodeZaiUsageLimits = Effect.fn("readOpenCodeZaiUsageLimits")(function* (
+  providers: ProviderListResponse,
+  checkedAt: string,
+): Effect.fn.Return<ServerProviderUsageLimits | undefined, never, HttpClient.HttpClient> {
+  if (!providers.connected.includes(PROVIDER_ID)) return undefined;
+  const provider = providers.all.find((entry) => entry.id === PROVIDER_ID);
+  const unavailable = (reason: "unsupported" | "probeFailed", message: string) =>
+    makeUnavailableUsageLimits({ checkedAt, reason, message });
+  if (!provider || provider.source === "custom") {
+    return unavailable(
+      "unsupported",
+      "Z.ai quota is unavailable for this OpenCode authentication method.",
+    );
+  }
+  const baseURL = provider.options.baseURL;
+  if (
+    baseURL !== undefined &&
+    (typeof baseURL !== "string" || baseURL.replace(/\/+$/, "") !== CODING_URL)
+  ) {
+    return unavailable("unsupported", "Z.ai quota is unavailable for a custom API endpoint.");
+  }
+  const key = provider.options.apiKey ?? provider.key;
+  if (typeof key !== "string" || key.trim().length === 0) {
+    return unavailable(
+      "unsupported",
+      "OpenCode did not expose a Z.ai API credential for quota reporting.",
+    );
+  }
+  const client = yield* HttpClient.HttpClient;
+  // Same read-only endpoint used by zai-org/zai-coding-plugins. Errors deliberately
+  // exclude response bodies and request details, which can contain credentials.
+  return yield* client
+    .execute(
+      HttpClientRequest.get(QUOTA_URL).pipe(
+        HttpClientRequest.setHeader("Authorization", `Bearer ${key}`),
+      ),
+    )
+    .pipe(
+      Effect.flatMap(HttpClientResponse.filterStatusOk),
+      Effect.flatMap((response) => response.json),
+      Effect.flatMap(Schema.decodeUnknownEffect(QuotaResponse)),
+      Effect.map((response) => {
+        const windows = response.data.limits.flatMap((limit) => {
+          const window = quotaWindow(limit);
+          return window ? [window] : [];
+        });
+        return windows.length > 0
+          ? makeUsageLimits({ checkedAt, windows })
+          : unavailable("unsupported", "Z.ai did not report any supported quota windows.");
+      }),
+      Effect.timeout("5 seconds"),
+      Effect.orElseSucceed(() =>
+        unavailable("probeFailed", "Could not refresh Z.ai quota. Try refreshing the provider."),
+      ),
+    );
+});

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -56,6 +56,12 @@ Filter with the environment dropdown to see what a single machine has.
 
 If a window looks stale, refresh Limits to re-check every provider and hub.
 
+OpenCode connections using **Z.AI Coding Plan** show the coding allowance and reset times
+reported by Z.ai, with MCP tool usage in a separate window. These are account-wide limits,
+including usage outside T3 Code. Refresh Limits to update them; historical OpenCode token and
+cost reporting is separate. Quota reporting requires OpenCode to expose the resolved API key
+and is unavailable for custom API endpoints or plugin-managed authentication.
+
 Pick `/usage-limits` from the composer's command menu, or send it as a message, to check the
 current model's limits without leaving the conversation. The result opens above the composer and
 closes when you dismiss it or send your next message. It uses the same snapshot as **Usage → Limits**, so it does not run the agent or refresh


### PR DESCRIPTION
## What Changed

OpenCode users authenticated with Z.AI Coding Plan can run GLM turns, but their provider snapshot never includes the subscription quota. This adds Z.ai's coding and MCP quota windows to the existing `usageLimits` snapshot during the OpenCode status probe, so the existing Limits view and `/usage-limits` command can consume them.

The reader uses the credential OpenCode resolved for that server, including configured remote OpenCode servers. It calls Z.ai's read-only quota endpoint, keeps coding and MCP windows distinct, preserves provider reset timestamps, and bounds the request to five seconds. A failed quota request leaves the coding provider ready and uses the existing last-good-quota behavior. Custom endpoints, plugin-managed auth, and unavailable credentials are reported as unsupported instead of guessing a host-local account.

## Why

This fills the Z.ai subscription-headroom gap using the existing OpenCode integration and wire contract. It adds no provider driver, configuration setting, database migration, client schema, or polling process. The endpoint is the one used by [Z.ai's official usage plugin](https://github.com/zai-org/zai-coding-plugins/blob/main/plugins/glm-plan-usage/skills/usage-query-skill/scripts/query-usage.mjs).

Related to #5539 and discussion #8148. Historical OpenCode token/cost reporting remains in #8456; this PR does not duplicate or depend on that work. These limits are account-wide, including consumption outside T3 Code.

## Validation

- 72 focused tests across the quota reader, OpenCode status probe, quota reconciliation, and shared Limits selection/pooling logic.
- Server typecheck, targeted lint/formatting, and `git diff --check`.
- Server and service-launcher bundles.
- Live read-only smoke using an isolated OpenCode server: the resolved Coding Plan credential returned coding and MCP windows through the new reader. No credentials or account data are included in fixtures or this PR.

No frontend components or layouts changed; the existing cross-client Limits contract carries the new data. No installed app or production state was modified for this contribution.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Built with GPT-6 in the Codex harness through T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode connections using the Z.AI Coding Plan now display coding allowance, reset times, and separate MCP tool usage limits.
  * Limit information refreshes with the Limits view and indicates when quota data is unavailable.
* **Documentation**
  * Added guidance about account-wide limits and unsupported custom endpoints or plugin-managed authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->