### PR TITLE
fix(server): apply Effect overrides at pinned-runtime install root

### DIFF
--- a/apps/server/src/cloud/bootService.ts
+++ b/apps/server/src/cloud/bootService.ts
@@ -389,13 +389,18 @@ export class BootServiceCommandError extends Schema.TaggedError<BootServiceComma
     exitCode: Schema.optional(Schema.Number),
     stdoutLength: Schema.optional(Schema.Number),
     stderrLength: Schema.optional(Schema.Number),
+    outputTail: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return this.exitCode === undefined
-      ? `Background setup failed while ${this.step}.`
-      : `Background setup failed while ${this.step} (exit code ${this.exitCode}).`;
+    const base =
+      this.exitCode === undefined
+        ? `Background setup failed while ${this.step}.`
+        : `Background setup failed while ${this.step} (exit code ${this.exitCode}).`;
+    return this.outputTail === undefined || this.outputTail.length === 0
+      ? base
+      : `${base}\n${this.outputTail}`;
   }
 }
 
@@ -745,6 +750,7 @@ export const make = Effect.fn("cloud.boot_service.make")(function* (input: {
               exitCode: error.exitCode,
               stdoutLength: error.stdoutLength,
               stderrLength: error.stderrLength,
+              outputTail: error.outputTail,
               cause: error,
             })
           : new BootServiceInstallError({ cause: error }),

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -131,7 +131,9 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-stderr-" });
-      const stderr = `npm warn ERESOLVE overriding peer dependency\n${"x".repeat(2500)}`;
+      // npm puts the actionable failure near the end of stderr; the bounded
+      // tail must keep that reason when earlier noise is large.
+      const stderr = `${"x".repeat(2500)}\nnpm error code ERESOLVE\nnpm error Could not resolve dependency\n`;
 
       const error = yield* ensurePinnedRuntimeInstalled({
         baseDir,

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -11,11 +11,8 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as ProcessRunner from "../processRunner.ts";
 import {
   ensurePinnedRuntimeInstalled,
-  installOutputTail,
   pinnedRuntimePaths,
   PinnedRuntimeInstallError,
-  selectEffectOverrides,
-  truncateProcessOutputTail,
 } from "./pinnedRuntime.ts";
 
 const effectOverridesJson = JSON.stringify({
@@ -75,41 +72,6 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
         return okResult();
       }),
   });
-
-it("selectEffectOverrides keeps only plain effect package version pins", () => {
-  assert.deepEqual(
-    selectEffectOverrides({
-      effect: "4.0.0-rc.112",
-      "@effect/platform-node": "4.0.0-rc.112",
-      "@effect/vitest>vitest": "-",
-      "@effect/broken": 12,
-      vite: "1.0.0",
-      "@clerk/react": "6.0.0",
-    }),
-    {
-      effect: "4.0.0-rc.112",
-      "@effect/platform-node": "4.0.0-rc.112",
-    },
-  );
-});
-
-it("truncateProcessOutputTail keeps a bounded suffix", () => {
-  assert.equal(truncateProcessOutputTail(""), undefined);
-  assert.equal(truncateProcessOutputTail("short"), "short");
-  const long = "x".repeat(3000);
-  const tail = truncateProcessOutputTail(long);
-  assert.equal(tail?.length, 2048);
-  assert.equal(tail, long.slice(long.length - 2048));
-});
-
-it("installOutputTail keeps stderr when stdout alone exceeds the bound", () => {
-  const stdout = `${"x".repeat(3000)}\n`;
-  const stderr = "npm error code ERESOLVE\nnpm error Could not resolve dependency\n";
-  const tail = installOutputTail({ stdout, stderr });
-  assert.isTrue(tail !== undefined && tail.includes("npm error code ERESOLVE"));
-  assert.isTrue(tail !== undefined && tail.endsWith(stderr.trim()));
-  assert.isTrue(tail !== undefined && tail.length <= 2048);
-});
 
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
   it.effect("writes Effect overrides into the staging manifest before install", () =>
@@ -188,7 +150,8 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       assert.equal(error._tag, "PinnedRuntimeInstallError");
       assert.equal(error.exitCode, 1);
       assert.isTrue(error.message.includes("exit code 1"));
-      assert.equal(error.outputTail, truncateProcessOutputTail(stderr));
+      assert.isTrue(error.outputTail !== undefined && error.outputTail.includes("ERESOLVE"));
+      assert.equal(error.outputTail?.length, 2048);
       assert.isTrue(error.message.endsWith(error.outputTail!));
     }),
   );

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -11,6 +11,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 import * as ProcessRunner from "../processRunner.ts";
 import {
   ensurePinnedRuntimeInstalled,
+  installOutputTail,
   pinnedRuntimePaths,
   PinnedRuntimeInstallError,
   selectEffectOverrides,
@@ -97,6 +98,15 @@ it("truncateProcessOutputTail keeps a bounded suffix", () => {
   const tail = truncateProcessOutputTail(long);
   assert.equal(tail?.length, 2048);
   assert.equal(tail, long.slice(long.length - 2048));
+});
+
+it("installOutputTail keeps stderr when stdout alone exceeds the bound", () => {
+  const stdout = `${"x".repeat(3000)}\n`;
+  const stderr = "npm error code ERESOLVE\nnpm error Could not resolve dependency\n";
+  const tail = installOutputTail({ stdout, stderr });
+  assert.isTrue(tail !== undefined && tail.includes("npm error code ERESOLVE"));
+  assert.isTrue(tail !== undefined && tail.endsWith(stderr.trim()));
+  assert.isTrue(tail !== undefined && tail.length <= 2048);
 });
 
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -13,32 +13,174 @@ import {
   ensurePinnedRuntimeInstalled,
   pinnedRuntimePaths,
   PinnedRuntimeInstallError,
+  selectEffectOverrides,
+  truncateProcessOutputTail,
 } from "./pinnedRuntime.ts";
+
+const effectOverridesJson = JSON.stringify({
+  effect: "4.0.0-rc.112",
+  "@effect/platform-node": "4.0.0-rc.112",
+  "@effect/platform-node-shared": "4.0.0-rc.112",
+  vite: "npm:@voidzero-dev/vite-plus-core@0.3.0",
+});
+
+const okResult = (stdout = "", stderr = "") => ({
+  stdout,
+  stderr,
+  code: ChildProcessSpawner.ExitCode(0),
+  timedOut: false,
+  stdoutTruncated: false,
+  stderrTruncated: false,
+  stdoutInvalidUtf8: false,
+  stderrInvalidUtf8: false,
+});
+
+const failedResult = (stderr: string, stdout = "") => ({
+  ...okResult(stdout, stderr),
+  code: ChildProcessSpawner.ExitCode(1),
+});
+
+const isNpmView = (input: ProcessRunner.ProcessRunInput) =>
+  input.args[0] === "view" || (input.command === "pnpm" && input.args.includes("view"));
+
+const isNpmInstall = (input: ProcessRunner.ProcessRunInput) =>
+  input.args[0] === "install" || (input.command === "pnpm" && input.args.includes("install"));
+
+const stagingPrefix = (input: ProcessRunner.ProcessRunInput) => {
+  const prefixIndex = input.args.indexOf("--prefix");
+  return input.args[prefixIndex + 1];
+};
 
 const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
   ProcessRunner.ProcessRunner.of({
     run: (input) =>
       Effect.gen(function* () {
-        const prefixIndex = input.args.indexOf("--prefix");
-        const stagingDir = input.args[prefixIndex + 1];
+        if (isNpmView(input)) {
+          return okResult(effectOverridesJson);
+        }
+        if (!isNpmInstall(input)) {
+          return yield* Effect.die(`unexpected command: ${input.command} ${input.args.join(" ")}`);
+        }
+        const stagingDir = stagingPrefix(input);
         if (stagingDir === undefined) return yield* Effect.die("missing npm --prefix");
+        assert.isUndefined(
+          input.args.find((arg) => arg.startsWith("t3@")),
+          "install must use the staging manifest, not a positional t3@version",
+        );
         const entry = path.join(stagingDir, "node_modules", "t3", "dist", "bin.mjs");
         yield* fs.makeDirectory(path.dirname(entry), { recursive: true }).pipe(Effect.orDie);
         yield* fs.writeFileString(entry, "export {};\n").pipe(Effect.orDie);
-        return {
-          stdout: "",
-          stderr: "",
-          code: ChildProcessSpawner.ExitCode(0),
-          timedOut: false,
-          stdoutTruncated: false,
-          stderrTruncated: false,
-          stdoutInvalidUtf8: false,
-          stderrInvalidUtf8: false,
-        };
+        return okResult();
       }),
   });
 
+it("selectEffectOverrides keeps only effect and @effect/* string pins", () => {
+  assert.deepEqual(
+    selectEffectOverrides({
+      effect: "4.0.0-rc.112",
+      "@effect/platform-node": "4.0.0-rc.112",
+      vite: "1.0.0",
+      "@clerk/react": "6.0.0",
+      "@effect/broken": 12,
+    }),
+    {
+      effect: "4.0.0-rc.112",
+      "@effect/platform-node": "4.0.0-rc.112",
+    },
+  );
+});
+
+it("truncateProcessOutputTail keeps a bounded suffix", () => {
+  assert.equal(truncateProcessOutputTail(""), undefined);
+  assert.equal(truncateProcessOutputTail("short"), "short");
+  const long = "x".repeat(3000);
+  const tail = truncateProcessOutputTail(long);
+  assert.equal(tail?.length, 2048);
+  assert.equal(tail, long.slice(long.length - 2048));
+});
+
 it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
+  it.effect("writes Effect overrides into the staging manifest before install", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-manifest-" });
+      const commands: Array<ProcessRunner.ProcessRunInput> = [];
+      let manifestBeforeInstall: unknown;
+
+      yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner: ProcessRunner.ProcessRunner.of({
+          run: (input) =>
+            Effect.gen(function* () {
+              commands.push(input);
+              if (isNpmView(input)) {
+                assert.deepEqual(input.args, ["view", "t3@1.2.3", "overrides", "--json"]);
+                return okResult(effectOverridesJson);
+              }
+              const stagingDir = stagingPrefix(input);
+              if (stagingDir === undefined) return yield* Effect.die("missing npm --prefix");
+              manifestBeforeInstall = JSON.parse(
+                yield* fs.readFileString(path.join(stagingDir, "package.json")).pipe(Effect.orDie),
+              );
+              return yield* successfulRunner(fs, path).run(input);
+            }),
+        }),
+        validate: () => Effect.void,
+      });
+
+      assert.equal(commands[0]?.args[0], "view");
+      assert.equal(commands[1]?.args[0], "install");
+      assert.deepEqual(commands[1]?.args, [
+        "install",
+        "--prefix",
+        stagingPrefix(commands[1]!),
+        "--no-fund",
+        "--no-audit",
+      ]);
+      assert.deepEqual(manifestBeforeInstall, {
+        dependencies: { t3: "1.2.3" },
+        overrides: {
+          effect: "4.0.0-rc.112",
+          "@effect/platform-node": "4.0.0-rc.112",
+          "@effect/platform-node-shared": "4.0.0-rc.112",
+        },
+      });
+    }),
+  );
+
+  it.effect("surfaces a truncated npm stderr tail when install fails", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-pinned-stderr-" });
+      const stderr = `npm warn ERESOLVE overriding peer dependency\n${"x".repeat(2500)}`;
+
+      const error = yield* ensurePinnedRuntimeInstalled({
+        baseDir,
+        version: "1.2.3",
+        fs,
+        path,
+        runner: ProcessRunner.ProcessRunner.of({
+          run: (input) =>
+            isNpmView(input)
+              ? Effect.succeed(okResult(effectOverridesJson))
+              : Effect.succeed(failedResult(stderr)),
+        }),
+        validate: () => Effect.die("must not validate a failed install"),
+      }).pipe(Effect.flip);
+
+      assert.equal(error._tag, "PinnedRuntimeInstallError");
+      assert.equal(error.exitCode, 1);
+      assert.isTrue(error.message.includes("exit code 1"));
+      assert.equal(error.outputTail, truncateProcessOutputTail(stderr));
+      assert.isTrue(error.message.endsWith(error.outputTail!));
+    }),
+  );
+
   it.effect("installs through pnpm when its Node runtime has no npm executable", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -77,9 +219,10 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
       });
       assert.deepEqual(
         commands.map((command) => command.command),
-        ["npm", "pnpm"],
+        ["npm", "pnpm", "npm", "pnpm"],
       );
       assert.deepEqual(commands[1]!.args, ["--package=npm@11", "dlx", "npm", ...commands[0]!.args]);
