### PR TITLE
fix(cursor): retry prompts that only returned a transport failure

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -52,6 +52,12 @@ const failPrompt = process.env.T3_ACP_FAIL_PROMPT === "1";
 const failSetConfigOption = process.env.T3_ACP_FAIL_SET_CONFIG_OPTION === "1";
 const exitOnSetConfigOption = process.env.T3_ACP_EXIT_ON_SET_CONFIG_OPTION === "1";
 const promptResponseText = process.env.T3_ACP_PROMPT_RESPONSE_TEXT;
+// Caps how many leading prompts answer with T3_ACP_PROMPT_RESPONSE_TEXT; later
+// prompts fall back to the default text so a retry can be told apart.
+const promptResponseTextPromptLimit =
+  process.env.T3_ACP_PROMPT_RESPONSE_TEXT_PROMPT_LIMIT === undefined
+    ? undefined
+    : Number(process.env.T3_ACP_PROMPT_RESPONSE_TEXT_PROMPT_LIMIT);
 const initialGrokReasoningEffort =
   process.env.T3_ACP_INITIAL_GROK_REASONING_EFFORT?.trim() || undefined;
 const promptDelayMs = Number(process.env.T3_ACP_PROMPT_DELAY_MS ?? "0");
@@ -76,6 +82,13 @@ let currentFast = false;
 let promptCount = 0;
 let overlappingFirstPromptId: string | undefined;
 const cancelledSessions = new Set<string>();
+
+function promptResponseTextFor(prompt: number): string | undefined {
+  if (promptResponseTextPromptLimit !== undefined && prompt > promptResponseTextPromptLimit) {
+    return undefined;
+  }
+  return promptResponseText;
+}
 
 function promptIdFromRequestMeta(
   request: Pick<AcpSchema.PromptRequest, "_meta">,
@@ -878,7 +891,7 @@ const program = Effect.gen(function* () {
           sessionId: requestedSessionId,
           update: {
             sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text: "after tool" },
+            content: { type: "text", text: promptResponseTextFor(promptCount) ?? "after tool" },
           },
         });
 
@@ -1223,7 +1236,7 @@ const program = Effect.gen(function* () {
         sessionId: requestedSessionId,
         update: {
           sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: promptResponseText ?? "hello from mock" },
+          content: { type: "text", text: promptResponseTextFor(promptCount) ?? "hello from mock" },
         },
       });
 

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -124,6 +124,44 @@ function waitForJsonLogMatch(
   });
 }
 
+const transportFailureText = "Error: RetriableError: [unavailable] Error";
+
+// A mock agent that answers prompts with a leaked Cursor transport diagnostic
+// and logs every request so tests can count prompt attempts.
+async function makeTransportFailureWrapper(extraEnv?: Record<string, string>) {
+  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "cursor-transport-failure-"));
+  const requestLogPath = NodePath.join(dir, "requests.ndjson");
+  await NodeFSP.writeFile(requestLogPath, "", "utf8");
+  const wrapperPath = await makeMockAgentWrapper({
+    T3_ACP_REQUEST_LOG_PATH: requestLogPath,
+    T3_ACP_PROMPT_RESPONSE_TEXT: transportFailureText,
+    ...extraEnv,
+  });
+  return { wrapperPath, requestLogPath };
+}
+
+async function countPromptRequests(requestLogPath: string) {
+  const requests = await readJsonLines(requestLogPath);
+  return requests.filter((entry) => entry.method === "session/prompt").length;
+}
+
+// Transport-failure retries back off on the clock. Pump it in small hops until
+// the effect settles; the mock agent runs on the real clock, so each hop also
+// gives its stdio replies a scheduler turn to land.
+function pumpRetryClock<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return Effect.raceFirst(
+    effect,
+    Effect.gen(function* () {
+      for (let attempt = 0; attempt < 400; attempt += 1) {
+        yield* TestClock.adjust("50 millis");
+      }
+      return yield* Effect.die(
+        new Error("Timed out pumping the test clock through transport-failure retries."),
+      );
+    }),
+  );
+}
+
 // Tests mutate `ServerSettingsService` mid-flight (e.g. setting
 // `providers.cursor.binaryPath` to a mock ACP wrapper). The adapter
 // captures `cursorSettings` once at construction, so without a resolver
