### PR TITLE
fix(server): bootstrap attachment cleanup without decoding the event log

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -353,6 +353,8 @@ describe("OrchestrationEngine", () => {
           }),
         ),
       hasEventAfter: () => Effect.succeed(false),
+      readEventsOfTypes: () => Stream.empty,
+      getHead: () => Effect.succeedNone,
       readAggregateRange: () => Stream.die("unused aggregate replay"),
       getAggregateReplayStats: () => Effect.die("unused aggregate replay stats"),
     };
@@ -1498,6 +1500,8 @@ describe("OrchestrationEngine", () => {
         return Stream.fromIterable(events);
       },
       hasEventAfter: () => Effect.succeed(false),
+      readEventsOfTypes: () => Stream.empty,
+      getHead: () => Effect.succeedNone,
       readAggregateRange: () => Stream.die("unused aggregate replay"),
       getAggregateReplayStats: () => Effect.die("unused aggregate replay stats"),
     };
@@ -1738,6 +1742,8 @@ describe("OrchestrationEngine", () => {
         return Stream.fromIterable(events);
       },
       hasEventAfter: () => Effect.succeed(false),
+      readEventsOfTypes: () => Stream.empty,
+      getHead: () => Effect.succeedNone,
       readAggregateRange: () => Stream.die("unused aggregate replay"),
       getAggregateReplayStats: () => Effect.die("unused aggregate replay stats"),
     };

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2068,6 +2068,136 @@ it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-atta
   },
 );
 