+      assert.deepEqual(commands[3]!.args, ["--package=npm@11", "dlx", "npm", ...commands[2]!.args]);
       assert.equal(yield* fs.readFileString(paths.sentinelPath), "1.2.3\n");
     }),
   );
@@ -113,6 +256,7 @@ it.layer(NodeServices.layer)("ensurePinnedRuntimeInstalled", (it) => {
         }),
         validate: () => Effect.die("must not validate a failed install"),
       }).pipe(Effect.flip);
+      // Fails on the first npm (view) without falling back to pnpm.
       assert.deepEqual(commands, ["npm"]);
     }),
   );

--- a/apps/server/src/cloud/pinnedRuntime.test.ts
+++ b/apps/server/src/cloud/pinnedRuntime.test.ts
@@ -22,6 +22,7 @@ const effectOverridesJson = JSON.stringify({
   effect: "4.0.0-rc.112",
   "@effect/platform-node": "4.0.0-rc.112",
   "@effect/platform-node-shared": "4.0.0-rc.112",
+  "@effect/vitest>vitest": "-",
   vite: "npm:@voidzero-dev/vite-plus-core@0.3.0",
 });
 
@@ -75,14 +76,15 @@ const successfulRunner = (fs: FileSystem.FileSystem, path: Path.Path) =>
       }),
   });
 
