### PR TITLE
fix(server): detect GitHub sign-in on gh releases without `--json`

### DIFF
--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -7,7 +7,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubCli from "./GitHubCli.ts";
-import { parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
+import { parseGitHubAuthStatus, parseGitHubAuthStatusText } from "./gitHubAuthStatus.ts";
 import * as GitHubSourceControlProvider from "./GitHubSourceControlProvider.ts";
 
 const processResult = (
@@ -398,5 +398,83 @@ it("reports an update hint instead of unauthenticated when gh predates --json", 
   assert.match(
     Option.getOrElse(auth.detail, () => ""),
     /2\.81\.0/,
+  );
+});
+
+it("reads the plain `gh auth status` fallback used by gh versions without --json", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth(
+    processResult(
+      [
+        "github.com",
+        "  ✓ Logged in to github.com account active-user (/home/dev/.config/gh/hosts.yml)",
+        "  - Active account: true",
+        "  - Git operations protocol: https",
+        "  - Token: gho_************************************",
+        "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'",
+        "",
+      ].join("\n"),
+    ),
+  );
+
+  assert.deepStrictEqual(
+    {
+      status: auth.status,
+      account: auth.account,
+      host: auth.host,
+    },
+    {
+      status: "authenticated",
+      account: Option.some("active-user"),
+      host: Option.some("github.com"),
+    },
+  );
+});
+
+it("prefers the active account when plain `gh auth status` lists several", () => {
+  assert.deepStrictEqual(
+    parseGitHubAuthStatusText(
+      [
+        "github.com",
+        "  ✓ Logged in to github.com account stale-user (keyring)",
+        "  - Active account: false",
+        "  ✓ Logged in to github.com as active-user (keyring)",
+        "  - Active account: true",
+        "",
+      ].join("\n"),
+    ),
+    {
+      parsed: true,
+      accounts: [
+        {
+          host: "github.com",
+          account: "stale-user",
+          authenticated: true,
+          active: false,
+          error: null,
+        },
+        {
+          host: "github.com",
+          account: "active-user",
+          authenticated: true,
+          active: true,
+          error: null,
+        },
+      ],
+    },
+  );
+});
+
+it("does not read failed plain `gh auth status` logins as authenticated accounts", () => {
+  assert.deepStrictEqual(
+    parseGitHubAuthStatusText(
+      [
+        "github.com",
+        "  X Failed to log in to github.com account stale-user (keyring)",
+        "  - Active account: true",
+        "  - The token in keyring is invalid.",
+        "",
+      ].join("\n"),
+    ),
+    { parsed: false, accounts: [] },
   );
 });

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -9,7 +9,11 @@ import {
 } from "@t3tools/contracts";
 
 import * as GitHubCli from "./GitHubCli.ts";
-import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
+import {
+  findAuthenticatedGitHubAccount,
+  parseGitHubAuthStatus,
+  parseGitHubAuthStatusText,
+} from "./gitHubAuthStatus.ts";
 import { decodeGitHubPullRequestListJson } from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import {
@@ -50,7 +54,10 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
 
 function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   const output = combinedAuthOutput(input);
-  const authStatus = parseGitHubAuthStatus(input.stdout);
+  const jsonStatus = parseGitHubAuthStatus(input.stdout);
+  // The JSON probe is preferred, but gh rejects `--json` before 2.81.0. `fallbackAuthArgs` reruns
+  // the same probe without the flag, and that plain text is what lands here on those versions.
+  const authStatus = jsonStatus.parsed ? jsonStatus : parseGitHubAuthStatusText(output);
   const authenticatedAccount = findAuthenticatedGitHubAccount(authStatus.accounts);
   const host = authenticatedAccount?.host;
 
@@ -74,7 +81,8 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   }
 
   // gh gained `auth status --json` in 2.81.0. Older versions reject the flag and exit
