### PR TITLE
fix(mobile): prevent Hermes crashes when opening threads

### DIFF
--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1,5 +1,5 @@
 import { derivePendingRequests } from "@t3tools/client-runtime/pending-requests";
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import {
   ApprovalRequestId,
@@ -26,6 +26,21 @@ import {
   type ThreadFeedEntry,
   type WorkLogEntry,
 } from "./threadActivity";
+
+// Match Hermes: these ES2023 array methods are absent on mobile.
+beforeEach(() => {
+  const methods = ["toSorted", "toReversed"] as const;
+  const descriptors = methods.map((method) =>
+    Object.getOwnPropertyDescriptor(Array.prototype, method),
+  );
+  for (const method of methods) Reflect.deleteProperty(Array.prototype, method);
+  return () => {
+    for (const [index, method] of methods.entries()) {
+      const descriptor = descriptors[index];
+      if (descriptor) Reflect.defineProperty(Array.prototype, method, descriptor);
+    }
+  };
+});
 
 const singleSelectQuestion = {
   id: "runtime",

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -658,7 +658,9 @@ export function omitSupersededLifecycleMarkers<T>(
     }
   }
 
-  return reversedEntries.toReversed();
+  // Hermes lacks toReversed; this array is local, so reversing it cannot mutate the input.
+  // oxlint-disable-next-line unicorn/no-array-reverse
+  return reversedEntries.reverse();
 }
 
 export function toolGroupSummaryKind(

--- a/packages/client-runtime/src/work-log/userInput.ts
+++ b/packages/client-runtime/src/work-log/userInput.ts
@@ -27,8 +27,9 @@ function questionFingerprint(
   questions: ReadonlyArray<unknown>,
 ): string | undefined {
   const texts = questions.map((question) => (typeof question === "string" ? question.trim() : ""));
+  // Sort the fresh array in place because Hermes does not provide toSorted.
   return texts.length > 0 && texts.every(Boolean)
-    ? JSON.stringify([turnId, texts.toSorted()])
+    ? JSON.stringify([turnId, texts.sort()])
     : undefined;
 }
 


### PR DESCRIPTION
## What Changed

Use `sort()` and `reverse()` on freshly allocated arrays in the shared question-answer and tool-activity rendering helpers. Run the mobile thread-feed tests with `Array.prototype.toSorted` and `Array.prototype.toReversed` unavailable to match Hermes.

## Why

Opening a thread containing an agent question can terminate the mobile release app with `TypeError: undefined is not a function`. Question folding calls `toSorted()`, which the bundled Hermes engine does not implement. Tool-activity presentation also calls the unsupported `toReversed()` method. Desktop supports both methods, so the same threads open successfully there.

The replacements preserve the original input arrays and avoid an unnecessary second copy. The Hermes-compatible test setup reproduces 43 failures before the fix.

## Validation

- 174 focused tests pass across mobile thread activity and shared work-log presentation.
- Mobile and client-runtime typechecks pass; changed-file lint, formatting, and `git diff --check` pass.
- Reproduced the failure with saved activity data from two affected threads and verified both feeds after the fix.
- Rebuilt and installed an iPhone Release app from the personal fork with this patch. Both affected threads open successfully, confirmed by the reporter, with no fatal JavaScript errors in the captured device console.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile compatibility by supporting Hermes runtimes that lack newer JavaScript array methods.
  - Ensured work-log processing and question handling continue to function correctly on affected mobile environments.

- **Tests**
  - Added coverage that simulates the mobile runtime’s available array methods and verifies compatible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->