### PR TITLE
perf(web): format minimap previews only when opened

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -5,6 +5,11 @@ import {
   hasQuestionAnswer,
 } from "@t3tools/client-runtime/work-log/user-input";
 import {
+  deriveTimelineMinimapItems,
+  resolveTimelineMinimapPreview,
+  type TimelineMinimapItem,
+} from "./timelineMinimapItems";
+import {
   type AssistantCitation,
   type EnvironmentId,
   type MessageId,
@@ -918,64 +923,12 @@ function getItemType(item: MessagesTimelineRow) {
   return item.kind === "message" ? `message:${item.message.role}` : item.kind;
 }
 
-interface TimelineMinimapItem {
-  readonly id: string;
-  readonly rowIndex: number;
-  readonly userText: string | null;
-  readonly assistantText: string | null;
-}
-
 interface TimelinePositionState {
   readonly contentLength?: number;
   readonly scroll?: number;
   readonly scrollLength?: number;
   readonly positionAtIndex?: (index: number) => number | undefined;
   readonly sizeAtIndex?: (index: number) => number | undefined;
-}
-
-function deriveTimelineMinimapItems(
-  rows: ReadonlyArray<MessagesTimelineRow>,
-): TimelineMinimapItem[] {
-  const items: TimelineMinimapItem[] = [];
-  for (let index = 0; index < rows.length; index += 1) {
-    const row = rows[index];
-    if (row?.kind !== "message" || row.message.role !== "user") {
-      continue;
-    }
-
-    items.push({
-      id: row.id,
-      rowIndex: index,
-      userText: compactMinimapPreview(row.message.text),
-      assistantText: compactMinimapPreview(resolveFinalAssistantTextForTurn(rows, index)),
-    });
-  }
-  return items;
-}
-
-function resolveFinalAssistantTextForTurn(
-  rows: ReadonlyArray<MessagesTimelineRow>,
-  userRowIndex: number,
-) {
-  let finalAssistantText: string | null = null;
-  for (let index = userRowIndex + 1; index < rows.length; index += 1) {
-    const row = rows[index];
-    if (row?.kind !== "message") {
-      continue;
-    }
-    if (row.message.role === "user") {
-      break;
-    }
-    if (row.message.role === "assistant") {
-      finalAssistantText = row.message.text ?? null;
-    }
-  }
-  return finalAssistantText;
-}
-
-function compactMinimapPreview(text: string | null | undefined) {
-  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
-  return compact.length > 0 ? compact : null;
 }
 
 function resolveTimelineRowTop(state: TimelinePositionState, rowIndex: number) {
@@ -1011,7 +964,13 @@ function TimelineMinimap({
 
   const resolvedActiveIndex =
     activeIndex !== null && activeIndex < items.length ? activeIndex : null;
-  const activeItem = resolvedActiveIndex === null ? null : (items[resolvedActiveIndex] ?? null);
+  const activeItem = useMemo(
+    () =>
+      resolveTimelineMinimapPreview(
+        resolvedActiveIndex === null ? null : (items[resolvedActiveIndex] ?? null),
+      ),
+    [items, resolvedActiveIndex],
+  );
   const activeTopPercent =
     resolvedActiveIndex === null
       ? 0

--- a/apps/web/src/components/chat/timelineMinimapItems.test.ts
+++ b/apps/web/src/components/chat/timelineMinimapItems.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 import { MessageId } from "@t3tools/contracts";
-import { deriveTimelineEntries } from "../../session-logic";
-import { deriveMessagesTimelineRows } from "./MessagesTimeline.logic";
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
 import { deriveTimelineMinimapItems, resolveTimelineMinimapPreview } from "./timelineMinimapItems";
 import type { ChatMessage } from "../../types";
 
-function rows(entries: ReadonlyArray<readonly ["user" | "assistant", string]>) {
+function rows(
+  entries: ReadonlyArray<readonly ["user" | "assistant", string]>,
+): MessagesTimelineRow[] {
   const messages: ChatMessage[] = entries.map(([role, text], index) => ({
     id: MessageId.make(`message-${index}`),
     role,
@@ -15,15 +16,16 @@ function rows(entries: ReadonlyArray<readonly ["user" | "assistant", string]>) {
     createdAt: new Date(index * 1000).toISOString(),
     updatedAt: new Date(index * 1000).toISOString(),
   }));
-  return deriveMessagesTimelineRows({
-    timelineEntries: deriveTimelineEntries(messages, [], []),
-    latestTurn: null,
-    runningTurnId: null,
-    isWorking: false,
-    activeTurnStartedAt: null,
-    turnDiffSummaryByAssistantMessageId: new Map(),
-    revertTurnCountByUserMessageId: new Map(),
-  });
+  return messages.map((message) => ({
+    kind: "message",
+    id: message.id,
+    createdAt: message.createdAt,
+    message,
+    durationStart: message.createdAt,
+    showAssistantMeta: false,
+    showAssistantCopyButton: false,
+    assistantCopyStreaming: false,
+  }));
 }
 
 describe("timeline minimap previews", () => {

--- a/apps/web/src/components/chat/timelineMinimapItems.test.ts
+++ b/apps/web/src/components/chat/timelineMinimapItems.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vite-plus/test";
+import { MessageId } from "@t3tools/contracts";
+import { deriveTimelineEntries } from "../../session-logic";
+import { deriveMessagesTimelineRows } from "./MessagesTimeline.logic";
+import { deriveTimelineMinimapItems, resolveTimelineMinimapPreview } from "./timelineMinimapItems";
+import type { ChatMessage } from "../../types";
+
+function rows(entries: ReadonlyArray<readonly ["user" | "assistant", string]>) {
+  const messages: ChatMessage[] = entries.map(([role, text], index) => ({
+    id: MessageId.make(`message-${index}`),
+    role,
+    text,
+    streaming: false,
+    turnId: null,
+    createdAt: new Date(index * 1000).toISOString(),
+    updatedAt: new Date(index * 1000).toISOString(),
+  }));
+  return deriveMessagesTimelineRows({
+    timelineEntries: deriveTimelineEntries(messages, [], []),
+    latestTurn: null,
+    runningTurnId: null,
+    isWorking: false,
+    activeTurnStartedAt: null,
+    turnDiffSummaryByAssistantMessageId: new Map(),
+    revertTurnCountByUserMessageId: new Map(),
+  });
+}
+
+describe("timeline minimap previews", () => {
+  it("previews the last assistant response before the next prompt and retains jump targets", () => {
+    const source = rows([
+      ["user", "  Inspect\n this  "],
+      ["assistant", "Working"],
+      ["assistant", " Done\t now "],
+      ["user", "Next"],
+      ["assistant", "Second answer"],
+    ]);
+    const items = deriveTimelineMinimapItems(source);
+    expect(items).toHaveLength(2);
+    expect(resolveTimelineMinimapPreview(items[0])).toEqual({
+      ...items[0],
+      userText: "Inspect this",
+      assistantText: "Done now",
+    });
+    expect(source[items[0]!.rowIndex]!.id).toBe(items[0]!.id);
+    expect(resolveTimelineMinimapPreview(items[1])?.assistantText).toBe("Second answer");
+    expect(items[0]?.assistantText).toBe(" Done\t now ");
+  });
+
+  it("handles an unanswered prompt, empty responses, and a closed preview", () => {
+    const items = deriveTimelineMinimapItems(
+      rows([
+        ["user", "First"],
+        ["assistant", " \n\t"],
+        ["user", "Next"],
+      ]),
+    );
+    expect(items.map((item) => resolveTimelineMinimapPreview(item)?.assistantText)).toEqual([
+      null,
+      null,
+    ]);
+    expect(resolveTimelineMinimapPreview(null)).toBeNull();
+  });
+
+  it("shows fresh streaming text without changing the jump target", () => {
+    const first = deriveTimelineMinimapItems(
+      rows([
+        ["user", "Explain"],
+        ["assistant", "First"],
+      ]),
+    )[0]!;
+    const next = { ...first, assistantText: "First\n second" };
+    expect(resolveTimelineMinimapPreview(next)).toEqual({
+      ...first,
+      assistantText: "First second",
+    });
+    expect(resolveTimelineMinimapPreview(first)?.assistantText).toBe("First");
+  });
+});

--- a/apps/web/src/components/chat/timelineMinimapItems.test.ts
+++ b/apps/web/src/components/chat/timelineMinimapItems.test.ts
@@ -37,13 +37,13 @@ describe("timeline minimap previews", () => {
     ]);
     const items = deriveTimelineMinimapItems(source);
     expect(items).toHaveLength(2);
-    expect(resolveTimelineMinimapPreview(items[0])).toEqual({
+    expect(resolveTimelineMinimapPreview(items[0]!)).toEqual({
       ...items[0],
       userText: "Inspect this",
       assistantText: "Done now",
     });
     expect(source[items[0]!.rowIndex]!.id).toBe(items[0]!.id);
-    expect(resolveTimelineMinimapPreview(items[1])?.assistantText).toBe("Second answer");
+    expect(resolveTimelineMinimapPreview(items[1]!)?.assistantText).toBe("Second answer");
     expect(items[0]?.assistantText).toBe(" Done\t now ");
   });
 

--- a/apps/web/src/components/chat/timelineMinimapItems.ts
+++ b/apps/web/src/components/chat/timelineMinimapItems.ts
@@ -1,0 +1,66 @@
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
+
+export interface TimelineMinimapItem {
+  readonly id: string;
+  readonly rowIndex: number;
+  readonly userText: string | null;
+  readonly assistantText: string | null;
+}
+
+/** Keep full source text untouched until a minimap preview is opened. */
+export function deriveTimelineMinimapItems(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+): TimelineMinimapItem[] {
+  const items: TimelineMinimapItem[] = [];
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index];
+    if (row?.kind !== "message" || row.message.role !== "user") {
+      continue;
+    }
+
+    items.push({
+      id: row.id,
+      rowIndex: index,
+      userText: row.message.text,
+      assistantText: resolveFinalAssistantTextForTurn(rows, index),
+    });
+  }
+  return items;
+}
+
+function resolveFinalAssistantTextForTurn(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+  userRowIndex: number,
+) {
+  let finalAssistantText: string | null = null;
+  for (let index = userRowIndex + 1; index < rows.length; index += 1) {
+    const row = rows[index];
+    if (row?.kind !== "message") {
+      continue;
+    }
+    if (row.message.role === "user") {
+      break;
+    }
+    if (row.message.role === "assistant") {
+      finalAssistantText = row.message.text ?? null;
+    }
+  }
+  return finalAssistantText;
+}
+
+function compactMinimapPreview(text: string | null | undefined) {
+  const compact = text?.replace(/\s+/g, " ").trim() ?? "";
+  return compact.length > 0 ? compact : null;
+}
+
+export function resolveTimelineMinimapPreview(
+  item: TimelineMinimapItem | null,
+): TimelineMinimapItem | null {
+  return item === null
+    ? null
+    : {
+        ...item,
+        userText: compactMinimapPreview(item.userText),
+        assistantText: compactMinimapPreview(item.assistantText),
+      };
+}


### PR DESCRIPTION
Streaming updates eagerly compacted every loaded prompt and response for the timeline minimap, including when its preview was closed. Keep the source text in the minimap index and compact only the selected preview. Message targets and preview content stay the same.

| Production client replay | Before | After |
| --- | ---: | ---: |
| Median update | 23.0 ms | 20.9 ms (−9.1%) |
| Median run p95 | 36.9 ms | 32.4 ms (−12.2%) |

Five rotated-order runs, 120 measured updates per run, 12 stable TypeScript fences and a growing prose tail. Same browser, origin, viewport and synthetic data; no concurrent builds or local checks. The measurements compare [ab67795](https://github.com/pingdotgg/t3code/commit/ab67795dde448a3608d8689f7ad1975bb977e5a9) with this PR's unchanged runtime implementation. Later commits adjust test fixtures only. CI validates integration with newer main. These are client rendering measurements, not provider/network throughput or production user percentiles.

A separate 200-response × 20KB stage benchmark reduced minimap item construction from 21.25 ms to below 0.1 ms. This is an isolated stage saving, not a whole-app multiplier. An open preview still formats its selected response in full.

[Exploration and rejected experiments](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/4d5742c1f18177ff/exploration-v2.md) · [Production samples](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/75cb235935f6a16d/production-header-final.json) · [Minimap stage samples](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/ce68619c3ead5f41/minimap-micro.json) · [Benchmark source and reproduction notes](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a6fcc41d29a44645/benchmark-source.zip)

Impacts the web timeline and the web renderer used by desktop. Mobile, server, providers, wire contracts and file/diff implementations are unchanged. No new dependency, truncation, observer or state-library migration. Conditional HTML parsing, toolbar measurement observers, and code-block memoization were discarded after compatibility or timing checks; this PR contains only lazy preview formatting. Further measured improvements are separate layers in [#11193](https://github.com/pingdotgg/t3code/pull/11193), [#11196](https://github.com/pingdotgg/t3code/pull/11196) and [#11198](https://github.com/pingdotgg/t3code/pull/11198).

Validation: 103 focused timeline tests, web typecheck, targeted lint with pre-existing timeline warnings, and current-head CI. Browser checks cover minimap keyboard navigation, long-history navigation, selected text/DOM identity through 30 streaming updates, Markdown disclosures, a 10,000-line file to EOF, and split/collapsed working-tree diffs. No new flicker was observed in these checks. Native mobile and Electron shell behavior were not exercised.

| Before | After |
| --- | --- |
| ![Before: final-turn minimap preview](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/98f3518ffa0f673e/before-preview.png) | ![After: same preview and viewport](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8db8d5cc5c147301/after-preview.png) |

Before navigation and streaming:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/56590efe867cdef9/before-demo.webm

After navigation and streaming:

https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/789dea2b5f537b59/after-demo.webm

Recordings show visual states and compress dropped-frame intervals; timing comes from separate unrecorded runs. 0.8 seconds of recorder-induced startup was trimmed. No private transcript or authentication data is included. The source tree contains no probe or evidence files.

Model: GPT-6. Harness: Codex.