-  // non-zero, which reads exactly like a signed-out CLI. Name the real problem instead.
+  // non-zero, which reads exactly like a signed-out CLI. The text fallback above covers the
+  // signed-in case, so only an unreadable old CLI reaches here.
   if (input.exitCode !== 0 && output.includes("unknown flag: --json")) {
     return providerAuth({
       status: "unknown",
@@ -105,6 +113,7 @@ export const discovery = {
   executable: "gh",
   versionArgs: ["--version"],
   authArgs: ["auth", "status", "--json", "hosts"],
+  fallbackAuthArgs: ["auth", "status"],
   parseAuth: parseGitHubAuth,
   installHint:
     "Install the GitHub command-line tool (`gh`) via https://cli.github.com/ or your package manager (for example `brew install gh`).",

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -169,6 +169,92 @@ it.effect("reports implemented tools separately from locally available executabl
   }).pipe(Effect.provide(testLayer));
 });
 
+it.effect("falls back to plain `gh auth status` when the installed gh rejects --json", () => {
+  const processMock = {
+    run: (input: VcsProcess.VcsProcessInput) => {
+      if (input.args[0] === "--version") {
+        return Effect.succeed(
+          processOutput(
+            input.command === "gh"
+              ? "gh version 2.46.0 (2025-12-13 Ubuntu 2.46.0-4)\n"
+              : `${input.command} version test\n`,
+          ),
+        );
+      }
+      if (input.command === "gh" && input.args.join(" ") === "auth status --json hosts") {
+        return Effect.succeed(
+          processOutput("", {
+            stderr: "unknown flag: --json\n\nUsage:  gh auth status [flags]\n",
+            exitCode: ChildProcessSpawner.ExitCode(1),
+          }),
+        );
+      }
+      if (input.command === "gh" && input.args.join(" ") === "auth status") {
+        return Effect.succeed(
+          processOutput(`github.com
+  ✓ Logged in to github.com account octocat (/home/dev/.config/gh/hosts.yml)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_************************************
+`),
+        );
+      }
+      return Effect.fail(
+        new VcsProcessSpawnError({
+          operation: input.operation,
+          command: input.command,
+          cwd: input.cwd,
+          cause: new Error(`${input.command} not found`),
+        }),
+      );
+    },
+  } satisfies Partial<VcsProcess.VcsProcess["Service"]>;
+  const testLayer = SourceControlDiscovery.layer.pipe(
+    Layer.provide(
+      ServerConfig.layerTest(process.cwd(), {
+        prefix: "t3-source-control-legacy-gh-discovery-",
+      }),
+    ),
+    Layer.provide(Layer.mock(VcsProcess.VcsProcess)(processMock)),
+    Layer.provide(
+      sourceControlProviderRegistryTestLayer({
+        process: processMock,
+        bitbucket: {
+          probeAuth: Effect.succeed({
+            status: "unauthenticated",
+            account: Option.none(),
+            host: Option.none(),
+            detail: Option.none(),
+          }),
+        },
+      }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
+  return Effect.gen(function* () {
+    const discovery = yield* SourceControlDiscovery.SourceControlDiscovery;
+    const result = yield* discovery.discover;
+    const github = result.sourceControlProviders.find((item) => item.kind === "github");
+
+    assert.ok(github);
+    assert.deepStrictEqual(
+      {
+        auth: github.auth.status,
+        account: github.auth.account,
+        host: github.auth.host,
+        detail: github.auth.detail,
+      },
+      {
+        auth: "authenticated",
+        account: Option.some("octocat"),
+        host: Option.some("github.com"),
+        detail: Option.none(),
+      },
+    );
+  }).pipe(Effect.provide(testLayer));
+});
+
 it.effect("probes provider authentication without exposing token details", () => {
   const processMock = {
     run: (input: VcsProcess.VcsProcessInput) => {

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -33,6 +33,12 @@ export type SourceControlCliDiscoverySpec = SourceControlDiscoverySpecBase & {
   readonly executable: string;
   readonly versionArgs: ReadonlyArray<string>;
   readonly authArgs: ReadonlyArray<string>;
+  /**
+   * Second auth probe for CLIs whose preferred flags only exist on newer releases. It runs only
+   * when `authArgs` leaves the status `unknown`, and its answer is used only when it resolves,
+   * so the richer probe still wins and its diagnostic survives when both fail.
+   */
+  readonly fallbackAuthArgs?: ReadonlyArray<string>;
   readonly probeTimeoutMs?: number;
   readonly parseAuth: (input: SourceControlAuthProbeInput) => SourceControlProviderAuth;
   readonly refineUnknownRemote?: (
@@ -209,6 +215,31 @@ function probeCli(input: {
     );
 }
 
+function probeCliAuth(input: {
+  readonly spec: SourceControlCliDiscoverySpec;
+  readonly process: VcsProcess.VcsProcess["Service"];
+  readonly cwd: string;
+  readonly args: ReadonlyArray<string>;
+}): Effect.Effect<SourceControlProviderAuth> {
+  return input.process
+    .run({
+      operation: "source-control.discovery.auth",
+      command: input.spec.executable,
+      args: input.args,
+      cwd: input.cwd,
+      allowNonZeroExit: true,
+      timeoutMs: probeTimeoutMs(input.spec),
+      maxOutputBytes: 8_000,
+      appendTruncationMarker: true,
+    })
+    .pipe(
+      Effect.map((result) => input.spec.parseAuth(result)),
+      Effect.catch((cause) =>
+        Effect.succeed(unknownAuth(Option.getOrUndefined(detailFromCause(cause)))),
+      ),
+    );
+}
+
 export function probeSourceControlProvider(input: {
   readonly spec: SourceControlProviderDiscoverySpec;
   readonly process: VcsProcess.VcsProcess["Service"];
@@ -246,32 +277,26 @@ export function probeSourceControlProvider(input: {
         } satisfies SourceControlProviderDiscoveryItem);
       }
 
-      return input.process
-        .run({
-          operation: "source-control.discovery.auth",
-          command: spec.executable,
-          args: spec.authArgs,
-          cwd: input.cwd,
-          allowNonZeroExit: true,
-          timeoutMs: probeTimeoutMs(spec),
-          maxOutputBytes: 8_000,
-          appendTruncationMarker: true,
-        })
-        .pipe(
-          Effect.map(
-            (result) =>
-              ({
-                ...item,
-                auth: spec.parseAuth(result),
-              }) satisfies SourceControlProviderDiscoveryItem,
-          ),
-          Effect.catch((cause) =>
-            Effect.succeed({
-              ...item,
-              auth: unknownAuth(Option.getOrUndefined(detailFromCause(cause))),
-            } satisfies SourceControlProviderDiscoveryItem),
-          ),
-        );
+      return probeCliAuth({
+        spec,
+        process: input.process,
+        cwd: input.cwd,
+        args: spec.authArgs,
+      }).pipe(
+        Effect.flatMap((auth) => {
+          const fallbackArgs = spec.fallbackAuthArgs;
+          if (auth.status !== "unknown" || fallbackArgs === undefined) {
+            return Effect.succeed(auth);
+          }
+          return probeCliAuth({
+            spec,
+            process: input.process,
+            cwd: input.cwd,
+            args: fallbackArgs,
+          }).pipe(Effect.map((fallback) => (fallback.status === "unknown" ? auth : fallback)));
+        }),
+        Effect.map((auth) => ({ ...item, auth }) satisfies SourceControlProviderDiscoveryItem),
+      );
     }),
   );
 }

--- a/apps/server/src/sourceControl/gitHubAuthStatus.ts
+++ b/apps/server/src/sourceControl/gitHubAuthStatus.ts
@@ -62,6 +62,41 @@ export function parseGitHubAuthStatus(text: string): GitHubAuthStatus {
   });
 }
 
+// gh only learned `auth status --json` in 2.81.0, so distributions pinned to an older release
+// (Debian and Ubuntu still ship 2.46.0) can report sign-in state through the text output only.
+// That text has been stable for years: one `Logged in to <host> account <login>` line per account
+// (`as <login>` before 2.40.0), each followed by its own `Active account:` line.
+const LOGGED_IN_LINE = /Logged in to (\S+) (?:account|as) ([^\s(]+)/u;
+const ACTIVE_ACCOUNT_LINE = /Active account:\s*(\S+)/iu;
+
+export function parseGitHubAuthStatusText(text: string): GitHubAuthStatus {
+  const accounts: Array<GitHubAuthStatusAccount> = [];
+
+  for (const line of text.split(/\r?\n/)) {
+    const loggedIn = LOGGED_IN_LINE.exec(line);
+    const host = loggedIn ? nonEmptyString(loggedIn[1] ?? "") : null;
+    const login = loggedIn ? nonEmptyString(loggedIn[2] ?? "") : null;
+    if (host !== null && login !== null) {
+      accounts.push({
+        host: host.toLowerCase(),
+        account: login,
+        authenticated: true,
+        active: false,
+        error: null,
+      });
+      continue;
+    }
+
+    const active = ACTIVE_ACCOUNT_LINE.exec(line);
+    const current = accounts.at(-1);
+    if (active && current) {
+      accounts[accounts.length - 1] = { ...current, active: active[1]?.toLowerCase() === "true" };
+    }
+  }
+
+  return { parsed: accounts.length > 0, accounts };
+}
+
 export function findAuthenticatedGitHubAccount(
   accounts: ReadonlyArray<GitHubAuthStatusAccount>,
 ): GitHubAuthStatusAccount | undefined {

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -11,7 +11,7 @@ and choose **Rescan**.
 
 ### GitHub
 
-Install [GitHub CLI](https://cli.github.com/) 2.81.0 or newer, then sign in:
+Install [GitHub CLI](https://cli.github.com/), then sign in:
 
 ```bash
 gh auth login
@@ -86,7 +86,7 @@ reopening a declined pull request.
 
 - **Not authenticated:** run the provider's login command on the server, then rescan. For Bitbucket,
   confirm the running server received the environment variables.
-- **GitHub sign-in cannot be verified:** update GitHub CLI to at least 2.81.0.
+- **GitHub sign-in cannot be verified:** update GitHub CLI, then rescan.
 - **Push fails despite a connected account:** check the Git remote's credentials. SSH and HTTPS
   remotes can require separate setup from the hosting provider's API access.
 - **A review cannot load:** open it on the host website while resolving connectivity, permissions,


### PR DESCRIPTION
## What Changed

`SourceControlCliDiscoverySpec` gains an optional `fallbackAuthArgs`. It runs a second auth probe only when the primary one leaves the status `unknown`, and its answer is used only when it resolves — so the richer probe still wins, and its diagnostic survives when both fail.

The GitHub spec sets it to plain `gh auth status` and parses that text output (`parseGitHubAuthStatusText`), the same approach `GitLabSourceControlProvider` already uses for `glab`. `gh auth status --json hosts` stays the primary probe.

## Why

Discovery probes `gh auth status --json hosts`. That flag landed in [gh 2.81.0](https://github.com/cli/cli/pull/11544) (released 2025-10-01). Every older release rejects it:

```
$ gh --version
gh version 2.46.0 (2025-12-13 Ubuntu 2.46.0-4)

$ gh auth status --json hosts
unknown flag: --json
$ echo $?
1

$ gh auth status
github.com
  ✓ Logged in to github.com account <redacted> (~/.config/gh/hosts.yml)
  - Active account: true
  - Git operations protocol: https
```

So **Settings → Source Control** shows "Could not verify GitHub. GitHub CLI is too old to report sign-in status." on a CLI that is signed in and fully usable. Debian and Ubuntu still ship gh 2.46.0 in their repositories, so this is the default experience on those distributions — `apt install gh` gets you a working, authenticated CLI that T3 Code refuses to use.

The text output already carries everything discovery needs, and it has been stable for years: one `Logged in to <host> account <login>` line per account (`as <login>` before 2.40.0), each followed by its own `Active account:` line. `X Failed to log in to ...` lines do not match, so broken accounts are not read as authenticated.

Telling users to upgrade is still the better long-term answer, but it should not be a hard requirement when the information is right there. The "update gh" hint is kept for the case where both probes come back unreadable.

## UI Changes

None beyond the provider row resolving to the signed-in account instead of the error state.

## Testing

- `SourceControlDiscovery.test.ts`: end-to-end discovery with a gh 2.46.0 mock — `--json` rejected, plain `auth status` text returned — now resolves to `authenticated`. Reverting the source change fails this test.
- `GitHubSourceControlProvider.test.ts`: text parsing for the signed-in case, multi-account active selection, and the failed-login case. Existing JSON-path tests unchanged.
- `tsc --noEmit`, `vp lint`, and `vp fmt --check` are clean.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub CLI authentication detection for older CLI versions that do not support JSON output.
  - Added fallback handling for plain-text authentication status, including active-account selection and failed-login detection.
  - GitHub source-control discovery now retries authentication checks when the primary method cannot determine a result.

- **Documentation**
  - Updated GitHub CLI setup guidance to recommend installing or updating the CLI without requiring a specific minimum version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->