### PR TITLE
perf(web): avoid scanning chat history for sidebar backgrounds

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -156,10 +156,8 @@ function SidebarProvider({
   return (
     <SidebarContext value={contextValue}>
       <div
-        className={cn(
-          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
-          className,
-        )}
+        // Inset layouts opt into bg-sidebar through className.
+        className={cn("group/sidebar-wrapper flex min-h-svh w-full", className)}
         data-sidebar-state={state}
         data-slot="sidebar-wrapper"
         style={


### PR DESCRIPTION
Every chat DOM update invalidated the outer sidebar wrapper's `:has([data-variant=inset])` rule, even though the app uses a normal sidebar. Remove that unused query. Inset compositions can set `bg-sidebar` explicitly through the existing `className` prop; current app callers and their backgrounds are unchanged.

Six counterbalanced production-browser rounds against the previous stack tip, now merged as main:

| Median | Before | After |
| --- | ---: | ---: |
| Cached thread switch | 163.975 ms | 104.425 ms |
| Growing code update | 104.85 ms | 27.05 ms |
| Switches with sampled blank frames | 0/48 | 0/48 |

Switching improves **36.3%** and growing-code synchronous updates **74.2%**, each improving in all six paired rounds. Prose-streaming differences were inconsistent; no reliable prose gain is claimed. These are client rendering measurements on this runner, not provider throughput or overall app speed.

[Methods, rejected experiments and exact revisions](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a3e39ff99db1826a/css-experiment.md) · [Raw samples and scripts](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/7367bf7b422af7c8/css-experiment-samples.zip)

Before:

![Before: conversation and sidebar](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/c5463f52606741fe/css-before.png)

[Before switching recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/bc0ce8c1871d430e/css-before-realtime.webm)

After:

![After: same conversation and sidebar appearance](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/be1a89db8918b8ca/css-after.png)

[After switching recording](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/8a52dc89ff765d62/css-after-realtime.webm)

Production build and targeted formatting/lint completed. Lint retains the unrelated existing Math.random-in-render warning. Browser checks covered light/dark, wide/narrow layouts, sidebar toggling, and interrupted navigation. Desktop shares this CSS; Electron was not run. Native mobile is unaffected.

GPT-6 / Codex, with agent-browser verification.