+it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-projection-attachments-typed-")))(
+  "OrchestrationProjectionPipeline",
+  (it) => {
+    it.effect("cleanup bootstrap never decodes unrelated history and advances to the head", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const sql = yield* SqlClient.SqlClient;
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionState = yield* ProjectionStateRepository;
+        const { attachmentsDir } = yield* ServerConfig;
+        const now = "2026-01-01T00:00:00.000Z";
+        const projectId = ProjectId.make("project-typed");
+        const threadId = ThreadId.make("thread-typed-gone");
+        const attachmentPath = path.join(
+          attachmentsDir,
+          "thread-typed-gone-00000000-0000-4000-8000-000000000001.png",
+        );
+
+        yield* eventStore.append({
+          type: "project.created",
+          eventId: EventId.make("evt-typed-project"),
+          aggregateKind: "project",
+          aggregateId: projectId,
+          occurredAt: now,
+          commandId: CommandId.make("cmd-typed-project"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-typed-project"),
+          metadata: {},
+          payload: {
+            projectId,
+            title: "Typed",
+            workspaceRoot: "/tmp/project-typed",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.created",
+          eventId: EventId.make("evt-typed-create"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: CommandId.make("cmd-typed-create"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-typed-create"),
+          metadata: {},
+          payload: {
+            threadId,
+            projectId,
+            title: "Thread typed",
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("codex"),
+              model: "gpt-5-codex",
+            },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        });
+        yield* eventStore.append({
+          type: "thread.deleted",
+          eventId: EventId.make("evt-typed-delete"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: now,
+          commandId: CommandId.make("cmd-typed-delete"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-typed-delete"),
+          metadata: {},
+          payload: { threadId, deletedAt: now },
+        });
+        // A caught-up profile whose history holds a row the schema cannot decode.
+        // It stands in for the oversized records a full replay would materialize:
+        // cleanup must reach the head without ever reading it.
+        const headAt = "2026-01-01T00:00:01.000Z";
+        yield* sql`
+          INSERT INTO orchestration_events (
+            event_id, aggregate_kind, stream_id, stream_version, event_type, occurred_at,
+            actor_kind, payload_json, metadata_json
+          ) VALUES (
+            'evt-typed-broken', 'thread', 'thread-typed-broken', 0, 'thread.message-sent',
+            ${headAt}, 'provider', '{', '{}'
+          )
+        `;
+        const head = Option.getOrThrow(yield* eventStore.getHead());
+        yield* projectionState.upsertMany(
+          Object.values(ORCHESTRATION_PROJECTOR_NAMES).map((projector) => ({
+            projector,
+            lastAppliedSequence: head.sequence,
+            updatedAt: headAt,
+          })),
+        );
+        yield* fileSystem.makeDirectory(attachmentsDir, { recursive: true });
+        yield* fileSystem.writeFileString(attachmentPath, "gone");
+
+        yield* projectionPipeline.bootstrap;
+
+        assert.isFalse(yield* exists(attachmentPath));
+        const cleanupCursor = projectionState.getByProjector({
+          projector: "projection.attachment-cleanup",
+        });
+        assert.deepEqual(
+          yield* cleanupCursor,
+          Option.some({
+            projector: "projection.attachment-cleanup",
+            lastAppliedSequence: head.sequence,
+            updatedAt: headAt,
+          }),
+        );
+
+        yield* projectionPipeline.bootstrap;
+        assert.deepEqual(
+          yield* cleanupCursor,
+          Option.some({
+            projector: "projection.attachment-cleanup",
+            lastAppliedSequence: head.sequence,
+            updatedAt: headAt,
+          }),
+        );
+      }),
+    );
+  },
+);
+
 it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
   it.effect("replays a bootstrap backlog larger than the event store default limit", () =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -2105,17 +2105,29 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         lastAppliedSequence: cleanupStart,
         updatedAt: cleanupState?.updatedAt ?? "1970-01-01T00:00:00.000Z",
       });
+      // Nothing appends until the engine starts its worker, so the head captured here
+      // is what the projectors replay through. Capturing it first keeps the cleanup
+      // cursor at or behind every projector cursor.
+      const head = yield* eventStore.getHead();
       yield* Effect.forEach(projectors, bootstrapProjector, { concurrency: 1, discard: true });
+      if (Option.isNone(head)) {
+        return;
+      }
 
       // Cleanup has its own cursor so retries never have to replay committed text.
       // All message and activity references are current before any files are removed.
+      // Only deletions and reverts matter here, and they are filtered in SQL: a full
+      // replay would decode every historical payload, and one page of oversized
+      // records is enough to exhaust the heap before the cursor can move.
       const pendingCleanup = new Map<string, OrchestrationEvent>();
-      let lastEvent: OrchestrationEvent | undefined;
       yield* Stream.runForEach(
-        eventStore.readFromSequence(cleanupStart, Number.MAX_SAFE_INTEGER),
+        eventStore.readEventsOfTypes({
+          types: ["thread.reverted", "thread.deleted"],
+          fromSequenceExclusive: cleanupStart,
+          toSequenceInclusive: head.value.sequence,
+        }),
         (event) =>
           Effect.sync(() => {
-            lastEvent = event;
             if (event.type === "thread.reverted" || event.type === "thread.deleted") {
               pendingCleanup.set(`${event.type}:${event.payload.threadId}`, event);
             }
@@ -2133,13 +2145,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         // Leave the cleanup cursor behind this event so the next bootstrap retries it.
         if (!cleaned) return;
       }
-      if (lastEvent) {
-        yield* projectionStateRepository.upsert({
-          projector: cleanupProjector,
-          lastAppliedSequence: lastEvent.sequence,
-          updatedAt: lastEvent.occurredAt,
-        });
-      }
+      yield* projectionStateRepository.upsert({
+        projector: cleanupProjector,
+        lastAppliedSequence: head.value.sequence,
+        updatedAt: head.value.occurredAt,
+      });
     }).pipe(
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(Path.Path, path),

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -11,6 +11,7 @@ import {
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -315,7 +316,112 @@ layer("OrchestrationEventStore", (it) => {
       assert.deepEqual(yield* Stream.runCollect(store.readFromSequence(0, -1)), []);
     }),
   );
+
+  it.effect("reads only the requested event types through the captured head", () =>
+    Effect.gen(function* () {
+      const store = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const now = "2026-01-01T00:00:00.000Z";
+      const deletedThreadId = ThreadId.make("typed-deleted");
+      const revertedThreadId = ThreadId.make("typed-reverted");
+      const base = {
+        aggregateKind: "thread" as const,
+        occurredAt: now,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+      };
+      const before = yield* store.append(messageEvent(deletedThreadId, "typed-before"));
+      const deleted = yield* store.append({
+        ...base,
+        type: "thread.deleted",
+        eventId: EventId.make("typed-deleted-1"),
+        aggregateId: deletedThreadId,
+        payload: { threadId: deletedThreadId, deletedAt: now },
+      });
+      // An undecodable payload of another type must never be touched by a typed read.
+      yield* sql`
+        INSERT INTO orchestration_events (
+          event_id, aggregate_kind, stream_id, stream_version, event_type, occurred_at,
+          actor_kind, payload_json, metadata_json
+        ) VALUES (
+          'typed-broken', 'thread', 'typed-broken-thread', 0, 'thread.message-sent',
+          ${now}, 'provider', '{', '{}'
+        )
+      `;
+      const reverted = yield* store.append({
+        ...base,
+        type: "thread.reverted",
+        eventId: EventId.make("typed-reverted-1"),
+        aggregateId: revertedThreadId,
+        payload: { threadId: revertedThreadId, turnCount: 1 },
+      });
+      const headAt = "2026-01-01T00:00:01.000Z";
+      const afterHead = yield* store.append({
+        ...base,
+        type: "thread.deleted",
+        eventId: EventId.make("typed-deleted-2"),
+        aggregateId: revertedThreadId,
+        occurredAt: headAt,
+        payload: { threadId: revertedThreadId, deletedAt: headAt },
+      });
+
+      assert.deepEqual(
+        yield* store.getHead(),
+        Option.some({ sequence: afterHead.sequence, occurredAt: headAt }),
+      );
+
+      const types = ["thread.deleted", "thread.reverted"] as const;
+      const replayed = yield* Stream.runCollect(
+        store.readEventsOfTypes({
+          types,
+          fromSequenceExclusive: before.sequence,
+          toSequenceInclusive: reverted.sequence,
+        }),
+      );
+      assert.deepEqual(
+        replayed.map((event) => [event.sequence, event.type]),
+        [
+          [deleted.sequence, "thread.deleted"],
+          [reverted.sequence, "thread.reverted"],
+        ],
+      );
+      assert.deepEqual(
+        yield* Stream.runCollect(
+          store.readEventsOfTypes({
+            types,
+            fromSequenceExclusive: reverted.sequence,
+            toSequenceInclusive: reverted.sequence,
+          }),
+        ),
+        [],
+      );
+      assert.deepEqual(
+        yield* Stream.runCollect(
+          store.readEventsOfTypes({
+            types: [],
+            fromSequenceExclusive: 0,
+            toSequenceInclusive: afterHead.sequence,
+          }),
+        ),
+        [],
+      );
+      // The broken row is still there for a full replay to trip over.
+      const fullReplay = yield* Stream.runCollect(store.readFromSequence(before.sequence)).pipe(
+        Effect.flip,
+      );
+      assert.isTrue(isPersistenceDecodeError(fullReplay));
+    }),
+  );
 });
+
+it.effect("getHead is none for an empty store", () =>
+  Effect.gen(function* () {
+    const store = yield* OrchestrationEventStore;
+    assert.deepEqual(yield* store.getHead(), Option.none());
+  }).pipe(Effect.provide(OrchestrationEventStoreLive.pipe(Layer.provide(SqlitePersistenceMemory)))),
+);
 
 for (const reader of ["all", "aggregate"] as const) {
   it.effect(`releases consumed pages during ${reader} replay`, () =>

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -72,6 +72,16 @@ const ReadFromSequenceRequestSchema = Schema.Struct({
   sequenceExclusive: NonNegativeInt,
   limit: Schema.Number,
 });
+const ReadEventsOfTypesRequestSchema = Schema.Struct({
+  types: Schema.Array(OrchestrationEventType),
+  fromSequenceExclusive: NonNegativeInt,
+  toSequenceInclusive: NonNegativeInt,
+  limit: Schema.Number,
+});
+const EventHeadRowSchema = Schema.Struct({
+  sequence: NonNegativeInt,
+  occurredAt: IsoDateTime,
+});
 const AggregateReplayRequestSchema = Schema.Struct({
   aggregateKind: OrchestrationAggregateKind,
   aggregateId: Schema.String,
@@ -228,6 +238,44 @@ const makeEventStore = Effect.gen(function* () {
       `,
   });
 
+  const readEventRowsOfTypes = SqlSchema.findAll({
+    Request: ReadEventsOfTypesRequestSchema,
+    Result: OrchestrationEventPersistedRowSchema,
+    execute: (request) =>
+      sql`
+        SELECT
+          sequence,
+          event_id AS "eventId",
+          event_type AS "type",
+          aggregate_kind AS "aggregateKind",
+          stream_id AS "aggregateId",
+          occurred_at AS "occurredAt",
+          command_id AS "commandId",
+          causation_event_id AS "causationEventId",
+          correlation_id AS "correlationId",
+          payload_json AS "payload",
+          metadata_json AS "metadata"
+        FROM orchestration_events
+        WHERE sequence > ${request.fromSequenceExclusive}
+          AND sequence <= ${request.toSequenceInclusive}
+          AND ${sql.in("event_type", request.types)}
+        ORDER BY sequence ASC
+        LIMIT ${request.limit}
+      `,
+  });
+
+  const readEventHeadRow = SqlSchema.findOneOption({
+    Request: Schema.Void,
+    Result: EventHeadRowSchema,
+    execute: () =>
+      sql`
+        SELECT sequence, occurred_at AS "occurredAt"
+        FROM orchestration_events
+        ORDER BY sequence DESC
+        LIMIT 1
+      `,
+  });
+
   const readAggregateReplayStats = SqlSchema.findOne({
     Request: AggregateReplayRequestSchema,
     Result: AggregateReplayStatsRowSchema,
@@ -323,6 +371,55 @@ const makeEventStore = Effect.gen(function* () {
     );
   };
 
+  const readEventsOfTypes: OrchestrationEventStoreShape["readEventsOfTypes"] = (input) => {
+    if (input.types.length === 0 || input.fromSequenceExclusive >= input.toSequenceInclusive) {
+      return Stream.empty;
+    }
+    return Stream.paginate(input.fromSequenceExclusive, (cursor) =>
+      readEventRowsOfTypes({
+        types: input.types,
+        fromSequenceExclusive: cursor,
+        toSequenceInclusive: input.toSequenceInclusive,
+        limit: READ_PAGE_SIZE,
+      }).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "OrchestrationEventStore.readEventsOfTypes:query",
+            "OrchestrationEventStore.readEventsOfTypes:decodeRows",
+          ),
+        ),
+        Effect.flatMap((rows) =>
+          Effect.forEach(rows, (row) =>
+            decodeEvent(row).pipe(
+              Effect.mapError(
+                toPersistenceDecodeError("OrchestrationEventStore.readEventsOfTypes:rowToEvent"),
+              ),
+            ),
+          ),
+        ),
+        Effect.map((events) => {
+          const last = events.at(-1);
+          return [
+            events,
+            last === undefined || events.length < READ_PAGE_SIZE
+              ? Option.none()
+              : Option.some(last.sequence),
+          ] as const;
+        }),
+      ),
+    );
+  };
+
+  const getHead: OrchestrationEventStoreShape["getHead"] = () =>
+    readEventHeadRow().pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "OrchestrationEventStore.getHead:query",
+          "OrchestrationEventStore.getHead:decodeRow",
+        ),
+      ),
+    );
+
   const findEventAfter = SqlSchema.findOneOption({
     Request: HasEventAfterRequestSchema,
     Result: Schema.Struct({ sequence: Schema.Number }),
@@ -414,6 +511,8 @@ const makeEventStore = Effect.gen(function* () {
   return {
     append,
     readFromSequence,
+    readEventsOfTypes,
+    getHead,
     readAggregateRange,
     getAggregateReplayStats,
     readAll: () => readFromSequence(0, Number.MAX_SAFE_INTEGER),

--- a/apps/server/src/persistence/Services/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Services/OrchestrationEventStore.ts
@@ -12,6 +12,7 @@
 import { OrchestrationEvent } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
 import type * as Stream from "effect/Stream";
 
 import type { OrchestrationEventStoreError } from "../Errors.ts";
@@ -28,6 +29,11 @@ export interface OrchestrationAggregateReplayStats {
   readonly payloadBytes: number;
   /** A creation in this range does not prove that the aggregate still exists. */
   readonly hasCreateEvent: boolean;
+}
+
+export interface OrchestrationEventHead {
+  readonly sequence: number;
+  readonly occurredAt: string;
 }
 
 /**
@@ -59,6 +65,23 @@ export interface OrchestrationEventStoreShape {
     sequenceExclusive: number,
     limit?: number,
   ) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError>;
+
+  /**
+   * Replay only the listed event types after a sequence, through a captured
+   * head. Rows of other types are filtered in SQL and never decoded, so a
+   * history full of oversized payloads costs nothing here.
+   */
+  readonly readEventsOfTypes: (input: {
+    readonly types: ReadonlyArray<OrchestrationEvent["type"]>;
+    readonly fromSequenceExclusive: number;
+    readonly toSequenceInclusive: number;
+  }) => Stream.Stream<OrchestrationEvent, OrchestrationEventStoreError>;
+
+  /** The newest event's sequence and time, without decoding its payload. */
+  readonly getHead: () => Effect.Effect<
+    Option.Option<OrchestrationEventHead>,
+    OrchestrationEventStoreError
+  >;
 
   /** Read one aggregate through a captured global head, without decoding other streams. */
   readonly readAggregateRange: (


### PR DESCRIPTION
## What Changed

Attachment cleanup at startup no longer replays the whole event log. A new event store query, `readEventsOfTypes`, returns only `thread.deleted` and `thread.reverted` rows, filtered in SQL. `getHead` captures the newest sequence before replay. Bootstrap streams those rows into the same dedupe map and advances the cleanup cursor to the captured head after a successful pass, even when nothing matched. Ordering, the recreate check, and retry on a failed cleanup are unchanged.

Tests cover the typed reader and the head query, plus a pipeline case where a caught-up history holds an undecodable row of another type. The old bootstrap fails it with `PersistenceDecodeError`. The new one succeeds and lands the cursor on the head.

## Why

Fixes #11182. Follow-up to #10777.

#10777 released consumed pages, but one 500-row page can still hold over a gigabyte of JSON. On the affected profile, page 42001 to 42500 holds 22 `thread.session-set` events that each carry a 73 MB `lastError`. Decoding that page exhausts the heap before the cursor moves, so nightlies 1400 through 1507 crash-loop at startup. Only 17 events in that history matter to cleanup.

A/B on one fresh copy of the profile through `dev:desktop` with an isolated home: the parent commit, which includes #10777, hit `JavaScript heap out of memory` at 3.8 GB about 4 s after spawn, three times in a row. This branch reached `backend ready` on the same copy. Cursor went from 0 to 225560, thread count unchanged.

The three touched server suites pass (71 tests). Typecheck and lint are clean.

Done with Claude Fable 5.1 in Claude Code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (no UI changes)
- [x] I included a video for animation/interaction changes (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved projection startup reliability by processing only relevant event types during attachment cleanup.
  * Attachment cleanup now consistently reaches the latest available event, including when no matching events are found.
  * Prevented unrelated malformed event data from blocking cleanup of deleted thread attachments.
* **Tests**
  * Added coverage for filtered event reading, empty event stores, malformed data handling, and repeated projection startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->