### PR TITLE
fix(cli): pin shared Effect dependency for npm installs

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,6 +25,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.260",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
     "@opencode-ai/sdk": "^1.3.15",

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -24,8 +24,9 @@
         "scripts/cli.ts",
         "src/provider/testFixtures/*.mjs",
       ],
+      // Keep the transitive Effect runtime pinned for standalone npm installs.
       // Native msgpack acceleration and the Vite+ web build prerequisite.
-      "ignoreDependencies": ["msgpackr-extract", "@t3tools/web"],
+      "ignoreDependencies": ["@effect/platform-node-shared", "msgpackr-extract", "@t3tools/web"],
     },
     "apps/desktop": {
       // Electron loads these bundles by filename rather than importing them.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       '@effect/platform-node':
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112(bufferutil@4.1.0)(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))(redis@6.2.1)(utf-8-validate@6.0.6)
+      '@effect/platform-node-shared':
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112(bufferutil@4.1.0)(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))(utf-8-validate@6.0.6)
       '@effect/sql-sqlite-bun':
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112(effect@4.0.0-rc.112(patch_hash=8bef799f35729cf3465eb428196f617b434a7c9f658d56acb2874d74b21b98b2))


### PR DESCRIPTION
Fresh npm installs can hang in an `ERESOLVE` loop because the pinned Effect platform packages allow newer `@effect/platform-node-shared` prereleases. npm selects rc.114, whose `effect` peer is unavailable, and ignores T3's published overrides because T3 is a dependency rather than the install root. Remote Update eventually fails at the install timeout.

Declare `@effect/platform-node-shared` as a direct catalog dependency so the published package pins it alongside the other Effect packages. Keep the intentional transitive pin in Knip's dependency exclusions. This fixes the package consumed by existing updaters and fresh npm installs once a new release is published; it does not repair existing npm tarballs.

Refs #11208. This is a smaller package-level alternative to the installer changes in #11232.

Validation:
- Built the web client and server CLI from upstream main plus this change.
- Exercised the publish command's metadata preparation and restoration with its publish subprocess redirected to `vp pm pack` (no registry publication).
- Installed the resulting tarball outside the workspace with an empty npm cache: 141 packages installed in 10 seconds on macOS arm64, Node 24.12.0 / npm 11.17.0.
- `npm ls effect @effect/platform-node-shared --all` shows one deduplicated rc.112 version of each; the installed CLI's `__service-preflight` returned `ready` with launcher protocol 2.
- All 15 CLI packaging tests pass; frozen-lockfile install, scoped Knip dependency check, formatting, and `git diff --check` pass.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a runtime dependency to improve compatibility for standalone server package installations.
  - Updated dependency analysis configuration to account for the new runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->