### PR TITLE
fix(web): file chip path copies say which machine they name

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -5,6 +5,7 @@ import { create, type ReactTestRenderer } from "react-test-renderer";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import { getSyntaxHighlighterPromise } from "../lib/syntaxHighlighting";
+import { useRemoteOpenResolution } from "../remoteOpen";
 import { GitHubIcon } from "./Icons";
 import { Button } from "./ui/button";
 import { setMarkdownTaskChecked } from "./files/filePreviewMode";
@@ -45,8 +46,13 @@ vi.mock("../state/entities", () => ({
   useProjects: () => [],
   useServerConfigs: () => new Map(),
 }));
-vi.mock("../remoteOpen", () => ({
-  useRemoteOpenResolution: () => ({ state: { mode: "local-exec" }, isResolved: true }),
+vi.mock("../remoteOpen", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../remoteOpen")>()),
+  useRemoteOpenResolution: vi.fn(() => ({
+    state: { mode: "local-exec" },
+    isResolved: true,
+    environmentLabel: "sol",
+  })),
 }));
 vi.mock("../editorPreferences", () => ({
   useOpenInPreferredEditor: () => vi.fn(),
@@ -527,6 +533,26 @@ describe("ChatMarkdown file option chips", () => {
 
     expect(html).toContain("index.ts · project/src");
     expect(html).toContain("index.ts · project/test");
+  });
+
+  it("marks chip paths with the hosting environment when viewing remotely", () => {
+    vi.mocked(useRemoteOpenResolution).mockReturnValue({
+      state: { mode: "remote-links", host: { kind: "ssh-alias", host: "sol" } },
+      isResolved: true,
+      environmentLabel: "sol",
+    });
+    try {
+      const html = renderToStaticMarkup(
+        <ChatMarkdown
+          cwd="/home/saphid/project"
+          text={"[Document](/home/saphid/theos-rules-receipts.md)"}
+        />,
+      );
+
+      expect(html).toContain('data-host-environment="sol"');
+    } finally {
+      vi.mocked(useRemoteOpenResolution).mockReset();
+    }
   });
 
   it("preserves rejected citations created by over-indented list recovery", () => {

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -149,7 +149,12 @@ import {
 import { readLocalApi } from "../localApi";
 import { useAssetUrlRefresh, useAssetUrlState } from "../assets/assetUrls";
 import { cn } from "../lib/utils";
-import { useRemoteOpenResolution, type RemoteOpenMode } from "../remoteOpen";
+import {
+  remotePathCopyQualifier,
+  remotePathScpHost,
+  useRemoteOpenResolution,
+  type RemoteOpenMode,
+} from "../remoteOpen";
 import { useRightPanelStore } from "../rightPanelStore";
 import { readThreadShell, useProjects } from "../state/entities";
 import { serverEnvironment } from "../state/server";
@@ -1113,6 +1118,11 @@ interface MarkdownFileLinkProps {
   /** What the files panel opens: workspace-relative inside the workspace, the
       absolute host path outside it, null when the panel cannot show the file. */
   panelPath: string | null;
+  /** Sidebar name of the environment hosting the file when the viewing client
+      is not on that machine; null on local environments. */
+  hostEnvironment: string | null;
+  /** Connectable SSH host for scp/rsync from this machine; null when unknown. */
+  scpHost: string | null;
   line?: number | undefined;
   label: string;
   copyMarkdown: string;
@@ -1810,6 +1820,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   iconPath,
   displayPath,
   panelPath,
+  hostEnvironment,
+  scpHost,
   line,
   label,
   copyMarkdown,
@@ -1994,6 +2006,10 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       const api = readLocalApi();
       if (!api) return;
 
+      // Off-machine paths are ambiguous to paste, so the menu, the toast, and
+      // the scp form all name the host that holds the file.
+      const copyTitle = (label: string) =>
+        hostEnvironment ? `${label} on ${hostEnvironment}` : label;
       try {
         const clicked = await api.contextMenu.show(
           [
@@ -2003,8 +2019,8 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
               ? ([{ id: "open-in-browser", label: "Open in integrated browser" }] as const)
               : []),
             ...(onReveal && revealLabel ? ([{ id: "reveal", label: revealLabel }] as const) : []),
-            { id: "copy-relative", label: "Copy relative path" },
-            { id: "copy-full", label: "Copy full path" },
+            { id: "copy-relative", label: copyTitle("Copy relative path") },
+            { id: "copy-full", label: copyTitle("Copy full path") },
           ] as const,
           position,
         );
@@ -2026,11 +2042,13 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
           return;
         }
         if (clicked === "copy-relative") {
-          handleCopy(displayPath, "Relative path");
+          handleCopy(displayPath, copyTitle("Relative path"));
           return;
         }
         if (clicked === "copy-full") {
-          handleCopy(targetPath, "Full path");
+          // `iconPath` is the position-free path, so the scp form works as an
+          // scp/rsync source even when the link targets `file.ts:12:3`.
+          handleCopy(scpHost ? `${scpHost}:${iconPath}` : targetPath, copyTitle("Full path"));
         }
       } catch (cause) {
         reportMarkdownActionFailure(
@@ -2045,12 +2063,15 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
       handleOpenInBrowser,
       handleOpenInEditor,
       handleRevealInFileManager,
+      hostEnvironment,
+      iconPath,
       onOpenInBrowser,
       onOpenMedia,
       onOpen,
       onReveal,
       openInEditorMenuLabel,
       revealLabel,
+      scpHost,
       targetPath,
     ],
   );
@@ -2100,6 +2121,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
                 className,
               )}
               data-markdown-copy={copyMarkdown}
+              {...(hostEnvironment !== null ? { "data-host-environment": hostEnvironment } : {})}
               onClick={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -2129,6 +2151,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
                 className,
               )}
               data-markdown-copy={copyMarkdown}
+              {...(hostEnvironment !== null ? { "data-host-environment": hostEnvironment } : {})}
               onClick={handleContextMenu}
               onContextMenu={handleContextMenu}
             >
@@ -2146,6 +2169,9 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
         <div className="overflow-x-auto whitespace-nowrap [scrollbar-color:color-mix(in_srgb,var(--contrast-border)_78%,transparent)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[color-mix(in_srgb,var(--contrast-border)_78%,transparent)] [&::-webkit-scrollbar-track]:bg-transparent">
           {targetPath}
         </div>
+        {hostEnvironment !== null && (
+          <div className="text-muted-foreground">Path on {hostEnvironment}</div>
+        )}
       </TooltipPopup>
     </Tooltip>
   );
@@ -2166,6 +2192,8 @@ function areMarkdownFileLinkPropsEqual(
     previous.copyMarkdown === next.copyMarkdown &&
     previous.theme === next.theme &&
     previous.threadRef === next.threadRef &&
+    previous.hostEnvironment === next.hostEnvironment &&
+    previous.scpHost === next.scpHost &&
     previous.onOpen === next.onOpen &&
     previous.onOpenInPanel === next.onOpenInPanel &&
     previous.openInEditorMenuLabel === next.openInEditorMenuLabel &&
@@ -2220,6 +2248,10 @@ function useChatMarkdownState({
     remoteOpen.isResolved,
   );
   const preparedConnection = usePreparedConnection(environmentId);
+  // File chips copy host paths; when this client is not on the environment
+  // machine, the copy needs to say which machine it names.
+  const remoteHostEnvironment = remotePathCopyQualifier(remoteOpen);
+  const remoteScpHost = remotePathScpHost(remoteOpen.state);
   const openMarkdownMedia = useCallback(
     (source: string, resolvedFilePath?: string, clickedImage?: HTMLImageElement | null) => {
       const requestId = ++mediaRequestId.current;
@@ -2526,6 +2558,8 @@ function useChatMarkdownState({
           iconPath={fileLinkMeta.filePath}
           displayPath={fileLinkMeta.displayPath}
           panelPath={panelPath}
+          hostEnvironment={remoteHostEnvironment}
+          scpHost={remoteScpHost}
           line={fileLinkMeta.line}
           label={labelParts.join(" · ")}
           copyMarkdown={copyMarkdown}
@@ -2567,6 +2601,8 @@ function useChatMarkdownState({
       resolvedTheme,
       revealInFileManagerLabel,
       revealMarkdownFileInFileManager,
+      remoteHostEnvironment,
+      remoteScpHost,
       threadRef,
     ],
   );

--- a/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.workspace-images.test.tsx
@@ -34,8 +34,13 @@ vi.mock("../state/entities", () => ({
   useProjects: () => [],
   useServerConfigs: () => new Map(),
 }));
-vi.mock("../remoteOpen", () => ({
-  useRemoteOpenResolution: () => ({ state: { mode: "local-exec" }, isResolved: true }),
+vi.mock("../remoteOpen", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../remoteOpen")>()),
+  useRemoteOpenResolution: () => ({
+    state: { mode: "local-exec" },
+    isResolved: true,
+    environmentLabel: null,
+  }),
 }));
 vi.mock("../editorPreferences", () => ({
   useOpenInPreferredEditor: () => vi.fn(),

--- a/apps/web/src/components/media/MediaActions.tsx
+++ b/apps/web/src/components/media/MediaActions.tsx
@@ -10,6 +10,11 @@ import { useCallback, useRef, useState, type ReactElement } from "react";
 
 import { writeTextToClipboard } from "../../hooks/useCopyToClipboard";
 import { readLocalApi } from "../../localApi";
+import {
+  remotePathCopyQualifier,
+  remotePathScpHost,
+  useRemoteOpenResolution,
+} from "../../remoteOpen";
 import { assetEnvironment } from "../../state/assets";
 import { readPreparedConnection } from "../../state/session";
 import { useAtomQueryRunner } from "../../state/use-atom-query-runner";
@@ -78,6 +83,7 @@ export function MediaActions({
   children: ReactElement;
 }) {
   const { save, copyImage } = useMediaActions(source);
+  const remoteOpen = useRemoteOpenResolution(source.asset?.environmentId ?? null);
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const menuOpen = useRef(false);
   const reference = source.reference;
@@ -97,11 +103,16 @@ export function MediaActions({
         typeof navigator !== "undefined" &&
         Boolean(navigator.clipboard?.write) &&
         typeof ClipboardItem !== "undefined";
+      // An off-machine file path is ambiguous to paste, so the menu names the
+      // environment that holds the file.
+      const hostEnvironment = remotePathCopyQualifier(remoteOpen);
+      const copyTitle = (label: string) =>
+        hostEnvironment ? `${label} on ${hostEnvironment}` : label;
       const items: ContextMenuItem<MediaActionId>[] = [];
       if (reference?.kind === "file") {
-        items.push({ id: "copy-full-path", label: "Copy full path" });
+        items.push({ id: "copy-full-path", label: copyTitle("Copy full path") });
         if (reference.relativePath)
-          items.push({ id: "copy-relative-path", label: "Copy relative path" });
+          items.push({ id: "copy-relative-path", label: copyTitle("Copy relative path") });
       } else if (reference?.kind === "url") {
         items.push({ id: "copy-url", label: "Copy URL" });
       }
@@ -118,9 +129,12 @@ export function MediaActions({
       const action = await api.contextMenu.show(items, position);
       if (!action) return;
       failureTitle = `Could not ${items.find((item) => item.id === action)?.label.toLowerCase() ?? "complete media action"}`;
+      const scpHost = remotePathScpHost(remoteOpen.state);
       const text =
         action === "copy-full-path" && reference?.kind === "file"
-          ? reference.path
+          ? scpHost
+            ? `${scpHost}:${reference.path}`
+            : reference.path
           : action === "copy-relative-path" && reference?.kind === "file"
             ? reference.relativePath
             : action === "copy-url" && reference?.kind === "url"
@@ -131,6 +145,7 @@ export function MediaActions({
         toastManager.add({
           type: "success",
           title: action === "copy-url" ? "URL copied" : "Path copied",
+          ...(hostEnvironment ? { description: `Path on ${hostEnvironment}` } : {}),
         });
       } else if (action === "open-file") {
         source.onOpenFile?.();

--- a/apps/web/src/remoteOpen.test.ts
+++ b/apps/web/src/remoteOpen.test.ts
@@ -7,7 +7,7 @@ import {
 import { buildRemoteOpenUrl, EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveRemoteOpenState } from "./remoteOpen";
+import { remotePathCopyQualifier, remotePathScpHost, resolveRemoteOpenState } from "./remoteOpen";
 
 const environmentId = EnvironmentId.make("environment-1");
 
@@ -115,6 +115,50 @@ describe("resolveRemoteOpenState", () => {
         remoteOpenTargets: undefined,
       }),
     ).toEqual({ mode: "local-exec" });
+  });
+});
+
+describe("remotePathCopyQualifier", () => {
+  const resolution = (
+    mode: "local-exec" | "remote-links" | "remote-unavailable",
+    isResolved = true,
+    environmentLabel: string | null = "sol",
+  ) => ({
+    state: (mode === "remote-links"
+      ? { mode, host: { kind: "ssh-alias" as const, host: "sol" } }
+      : { mode }) as ReturnType<typeof resolveRemoteOpenState>,
+    isResolved,
+    environmentLabel,
+  });
+
+  it("names the environment when the client is off its machine", () => {
+    expect(remotePathCopyQualifier(resolution("remote-links"))).toBe("sol");
+    expect(remotePathCopyQualifier(resolution("remote-unavailable"))).toBe("sol");
+  });
+
+  it("leaves local copies unqualified", () => {
+    expect(remotePathCopyQualifier(resolution("local-exec"))).toBeNull();
+  });
+
+  it("stays quiet before the environment resolves", () => {
+    expect(remotePathCopyQualifier(resolution("remote-links", false))).toBeNull();
+  });
+
+  it("stays quiet when the environment has no name", () => {
+    expect(remotePathCopyQualifier(resolution("remote-links", true, null))).toBeNull();
+  });
+});
+
+describe("remotePathScpHost", () => {
+  it("returns the connectable host for remote links", () => {
+    expect(
+      remotePathScpHost({ mode: "remote-links", host: { kind: "mdns", host: "sol.local" } }),
+    ).toBe("sol.local");
+  });
+
+  it("returns null when no SSH route exists", () => {
+    expect(remotePathScpHost({ mode: "local-exec" })).toBeNull();
+    expect(remotePathScpHost({ mode: "remote-unavailable" })).toBeNull();
   });
 });
 

--- a/apps/web/src/remoteOpen.ts
+++ b/apps/web/src/remoteOpen.ts
@@ -39,6 +39,8 @@ export type RemoteOpenMode = RemoteOpenState["mode"];
 export interface RemoteOpenResolution {
   readonly state: RemoteOpenState;
   readonly isResolved: boolean;
+  /** Sidebar name of the environment, for prose that outlives the host string. */
+  readonly environmentLabel: string | null;
 }
 
 const LOCAL_EXEC: RemoteOpenState = { mode: "local-exec" };
@@ -46,6 +48,7 @@ const REMOTE_UNAVAILABLE: RemoteOpenState = { mode: "remote-unavailable" };
 const UNRESOLVED_REMOTE_OPEN: RemoteOpenResolution = {
   state: LOCAL_EXEC,
   isResolved: false,
+  environmentLabel: null,
 };
 
 function parseHostname(url: string): string | null {
@@ -114,12 +117,42 @@ export function useRemoteOpenResolution(environmentId: EnvironmentId | null): Re
         isDesktopRenderer: window.desktopBridge !== undefined,
       }),
       isResolved: true,
+      environmentLabel: presentation.entry.target.label,
     };
   }, [presentation]);
 }
 
 export function useRemoteOpenState(environmentId: EnvironmentId | null): RemoteOpenState {
   return useRemoteOpenResolution(environmentId).state;
+}
+
+/**
+ * One sentence for path-copy UIs: the copied path is only unambiguous on the
+ * machine it names. Local-exec means this machine and the caller needs no
+ * qualifier; anything else means the file lives on the environment host, so
+ * the label and clipboard value should say which one.
+ */
+export function remotePathCopyQualifier(resolution: {
+  readonly state: RemoteOpenState;
+  readonly isResolved: boolean;
+  readonly environmentLabel: string | null;
+}): string | null {
+  if (
+    !resolution.isResolved ||
+    resolution.state.mode === "local-exec" ||
+    resolution.environmentLabel === null
+  ) {
+    return null;
+  }
+  return resolution.environmentLabel;
+}
+
+/**
+ * Connectable SSH host for scp/rsync from this machine, or null when no SSH
+ * route is known (local, or tunnel/relay environments without advertised hosts).
+ */
+export function remotePathScpHost(state: RemoteOpenState): string | null {
+  return state.mode === "remote-links" ? state.host.host : null;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,7 +778,7 @@ importers:
         version: link:../../packages/shared
       alchemy:
         specifier: 2.0.0-beta.76
-        version: 2.0.0-beta.76(b3825b36417e56a486ccb5f22a7f3d7e)
+        version: 2.0.0-beta.76(197b68e0d20fdf20cf352009eca17c9f)
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
         version: 1.0.0-rc.5-ab785fc(8ab70e2706da13c78d64d8a92fef1884)
@@ -16450,7 +16450,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  alchemy@2.0.0-beta.76(b3825b36417e56a486ccb5f22a7f3d7e):
+  alchemy@2.0.0-beta.76(197b68e0d20fdf20cf352009eca17c9f):
     dependencies:
       '@alchemy.run/cloudflare-runtime': 2.0.0-beta.76(@distilled.cloud/cloudflare@1.0.0-rc.8(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2)))(@effect/platform-bun@4.0.0-rc.112(bufferutil@4.1.0)(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))(utf-8-validate@6.0.6))(@effect/platform-node@4.0.0-rc.112(bufferutil@4.1.0)(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))(redis@6.2.1)(utf-8-validate@6.0.6))(@types/node@24.12.4)(@voidzero-dev/vite-plus-core@0.3.0(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@7.0.2)(unrun@0.2.39)(yaml@2.9.0))(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))(rolldown@1.2.5)(typescript@7.0.2)
       '@alchemy.run/floci': 2.0.0-beta.76(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))


### PR DESCRIPTION
## What Changed

Remote file chips now name the environment in their copy-menu labels, tooltip, and success toast. When an SSH hostname is known, **Copy full path** copies `host:path`; relative paths remain relative. File-backed image and video menus use the same host labels and full-path format. Local environments keep their existing labels and paths.

## Why

A path copied from a remote environment can look like a file on the viewing machine. Naming the environment makes its location clear, and the hostname prefix makes the full path usable as an `scp` or `rsync` source.

## Verification

- `vp test run src/remoteOpen.test.ts src/components/ChatMarkdown.test.tsx src/components/ChatMarkdown.workspace-images.test.tsx --project unit`, in `apps/web`: **97 tests passed** across 3 files on `dc7244cc`.
- Repeated the file-chip context-menu copy and paste in an isolated web client on base `211618fd` and candidate `dc7244cc`. The pasted full path changed from `/tmp/t3-pr11229-demo/docs/deploy.md` to `build-server.local:/tmp/t3-pr11229-demo/docs/deploy.md`.
- CI, CodeRabbit, and both Macroscope checks passed on `dc7244cc`. Macroscope approved that commit. CodeRabbit's docstring-coverage advisory is non-blocking; both new exported helpers have doc comments.

## UI Changes

Same synthetic project, dark theme, and 960 × 680 browser viewport for both revisions. The fixture supplies the environment name **Build server** and advertised SSH hostname `build-server.local`. These captures exercise the real web UI; they do not test an SSH transfer, Electron's native menu, or the media-specific menus.

The comparison below alternates actual before/after screenshots. It is a still-state comparison.

![Before and after: remote copy-menu labels now name Build server](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/menu-before-after.gif)

[Before screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/menu-before.png) · [After screenshot](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/menu-after.png)

<details>
<summary>Copied path, pasted back into the composer</summary>

Before, base `211618fd`: the path has no hostname.

![Before: pasted full path has no hostname](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/clipboard-before-detail.png)

After, candidate `dc7244cc`: the pasted path includes `build-server.local:`.

![After: pasted full path includes the environment hostname](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/clipboard-after-detail.png)

</details>

<details>
<summary>Recorded copy-and-paste interactions</summary>

These GIFs come from the recordings, sampled at 12 fps with no speed change. The original MP4s retain the captured timing. The detail images above make the changed text readable on a phone.

Before, base `211618fd`: open the menu, copy the full path, then paste.

![Before: copy full path and paste the unqualified path](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/before-copy-path.gif)

[Before recording, MP4](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/before.mp4)

After, candidate `dc7244cc`: the menu and toast name the environment, and the pasted path includes its hostname.

![After: copy full path on Build server and paste the qualified path](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/after-copy-path.gif)

[After recording, MP4](https://github.com/saphid/t3code/releases/download/pr-evidence-11229-20260918/after.mp4)

</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implementation used Claude Code; its model was not recorded in the original PR. Evidence and focused verification used GPT-6 Astra in Codex through T3 Code.
