### PR TITLE
fix(web): let browsers pick VSCodium, Cursor or Zed for remote open

### DIFF
--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,4 +1,4 @@
-import { EDITORS, EditorId, EnvironmentId } from "@t3tools/contracts";
+import { EditorId, EnvironmentId } from "@t3tools/contracts";
 import {
   mapAtomCommandResult,
   type AtomCommandFailure,
@@ -38,12 +38,17 @@ export class PreferredEditorUnavailableError extends Schema.TaggedError<Preferre
   }
 }
 
+/**
+ * The remembered editor when it is available, else the first available one.
+ * Callers order `availableEditors` by preference (the server's PATH probe
+ * follows the EDITORS catalog; the browser remote list leads with VS Code).
+ */
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
   const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);
 
   const effectiveEditor = useMemo(() => {
     if (lastEditor && availableEditors.includes(lastEditor)) return lastEditor;
-    return EDITORS.find((editor) => availableEditors.includes(editor.id))?.id ?? null;
+    return availableEditors[0] ?? null;
   }, [lastEditor, availableEditors]);
 
   return [effectiveEditor, setLastEditor] as const;
@@ -55,9 +60,9 @@ export function resolveAndPersistPreferredEditor(
   const availableEditorIds = new Set(availableEditors);
   const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
   if (stored && availableEditorIds.has(stored)) return stored;
-  const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
+  const editor = availableEditors[0] ?? null;
   if (editor) setLocalStorageItem(LAST_EDITOR_KEY, editor, EditorId);
-  return editor ?? null;
+  return editor;
 }
 
 export function useOpenInPreferredEditor(

--- a/apps/web/src/remoteOpen.test.ts
+++ b/apps/web/src/remoteOpen.test.ts
@@ -7,7 +7,7 @@ import {
 import { buildRemoteOpenUrl, EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveRemoteOpenState } from "./remoteOpen";
+import { BROWSER_REMOTE_EDITORS, resolveRemoteOpenState } from "./remoteOpen";
 
 const environmentId = EnvironmentId.make("environment-1");
 
@@ -115,6 +115,14 @@ describe("resolveRemoteOpenState", () => {
         remoteOpenTargets: undefined,
       }),
     ).toEqual({ mode: "local-exec" });
+  });
+});
+
+describe("BROWSER_REMOTE_EDITORS", () => {
+  it("leads with VS Code and offers the other remote-capable editors", () => {
+    expect(BROWSER_REMOTE_EDITORS[0]).toBe("vscode");
+    expect(BROWSER_REMOTE_EDITORS).toEqual(expect.arrayContaining(["vscodium", "cursor", "zed"]));
+    expect(BROWSER_REMOTE_EDITORS).not.toContain("idea");
   });
 });
 

--- a/apps/web/src/remoteOpen.ts
+++ b/apps/web/src/remoteOpen.ts
@@ -124,24 +124,36 @@ export function useRemoteOpenState(environmentId: EnvironmentId | null): RemoteO
 
 /**
  * Editors offered in remote-link mode. The desktop app probes the machine the
- * renderer runs on; a browser cannot, so it offers VS Code only.
+ * renderer runs on. A browser cannot, so it offers every remote-capable
+ * editor and remembers the pick; VS Code leads as the default.
+ */
+export const BROWSER_REMOTE_EDITORS: ReadonlyArray<EditorId> = [
+  "vscode",
+  ...REMOTE_CAPABLE_EDITOR_IDS.filter((id) => id !== "vscode"),
+];
+
+/**
+ * Desktop fallback when the probe fails, finds nothing, or is missing from an
+ * older desktop shell (the bridge contract documents VS Code only there).
  */
 const REMOTE_FALLBACK_EDITORS: ReadonlyArray<EditorId> = ["vscode"];
 
 let cachedProbedEditors: ReadonlyArray<EditorId> | null = null;
 
 export function useRemoteCapableEditors(): ReadonlyArray<EditorId> {
+  const bridge = window.desktopBridge;
+  const unprobedEditors = bridge === undefined ? BROWSER_REMOTE_EDITORS : REMOTE_FALLBACK_EDITORS;
   const [editors, setEditors] = useState<ReadonlyArray<EditorId>>(
-    () => cachedProbedEditors ?? REMOTE_FALLBACK_EDITORS,
+    () => cachedProbedEditors ?? unprobedEditors,
   );
 
   useEffect(() => {
     if (cachedProbedEditors !== null) {
       return;
     }
-    const probe = window.desktopBridge?.probeRemoteEditors;
+    const probe = bridge?.probeRemoteEditors;
     if (probe === undefined) {
-      cachedProbedEditors = REMOTE_FALLBACK_EDITORS;
+      cachedProbedEditors = unprobedEditors;
       return;
     }
     let cancelled = false;
@@ -160,7 +172,7 @@ export function useRemoteCapableEditors(): ReadonlyArray<EditorId> {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [bridge, unprobedEditors]);
 
   return editors;
 }


### PR DESCRIPTION
## What Changed

In remote-link mode, a browser now offers every editor that can open a `vscode-remote` or `zed://ssh` deep link (VS Code first, then VSCodium, Cursor, Insiders, Zed and the other forks) instead of VS Code only, and remembers the pick like it already does for local editors. The desktop app keeps probing its own machine.

`usePreferredEditor` and `resolveAndPersistPreferredEditor` now fall back to the first entry of the list they are given rather than the first catalog entry that happens to be in it. The server's PATH probe already returns editors in catalog order, so local behavior is unchanged; it lets the browser list lead with VS Code.

An older desktop shell that exposes the bridge without `probeRemoteEditors` keeps the VS Code-only fallback the bridge contract documents; only a real browser gets the full list.

## Why

A browser cannot probe which editors are installed on the viewing machine, so the picker hardcoded VS Code. On a machine with VSCodium or Cursor but no VS Code, nothing handles `vscode://`, and clicking Open does nothing. The remote schemes for those editors were already in the catalog (`REMOTE_CAPABLE_EDITOR_IDS`); the picker just never offered them outside the desktop app.

Verified with `vp test run apps/web/src/remoteOpen.test.ts`, typecheck of `apps/web`, and focused `vp fmt --check` and `vp lint` on the changed files.

Model: Claude Fable 5.1
Harness: Claude Code in T3 Code

## UI Changes

The dropdown next to **Open**, viewed in a browser against a remote server.

| Before | After |
| --- | --- |
| ![Before: VS Code only](https://raw.githubusercontent.com/HaukeSchnau/pr-assets/main/t3code-11209/before.png) | ![After: Cursor, VS Code, VS Code Insiders, VSCodium, Zed](https://raw.githubusercontent.com/HaukeSchnau/pr-assets/main/t3code-11209/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