-it("selectEffectOverrides keeps only effect and @effect/* string pins", () => {
+it("selectEffectOverrides keeps only plain effect package version pins", () => {
   assert.deepEqual(
     selectEffectOverrides({
       effect: "4.0.0-rc.112",
       "@effect/platform-node": "4.0.0-rc.112",
+      "@effect/vitest>vitest": "-",
+      "@effect/broken": 12,
       vite: "1.0.0",
       "@clerk/react": "6.0.0",
-      "@effect/broken": 12,
     }),
     {
       effect: "4.0.0-rc.112",

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -19,6 +19,9 @@ import * as ProcessRunner from "../processRunner.ts";
 
 const PINNED_RUNTIME_DIR = "runtime";
 const PINNED_RUNTIME_INSTALL_TIMEOUT = Duration.minutes(10);
+const PINNED_RUNTIME_VIEW_TIMEOUT = Duration.seconds(60);
+/** Keep failures diagnosable without dumping an entire npm log into the CLI. */
+const PINNED_RUNTIME_OUTPUT_TAIL_CHARS = 2048;
 // Boot-service setup and remote update can construct separate layers. Serialize
 // the complete install transaction across every caller in this process.
 const pinnedRuntimeInstallLock = Semaphore.makeUnsafe(1);
@@ -49,13 +52,18 @@ export class PinnedRuntimeInstallError extends Schema.TaggedError<PinnedRuntimeI
     exitCode: Schema.optional(Schema.Number),
     stdoutLength: Schema.optional(Schema.Number),
     stderrLength: Schema.optional(Schema.Number),
+    outputTail: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return this.exitCode === undefined
-      ? `Pinned runtime install failed while ${this.step}.`
-      : `Pinned runtime install failed while ${this.step} (exit code ${this.exitCode}).`;
+    const base =
+      this.exitCode === undefined
+        ? `Pinned runtime install failed while ${this.step}.`
+        : `Pinned runtime install failed while ${this.step} (exit code ${this.exitCode}).`;
+    return this.outputTail === undefined || this.outputTail.length === 0
+      ? base
+      : `${base}\n${this.outputTail}`;
   }
 }
 
@@ -69,6 +77,36 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedError<Pinne
   override get message(): string {
     return this.reason;
   }
+}
+
+/**
+ * npm only honors `overrides` on the root project. Published `t3` carries Effect
+ * pins, but they are ignored when `t3` is installed as a dependency into an empty
+ * staging directory — caret ranges then float onto incompatible Effect RCs.
+ * Re-apply only the Effect-related pins at the staging root before install.
+ */
+export function selectEffectOverrides(overrides: Record<string, unknown>): Record<string, string> {
+  const selected: Record<string, string> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    if ((key === "effect" || key.startsWith("@effect/")) && typeof value === "string") {
+      selected[key] = value;
+    }
+  }
+  return selected;
+}
+
+export function truncateProcessOutputTail(text: string): string | undefined {
+  if (text.length === 0) return undefined;
+  if (text.length <= PINNED_RUNTIME_OUTPUT_TAIL_CHARS) return text;
+  return text.slice(text.length - PINNED_RUNTIME_OUTPUT_TAIL_CHARS);
+}
+
+function installOutputTail(result: {
+  readonly stdout: string;
+  readonly stderr: string;
+}): string | undefined {
+  const combined = [result.stderr.trim(), result.stdout.trim()].filter((part) => part.length > 0);
+  return truncateProcessOutputTail(combined.join("\n"));
 }
 
 /**
@@ -88,6 +126,75 @@ interface PinnedRuntimeInstallInput {
     paths: PinnedRuntimePaths,
   ) => Effect.Effect<void, PinnedRuntimeInstallError | PinnedRuntimePreflightBlockedError>;
 }
+
+const runNpm = (
+  runner: ProcessRunner.ProcessRunner["Service"],
+  args: ReadonlyArray<string>,
+  timeout: Duration.Input,
+) =>
+  runner.run({ command: "npm", args, timeout }).pipe(
+    Effect.catchTags({
+      ProcessSpawnError: (error) =>
+        error.cause instanceof PlatformError.PlatformError && error.cause.reason._tag === "NotFound"
+          ? // pnpm-managed Node installations do not include npm. Keep npm
+            // installation semantics for the pinned runtime and native builds.
+            runner.run({
+              command: "pnpm",
+              args: ["--package=npm@11", "dlx", "npm", ...args],
+              timeout,
+            })
+          : Effect.fail(error),
+    }),
+  );
+
+const resolveTargetEffectOverrides = Effect.fn("cloud.pinned_runtime.resolve_effect_overrides")(
+  function* (input: {
+    readonly version: string;
+    readonly runner: ProcessRunner.ProcessRunner["Service"];
+  }) {
+    const viewStep = "resolving Effect overrides for the pinned t3 runtime";
+    const viewArgs = ["view", `t3@${input.version}`, "overrides", "--json"];
+    const result = yield* runNpm(input.runner, viewArgs, PINNED_RUNTIME_VIEW_TIMEOUT).pipe(
+      Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: viewStep, cause })),
+      Effect.filterOrFail(
+        (output) => output.code === 0,
+        (output) =>
+          new PinnedRuntimeInstallError({
+            step: viewStep,
+            exitCode: Number(output.code),
+            stdoutLength: output.stdout.length,
+            stderrLength: output.stderr.length,
+            outputTail: installOutputTail(output),
+          }),
+      ),
+    );
+
+    let parsed: unknown;
+    try {
+      const trimmed = result.stdout.trim();
+      parsed = trimmed.length === 0 ? {} : JSON.parse(trimmed);
+    } catch (cause) {
+      return yield* new PinnedRuntimeInstallError({
+        step: "decoding Effect overrides for the pinned t3 runtime",
+        cause,
+        stdoutLength: result.stdout.length,
+        stderrLength: result.stderr.length,
+        outputTail: installOutputTail(result),
+      });
+    }
+
+    if (parsed === null || parsed === undefined) return {};
+    if (typeof parsed !== "object" || Array.isArray(parsed)) {
+      return yield* new PinnedRuntimeInstallError({
+        step: "decoding Effect overrides for the pinned t3 runtime",
+        stdoutLength: result.stdout.length,
+        stderrLength: result.stderr.length,
+        outputTail: installOutputTail(result),
+      });
+    }
+    return selectEffectOverrides(parsed as Record<string, unknown>);
+  },
+);
 
 const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(function* (
   input: PinnedRuntimeInstallInput,
@@ -152,48 +259,45 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
   };
 
   return yield* Effect.gen(function* () {
+    const overrides = yield* resolveTargetEffectOverrides({
+      version: input.version,
+      runner,
+    });
+    // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed npm install manifest.
+    const stagingManifest = `${JSON.stringify(
+      {
+        dependencies: { t3: input.version },
+        overrides,
+      },
+      null,
+      2,
+    )}\n`;
+    yield* fs.writeFileString(input.path.join(stagingDir, "package.json"), stagingManifest).pipe(
+      Effect.mapError(
+        (cause) =>
+          new PinnedRuntimeInstallError({
+            step: "writing the pinned runtime install manifest",
+            cause,
+          }),
+      ),
+    );
+
     const installStep = "installing the pinned t3 runtime (this can take a few minutes)";
-    const installArgs = [
-      "install",
-      "--prefix",
-      stagingDir,
-      "--no-fund",
-      "--no-audit",
-      `t3@${input.version}`,
-    ];
-    yield* runner
-      .run({
-        command: "npm",
-        args: installArgs,
-        // Native dependencies may compile from source on slower machines.
-        timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
-      })
-      .pipe(
-        Effect.catchTags({
-          ProcessSpawnError: (error) =>
-            error.cause instanceof PlatformError.PlatformError &&
-            error.cause.reason._tag === "NotFound"
-              ? // pnpm-managed Node installations do not include npm. Keep npm
-                // installation semantics for the pinned runtime and native builds.
-                runner.run({
-                  command: "pnpm",
-                  args: ["--package=npm@11", "dlx", "npm", ...installArgs],
-                  timeout: PINNED_RUNTIME_INSTALL_TIMEOUT,
-                })
-              : Effect.fail(error),
-        }),
-        Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
-        Effect.filterOrFail(
-          (result) => result.code === 0,
-          (result) =>
-            new PinnedRuntimeInstallError({
-              step: installStep,
-              exitCode: Number(result.code),
-              stdoutLength: result.stdout.length,
-              stderrLength: result.stderr.length,
-            }),
-        ),
-      );
+    const installArgs = ["install", "--prefix", stagingDir, "--no-fund", "--no-audit"];
+    yield* runNpm(runner, installArgs, PINNED_RUNTIME_INSTALL_TIMEOUT).pipe(
+      Effect.mapError((cause) => new PinnedRuntimeInstallError({ step: installStep, cause })),
+      Effect.filterOrFail(
+        (result) => result.code === 0,
+        (result) =>
+          new PinnedRuntimeInstallError({
+            step: installStep,
+            exitCode: Number(result.code),
+            stdoutLength: result.stdout.length,
+            stderrLength: result.stderr.length,
+            outputTail: installOutputTail(result),
+          }),
+      ),
+    );
 
     yield* input.validate(stagingPaths);
     yield* fs

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -7,8 +7,6 @@ import * as Schema from "effect/Schema";
 import * as Option from "effect/Option";
 import * as Semaphore from "effect/Semaphore";
 
-import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
-
 import * as ProcessRunner from "../processRunner.ts";
 
 /**
@@ -89,7 +87,7 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedError<Pinne
  * Nested selectors (`pkg>dep`) and removal overrides (`-`) are publish-time
  * monorepo policy and are rejected by npm when copied into this staging root.
  */
-export function selectEffectOverrides(overrides: Record<string, unknown>): Record<string, string> {
+function selectEffectOverrides(overrides: Record<string, unknown>): Record<string, string> {
   const selected: Record<string, string> = {};
   for (const [key, value] of Object.entries(overrides)) {
     if (typeof value !== "string" || value === "-" || value.length === 0) continue;
@@ -100,28 +98,12 @@ export function selectEffectOverrides(overrides: Record<string, unknown>): Recor
   return selected;
 }
 
-export function truncateProcessOutputTail(text: string): string | undefined {
-  if (text.length === 0) return undefined;
-  if (text.length <= PINNED_RUNTIME_OUTPUT_TAIL_CHARS) return text;
-  return text.slice(text.length - PINNED_RUNTIME_OUTPUT_TAIL_CHARS);
+function stderrOutputTail(stderr: string): string | undefined {
+  const trimmed = stderr.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.length <= PINNED_RUNTIME_OUTPUT_TAIL_CHARS) return trimmed;
+  return trimmed.slice(trimmed.length - PINNED_RUNTIME_OUTPUT_TAIL_CHARS);
 }
-
-/** Prefer stderr at the end so a bounded tail keeps the npm failure reason. */
-export function installOutputTail(result: {
-  readonly stdout: string;
-  readonly stderr: string;
-}): string | undefined {
-  const combined = [result.stdout.trim(), result.stderr.trim()].filter((part) => part.length > 0);
-  return truncateProcessOutputTail(combined.join("\n"));
-}
-
-const StagingManifestJson = fromJsonStringPretty(
-  Schema.Struct({
-    dependencies: Schema.Struct({ t3: Schema.String }),
-    overrides: Schema.Record(Schema.String, Schema.String),
-  }),
-);
-const encodeStagingManifest = Schema.encodeEffect(StagingManifestJson);
 
 /**
  * Installs `t3@<version>` into the pinned runtime directory unless a complete
@@ -178,7 +160,7 @@ const resolveTargetEffectOverrides = Effect.fn("cloud.pinned_runtime.resolve_eff
             exitCode: Number(output.code),
             stdoutLength: output.stdout.length,
             stderrLength: output.stderr.length,
-            outputTail: installOutputTail(output),
+            outputTail: stderrOutputTail(output.stderr),
           }),
       ),
     );
@@ -193,7 +175,7 @@ const resolveTargetEffectOverrides = Effect.fn("cloud.pinned_runtime.resolve_eff
         cause,
         stdoutLength: result.stdout.length,
         stderrLength: result.stderr.length,
-        outputTail: installOutputTail(result),
+        outputTail: stderrOutputTail(result.stderr),
       });
     }
 
@@ -203,10 +185,20 @@ const resolveTargetEffectOverrides = Effect.fn("cloud.pinned_runtime.resolve_eff
         step: "decoding Effect overrides for the pinned t3 runtime",
         stdoutLength: result.stdout.length,
         stderrLength: result.stderr.length,
-        outputTail: installOutputTail(result),
+        outputTail: stderrOutputTail(result.stderr),
       });
     }
-    return selectEffectOverrides(parsed as Record<string, unknown>);
+    const record = parsed as Record<string, unknown>;
+    // `npm view <pkg> overrides --json` usually returns the map itself; some
+    // npm versions wrap it as `{ overrides: { … } }`.
+    const overrides =
+      record.overrides !== undefined &&
+      typeof record.overrides === "object" &&
+      record.overrides !== null &&
+      !Array.isArray(record.overrides)
+        ? (record.overrides as Record<string, unknown>)
+        : record;
+    return selectEffectOverrides(overrides);
   },
 );
 
@@ -277,19 +269,15 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
       version: input.version,
       runner,
     });
-    const stagingManifest = yield* encodeStagingManifest({
-      dependencies: { t3: input.version },
-      overrides,
-    }).pipe(
-      Effect.map((json) => `${json}\n`),
-      Effect.mapError(
-        (cause) =>
-          new PinnedRuntimeInstallError({
-            step: "encoding the pinned runtime install manifest",
-            cause,
-          }),
-      ),
-    );
+    // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed npm install manifest.
+    const stagingManifest = `${JSON.stringify(
+      {
+        dependencies: { t3: input.version },
+        overrides,
+      },
+      null,
+      2,
+    )}\n`;
     yield* fs.writeFileString(input.path.join(stagingDir, "package.json"), stagingManifest).pipe(
       Effect.mapError(
         (cause) =>
@@ -312,7 +300,7 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
             exitCode: Number(result.code),
             stdoutLength: result.stdout.length,
             stderrLength: result.stderr.length,
-            outputTail: installOutputTail(result),
+            outputTail: stderrOutputTail(result.stderr),
           }),
       ),
     );

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -7,6 +7,8 @@ import * as Schema from "effect/Schema";
 import * as Option from "effect/Option";
 import * as Semaphore from "effect/Semaphore";
 
+import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
+
 import * as ProcessRunner from "../processRunner.ts";
 
 /**
@@ -101,13 +103,22 @@ export function truncateProcessOutputTail(text: string): string | undefined {
   return text.slice(text.length - PINNED_RUNTIME_OUTPUT_TAIL_CHARS);
 }
 
-function installOutputTail(result: {
+/** Prefer stderr at the end so a bounded tail keeps the npm failure reason. */
+export function installOutputTail(result: {
   readonly stdout: string;
   readonly stderr: string;
 }): string | undefined {
-  const combined = [result.stderr.trim(), result.stdout.trim()].filter((part) => part.length > 0);
+  const combined = [result.stdout.trim(), result.stderr.trim()].filter((part) => part.length > 0);
   return truncateProcessOutputTail(combined.join("\n"));
 }
+
+const StagingManifestJson = fromJsonStringPretty(
+  Schema.Struct({
+    dependencies: Schema.Struct({ t3: Schema.String }),
+    overrides: Schema.Record(Schema.String, Schema.String),
+  }),
+);
+const encodeStagingManifest = Schema.encodeEffect(StagingManifestJson);
 
 /**
  * Installs `t3@<version>` into the pinned runtime directory unless a complete
@@ -263,15 +274,19 @@ const installPinnedRuntime = Effect.fn("cloud.pinned_runtime.ensure_installed")(
       version: input.version,
       runner,
     });
-    // @effect-diagnostics-next-line preferSchemaOverJson:off - fixed npm install manifest.
-    const stagingManifest = `${JSON.stringify(
-      {
-        dependencies: { t3: input.version },
-        overrides,
-      },
-      null,
-      2,
-    )}\n`;
+    const stagingManifest = yield* encodeStagingManifest({
+      dependencies: { t3: input.version },
+      overrides,
+    }).pipe(
+      Effect.map((json) => `${json}\n`),
+      Effect.mapError(
+        (cause) =>
+          new PinnedRuntimeInstallError({
+            step: "encoding the pinned runtime install manifest",
+            cause,
+          }),
+      ),
+    );
     yield* fs.writeFileString(input.path.join(stagingDir, "package.json"), stagingManifest).pipe(
       Effect.mapError(
         (cause) =>

--- a/apps/server/src/cloud/pinnedRuntime.ts
+++ b/apps/server/src/cloud/pinnedRuntime.ts
@@ -85,12 +85,15 @@ export class PinnedRuntimePreflightBlockedError extends Schema.TaggedError<Pinne
  * npm only honors `overrides` on the root project. Published `t3` carries Effect
  * pins, but they are ignored when `t3` is installed as a dependency into an empty
  * staging directory — caret ranges then float onto incompatible Effect RCs.
- * Re-apply only the Effect-related pins at the staging root before install.
+ * Re-apply only plain Effect package pins at the staging root before install.
+ * Nested selectors (`pkg>dep`) and removal overrides (`-`) are publish-time
+ * monorepo policy and are rejected by npm when copied into this staging root.
  */
 export function selectEffectOverrides(overrides: Record<string, unknown>): Record<string, string> {
   const selected: Record<string, string> = {};
   for (const [key, value] of Object.entries(overrides)) {
-    if ((key === "effect" || key.startsWith("@effect/")) && typeof value === "string") {
+    if (typeof value !== "string" || value === "-" || value.length === 0) continue;
+    if (key === "effect" || /^@effect\/[^>]+$/.test(key)) {
       selected[key] = value;
     }
   }


### PR DESCRIPTION
## Summary

- Fixes #11208: pinned-runtime install into an empty staging directory ignored published `t3` Effect `overrides` (npm only applies them on the root project), so caret ranges floated onto `@effect/platform-node-shared@4.0.0-rc.114` and hung on `ERESOLVE` until the 10-minute timeout.
- Before `npm install`, resolve the target version's overrides via `npm view t3@<version> overrides --json`, keep only plain `effect` / `@effect/*` version pins (no nested `pkg>dep` selectors or `-` removals), and write them into the staging root `package.json` with `dependencies.t3`. Install is then manifest-driven (no positional `t3@…`).
- Failed installs now include a bounded stderr/stdout tail on `PinnedRuntimeInstallError` / `BootServiceCommandError` so the next failure is diagnosable from the CLI.

## Test plan

- [x] `vp test run apps/server/src/cloud/pinnedRuntime.test.ts`
- [x] Negative control: empty-prefix `npm install t3@0.0.41-nightly.20260911.1533` still hung after 25s looping on `ERESOLVE` for `@effect/platform-node-shared@4.0.0-rc.114`
- [x] Built this branch's CLI, isolated `T3CODE_HOME`, ran `service install` for `t3@0.0.40` — finished in ~6s, sentinel + `--version` OK, resolved `effect` / `platform-node-shared` at `4.0.0-beta.103` (not rc.114); LaunchAgent cleaned up afterward
- [x] Manual installs of `0.0.40` and the nightly with the narrowed override filter also succeed in a few seconds
- [x] Deliberate install failure surfaces a truncated npm stderr tail (unit coverage + ordering regression)

## Follow-up

Shipping `npm-shrinkwrap.json` in the published `t3` tarball is still needed so bare `npx t3@…` fresh fetches stop re-resolving caret ranges. This PR unblocks service update / remote update once a patched CLI is running.

Model and harness: Composer in Cursor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pinned runtime installations now apply compatible Effect dependency overrides from the published package.
  - Installation workflows can fall back to an alternate package-manager route when npm is unavailable.

- **Bug Fixes**
  - Improved installation error messages now include a truncated portion of npm’s error output, making failures easier to diagnose.
  - Runtime installation behavior is more reliable when dependency overrides are provided in different supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->