### PR TITLE
feat(web): command palette search matches thread IDs

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -583,6 +583,28 @@ describe("buildThreadActionItems", () => {
     expect(item?.description).toBe("T3 Code · #feat/search");
   });
 
+  it("surfaces threads when the query is their ID", () => {
+    const threadId = ThreadId.make("thread-1");
+    const items = buildThreadActionItems({
+      threads: [makeThread({ id: threadId, title: "Refactor relay" })],
+      projectTitleById: new Map([[PROJECT_ID, "T3 Code"]]),
+      sortOrder: "updated_at",
+      icon: null,
+      runThread: async (_thread) => undefined,
+    });
+
+    const groups = filterCommandPaletteGroups({
+      activeGroups: [],
+      query: threadId,
+      isInSubmenu: false,
+      projectSearchItems: [],
+      settingsSearchItems: [],
+      threadSearchItems: items,
+    });
+
+    expect(groups.flatMap((group) => group.items)).toEqual(items);
+  });
+
   it("prefers renderDescription when provided", () => {
     const [item] = buildThreadActionItems({
       threads: [makeThread({ branch: "feat/search", worktreePath: "/tmp/wt" })],

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -583,10 +583,19 @@ describe("buildThreadActionItems", () => {
     expect(item?.description).toBe("T3 Code · #feat/search");
   });
 
-  it("surfaces threads when the query is their ID", () => {
-    const threadId = ThreadId.make("thread-1");
+  it("surfaces threads when the query is their ID, without outranking title matches", () => {
+    const idThread = makeThread({
+      id: ThreadId.make("thread-alpha-1234"),
+      title: "Unrelated work",
+      updatedAt: "2026-03-05T00:00:00.000Z",
+    });
+    const titleThread = makeThread({
+      id: ThreadId.make("thread-other-9999"),
+      title: "Fix thread-alpha-1234 flakes",
+      updatedAt: "2026-03-04T00:00:00.000Z",
+    });
     const items = buildThreadActionItems({
-      threads: [makeThread({ id: threadId, title: "Refactor relay" })],
+      threads: [idThread, titleThread],
       projectTitleById: new Map([[PROJECT_ID, "T3 Code"]]),
       sortOrder: "updated_at",
       icon: null,
@@ -595,14 +604,17 @@ describe("buildThreadActionItems", () => {
 
     const groups = filterCommandPaletteGroups({
       activeGroups: [],
-      query: threadId,
+      query: "  THREAD-ALPHA-1234  ",
       isInSubmenu: false,
       projectSearchItems: [],
       settingsSearchItems: [],
       threadSearchItems: items,
     });
 
-    expect(groups.flatMap((group) => group.items)).toEqual(items);
+    expect(groups.flatMap((group) => group.items)).toEqual([
+      expect.objectContaining({ value: `thread:${titleThread.id}` }),
+      expect.objectContaining({ value: `thread:${idThread.id}` }),
+    ]);
   });
 
   it("prefers renderDescription when provided", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -302,6 +302,8 @@ export function buildThreadActionItems<TThread extends BuildThreadActionItemsThr
           projectTitle ?? ``,
           thread.branch ?? ``,
           contentMatch?.snippet ?? ``,
+          // Last so pasted IDs never outrank title matches for shared substrings.
+          thread.id,
         ],
         title: thread.title,
         description,


### PR DESCRIPTION
## What Changed

The command palette (⌘K) now matches threads by their ID. Pasting a thread ID from "Copy thread ID" into the palette search surfaces that thread directly, which previously returned nothing unless the ID happened to appear in the title, branch, or message content.

Scope: web client only (`apps/web` command palette). Mobile's thread search screens, the server-side content search (`searchThreads`), and wire contracts are unchanged. Desktop inherits the change through its bundled web UI.

## Why

Thread IDs are already a first-class user-facing handle (the thread action menu exposes "Copy thread ID"), and support workflows revolve around pasting an ID to find a thread. The palette's `buildThreadActionItems` builds its search haystack from title, PR relations, project title, branch, and content snippets, but never the ID, so an exact ID query missed every thread.

The fix is one line plus a test: add `thread.id` to the search terms, last so pasted IDs never outrank title matches for shared substrings. No upstream issue or Ideas discussion exists for this; this PR body carries the motivation.

## Verification

- New test `surfaces threads when the query is their ID, without outranking title matches` in `apps/web/src/components/CommandPalette.logic.test.ts`: builds two threads where one matches by ID and the other by a title that embeds that ID, queries with an uppercase, whitespace-padded ID, and asserts both surface with the title match ranked first.
- `pnpm exec vp test run apps/web/src/components/CommandPalette.logic.test.ts`: 29 passed, 0 failed.
- `pnpm run typecheck` in `apps/web`: passed (0 errors).

No screenshots: this changes which results a query returns, not any layout or styling. A live client capture pass was attempted in an isolated environment but the fresh-install web client could not establish its connection on either this branch or the merge-base, so evidence is the focused test above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (skipped: no visual/layout change; see Verification)

Implementation used enablers/xlarge (GLM) in T3 Code. Independent review used GPT 6 Astra (high) via CLIProxyAPI (the configured Fable 5.1 reviewer was unavailable at the gateway; its one test-coverage suggestion is applied in 415f4a5607).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Thread IDs can now be searched in the command palette.
  - Title matches continue to rank ahead of matches found by thread ID.

- **Tests**
  - Added coverage confirming that searching by a thread ID surfaces the corresponding thread actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->