### PR TITLE
fix(mobile): keep Android file icons on the line with wrapped filenames

### DIFF
--- a/apps/mobile/modules/t3-markdown-text/android/build.gradle
+++ b/apps/mobile/modules/t3-markdown-text/android/build.gradle
@@ -8,6 +8,10 @@ android {
   namespace 'expo.modules.t3markdowntext'
   compileSdk rootProject.ext.compileSdkVersion
 
+  testOptions {
+    unitTests.includeAndroidResources = true
+  }
+
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
@@ -17,4 +21,12 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
   implementation 'com.facebook.react:react-android'
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.16.1'
+}
+
+tasks.withType(Test).configureEach {
+  javaLauncher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(21)
+  }
 }

--- a/apps/mobile/modules/t3-markdown-text/android/src/main/java/expo/modules/t3markdowntext/T3MarkdownTextSelectionModule.kt
+++ b/apps/mobile/modules/t3-markdown-text/android/src/main/java/expo/modules/t3markdowntext/T3MarkdownTextSelectionModule.kt
@@ -28,19 +28,23 @@ private object MarkdownSpannableFactory : Spannable.Factory() {
     SpannableStringBuilder(source)
 }
 
-private fun copyTextWithoutInlineImages(
+internal fun copyTextWithoutInlineImages(
   text: CharSequence,
   start: Int,
   end: Int
 ): String {
   if (text !is Spanned) return text.subSequence(start, end).toString()
 
+  fun isInlineImage(index: Int): Boolean =
+    index >= 0 && text[index].toString() == OBJECT_REPLACEMENT_CHARACTER &&
+      text.getSpans(index, index + 1, ReplacementSpan::class.java).isNotEmpty()
+
   return buildString {
     for (index in start until end) {
-      val isInlineImage =
-        text[index].toString() == OBJECT_REPLACEMENT_CHARACTER &&
-          text.getSpans(index, index + 1, ReplacementSpan::class.java).isNotEmpty()
-      if (!isInlineImage) append(text[index])
+      // The renderer inserts one NBSP after each image to keep its label on the same line.
+      // Inspect the original text even when selection starts after the image.
+      val isIconSpacer = text[index] == '\u00A0' && isInlineImage(index - 1)
+      if (!isInlineImage(index) && !isIconSpacer) append(text[index])
     }
   }
 }

--- a/apps/mobile/modules/t3-markdown-text/android/src/test/java/expo/modules/t3markdowntext/MarkdownSelectionCopyTest.kt
+++ b/apps/mobile/modules/t3-markdown-text/android/src/test/java/expo/modules/t3markdowntext/MarkdownSelectionCopyTest.kt
@@ -1,0 +1,48 @@
+package expo.modules.t3markdowntext
+
+import android.graphics.drawable.ColorDrawable
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ImageSpan
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36], manifest = Config.NONE)
+class MarkdownSelectionCopyTest {
+  private fun withIcon(value: String): SpannableString = SpannableString(value).apply {
+    val index = value.indexOf('\uFFFC')
+    setSpan(ImageSpan(ColorDrawable()), index, index + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+  }
+
+  @Test
+  fun removesIconAndInjectedSpacer() {
+    val text = withIcon("\uFFFC\u00A0main.go:12 starts the server.")
+    assertEquals("main.go:12 starts the server.", copyTextWithoutInlineImages(text, 0, text.length))
+  }
+
+  @Test
+  fun removesSpacerWhenSelectionStartsAfterIcon() {
+    val text = withIcon("\uFFFC\u00A0main.go:12 starts the server.")
+    assertEquals("main.go:12", copyTextWithoutInlineImages(text, 1, 12))
+  }
+
+  @Test
+  fun preservesAuthoredWhitespaceAndLiteralObjectCharacters() {
+    val text = withIcon("before\u00A0 \uFFFC\u00A0\u00A0 main.go after\u00A0\uFFFC\u00A0")
+    assertEquals(
+      "before\u00A0 \u00A0 main.go after\u00A0\uFFFC\u00A0",
+      copyTextWithoutInlineImages(text, 0, text.length)
+    )
+  }
+
+  @Test
+  fun preservesTextWithoutImageSpans() {
+    val text = "\uFFFC\u00A0main.go"
+    assertEquals(text, copyTextWithoutInlineImages(text, 0, text.length))
+    assertEquals(text, copyTextWithoutInlineImages(SpannableString(text), 0, text.length))
+  }
+}

--- a/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.tsx
+++ b/apps/mobile/modules/t3-markdown-text/src/NativeMarkdownSelectableText.tsx
@@ -222,6 +222,12 @@ export function NativeMarkdownSelectableText(props: {
       }
     }
 
+    // Android renders the icon as an inline Image before the text. A regular space
+    // lets the line break between them, stranding the icon on the previous line.
+    if (Platform.OS === "android" && (run.fileIcon || linkIcon)) {
+      text = `\u00A0${text}`;
+    }
+
     return { key: `${signature}:${occurrence}`, run, text, linkIcon };
   });
   // T3MarkdownText only rebuilds its attributed string during native layout. A


### PR DESCRIPTION
## What Changed

On Android, a file or link icon can stay on the previous line when its filename wraps. #11118 fixed the vertical icon drift and explicitly left this wrapping issue out of scope ("An icon can still stay on the previous line when its filename wraps").

Android renders the icon as an inline `Image` before the label, and the regular space between them is a line-break opportunity. This prefixes the label with a non-breaking space on Android so the icon and its label wrap together. The native copy sanitizer strips that spacer alongside the image placeholder, including when the selection starts after the icon, so copied text matches what was authored.

This is the wrapping half of #11079 (reverted in #11098). The drift half is intentionally not re-added, since #11118 solved it natively. The renderer files are shared between platforms (#11128); the new branch only runs on Android and the iOS text path is untouched.

## Why

The NBSP is the smallest change that ties the icon to its label in a single `TextView` run without changing layout for any other text.

## Verification

- `nativeMarkdownText.test.ts`: 35 passed
- Mobile typecheck and lint on the changed file: clean
- Robolectric `MarkdownSelectionCopyTest` (4 tests) via `:t3tools-mobile-markdown-text:testDebugUnitTest`: all pass
- Native sanitizer change needs a new Android binary; an older installed build keeps the previous copy behavior.

## UI Changes

Same seeded message on a Pixel 9 Pro API 36 emulator. The "before" runs the upstream `main` renderer on a binary that already includes #11118, so drift is out of the picture and only wrapping differs. Four of the ten bullets strand their icon at the end of a line before the change.

| Android before | Android after |
| --- | --- |
| ![Android before: file icons stranded at line ends with filenames on the next line](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-11234/649a39c6d8e7-android-icon-wrap-before.png) | ![Android after: every icon wraps together with its filename](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-11234/755f4e2ce7df-android-icon-wrap-after.png) |

iOS with this branch's bundle, iPhone 17 simulator. The Android-only branch does not run here and inline icons render as before:

![iOS: inline file icons unchanged](https://codex-file-host.shawnadedeji.workers.dev/files/t3code-11234/043c06beb4aa-ios-icon-wrap-after.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes. Not applicable; static layout.

Model: Claude Fable 5.1. Harness: Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android text wrapping so file and external-link icons remain attached to their associated text.
  - Updated text selection and copying to exclude inline image placeholders and automatically inserted spacing, while preserving authored whitespace and literal characters.
  - Copying text without inline images now behaves consistently when selections begin immediately after an icon or when no inline images are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->