### PR TITLE
fix(projects): reach other Windows drives when adding a project

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -18,7 +18,7 @@ import * as WorkspacePaths from "./WorkspacePaths.ts";
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, readdir: vi.fn(actual.readdir) };
+  return { ...actual, readdir: vi.fn(actual.readdir), access: vi.fn(actual.access) };
 });
 
 const TestLayer = Layer.empty.pipe(
@@ -734,6 +734,38 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
         });
         expect(result).toEqual({ parentPath: cwd, entries: [] });
       }),
+    );
+
+    it.effect("lists the attached drives at the Windows drive list", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        vi.mocked(NodeFSP.access).mockImplementation(((target: string) =>
+          target === "C:\\" || target === "F:\\"
+            ? Promise.resolve()
+            : Promise.reject(new Error("ENOENT"))) as typeof NodeFSP.access);
+
+        const result = yield* workspaceEntries.browse({ partialPath: "\\" });
+
+        expect(result).toEqual({
+          parentPath: "\\",
+          entries: [
+            { name: "C:", fullPath: "C:\\" },
+            { name: "F:", fullPath: "F:\\" },
+          ],
+        });
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+    );
+
+    it.effect("keeps a bare backslash a normal path off Windows", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const accessSpy = vi.mocked(NodeFSP.access);
+        accessSpy.mockClear();
+
+        yield* workspaceEntries.browse({ partialPath: "\\" });
+
+        expect(accessSpy).not.toHaveBeenCalled();
+      }).pipe(Effect.provideService(HostProcessPlatform, "darwin")),
     );
   });
 });

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -19,7 +19,12 @@ import type {
   ProjectSearchEntriesResult,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
-import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
+import {
+  isExplicitRelativePath,
+  isWindowsAbsolutePath,
+  isWindowsDriveListPath,
+  WINDOWS_DRIVE_LIST_PATH,
+} from "@t3tools/shared/path";
 import { normalizeSearchQuery } from "@t3tools/shared/searchRanking";
 
 import { expandHomePathWith } from "../pathExpansion.ts";
@@ -103,6 +108,32 @@ export class WorkspaceEntries extends Context.Service<
   }
 >()("t3/workspace/WorkspaceEntries") {}
 