@@ -162,15 +200,54 @@ const cursorAdapterTestLayer = it.layer(
 );
 
 cursorAdapterTestLayer("CursorAdapterLive", (it) => {
-  it.effect("rejects a Cursor transport error returned as a successful assistant answer", () =>
+  it.effect("retries a prompt whose only output was a Cursor transport error", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-transport-error-retry");
+      // Only the first prompt fails; the retry gets the default answer.
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper({ T3_ACP_PROMPT_RESPONSE_TEXT_PROMPT_LIMIT: "1" }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* pumpRetryClock(
+        adapter.sendTurn({ threadId, input: "continue", attachments: [] }),
+      );
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(completed.length, 1);
+      assert.equal(String(completed[0]?.turnId), String(turn.turnId));
+      assert.deepStrictEqual(completed[0]?.payload, { state: "completed", stopReason: "end_turn" });
+      // The retry continues the turn instead of opening a new one.
+      assert.equal(runtimeEvents.filter((event) => event.type === "turn.started").length, 1);
+      const deltas = runtimeEvents.flatMap((event) =>
+        event.type === "content.delta" ? [event.payload.delta] : [],
+      );
+      assert.deepStrictEqual(deltas, [transportFailureText, "hello from mock"]);
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 2);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("fails the turn once Cursor transport error retries are exhausted", () =>
     Effect.gen(function* () {
       const adapter = yield* CursorAdapter;
       const settings = yield* ServerSettingsService;
       const threadId = ThreadId.make("cursor-transport-error-answer");
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockAgentWrapper({
-          T3_ACP_PROMPT_RESPONSE_TEXT: "Error: RetriableError: WritableIterable is closed",
-        }),
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper(),
       );
       yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
       const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
@@ -184,17 +261,105 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         cwd: process.cwd(),
         runtimeMode: "full-access",
       });
-      const error = yield* adapter
-        .sendTurn({ threadId, input: "continue", attachments: [] })
-        .pipe(Effect.flip);
+      const error = yield* pumpRetryClock(
+        adapter.sendTurn({ threadId, input: "continue", attachments: [] }).pipe(Effect.flip),
+      );
       assert.equal(error._tag, "ProviderAdapterRequestError");
       if (error._tag === "ProviderAdapterRequestError") {
         assert.equal(error.detail, "Cursor reported a transport failure.");
-        assert.equal(error.cause, "Error: RetriableError: WritableIterable is closed");
+        assert.equal(error.cause, transportFailureText);
       }
       yield* adapter.stopSession(threadId);
       const runtimeEvents = yield* Fiber.join(runtimeEventsFiber);
       assert.isFalse(runtimeEvents.some((event) => event.type === "turn.completed"));
+      // The initial attempt plus one retry per configured backoff.
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 3);
+    }),
+  );
+
+  it.effect("does not retry a Cursor transport error once the prompt did work", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-transport-error-after-work");
+      // Assistant text, a tool call, then the diagnostic as its own segment.
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper({ T3_ACP_EMIT_INTERLEAVED_ASSISTANT_TOOL_CALLS: "1" }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const error = yield* pumpRetryClock(
+        adapter.sendTurn({ threadId, input: "continue", attachments: [] }).pipe(Effect.flip),
+      );
+      assert.equal(error._tag, "ProviderAdapterRequestError");
+      if (error._tag === "ProviderAdapterRequestError") {
+        assert.equal(error.detail, "Cursor reported a transport failure.");
+      }
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 1);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("settles as cancelled when interrupted while waiting to retry a transport error", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-transport-error-interrupt");
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper(),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const sawDiagnostic = yield* Deferred.make<void>();
+      yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId && event.type === "content.delta"),
+        Stream.take(1),
+        Stream.runForEach(() => Deferred.succeed(sawDiagnostic, undefined).pipe(Effect.asVoid)),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "continue", attachments: [] })
+        .pipe(Effect.forkChild);
+      // The diagnostic is projected right before the adapter starts its backoff;
+      // 10ms hops stay well short of the first delay, so the interrupt below
+      // lands while the adapter is waiting to retry.
+      yield* Effect.gen(function* () {
+        for (let attempt = 0; attempt < 200; attempt += 1) {
+          if (yield* Deferred.isDone(sawDiagnostic)) {
+            return;
+          }
+          yield* TestClock.adjust("10 millis");
+        }
+        throw new Error("Timed out waiting for the mock agent's transport diagnostic.");
+      });
+      yield* adapter.interruptTurn(threadId);
+      const turn = yield* pumpRetryClock(Fiber.join(sendTurnFiber));
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(completed.length, 1);
+      assert.equal(String(completed[0]?.turnId), String(turn.turnId));
+      assert.deepStrictEqual(completed[0]?.payload, {
+        state: "cancelled",
+        stopReason: "cancelled",
+      });
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 1);
+      yield* adapter.stopSession(threadId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -11,6 +11,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
@@ -143,6 +144,19 @@ async function makeTransportFailureWrapper(extraEnv?: Record<string, string>) {
 async function countPromptRequests(requestLogPath: string) {
   const requests = await readJsonLines(requestLogPath);
   return requests.filter((entry) => entry.method === "session/prompt").length;
+}
+
+// Captures the warning the adapter logs right before it starts waiting to
+// retry, so a test can act while that backoff is pending. Provide `layer` to
+// the sendTurn under test.
+function watchForRetryWait() {
+  const waiting = Deferred.makeUnsafe<void>();
+  const logger = Logger.make(({ message }) => {
+    if (String(message).includes("retrying the prompt")) {
+      Deferred.doneUnsafe(waiting, Effect.void);
+    }
+  });
+  return { waiting, layer: Logger.layer([logger]) };
 }
 
 // Transport-failure retries back off on the clock. Pump it in small hops until
@@ -320,13 +334,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         Stream.runCollect,
         Effect.forkChild,
       );
-      const sawDiagnostic = yield* Deferred.make<void>();
-      yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId && event.type === "content.delta"),
-        Stream.take(1),
-        Stream.runForEach(() => Deferred.succeed(sawDiagnostic, undefined).pipe(Effect.asVoid)),
-        Effect.forkChild,
-      );
+      const retryWait = watchForRetryWait();
       yield* adapter.startSession({
         threadId,
         provider: ProviderDriverKind.make("cursor"),
@@ -335,21 +343,11 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
       });
       const sendTurnFiber = yield* adapter
         .sendTurn({ threadId, input: "continue", attachments: [] })
