### PR TITLE
fix(web): composite the agent cursor into browser recordings

### DIFF
--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -8,6 +8,10 @@ import { previewBridge } from "~/components/preview/previewBridge";
 import { ensureClientSettingsHydrated, getClientSettings } from "~/hooks/useSettings";
 import { appAtomRegistry } from "~/rpc/atomRegistry";
 
+import {
+  attachRecordingCursorCompositor,
+  type RecordingCursorCompositor,
+} from "./browserRecordingCursor";
 import { acquireBrowserSurfaceActivity } from "./browserSurfaceStore";
 
 export class BrowserRecordingUnavailableError extends Schema.TaggedError<BrowserRecordingUnavailableError>()(
@@ -122,6 +126,7 @@ interface ActiveRecording {
   readonly startupSettled: Promise<void>;
   releaseSurfaceActivity: (() => void) | null;
   stream: MediaStream | null;
+  cursorCompositor: RecordingCursorCompositor | null;
   recorder: MediaRecorder | null;
   savedBlob?: Blob;
   uploadPromise?: Promise<string>;
@@ -248,9 +253,12 @@ const preferredMimeTypes = [
   "video/webm",
 ] as const;
 
-const createMediaRecorder = (stream: MediaStream): MediaRecorder => {
+const createMediaRecorder = (
+  stream: MediaStream,
+  settingsStream: MediaStream = stream,
+): MediaRecorder => {
   const mimeType = preferredMimeTypes.find((candidate) => MediaRecorder.isTypeSupported(candidate));
-  const settings = stream.getVideoTracks()[0]?.getSettings();
+  const settings = settingsStream.getVideoTracks()[0]?.getSettings();
   // Browser defaults under-budget native-resolution text and motion. Scale with captured pixels
   // and frames, while bounding storage and encoder load for very large displays.
   const videoBitsPerSecond = Math.round(
@@ -429,6 +437,8 @@ const cleanupFailedRecordingStart = async (
     errors.push(error);
   }
   try {
+    recording.cursorCompositor?.dispose();
+    recording.cursorCompositor = null;
     stopMediaStream(recording.stream);
   } catch (error) {
     errors.push(error);
@@ -524,6 +534,7 @@ export async function startBrowserRecording(
     startupSettled,
     releaseSurfaceActivity,
     stream: null,
+    cursorCompositor: null,
     recorder: null,
     lifecycle: startingLifecycle,
   };
@@ -612,9 +623,21 @@ export async function startBrowserRecording(
     ]);
     await throwIfStartupCancelled();
 
+    // The raw tab capture has no pointer rendered in it; composite the agent
+    // cursor onto a canvas when the environment supports it so recordings show
+    // the pointer where the live preview does. Falls back to the raw stream.
+    const cursorCompositor = await attachRecordingCursorCompositor({
+      tabId,
+      serverTabId,
+      stream,
+      threadRef,
+      frameRate,
+    });
+    recording.cursorCompositor = cursorCompositor;
+
     let recorder: MediaRecorder;
     try {
-      recorder = createMediaRecorder(stream);
+      recorder = createMediaRecorder(cursorCompositor?.stream ?? stream, stream);
       recording.recorder = recorder;
       recorder.addEventListener("dataavailable", (event) => {
         if (event.data.size > 0) chunks.push(event.data);
@@ -695,6 +718,8 @@ const finalizeBrowserRecording = async (
         });
       }
       // Encoding has flushed; release native capture before materializing and saving the file.
+      recording.cursorCompositor?.dispose();
+      recording.cursorCompositor = null;
       stopMediaStream(recording.stream);
       recording.stream = null;
       const mimeType =
@@ -739,6 +764,8 @@ const finalizeBrowserRecording = async (
     cleanupErrors.push(cause);
   }
   try {
+    recording.cursorCompositor?.dispose();
+    recording.cursorCompositor = null;
     stopMediaStream(recording.stream);
   } catch (cause) {
     cleanupErrors.push(cause);
@@ -786,6 +813,8 @@ const discardBrowserRecording = async (
   try {
     await bridge.recording.stopScreencast(recording.tabId).catch(() => undefined);
     await stopMediaRecorder(recording.recorder).catch(() => undefined);
+    recording.cursorCompositor?.dispose();
+    recording.cursorCompositor = null;
     stopMediaStream(recording.stream);
     return null;
   } finally {

--- a/apps/web/src/browser/browserRecording.ts
+++ b/apps/web/src/browser/browserRecording.ts
@@ -253,6 +253,12 @@ const preferredMimeTypes = [
   "video/webm",
 ] as const;
 
+/**
+ * Builds the recorder for a capture stream. Bitrate scales with the captured
+ * resolution and frame rate; `settingsStream` lets callers read those settings
+ * from the raw capture even when `stream` is a re-encoded canvas stream whose
+ * track settings may not be populated yet.
+ */
 const createMediaRecorder = (
   stream: MediaStream,
   settingsStream: MediaStream = stream,

--- a/apps/web/src/browser/browserRecordingCursor.test.ts
+++ b/apps/web/src/browser/browserRecordingCursor.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import type { DesktopPreviewPointerEvent } from "@t3tools/contracts";
+
+import {
+  BROWSER_RECORDING_CURSOR_ACTIVE_MS,
+  BROWSER_RECORDING_CURSOR_PING_MS,
+  drawRecordingCursor,
+  resolveFrameDrawRect,
+  resolveRecordingCursorPlacement,
+} from "./browserRecordingCursor";
+
+const NOW_MS = 1_800_000_000_000;
+
+const pointerEvent = (overrides: {
+  readonly phase?: "move" | "click";
+  readonly x?: number;
+  readonly y?: number;
+  readonly ageMs?: number;
+}): DesktopPreviewPointerEvent => ({
+  tabId: "recording-tab",
+  phase: overrides.phase ?? "move",
+  x: overrides.x ?? 100,
+  y: overrides.y ?? 150,
+  sequence: 1,
+  createdAt: new Date(NOW_MS - (overrides.ageMs ?? 0)).toISOString(),
+});
+
+const source = (overrides?: {
+  readonly event?: DesktopPreviewPointerEvent;
+  readonly contentWidth?: number;
+  readonly contentHeight?: number;
+  readonly scale?: number;
+  readonly zoomFactor?: number;
+  readonly frameWidth?: number;
+  readonly frameHeight?: number;
+  readonly controller?: "human" | "agent" | "none";
+}) => ({
+  event: overrides?.event ?? pointerEvent({}),
+  content: {
+    width: overrides?.contentWidth ?? 800,
+    height: overrides?.contentHeight ?? 600,
+    scale: overrides?.scale ?? 1,
+  },
+  zoomFactor: overrides?.zoomFactor ?? 1,
+  frameWidth: overrides?.frameWidth ?? 800,
+  frameHeight: overrides?.frameHeight ?? 600,
+  controller: overrides?.controller ?? "agent",
+  nowMs: NOW_MS,
+});
+
+describe("resolveRecordingCursorPlacement", () => {
+  it("maps guest viewport pixels onto the captured frame", () => {
+    const placement = resolveRecordingCursorPlacement(source());
+    expect(placement).toMatchObject({ x: 100, y: 150, size: 20, opacity: 1 });
+  });
+
+  it("cancels zoom and presentation scale out of the relative position", () => {
+    const placement = resolveRecordingCursorPlacement(
+      source({ contentWidth: 400, contentHeight: 300, scale: 0.5, zoomFactor: 2 }),
+    );
+    // The event stays at the same relative position, so a 2x frame lands at 2x pixels.
+    expect(placement).toMatchObject({ x: 200, y: 300, size: 40 });
+  });
+
+  it("clamps positions to the captured frame", () => {
+    const placement = resolveRecordingCursorPlacement(
+      source({ event: pointerEvent({ x: 10_000, y: -50 }) }),
+    );
+    expect(placement).toMatchObject({ x: 800, y: 0 });
+  });
+
+  it("dims the cursor once the pointer event goes stale", () => {
+    const active = resolveRecordingCursorPlacement(source());
+    const idle = resolveRecordingCursorPlacement(
+      source({ event: pointerEvent({ ageMs: BROWSER_RECORDING_CURSOR_ACTIVE_MS + 1 }) }),
+    );
+    expect(active?.opacity).toBe(1);
+    expect(idle?.opacity).toBe(0.35);
+  });
+
+  it("expands the click ping only for fresh click events", () => {
+    const freshClick = resolveRecordingCursorPlacement(
+      source({ event: pointerEvent({ phase: "click", ageMs: 150 }) }),
+    );
+    const settledClick = resolveRecordingCursorPlacement(
+      source({
+        event: pointerEvent({ phase: "click", ageMs: BROWSER_RECORDING_CURSOR_PING_MS + 1 }),
+      }),
+    );
+    const move = resolveRecordingCursorPlacement(source());
+    expect(freshClick?.pingProgress).toBeCloseTo(0.25);
+    expect(settledClick?.pingProgress).toBeNull();
+    expect(move?.pingProgress).toBeNull();
+  });
+
+  it("returns null when the content presentation cannot be trusted", () => {
+    expect(resolveRecordingCursorPlacement(source({ scale: 0 }))).toBeNull();
+    expect(resolveRecordingCursorPlacement(source({ frameWidth: 0 }))).toBeNull();
+  });
+});
+
+describe("resolveFrameDrawRect", () => {
+  it("fits a matching-aspect frame edge to edge", () => {
+    expect(resolveFrameDrawRect(800, 600, 1600, 1200)).toEqual({
+      scale: 0.5,
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("letterboxes a mismatched-aspect frame with centered bars", () => {
+    const rect = resolveFrameDrawRect(800, 600, 1600, 900);
+    expect(rect).toEqual({
+      scale: 0.5,
+      x: 0,
+      y: 75,
+      width: 800,
+      height: 450,
+    });
+  });
+
+  it("rejects frames without a usable size", () => {
+    expect(resolveFrameDrawRect(800, 600, 0, 900)).toBeNull();
+  });
+});
+
+describe("drawRecordingCursor", () => {
+  const createContext = () => {
+    const calls: string[] = [];
+    const points: Array<readonly [number, number]> = [];
+    let alpha = 1;
+    return {
+      calls,
+      points,
+      get globalAlpha() {
+        return alpha;
+      },
+      set globalAlpha(value: number) {
+        alpha = value;
+        calls.push(`alpha:${value}`);
+      },
+      beginPath: () => calls.push("beginPath"),
+      moveTo: (x: number, y: number) => {
+        calls.push("moveTo");
+        points.push([x, y]);
+      },
+      lineTo: (x: number, y: number) => {
+        calls.push("lineTo");
+        points.push([x, y]);
+      },
+      closePath: () => calls.push("closePath"),
+      arc: () => calls.push("arc"),
+      fill: () => calls.push("fill"),
+      stroke: () => calls.push("stroke"),
+      save: () => calls.push("save"),
+      restore: () => calls.push("restore"),
+    } as unknown as CanvasRenderingContext2D & {
+      calls: string[];
+      points: Array<readonly [number, number]>;
+    };
+  };
+
+  it("places the arrow tip on the pointer position and restores the context", () => {
+    const context = createContext();
+    drawRecordingCursor(context, { x: 320, y: 480, size: 64, opacity: 1, pingProgress: null });
+    expect(context.points[0]).toEqual([320, 480]);
+    expect(context.calls.at(0)).toBe("save");
+    expect(context.calls.at(-1)).toBe("restore");
+  });
+});

--- a/apps/web/src/browser/browserRecordingCursor.ts
+++ b/apps/web/src/browser/browserRecordingCursor.ts
@@ -96,6 +96,11 @@ export function resolveRecordingCursorPlacement(
   };
 }
 
+/**
+ * Paints one cursor placement onto the recording canvas: a white arrow with its
+ * tip at the pointer position, plus an expanding dark ring while a click is
+ * fresh. Colors are fixed rather than themed so the cursor reads on any page.
+ */
 export function drawRecordingCursor(
   context: CanvasRenderingContext2D,
   placement: RecordingCursorPlacement,

--- a/apps/web/src/browser/browserRecordingCursor.ts
+++ b/apps/web/src/browser/browserRecordingCursor.ts
@@ -1,0 +1,344 @@
+import type { DesktopPreviewPointerEvent, ScopedThreadRef } from "@t3tools/contracts";
+
+import {
+  agentBrowserCursorOpacity,
+  type BrowserController,
+} from "~/components/preview/agentBrowserCursorLogic";
+import { readThreadPreviewState } from "~/previewStateStore";
+
+import { useBrowserPointerStore } from "./browserPointerStore";
+import { useBrowserSurfaceStore } from "./browserSurfaceStore";
+
+/** How long a pointer event keeps the cursor fully opaque, matching the live overlay. */
+export const BROWSER_RECORDING_CURSOR_ACTIVE_MS = 700;
+/** How long the click ring expands after a click event. */
+export const BROWSER_RECORDING_CURSOR_PING_MS = 600;
+/** Upper bound on waiting for the first captured frame before falling back to the raw stream. */
+const FIRST_FRAME_TIMEOUT_MS = 1_500;
+
+/** Icon footprint in content-box CSS pixels, approximating the live overlay's icon size. */
+const CURSOR_ICON_CSS_SIZE = 20;
+
+/** Unit-space arrow outline relative to the tip, drawn at the recorded frame's pixel scale. */
+const CURSOR_ARROW_UNITS: ReadonlyArray<readonly [number, number]> = [
+  [0, 0],
+  [0, 0.74],
+  [0.18, 0.58],
+  [0.31, 0.88],
+  [0.45, 0.82],
+  [0.32, 0.53],
+  [0.58, 0.53],
+];
+
+export interface RecordingCursorSource {
+  readonly event: DesktopPreviewPointerEvent;
+  readonly content: {
+    readonly width: number;
+    readonly height: number;
+    readonly scale: number;
+  };
+  readonly zoomFactor: number;
+  readonly frameWidth: number;
+  readonly frameHeight: number;
+  readonly controller: BrowserController;
+  readonly nowMs: number;
+}
+
+export interface RecordingCursorPlacement {
+  readonly x: number;
+  readonly y: number;
+  readonly size: number;
+  readonly opacity: number;
+  readonly pingProgress: number | null;
+}
+
+const isPositiveFinite = (value: number): boolean => Number.isFinite(value) && value > 0;
+
+const clamp = (value: number, bound: number): number =>
+  Math.min(bound, Math.max(0, Number.isFinite(value) ? value : 0));
+
+/**
+ * Maps an agent pointer event from guest viewport CSS pixels into the captured
+ * frame's pixel space. The captured frame is the full guest render, so the
+ * cursor's relative position inside the content box is what matters; zoom and
+ * presentation scale cancel out of the ratio.
+ */
+export function resolveRecordingCursorPlacement(
+  source: RecordingCursorSource,
+): RecordingCursorPlacement | null {
+  const { event, content, zoomFactor, frameWidth, frameHeight, controller, nowMs } = source;
+  if (
+    !isPositiveFinite(frameWidth) ||
+    !isPositiveFinite(frameHeight) ||
+    !isPositiveFinite(content.width) ||
+    !isPositiveFinite(content.height) ||
+    !isPositiveFinite(content.scale) ||
+    !isPositiveFinite(zoomFactor)
+  ) {
+    return null;
+  }
+  const x = clamp(event.x * zoomFactor * content.scale * (frameWidth / content.width), frameWidth);
+  const y = clamp(
+    event.y * zoomFactor * content.scale * (frameHeight / content.height),
+    frameHeight,
+  );
+  const createdAt = Date.parse(event.createdAt);
+  const ageMs = Number.isFinite(createdAt) ? Math.max(0, nowMs - createdAt) : 0;
+  return {
+    x,
+    y,
+    size: CURSOR_ICON_CSS_SIZE * (frameWidth / content.width),
+    opacity: agentBrowserCursorOpacity(ageMs < BROWSER_RECORDING_CURSOR_ACTIVE_MS, controller),
+    pingProgress:
+      event.phase === "click" && ageMs < BROWSER_RECORDING_CURSOR_PING_MS
+        ? ageMs / BROWSER_RECORDING_CURSOR_PING_MS
+        : null,
+  };
+}
+
+export function drawRecordingCursor(
+  context: CanvasRenderingContext2D,
+  placement: RecordingCursorPlacement,
+): void {
+  const { x, y, size, opacity, pingProgress } = placement;
+  context.save();
+  context.globalAlpha = opacity;
+  context.beginPath();
+  for (const [index, [unitX, unitY]] of CURSOR_ARROW_UNITS.entries()) {
+    const pointX = x + unitX * size;
+    const pointY = y + unitY * size;
+    if (index === 0) context.moveTo(pointX, pointY);
+    else context.lineTo(pointX, pointY);
+  }
+  context.closePath();
+  context.fillStyle = "#ffffff";
+  context.strokeStyle = "rgba(0, 0, 0, 0.85)";
+  context.lineWidth = Math.max(1, size * 0.06);
+  context.lineJoin = "round";
+  context.fill();
+  context.stroke();
+  if (pingProgress !== null) {
+    context.beginPath();
+    context.arc(x + size * 0.4, y + size * 0.4, size * (0.2 + 0.6 * pingProgress), 0, Math.PI * 2);
+    context.globalAlpha = opacity * 0.55 * (1 - pingProgress);
+    context.lineWidth = Math.max(1, size * 0.07);
+    context.strokeStyle = "rgba(0, 0, 0, 0.9)";
+    context.stroke();
+  }
+  context.restore();
+}
+
+export interface FrameDrawRect {
+  readonly scale: number;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Fits a captured frame into the recording canvas, centered with black bars.
+ * The canvas keeps its start dimensions for the whole recording, so a guest
+ * resize letterboxes instead of changing the video's dimensions mid-stream.
+ */
+export function resolveFrameDrawRect(
+  canvasWidth: number,
+  canvasHeight: number,
+  frameWidth: number,
+  frameHeight: number,
+): FrameDrawRect | null {
+  if (
+    !isPositiveFinite(canvasWidth) ||
+    !isPositiveFinite(canvasHeight) ||
+    !isPositiveFinite(frameWidth) ||
+    !isPositiveFinite(frameHeight)
+  ) {
+    return null;
+  }
+  const scale = Math.min(canvasWidth / frameWidth, canvasHeight / frameHeight);
+  const width = frameWidth * scale;
+  const height = frameHeight * scale;
+  return {
+    scale,
+    x: (canvasWidth - width) / 2,
+    y: (canvasHeight - height) / 2,
+    width,
+    height,
+  };
+}
+
+export interface RecordingCursorCompositor {
+  /** Stream to hand to the recorder instead of the raw capture. */
+  readonly stream: MediaStream;
+  readonly dispose: () => void;
+}
+
+/**
+ * Pipes the raw tab capture through an offscreen canvas that has the agent
+ * pointer composited on top of every frame. The canvas keeps the dimensions the
+ * capture reported at start; later guest resizes are letterboxed so the recorded
+ * video never changes dimensions mid-stream. Cursor animation is driven by
+ * guest frames plus bounded timer redraws after pointer events, never a
+ * continuous loop. Returns null when the environment cannot support the
+ * pipeline or no frame arrives in time, in which case the recording falls back
+ * to the raw stream.
+ */
+export const attachRecordingCursorCompositor = async (input: {
+  readonly tabId: string;
+  /** Server-local tab id, the namespace the preview overlay state is keyed by. */
+  readonly serverTabId: string;
+  readonly stream: MediaStream;
+  readonly threadRef: ScopedThreadRef | null;
+  readonly frameRate: number;
+}): Promise<RecordingCursorCompositor | null> => {
+  let video: HTMLVideoElement | null = null;
+  try {
+    const settings = input.stream.getVideoTracks()[0]?.getSettings();
+    const canvasWidth = settings?.width;
+    const canvasHeight = settings?.height;
+    if (
+      typeof canvasWidth !== "number" ||
+      typeof canvasHeight !== "number" ||
+      !isPositiveFinite(canvasWidth) ||
+      !isPositiveFinite(canvasHeight)
+    ) {
+      return null;
+    }
+    video = document.createElement("video");
+    if (typeof video.requestVideoFrameCallback !== "function") return null;
+    const element = video;
+    element.muted = true;
+    element.srcObject = input.stream;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) return null;
+
+    let disposed = false;
+    let frameHandle: number | null = null;
+    let animationTimer: number | null = null;
+    let animationDeadline = 0;
+    let resolveFirstFrame: (() => void) | null = null;
+    const firstFrame = new Promise<void>((resolve) => {
+      resolveFirstFrame = resolve;
+    });
+
+    const draw = (): void => {
+      const frameWidth = element.videoWidth;
+      const frameHeight = element.videoHeight;
+      const rect = resolveFrameDrawRect(canvasWidth, canvasHeight, frameWidth, frameHeight);
+      if (!rect) return;
+      context.fillStyle = "#000000";
+      context.fillRect(0, 0, canvasWidth, canvasHeight);
+      context.drawImage(element, rect.x, rect.y, rect.width, rect.height);
+
+      const event = useBrowserPointerStore.getState().byTabId[input.tabId];
+      const presentation = useBrowserSurfaceStore.getState().byTabId[input.tabId]?.content ?? null;
+      const overlay = input.threadRef
+        ? (readThreadPreviewState(input.threadRef).desktopByTabId[input.serverTabId] ?? null)
+        : null;
+      if (!event || !presentation) return;
+      const placement = resolveRecordingCursorPlacement({
+        event,
+        content: presentation,
+        zoomFactor: overlay?.zoomFactor ?? 1,
+        frameWidth,
+        frameHeight,
+        controller: overlay?.controller ?? "none",
+        nowMs: Date.now(),
+      });
+      if (!placement) return;
+      drawRecordingCursor(context, {
+        x: rect.x + placement.x * rect.scale,
+        y: rect.y + placement.y * rect.scale,
+        size: placement.size * rect.scale,
+        opacity: placement.opacity,
+        pingProgress: placement.pingProgress,
+      });
+    };
+
+    const scheduleNextFrame = (): void => {
+      if (disposed) return;
+      frameHandle = element.requestVideoFrameCallback(() => {
+        resolveFirstFrame?.();
+        resolveFirstFrame = null;
+        draw();
+        scheduleNextFrame();
+      });
+    };
+    scheduleNextFrame();
+
+    const scheduleAnimation = (): void => {
+      animationDeadline = Math.max(
+        animationDeadline,
+        Date.now() + Math.max(BROWSER_RECORDING_CURSOR_ACTIVE_MS, BROWSER_RECORDING_CURSOR_PING_MS),
+      );
+      if (animationTimer !== null) return;
+      const interval = Math.max(16, Math.round(1_000 / input.frameRate));
+      const tick = (): void => {
+        animationTimer = null;
+        draw();
+        if (Date.now() < animationDeadline) {
+          animationTimer = window.setTimeout(tick, interval);
+        }
+      };
+      animationTimer = window.setTimeout(tick, interval);
+    };
+    let failed = false;
+    let output: MediaStream | null = null;
+    // Shared by dispose, the startup-failure path, and the catch below.
+    let teardown: (() => void) | null = null;
+    // Only this tab's pointer events may trigger redraws; agents driving other
+    // tabs must not cause full-frame repaints of this recording.
+    const unsubscribePointerEvents = useBrowserPointerStore.subscribe((state, previous) => {
+      if (state.byTabId[input.tabId] !== previous.byTabId[input.tabId]) {
+        draw();
+        scheduleAnimation();
+      }
+    });
+    teardown = () => {
+      disposed = true;
+      unsubscribePointerEvents();
+      if (animationTimer !== null) window.clearTimeout(animationTimer);
+      if (frameHandle !== null) element.cancelVideoFrameCallback(frameHandle);
+      element.srcObject = null;
+      for (const track of output?.getTracks() ?? []) track.stop();
+    };
+
+    try {
+      // play() resolves only once a frame arrives; guest frames can be slow to
+      // start, so bound the wait and fall back to the raw stream instead of
+      // stalling recording startup.
+      void element.play().catch(() => {
+        if (resolveFirstFrame === null) return;
+        failed = true;
+        resolveFirstFrame();
+        resolveFirstFrame = null;
+      });
+      const timeoutId = window.setTimeout(() => {
+        // Timed out waiting for the first frame: fall back to the raw stream
+        // rather than hand the recorder a canvas that may never paint.
+        failed = true;
+        resolveFirstFrame?.();
+        resolveFirstFrame = null;
+      }, FIRST_FRAME_TIMEOUT_MS);
+      await firstFrame;
+      window.clearTimeout(timeoutId);
+      if (failed) return null;
+
+      output = canvas.captureStream(input.frameRate);
+      return {
+        stream: output,
+        dispose: () => teardown?.(),
+      };
+    } finally {
+      // A captureStream throw leaves the loop and subscription with no owner.
+      if (failed || output === null) teardown();
+    }
+  } catch {
+    if (video) video.srcObject = null;
+    return null;
+  }
+};


### PR DESCRIPTION
## What Changed

Browser preview recordings now show the agent's pointer. The raw tab capture is piped through an offscreen canvas that composites the same pointer overlay the live preview shows — arrow at the click/move position, expanding ring on clicks — and the recorder encodes that canvas instead of the bare stream. Recordings stay video-only (no audio track).

Scope: `apps/web` renderer only (the recording compositing step). No changes to the wire contracts, the desktop capture path, other clients, or providers. When the environment can't support the canvas pipeline (or no frame arrives within 1.5s of start), the recording falls back to the raw stream exactly as before.

## Why

Recordings capture the guest tab via `getDisplayMedia`, which renders no pointer. When an agent drives the browser, the saved video shows clicks happening with no visible cursor, so the recording doesn't match what the user watched live and is much harder to read back. The pointer events (guest viewport CSS coordinates) already stream into the renderer for the live overlay; compositing them onto the canvas at the same relative position is the smallest change that makes the recording match the live view.

Details worth noting for review:

- Coordinate mapping: `event.x * zoom * presentationScale / contentWidth` reduces to the pointer's relative position inside the guest viewport, applied to the captured frame. Zoom and presentation scale cancel out of the ratio.
- The canvas keeps its start dimensions for the whole recording; guest resizes mid-recording letterbox instead of changing the video's dimensions mid-stream (resizing during recording already corrupts exported MP4s upstream).
- Cursor animation is driven by guest frames plus bounded timer redraws after pointer events (≤ `ACTIVE_MS + PING_MS` at the capture frame rate); there is no continuous repaint loop.
- `video.play()` is not awaited unbounded: startup races the first captured frame against a 1.5s timeout and falls back to the raw stream.

## Verification

- `pnpm tc` in `apps/web`: 0 errors.
- `vp test run apps/web/src/browser/browserRecordingCursor.test.ts apps/web/src/browser/browserRecording.test.ts`: 41 passed, 0 failed. New tests cover the pointer→frame coordinate mapping (including zoom × presentation-scale cancellation), clamping, idle/active opacity, click-ping timing, the letterbox fit (`resolveFrameDrawRect`), and the arrow tip placement.
- Placement math reviewed over three adversarial review rounds; findings (store-key namespace mismatch between the pointer store (runtime tab id) and preview overlay state (server tab id), frozen-canvas distortion, startup hang on slow first frame, teardown leaks, bitrate source) are addressed in the final commit.
- No integrated video sample attached yet — happy to produce one on request.

## UI Changes

The change is visible inside recorded videos (a pointer now appears where the agent clicks), not in the app's own UI. No screenshots of static UI changed; a sample recording can be added on request.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Implementation and review-loop orchestration used enablers/large in T3 Code (OpenCode harness); independent adversarial review used Claude Fable 5.1 via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser recordings now display the agent cursor, including click indicators.
  * Cursor placement adapts to scaling, zoom, aspect ratios, and letterboxing.
  * Recordings automatically use standard capture when cursor compositing is unavailable.

* **Bug Fixes**
  * Improved cursor visibility and positioning across different recording dimensions.
  * Recording resources are now cleaned up reliably when recordings end or are discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->