+const WINDOWS_DRIVE_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+
+/**
+ * Windows has no API for "list the drives", so each letter is probed directly.
+ * A disconnected network drive can leave `access` hanging, so probes are
+ * bounded and run together: a dead letter costs the timeout, not the listing.
+ */
+const WINDOWS_DRIVE_PROBE_TIMEOUT = "2 seconds";
+
+const listWindowsDriveRoots = Effect.fn("WorkspaceEntries.listWindowsDriveRoots")(function* () {
+  const probedDrives = yield* Effect.forEach(
+    WINDOWS_DRIVE_LETTERS,
+    (letter) =>
+      Effect.tryPromise({
+        try: () => NodeFSP.access(`${letter}:\\`),
+        catch: () => null,
+      }).pipe(
+        Effect.timeout(WINDOWS_DRIVE_PROBE_TIMEOUT),
+        Effect.as<string | null>(`${letter}:`),
+        Effect.orElseSucceed(() => null),
+      ),
+    { concurrency: "unbounded" },
+  );
+  return probedDrives.filter((drive) => drive !== null);
+});
+
 const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(function* (
   input: FilesystemBrowseInput,
   path: Path.Path,
@@ -181,6 +212,14 @@ export const make = Effect.gen(function* () {
 
   const browse: WorkspaceEntries["Service"]["browse"] = Effect.fn("WorkspaceEntries.browse")(
     function* (input) {
+      if ((yield* HostProcessPlatform) === "win32" && isWindowsDriveListPath(input.partialPath)) {
+        const driveRoots = yield* listWindowsDriveRoots();
+        return {
+          parentPath: WINDOWS_DRIVE_LIST_PATH,
+          entries: driveRoots.map((drive) => ({ name: drive, fullPath: `${drive}\\` })),
+        };
+      }
+
       const resolvedInputPath = yield* resolveBrowseTarget(input, path);
       const endsWithSeparator = /[\\/]$/.test(input.partialPath) || input.partialPath === "~";
       const parentPath = endsWithSeparator ? resolvedInputPath : path.dirname(resolvedInputPath);

--- a/apps/web/src/lib/projectPaths.test.ts
+++ b/apps/web/src/lib/projectPaths.test.ts
@@ -92,8 +92,27 @@ describe("projectPaths", () => {
     expect(getBrowseParentPath("C:\\Work\\Repo\\")).toBe("C:\\Work\\");
     expect(getBrowseParentPath("\\\\server\\share\\")).toBeNull();
     expect(getBrowseParentPath("\\\\server\\share\\repo\\")).toBe("\\\\server\\share\\");
-    expect(getBrowseParentPath("C:\\")).toBeNull();
+    expect(getBrowseParentPath("C:\\")).toBe("\\");
     expect(getBrowseParentPath("/home/user\\project/docs/")).toBe("/home/user\\project/");
+  });
+
+  it("reaches other drives through the drive list", () => {
+    // A drive root goes up to the drive list instead of dead-ending, so a
+    // project on D:/F: is reachable without typing its path blind.
+    expect(getBrowseParentPath("F:\\work\\")).toBe("F:\\");
+    expect(getBrowseParentPath("F:\\")).toBe("\\");
+    expect(canNavigateUp("C:\\")).toBe(true);
+    expect(getBrowseParentPath("\\")).toBeNull();
+    expect(canNavigateUp("\\")).toBe(false);
+
+    expect(appendBrowsePathSegment("\\", "F:")).toBe("F:\\");
+    expect(appendBrowsePathSegment("\\f", "F:")).toBe("F:\\");
+    expect(getBrowseDirectoryPath("\\f")).toBe("\\");
+    expect(getBrowseLeafPathSegment("\\f")).toBe("f");
+
+    expect(isFilesystemBrowseQuery("\\", "Win32")).toBe(true);
+    expect(isFilesystemBrowseQuery("\\f", "Win32")).toBe(true);
+    expect(isFilesystemBrowseQuery("\\", "MacIntel")).toBe(false);
   });
 
   it("detects browse path boundaries", () => {

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -12,6 +12,8 @@ import * as Arr from "effect/Array";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
 
+import { isWindowsDriveListPath } from "@t3tools/shared/path";
+
 import {
   appendBrowsePathSegment,
   ensureBrowseDirectoryPath,
@@ -19,6 +21,7 @@ import {
   inferProjectTitleFromPath,
   isExplicitRelativeProjectPath,
   isUnsupportedWindowsProjectPath,
+  isWindowsPlatform,
   resolveProjectPathForDispatch,
 } from "../state/projects.ts";
 import type { EnvironmentProject } from "../state/models.ts";
@@ -276,6 +279,11 @@ export function resolveAddProjectPath(input: {
   }
   if (isUnsupportedWindowsProjectPath(rawPath, input.platform)) {
     return { ok: false, error: "Windows-style paths are only supported on Windows environments." };
+  }
+  // The drive list is a browse level, not a directory: resolving it would
+  // quietly add a project at whichever drive root the server happens to be on.
+  if (isWindowsPlatform(input.platform) && isWindowsDriveListPath(rawPath)) {
+    return { ok: false, error: "Choose a drive to add a project from." };
   }
   if (isExplicitRelativeProjectPath(rawPath) && !input.currentProjectCwd) {
     return { ok: false, error: "Relative paths require an active project in this environment." };

--- a/packages/client-runtime/src/state/projects.ts
+++ b/packages/client-runtime/src/state/projects.ts
@@ -2,9 +2,11 @@ import {
   isExplicitRelativePath,
   isUncPath,
   isWindowsAbsolutePath,
+  isWindowsDriveListPath,
   isWindowsDrivePath,
   normalizeProjectPathForComparison,
   normalizeProjectPathForDispatch,
+  WINDOWS_DRIVE_LIST_PATH,
 } from "@t3tools/shared/path";
 
 export { normalizeProjectPathForComparison, normalizeProjectPathForDispatch };
@@ -79,6 +81,9 @@ function splitAbsolutePath(value: string): {
 
 export function isFilesystemBrowseQuery(value: string, platform = ""): boolean {
   const allowWindowsPaths = isWindowsPlatform(platform);
+  // A leading backslash is the drive list, optionally followed by filter text
+  // ("\c"). UNC paths land here too, and `isWindowsAbsolutePath` already covers
+  // them, so the prefix check only has to widen the entry point.
   return (
     value.startsWith("./") ||
     value.startsWith("../") ||
@@ -86,7 +91,7 @@ export function isFilesystemBrowseQuery(value: string, platform = ""): boolean {
     value.startsWith("..\\") ||
     value.startsWith("/") ||
     value.startsWith("~/") ||
-    (allowWindowsPaths && isWindowsAbsolutePath(value))
+    (allowWindowsPaths && (isWindowsAbsolutePath(value) || value.startsWith("\\")))
   );
 }
 
@@ -146,8 +151,12 @@ export function inferProjectTitleFromPath(value: string): string {
 }
 
 export function appendBrowsePathSegment(currentPath: string, segment: string): string {
-  const separator = preferredPathSeparator(currentPath);
-  return `${getBrowseDirectoryPath(currentPath)}${segment}${separator}`;
+  const directoryPath = getBrowseDirectoryPath(currentPath);
+  // Drive-list entries are drive roots ("C:"), not children of the sentinel.
+  if (isWindowsDriveListPath(directoryPath)) {
+    return `${segment}\\`;
+  }
+  return `${directoryPath}${segment}${preferredPathSeparator(currentPath)}`;
 }
 
 export function getBrowseLeafPathSegment(currentPath: string): string {
@@ -173,9 +182,15 @@ export function ensureBrowseDirectoryPath(currentPath: string): string {
 
 export function getBrowseParentPath(currentPath: string): string | null {
   const trimmed = normalizeProjectPathForDispatch(currentPath);
+  // The drive list is the top of a Windows environment; nothing sits above it.
+  if (isWindowsDriveListPath(trimmed)) return null;
   const absolutePath = splitAbsolutePath(trimmed);
   if (absolutePath) {
-    if (absolutePath.segments.length === 0) return null;
+    if (absolutePath.segments.length === 0) {
+      // A drive root goes up to the drive list, so other drives stay reachable
+      // without knowing their paths. UNC shares have no such level.
+      return isWindowsDrivePath(trimmed) ? WINDOWS_DRIVE_LIST_PATH : null;
+    }
     if (absolutePath.segments.length === 1) return absolutePath.root;
     const parentSegments = absolutePath.segments.slice(0, -1).join(absolutePath.separator);
     return `${absolutePath.root}${parentSegments}${absolutePath.separator}`;

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -10,6 +10,18 @@ export function isWindowsAbsolutePath(value: string): boolean {
   return isUncPath(value) || isWindowsDrivePath(value);
 }
 
+/**
+ * The level above every drive root on a Windows environment, where the drive
+ * list lives. Windows has no real path for it, so T3 addresses it with a bare
+ * backslash. Deliberately not `/`: on posix that is a real directory, and
+ * keeping the two apart lets the path helpers stay platform-free.
+ */
+export const WINDOWS_DRIVE_LIST_PATH = "\\";
+
+export function isWindowsDriveListPath(value: string): boolean {
+  return value === WINDOWS_DRIVE_LIST_PATH;
+}
+
 export function isExplicitRelativePath(value: string): boolean {
   return (
     value === "." ||


### PR DESCRIPTION
## Problem

On Windows you can't get to a project on a second drive. The path browser starts on the home drive and can never leave it: browsing up from `C:\` dead-ends (`getBrowseParentPath("C:\\")` returned `null`, so no `..` row appears), and nothing in the app enumerates drives. A project on `D:` or `F:` was only reachable by already knowing the path and typing it blind — and on mobile, where there's no native folder picker, that's the only way in.

The path handling itself was never the problem: typing `F:\work` resolves and adds fine today. What was missing was any way to *reach* it.

## Fix

Adds the drive list as a real browse level above the drive roots, addressed by a bare backslash (`WINDOWS_DRIVE_LIST_PATH`). Deliberately not `/`, which is a real directory on posix — keeping them apart lets the path helpers stay platform-free.

- **Server** (`WorkspaceEntries.browse`): on `win32`, a bare backslash returns the attached drives. Windows has no "list the drives" API, so each letter is probed with `access`. Probes run together and are bounded at 2s, so a disconnected network drive costs the timeout rather than the whole listing.
- **Clients** (shared helpers, so web palette and mobile Add Project both follow): a drive root now navigates up into the drive list instead of dead-ending, selecting a drive enters its root, and a leading backslash stays a browse query so `\f` filters. UNC shares still have no level above them.
- Submitting the drive list itself is rejected with "Choose a drive to add a project from." instead of quietly creating a project at whichever drive root the server happens to sit on.

Remote environments work too: the client keys off the environment's reported platform, so a Mac browsing a remote Windows server gets that server's drive list.

## Surfaces

Web palette, mobile Add Project, and desktop (wraps web) all route through the shared browse helpers and the one server endpoint. The desktop native folder picker already allowed any drive and is untouched. No contract change — `partialPath` is already a string.

## Verification

`vp test run` on the affected scope: 1425 passing, including new coverage for drive-list browsing (platform-gated, so it passes on Linux CI), up-navigation from a drive root, and `\f` filtering. Lint, format, and typecheck clean on the changed files.

No before/after images attached — the change is navigation behavior and capturing it needs a dev server plus a browser session. Happy to add a short clip if you want one.

Made with Claude Opus 5 in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows drive-list browsing, allowing users to view available drives when starting from the root path.
  * Improved navigation between the drive list, drive roots, and folders.
  * Added platform-aware handling for Windows browse paths.

* **Bug Fixes**
  * Prevented attempts to add a project from the Windows drive-list view; users are prompted to select a specific drive first.
  * Preserved standard path behavior on non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->