-        .pipe(Effect.forkChild);
-      // The diagnostic is projected right before the adapter starts its backoff;
-      // 10ms hops stay well short of the first delay, so the interrupt below
-      // lands while the adapter is waiting to retry.
-      yield* Effect.gen(function* () {
-        for (let attempt = 0; attempt < 200; attempt += 1) {
-          if (yield* Deferred.isDone(sawDiagnostic)) {
-            return;
-          }
-          yield* TestClock.adjust("10 millis");
-        }
-        throw new Error("Timed out waiting for the mock agent's transport diagnostic.");
-      });
+        .pipe(Effect.provide(retryWait.layer), Effect.forkChild);
+      yield* Deferred.await(retryWait.waiting);
       yield* adapter.interruptTurn(threadId);
-      const turn = yield* pumpRetryClock(Fiber.join(sendTurnFiber));
+      // No clock pumping: the interrupt itself has to wake the waiting retry.
+      const turn = yield* Fiber.join(sendTurnFiber);
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
       assert.equal(completed.length, 1);
@@ -359,6 +357,79 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
         stopReason: "cancelled",
       });
       assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 1);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("settles as cancelled when the session stops while waiting to retry", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-transport-error-stop");
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper(),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      const retryWait = watchForRetryWait();
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const sendTurnFiber = yield* adapter
+        .sendTurn({ threadId, input: "continue", attachments: [] })
+        .pipe(Effect.provide(retryWait.layer), Effect.forkChild);
+      yield* Deferred.await(retryWait.waiting);
+      yield* adapter.stopSession(threadId);
+      // No clock pumping: stopping the session has to wake the waiting retry.
+      const turn = yield* Fiber.join(sendTurnFiber);
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const completed = runtimeEvents.filter((event) => event.type === "turn.completed");
+      assert.equal(completed.length, 1);
+      assert.equal(String(completed[0]?.turnId), String(turn.turnId));
+      assert.deepStrictEqual(completed[0]?.payload, {
+        state: "cancelled",
+        stopReason: "cancelled",
+      });
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 1);
+    }),
+  );
+
+  it.effect("lets a steer during the backoff take the turn instead of replaying the prompt", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CursorAdapter;
+      const settings = yield* ServerSettingsService;
+      const threadId = ThreadId.make("cursor-transport-error-steer");
+      // Only the first prompt fails, so the steer's own prompt completes at once.
+      const { wrapperPath, requestLogPath } = yield* Effect.promise(() =>
+        makeTransportFailureWrapper({ T3_ACP_PROMPT_RESPONSE_TEXT_PROMPT_LIMIT: "1" }),
+      );
+      yield* settings.updateSettings({ providers: { cursor: { binaryPath: wrapperPath } } });
+      const retryWait = watchForRetryWait();
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("cursor"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      const originalFiber = yield* adapter
+        .sendTurn({ threadId, input: "continue", attachments: [] })
+        .pipe(Effect.provide(retryWait.layer), Effect.forkChild);
+      yield* Deferred.await(retryWait.waiting);
+      // The steer finishes well inside the backoff, so the in-flight count is
+      // back at 1 by the time the original attempt would retry.
+      yield* adapter.sendTurn({ threadId, input: "actually do this", attachments: [] });
+      const error = yield* pumpRetryClock(Fiber.join(originalFiber).pipe(Effect.flip));
+      assert.equal(error._tag, "ProviderAdapterRequestError");
+      // The original attempt and the steer, with no replay of the original prompt.
+      assert.equal(yield* Effect.promise(() => countPromptRequests(requestLogPath)), 2);
       yield* adapter.stopSession(threadId);
     }),
   );

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -182,6 +182,12 @@ interface CursorSessionContext {
   readonly promptActivity: PromptActivity;
   /** Settled by `interruptTurn` so a pending transport-failure retry settles as cancelled. */
   turnInterrupted: Deferred.Deferred<void>;
+  /**
+   * Bumped by every sendTurn. A transport-failure retry replays its prompt
+   * only while no later prompt (a steer) has arrived; `promptsInFlight` is
+   * transient and can be back at 1 by then.
+   */
+  promptSequence: number;
   stopped: boolean;
 }
 
