### PR TITLE
feat(web): reset right panel width on double click

### DIFF
--- a/apps/web/src/components/preview/RightPanelResizeHandle.tsx
+++ b/apps/web/src/components/preview/RightPanelResizeHandle.tsx
@@ -13,6 +13,8 @@ interface Props {
  *   user can grab a few pixels off the edge without aiming.
  * - Visual indicator is a 1px line that lights up on hover/active to mirror
  *   VS Code / Cursor.
+ * - Double-click restores the panel's default width, the same gesture the app
+ *   sidebar's rail uses.
  */
 export function RightPanelResizeHandle({ handlers, className }: Props) {
   return (

--- a/apps/web/src/components/preview/RightPanelResizeHandle.tsx
+++ b/apps/web/src/components/preview/RightPanelResizeHandle.tsx
@@ -13,8 +13,7 @@ interface Props {
  *   user can grab a few pixels off the edge without aiming.
  * - Visual indicator is a 1px line that lights up on hover/active to mirror
  *   VS Code / Cursor.
- * - Double-click restores the panel's default width, the same gesture the app
- *   sidebar's rail uses.
+ * - Double-click restores the panel's default width.
  */
 export function RightPanelResizeHandle({ handlers, className }: Props) {
   return (

--- a/apps/web/src/hooks/useResizableWidth.test.tsx
+++ b/apps/web/src/hooks/useResizableWidth.test.tsx
@@ -25,6 +25,7 @@ const style = {
   },
 };
 const setItem = vi.fn();
+const removeItem = vi.fn();
 const cancelAnimationFrame = vi.fn();
 let events: EventTarget;
 let frame: FrameRequestCallback | undefined;
@@ -64,7 +65,7 @@ beforeEach(async () => {
   vi.stubGlobal("window", {
     addEventListener: events.addEventListener.bind(events),
     removeEventListener: events.removeEventListener.bind(events),
-    localStorage: { getItem: () => null, setItem },
+    localStorage: { getItem: () => null, setItem, removeItem },
   });
   vi.stubGlobal("document", { body: { style } });
   vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
@@ -123,5 +124,28 @@ describe("panel resize cleanup", () => {
     expect(setItem).toHaveBeenCalledExactlyOnceWith("test-panel-width", "450");
     expect(style.cursor).toBe("");
     expect(captured).toBe(false);
+  });
+});
+
+describe("panel width reset", () => {
+  it("restores the default width on double click and forgets the stored width", async () => {
+    await act(() => {
+      result.handlers.onPointerDown(pointer());
+      result.handlers.onPointerMove(pointer(50));
+      result.handlers.onPointerUp(pointer(50));
+    });
+    expect(result.width).toBe(450);
+
+    // A double-click lands two motionless drags on the handle before
+    // `dblclick` fires, so the reset has to outlive their drag-end writes.
+    await act(() => {
+      result.handlers.onPointerDown(pointer(50));
+      result.handlers.onPointerUp(pointer(50));
+      result.handlers.onPointerDown(pointer(50));
+      result.handlers.onPointerUp(pointer(50));
+      result.handlers.onDoubleClick();
+    });
+    expect(result.width).toBe(400);
+    expect(removeItem).toHaveBeenCalledExactlyOnceWith("test-panel-width");
   });
 });

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -7,7 +7,11 @@ import {
   useState,
 } from "react";
 
-import { getLocalStorageItem, setLocalStorageItem } from "./useLocalStorage";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "./useLocalStorage";
 
 const WidthSchema = Schema.Finite;
 
@@ -25,12 +29,15 @@ export interface UseResizableWidthOptions {
   readonly edge: "left" | "right";
 }
 
+/** Everything a drag handle for this panel needs; spread onto the handle. */
 export interface ResizableWidthHandlers {
   readonly onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onLostPointerCapture: (event: ReactPointerEvent<HTMLElement>) => void;
+  /** Restores `defaultWidth` and forgets the user's stored width. */
+  readonly onDoubleClick: () => void;
 }
 
 /**
@@ -40,7 +47,8 @@ export interface ResizableWidthHandlers {
  *
  * The hook updates an internal `width` state during drag (so the panel
  * follows the cursor live) and only commits to localStorage when the user
- * lifts the pointer.
+ * lifts the pointer. Double-clicking the handle restores `defaultWidth`,
+ * matching the app sidebar's rail.
  */
 export function useResizableWidth(options: UseResizableWidthOptions): {
   readonly width: number;
@@ -184,6 +192,20 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     [cancelDrag],
   );
 
+  // Fires after the second pointer release, so the pair of no-op drags a
+  // double-click produces has already settled and this write wins. The stored
+  // width is cleared rather than overwritten with `defaultWidth`: a forgotten
+  // preference keeps tracking the caller's default, which some surfaces derive
+  // from the viewport.
+  const onDoubleClick = useCallback(() => {
+    try {
+      removeLocalStorageItem(storageKey);
+    } catch (error) {
+      console.error("Could not clear persisted panel width.", error);
+    }
+    setWidth(defaultWidth);
+  }, [defaultWidth, storageKey]);
+
   return {
     width: clampedWidth,
     handlers: {
@@ -192,6 +214,7 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
       onPointerUp,
       onPointerCancel,
       onLostPointerCapture: onPointerCancel,
+      onDoubleClick,
     },
   };
 }

--- a/apps/web/src/hooks/useResizableWidth.ts
+++ b/apps/web/src/hooks/useResizableWidth.ts
@@ -29,14 +29,12 @@ export interface UseResizableWidthOptions {
   readonly edge: "left" | "right";
 }
 
-/** Everything a drag handle for this panel needs; spread onto the handle. */
 export interface ResizableWidthHandlers {
   readonly onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onLostPointerCapture: (event: ReactPointerEvent<HTMLElement>) => void;
-  /** Restores `defaultWidth` and forgets the user's stored width. */
   readonly onDoubleClick: () => void;
 }
 
@@ -47,8 +45,7 @@ export interface ResizableWidthHandlers {
  *
  * The hook updates an internal `width` state during drag (so the panel
  * follows the cursor live) and only commits to localStorage when the user
- * lifts the pointer. Double-clicking the handle restores `defaultWidth`,
- * matching the app sidebar's rail.
+ * lifts the pointer. Double-clicking the handle restores `defaultWidth`.
  */
 export function useResizableWidth(options: UseResizableWidthOptions): {
   readonly width: number;
@@ -192,11 +189,6 @@ export function useResizableWidth(options: UseResizableWidthOptions): {
     [cancelDrag],
   );
 
-  // Fires after the second pointer release, so the pair of no-op drags a
-  // double-click produces has already settled and this write wins. The stored
-  // width is cleared rather than overwritten with `defaultWidth`: a forgotten
-  // preference keeps tracking the caller's default, which some surfaces derive
-  // from the viewport.
   const onDoubleClick = useCallback(() => {
     try {
       removeLocalStorageItem(storageKey);


### PR DESCRIPTION
## What Changed

- Double-clicking the right panel's resize handle restores its default width.
- The persisted width is cleared, so the reset survives a reload.

## Why

The right panel can be dragged to any width but had no way back to the default, so a mis-drag is a one-way door. The left sidebar's rail has had double-click-to-reset since #6320; this brings the right panel to parity and matches VS Code / Cursor.

The reset lives in `useResizableWidth` rather than in the handle, so every surface built on `PreviewPanelShell` picks it up — the thread right panel, the pull requests panel, and the preview/device panels — each restoring its own default and clearing its own storage key. It clears the stored width instead of overwriting it with `defaultWidth`, because the pull requests panel derives its default from the viewport; writing a value in would freeze a stale one.

A maximized panel renders no handle, so the gesture is unavailable there, as before.

One ordering detail: a double-click delivers two motionless drags before `dblclick` fires, and each of those persists the current width. The reset lands last and wins. The new test replays that exact sequence so a future refactor can't quietly break it.

## UI Changes

https://github.com/user-attachments/assets/8a5f53bf-1022-449a-bb56-87f8c726a1cc

**Before** — dragged out to a custom width

<img width="1862" height="972" alt="still-before-dragged-wide" src="https://github.com/user-attachments/assets/c1a1e697-d987-4240-bd5d-9110cc1cf245" />

**After** — double-click on the handle restores the default

<img width="1862" height="972" alt="still-after-default-width" src="https://github.com/user-attachments/assets/311145bf-293b-410a-9981-dfbcd07577b9" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with Claude Opus 5 using the Claude Code harness in T3 Code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Double-clicking the resizable panel now restores its default width.
  * The saved custom width is cleared when the panel is reset.

* **Tests**
  * Added coverage verifying panel reset behavior and removal of the saved width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->