### PR TITLE
fix(ssh): resolve user-installed t3 without changing PATH

### DIFF
--- a/packages/ssh/src/runnerProcess.test.ts
+++ b/packages/ssh/src/runnerProcess.test.ts
@@ -23,6 +23,51 @@ const decodeStarted = Schema.decodeUnknownSync(Schema.fromJsonString(Started));
 describe.skipIf(HostProcessPlatform.defaultValue() === "win32")(
   "remote runner process ownership",
   () => {
+    it.live("runs a user-installed CLI without changing Node precedence", () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const fixture = yield* fs.makeTempDirectoryScoped({ prefix: "t3-runner-user-cli-" });
+        const bin = path.join(fixture, "bin");
+        const home = path.join(fixture, "home");
+        const userBin = path.join(home, ".local/bin");
+        yield* fs.makeDirectory(bin);
+        yield* fs.makeDirectory(userBin, { recursive: true });
+        yield* fs.symlink(process.execPath, path.join(bin, "node"));
+        yield* fs.writeFileString(
+          path.join(userBin, "node"),
+          "#!/bin/sh\nprintf 'wrong node\\n' >&2\nexit 88\n",
+        );
+        yield* fs.chmod(path.join(userBin, "node"), 0o700);
+        yield* fs.writeFileString(
+          path.join(userBin, "t3"),
+          '#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify(process.argv.slice(2)) + "\\n");\n',
+        );
+        yield* fs.chmod(path.join(userBin, "t3"), 0o700);
+        for (const packageManager of ["npx", "npm"]) {
+          yield* fs.writeFileString(path.join(bin, packageManager), "#!/bin/sh\nexit 89\n");
+          yield* fs.chmod(path.join(bin, packageManager), 0o700);
+        }
+
+        const child = yield* spawner.spawn(
+          ChildProcess.make("/bin/sh", ["-s", "--", "auth", "pairing", "create"], {
+            cwd: fixture,
+            env: { HOME: home, PATH: bin },
+            detached: false,
+            stdin: Stream.make(
+              new TextEncoder().encode(buildRemoteT3RunnerScript({ nodeEngineRange: "" })),
+            ),
+          }),
+        );
+        const stdout = yield* child.stdout.pipe(Stream.decodeText(), Stream.mkString);
+        const stderr = yield* child.stderr.pipe(Stream.decodeText(), Stream.mkString);
+        assert.equal(yield* child.exitCode, 0);
+        assert.equal(stdout.trim(), '["auth","pairing","create"]');
+        assert.equal(stderr, "");
+      }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),
+    );
+
     it.live.each(["npx", "npm"] as const)(
       "keeps the server PID and graceful shutdown through the %s fallback",
       (packageManager) =>

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -106,17 +106,14 @@ describe("ssh tunnel scripts", () => {
     const script = buildRemoteT3RunnerScript({ nodeEngineRange: TEST_NODE_ENGINE_RANGE });
 
     assert.include(script, "T3_NODE_SCRIPT_PATH=''");
-    assert.include(script, 'exec t3 "$@"');
     assert.include(script, 'exec "$T3_CLI_PATH" "$@"');
+    assert.include(script, "resolve_installed_t3_cli()");
     assert.include(script, "could not install 't3@latest'");
     assert.include(script, "require_installed_t3_cli npx --yes --package 't3@latest'");
     assert.include(script, "require_installed_t3_cli npm exec --yes --package 't3@latest'");
     assert.include(script, "npm produced no t3 executable");
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/bin"');
-    assert.isBelow(
-      script.indexOf('prepend_path_if_dir "$HOME/.local/bin"'),
-      script.indexOf("if command -v node >/dev/null 2>&1"),
-    );
+    assert.include(script, '"$HOME/.local/bin/t3" "$HOME/bin/t3"');
     assert.include(script, `T3_NODE_ENGINE_RANGE='${TEST_NODE_ENGINE_RANGE}'`);
     assert.include(script, "remote_node_satisfies_engine()");
     assert.include(script, "function satisfiesSemverRange");

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -113,6 +113,10 @@ describe("ssh tunnel scripts", () => {
     assert.include(script, "require_installed_t3_cli npm exec --yes --package 't3@latest'");
     assert.include(script, "npm produced no t3 executable");
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/bin"');
+    assert.isBelow(
+      script.indexOf('prepend_path_if_dir "$HOME/.local/bin"'),
+      script.indexOf("if command -v node >/dev/null 2>&1"),
+    );
     assert.include(script, `T3_NODE_ENGINE_RANGE='${TEST_NODE_ENGINE_RANGE}'`);
     assert.include(script, "remote_node_satisfies_engine()");
     assert.include(script, "function satisfiesSemverRange");

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -329,13 +329,12 @@ NODE
 }
 
 ensure_remote_node_path() {
-  prepend_path_if_dir "$HOME/.local/bin"
-  prepend_path_if_dir "$HOME/bin"
-
   if command -v node >/dev/null 2>&1 && remote_node_satisfies_engine >/dev/null 2>&1; then
     return 0
   fi
 
+  prepend_path_if_dir "$HOME/.local/bin"
+  prepend_path_if_dir "$HOME/bin"
   prepend_path_if_dir "/opt/homebrew/bin"
   prepend_path_if_dir "/usr/local/bin"
   prepend_path_if_dir "/usr/bin"
@@ -415,8 +414,21 @@ if [ -n "$T3_NODE_SCRIPT_PATH" ]; then
   fi
   exec node "$T3_NODE_SCRIPT_PATH" "$@"
 fi
-if command -v t3 >/dev/null 2>&1; then
-  exec t3 "$@"
+resolve_installed_t3_cli() {
+  if command -v t3 >/dev/null 2>&1; then
+    command -v t3
+    return 0
+  fi
+  for T3_USER_CLI in "$HOME/.local/bin/t3" "$HOME/bin/t3"; do
+    if [ -x "$T3_USER_CLI" ]; then
+      printf '%s\n' "$T3_USER_CLI"
+      return 0
+    fi
+  done
+  return 1
+}
+if T3_CLI_PATH="$(resolve_installed_t3_cli)"; then
+  exec "$T3_CLI_PATH" "$@"
 fi
 # npm extracts a package before it runs the native builds of its dependencies,
 # so a failed build (t3 depends on node-pty, which needs a C toolchain) leaves

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -419,12 +419,14 @@ resolve_installed_t3_cli() {
     command -v t3
     return 0
   fi
-  for T3_USER_CLI in "$HOME/.local/bin/t3" "$HOME/bin/t3"; do
-    if [ -x "$T3_USER_CLI" ]; then
-      printf '%s\n' "$T3_USER_CLI"
-      return 0
-    fi
-  done
+  if [ -n "\${HOME:-}" ]; then
+    for T3_USER_CLI in "$HOME/.local/bin/t3" "$HOME/bin/t3"; do
+      if [ -x "$T3_USER_CLI" ]; then
+        printf '%s\n' "$T3_USER_CLI"
+        return 0
+      fi
+    done
+  fi
   return 1
 }
 if T3_CLI_PATH="$(resolve_installed_t3_cli)"; then

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -329,12 +329,13 @@ NODE
 }
 
 ensure_remote_node_path() {
+  prepend_path_if_dir "$HOME/.local/bin"
+  prepend_path_if_dir "$HOME/bin"
+
   if command -v node >/dev/null 2>&1 && remote_node_satisfies_engine >/dev/null 2>&1; then
     return 0
   fi
 
-  prepend_path_if_dir "$HOME/.local/bin"
-  prepend_path_if_dir "$HOME/bin"
   prepend_path_if_dir "/opt/homebrew/bin"
   prepend_path_if_dir "/usr/local/bin"
   prepend_path_if_dir "/usr/bin"


### PR DESCRIPTION
## What Changed

Resolve `t3` explicitly from `~/.local/bin` or `~/bin` when it is absent from a non-interactive SSH `PATH`. The runner executes the discovered CLI by absolute path, so it does not reorder `PATH` or change which Node installation is selected.

The regression test executes the generated POSIX runner with a compatible system Node, an incompatible user-local Node, a user-local `t3`, and package-manager fallbacks that fail if invoked. It verifies that the installed CLI runs with the original Node precedence and that `npm`/`npx` are not used.

## Why

A T3 Connect environment accessed over the local network had a compatible `/usr/bin/node`, while non-interactive SSH sessions omitted the user CLI directories from `PATH`. `ensure_remote_node_path` returned immediately after validating Node, so a `t3` installed in `~/.local/bin` was not discovered and the runner unnecessarily fell back to `npx`.

During the incident, repeated pairing attempts accumulated while npm package resolution stalled: 29 concurrent npm processes consumed about 24 GiB of RAM and saturated the CPU at 99%. This change fixes the confirmed CLI-discovery trigger; retry serialization and generic package-install timeouts remain separate concerns.

Validation:
- `vp test run packages/ssh/src/tunnel.test.ts packages/ssh/src/runnerProcess.test.ts` — 36 tests passed on Linux
- `vp fmt --check packages/ssh/src/tunnel.ts packages/ssh/src/tunnel.test.ts packages/ssh/src/runnerProcess.test.ts`
- `vp run --filter @t3tools/ssh typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

Model: GPT-5
Harness: Codex desktop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remote SSH sessions now locate the T3 CLI from the system `PATH` or supported user-local locations (`~/.local/bin` and `~/bin`).
  - The resolved CLI path is used directly, improving reliability when user-installed T3 binaries are not on `PATH`.
  - T3 execution now remains reliable when user-local Node.js or fallback command entries could otherwise interfere.
  - Node.js resolution behavior remains unchanged, preserving existing precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->