@@ -505,6 +511,7 @@ export function makeCursorAdapter(
       Effect.gen(function* () {
         if (ctx.stopped) return;
         ctx.stopped = true;
+        yield* Deferred.succeed(ctx.turnInterrupted, undefined);
         yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
         yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
         if (ctx.notificationFiber) {
@@ -837,6 +844,7 @@ export function makeCursorAdapter(
             activeTurnId: undefined,
             cursorSkillNames: undefined,
             promptsInFlight: 0,
+            promptSequence: 0,
             assistantReply: new CursorTransportFailure(),
             promptActivity,
             turnInterrupted: yield* Deferred.make<void>(),
@@ -990,6 +998,8 @@ export function makeCursorAdapter(
         // resolving from here on does not settle the turn; the matching
         // decrement is the `ensuring` below.
         ctx.promptsInFlight += 1;
+        ctx.promptSequence += 1;
+        const promptSequence = ctx.promptSequence;
 
         return yield* Effect.gen(function* () {
           const turnModelSelection =
@@ -1127,7 +1137,7 @@ export function makeCursorAdapter(
           // a steer, a cancel, or any work leaves the failure to the check below.
           for (const delay of TRANSPORT_FAILURE_RETRY_DELAYS) {
             if (
-              ctx.promptsInFlight !== 1 ||
+              ctx.promptSequence !== promptSequence ||
               result.stopReason === "cancelled" ||
               failure === undefined ||
               !promptDidNoWork(ctx.promptActivity)
@@ -1147,12 +1157,13 @@ export function makeCursorAdapter(
               Effect.as(true),
               Effect.timeoutOrElse({ duration: delay, orElse: () => Effect.succeed(false) }),
             );
-            // A stop or a steer that landed during the backoff owns the turn now.
-            if (ctx.stopped || ctx.promptsInFlight !== 1) {
-              break;
-            }
+            // interruptTurn and stopSession both settle the wait as cancelled.
             if (interrupted) {
               result = { stopReason: "cancelled" };
+              break;
+            }
+            // A steer that landed during the backoff owns the turn now.
+            if (ctx.promptSequence !== promptSequence) {
               break;
             }
             resetPromptActivity(ctx.promptActivity);

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -24,6 +24,7 @@ import {
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
@@ -91,6 +92,16 @@ const CURSOR_RESUME_VERSION = 1 as const;
 const ACP_PLAN_MODE_ALIASES = ["plan", "architect"];
 const ACP_IMPLEMENT_MODE_ALIASES = ["code", "agent", "default", "chat", "implement"];
 const ACP_APPROVAL_MODE_ALIASES = ["ask"];
+/**
+ * Cursor's ACP leaks transient transport failures as assistant text and then
+ * reports a successful turn (#7830). A prompt whose only output was such a
+ * diagnostic did no work, so replaying it cannot duplicate anything; retry it
+ * with these backoffs before failing the turn.
+ */
+const TRANSPORT_FAILURE_RETRY_DELAYS: ReadonlyArray<Duration.Duration> = [
+  Duration.seconds(1),
+  Duration.seconds(3),
+];
 
 function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
   const result = encodeUnknownJsonStringExit(input);
@@ -129,6 +140,27 @@ interface PendingUserInput {
   readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
 }
 
+/** What the agent produced since the current prompt attempt was sent. */
+interface PromptActivity {
+  /** Assistant items started. A leaked transport diagnostic is itself one. */
+  assistantItems: number;
+  /**
+   * Tool calls and requests to the user (approvals, questions, plan proposals):
+   * side effects a replay would repeat. Plan and todo updates are progress
+   * notes the replay regenerates, so they do not count.
+   */
+  work: number;
+}
+
+function promptDidNoWork(activity: PromptActivity): boolean {
+  return activity.assistantItems <= 1 && activity.work === 0;
+}
+
+function resetPromptActivity(activity: PromptActivity): void {
+  activity.assistantItems = 0;
+  activity.work = 0;
+}
+
 interface CursorSessionContext {
   readonly threadId: ThreadId;
   session: ProviderSession;
@@ -146,6 +178,10 @@ interface CursorSessionContext {
    * continues it, and only the last remaining prompt settles the turn. */
   promptsInFlight: number;
   assistantReply: CursorTransportFailure;
+  /** Activity since the current prompt attempt; gates transport-failure retries. */
+  readonly promptActivity: PromptActivity;
+  /** Settled by `interruptTurn` so a pending transport-failure retry settles as cancelled. */
+  turnInterrupted: Deferred.Deferred<void>;
   stopped: boolean;
 }
 
@@ -514,6 +550,7 @@ export function makeCursorAdapter(
 
           const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
           const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const promptActivity: PromptActivity = { assistantItems: 0, work: 0 };
           const sessionScope = yield* Scope.make("sequential");
           let sessionScopeTransferred = false;
           yield* Effect.addFinalizer(() =>
@@ -600,6 +637,7 @@ export function makeCursorAdapter(
                   const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
                   const runtimeRequestId = RuntimeRequestId.make(requestId);
                   const answers = yield* Deferred.make<ProviderUserInputAnswers>();
+                  promptActivity.work += 1;
                   pendingUserInputs.set(requestId, { answers });
                   yield* offerRuntimeEvent({
                     type: "user-input.requested",
@@ -639,6 +677,7 @@ export function makeCursorAdapter(
                     params,
                     "acp.cursor.extension",
                   );
+                  promptActivity.work += 1;
                   yield* offerRuntimeEvent({
                     type: "turn.proposed.completed",
                     ...(yield* makeEventStamp()),
@@ -689,6 +728,7 @@ export function makeCursorAdapter(
                     params,
                     "acp.jsonrpc",
                   );
+                  promptActivity.work += 1;
                   if (input.runtimeMode === "full-access") {
                     const autoApprovedOptionId = selectAutoApprovedPermissionOption(params);
                     if (autoApprovedOptionId !== undefined) {
@@ -798,6 +838,8 @@ export function makeCursorAdapter(
             cursorSkillNames: undefined,
             promptsInFlight: 0,
             assistantReply: new CursorTransportFailure(),
+            promptActivity,
+            turnInterrupted: yield* Deferred.make<void>(),
             stopped: false,
           };
 
@@ -811,6 +853,7 @@ export function makeCursorAdapter(
                   case "ModeChanged":
                     return;
                   case "AssistantItemStarted":
+                    ctx.promptActivity.assistantItems += 1;
                     ctx.assistantReply = new CursorTransportFailure();
                     yield* offerRuntimeEvent(
                       makeAcpAssistantItemEvent({
@@ -851,6 +894,7 @@ export function makeCursorAdapter(
                     );
                     return;
                   case "ToolCallUpdated":
+                    ctx.promptActivity.work += 1;
                     yield* logNative(
                       ctx.threadId,
                       "session/update",
@@ -970,6 +1014,8 @@ export function makeCursorAdapter(
           if (steeringTurnId === undefined) {
             ctx.lastPlanFingerprint = undefined;
             ctx.assistantReply = new CursorTransportFailure();
+            resetPromptActivity(ctx.promptActivity);
+            ctx.turnInterrupted = yield* Deferred.make<void>();
           }
           ctx.session = {
             ...ctx.session,
@@ -1058,7 +1104,7 @@ export function makeCursorAdapter(
           }
 
           // ACP has no system-message field; keep runtime context separate from the user's text.
-          const result = yield* ctx.acp
+          const prompt = ctx.acp
             .prompt({
               prompt: [
                 ...promptParts,
@@ -1074,8 +1120,47 @@ export function makeCursorAdapter(
               ),
             );
 
+          let result = yield* prompt;
           yield* ctx.acp.drainEvents;
-          const failure = ctx.assistantReply.failure;
+          let failure = ctx.assistantReply.failure;
+          // Retry only while the attempt produced nothing but the diagnostic;
+          // a steer, a cancel, or any work leaves the failure to the check below.
+          for (const delay of TRANSPORT_FAILURE_RETRY_DELAYS) {
+            if (
+              ctx.promptsInFlight !== 1 ||
+              result.stopReason === "cancelled" ||
+              failure === undefined ||
+              !promptDidNoWork(ctx.promptActivity)
+            ) {
+              break;
+            }
+            yield* Effect.logWarning(
+              "Cursor reported a transport failure before doing any work; retrying the prompt.",
+              {
+                threadId: input.threadId,
+                turnId,
+                failure,
+                delayMs: Duration.toMillis(delay),
+              },
+            );
+            const interrupted = yield* Deferred.await(ctx.turnInterrupted).pipe(
+              Effect.as(true),
+              Effect.timeoutOrElse({ duration: delay, orElse: () => Effect.succeed(false) }),
+            );
+            // A stop or a steer that landed during the backoff owns the turn now.
+            if (ctx.stopped || ctx.promptsInFlight !== 1) {
+              break;
+            }
+            if (interrupted) {
+              result = { stopReason: "cancelled" };
+              break;
+            }
+            resetPromptActivity(ctx.promptActivity);
+            ctx.assistantReply = new CursorTransportFailure();
+            result = yield* prompt;
+            yield* ctx.acp.drainEvents;
+            failure = ctx.assistantReply.failure;
+          }
           if (ctx.promptsInFlight === 1 && result.stopReason !== "cancelled" && failure) {
             return yield* new ProviderAdapterRequestError({
               provider: PROVIDER,
@@ -1132,6 +1217,7 @@ export function makeCursorAdapter(
     const interruptTurn: CursorAdapterShape["interruptTurn"] = (threadId) =>
       Effect.gen(function* () {
         const ctx = yield* requireSession(threadId);
+        yield* Deferred.succeed(ctx.turnInterrupted, undefined);
         yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
         yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
         yield* Effect.ignore(


### PR DESCRIPTION
Refs #7830. Cursor's ACP leaks transient transport failures (`Error: RetriableError: [unavailable] …`, `ConnectError: [unavailable]`, …) as assistant text and then reports `end_turn`. Since #10337 T3 fails those turns instead of accepting them as answers, but every blip still costs the user a manual resend, while Cursor's own interactive agent retries these internally. A retry was also asked for in the follow-up on #10337.

#10337 left retries out because a failed turn may already have done work a replay would repeat. This retries only when the failed attempt provably did no work: no tool calls, no approval, question, or plan-proposal requests, and no assistant text other than the diagnostic. Steers, cancels, and anything that ran a tool keep the existing fail-fast path. Retries are bounded to two (1s, then 3s) in the same ACP session; interrupting the turn or stopping the session during the backoff settles it as cancelled without sending the prompt again, and a steer landing during the backoff takes over the turn instead (tracked with a per-session prompt sequence, since the in-flight count can already be back at 1 by the time the retry fires). Plan and todo updates do not block a retry: they are progress notes the replay regenerates, not side effects.

The leaked diagnostic stays visible in the thread ahead of the retried answer; hiding it would mean buffering the assistant stream, which is out of scope here. This does not change the matcher breadth discussed in #10480: `[internal] Failed to run step, exceeded max retries` is still classified as a transport failure, and since it carries no tool calls it now gets the same two retries before the turn fails.

Reproduced on 0.0.40 with cursor-agent 2026.09.08-6caf4ff (macOS): the first prompt of a fresh session came back after three seconds with `Error: RetriableError: [unavailable] Error` as the only output, and the adapter failed the turn. Server trace:

```
ProviderAdapterRequestError: Provider adapter request failed (cursor) for session/prompt: Cursor reported a transport failure.
  [cause]: Error: Error: RetriableError: [unavailable] Error
```

Tests: six mock-provider tests in `CursorAdapter.test.ts` replace the previous transport-error test (retry succeeds, retries exhaust, prior work blocks the retry, interrupt or stop during the backoff settles as cancelled, a steer during the backoff takes over without a replay). The backoff tests synchronize on the warning the adapter logs right before it waits, captured by a test-scoped logger. The mock agent gains `T3_ACP_PROMPT_RESPONSE_TEXT_PROMPT_LIMIT` so only the first N prompts answer with the scripted text. `vp test run` on the file (26 tests, several consecutive runs), `vp lint` and `vp fmt --check` on the changed files, and `vp run --filter t3 typecheck` pass.

Model: Claude Fable 5.1. Harness: Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cursor sessions now automatically retry prompts after transient transport failures.
  - Retries stop cleanly when the session is interrupted or stopped.
  - Newer user guidance can take over during a retry wait without replaying the previous prompt.
  - Retry failures now provide clearer diagnostic details after the retry limit is reached.
  - Prompts that already produced work are no longer retried unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->