### PR TITLE
fix(web): themed panel toggles show their disabled state

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1303,6 +1303,18 @@ html[data-theme-id] [data-workspace-titlebar-controls] [data-slot="tooltip-trigg
   color: var(--contrast-toolbar-foreground);
 }
 
+html[data-theme-id] [data-panel-layout-controls] [data-slot="toggle"]:disabled,
+html[data-theme-id] [data-panel-layout-controls] [data-slot="tooltip-trigger"]:disabled,
+html[data-theme-id] [data-workspace-titlebar-controls] [data-slot="toggle"]:disabled,
+html[data-theme-id] [data-workspace-titlebar-controls] [data-slot="tooltip-trigger"]:disabled {
+  --control-icon-color: color-mix(
+    in oklab,
+    var(--contrast-toolbar-foreground) 55%,
+    var(--toolbar-background)
+  );
+  color: color-mix(in oklab, var(--contrast-toolbar-foreground) 55%, var(--toolbar-background));
+}
+
 html[data-theme-id] [data-chat-header] [data-slot="button"]:hover,
 html[data-theme-id] [data-chat-header] [data-slot="button"][data-pressed],
 html[data-theme-id] [data-chat-header] [data-slot="menu-trigger"]:hover,


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Opus 5 on behalf of Oliver**

### ELI5

The button that opens the right panel is greyed out when there's nothing to open. In any custom theme it wasn't actually greyed out — it looked identical to a working button. Now it's dimmed everywhere.

### Problem

`html[data-theme-id] [data-panel-layout-controls] [data-slot="toggle"]` matches at specificity (0,3,1). The ghost variant's own `disabled:text-muted-foreground` compiles to a class plus `:disabled` — (0,2,0). The themed rule wins, so a disabled panel toggle kept the full-strength toolbar foreground and rendered exactly like an enabled one.

The comment on that rule accounts for hover and pressed, but not disabled. The default theme escaped it only because `applyThemePalette` leaves `data-theme-id` unset for the built-in palette, so the ghost variant is uncontested there.

Two surfaces hit this: the right-panel toggle on `/pull-requests` (disabled until a pull request is selected) and the terminal toggle in `ChatView` (disabled when no terminal is available). Those are the only two consumers of `[data-panel-layout-controls]` / `[data-workspace-titlebar-controls]`.

### Fix

Restate the disabled color alongside the rule that was overriding it. Adding `:disabled` takes it to (0,4,1), and the color is mixed from the theme's own tokens rather than hardcoded, so it follows user-authored palettes too:

```css
--control-icon-color: color-mix(in oklab, var(--contrast-toolbar-foreground) 55%, var(--toolbar-background));
```

55% puts the themed disabled values next to the default theme's muted foreground rather than inventing a new level of dimming. Measured icon color, disabled vs enabled:

| Theme | Before (disabled / enabled) | After (disabled / enabled) |
|---|---|---|
| Default · dark | L 0.604 / 0.970 | unchanged |
| Default · light | L 0.552 / 0.274 | unchanged |
| T3 Chat · dark | L 0.981 / 0.981 | L 0.642 / 0.981 |
| Ocean · dark | L 0.990 / 0.990 | L 0.654 / 0.990 |
| Ember · light | L 0.222 / 0.222 | L 0.562 / 0.222 |

Mirrored across all four selectors from the rule above, including the `tooltip-trigger` ones — `RightPanelMaximizeControl` has `TooltipTrigger` render the `Toggle` directly, which is the case that rule's comment was written for, and keeping the pair in sync stops a future disabled trigger-rendered toggle from regressing the same way.

### UI Changes

Captured on a dev server with real data, on `/pull-requests`. Both columns show the panel **closed**, so the only variable is whether the button is disabled. Left column: no pull request selected. Right column: one selected and the panel toggled shut.

#### Before

![Before](https://github.com/flamboh/t3code/releases/download/pr-assets-panel-toggle-disabled-202609110423/pr-before.png)

#### After

![After](https://github.com/flamboh/t3code/releases/download/pr-assets-panel-toggle-disabled-202609110423/pr-after.png)

### Notes

No test. This is a cascade fix, and per `AGENTS.md` a test that renders the component to assert a computed attribute would mirror the implementation. Evidence is the measurement above, taken through Chrome from the running app in all five built-in theme/appearance combinations. `vp fmt` applied; `vp lint` has no coverage for `.css`.

Written by Opus 5 in Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the appearance of disabled panel-layout and workspace-titlebar controls.
  - Disabled toggle and tooltip-trigger controls now use a themed, visually distinct color for clearer differentiation from enabled controls.
  - Icon and text colors are now styled consistently across these disabled controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->