### PR TITLE
fix(web): respect model changes from other clients

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1571,6 +1571,9 @@ export default function ChatView(props: ChatViewProps) {
   );
   const setComposerDraftReviewComments = useComposerDraftStore((store) => store.setReviewComments);
   const setComposerDraftModelSelection = useComposerDraftStore((store) => store.setModelSelection);
+  const acknowledgeComposerModelSelection = useComposerDraftStore(
+    (store) => store.acknowledgeModelSelection,
+  );
   const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
   const setComposerDraftInteractionMode = useComposerDraftStore(
     (store) => store.setInteractionMode,
@@ -6538,6 +6541,7 @@ export default function ChatView(props: ChatViewProps) {
     }
     const context = composerRef.current?.getSendContext();
     if (!context?.providerAvailable) return;
+    const submittedDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
 
     // Compaction is a standalone command; the draft and its attachments stay local.
     const threadId = activeThread.id;
@@ -6597,6 +6601,7 @@ export default function ChatView(props: ChatViewProps) {
           );
         }
       } else {
+        acknowledgeComposerModelSelection(composerDraftTarget, submittedDraft);
         clearUsageLimitsFor(routeThreadKey);
       }
     } finally {
@@ -6706,6 +6711,7 @@ export default function ChatView(props: ChatViewProps) {
       interactionMode: sendInteractionMode,
       interactionModeEnabled: sendInteractionModeEnabled,
     } = sendCtx;
+    const submittedDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
     const annotationImageAlreadyAttached =
       directAnnotation?.image !== undefined &&
       sendContextImages.some((image) => image.id === directAnnotation.image?.id);
@@ -7250,6 +7256,10 @@ export default function ChatView(props: ChatViewProps) {
         failure = startResult;
       } else {
         turnStartSucceeded = true;
+        acknowledgeComposerModelSelection(
+          scopeThreadRef(activeThread.environmentId, threadIdForSend),
+          submittedDraft,
+        );
         // The turn is under way and will spend quota, so that thread's limits
         // snapshot is stale. Uploads may have outlasted a navigation, so only
         // the sending thread's panel clears.
@@ -7656,6 +7666,7 @@ export default function ChatView(props: ChatViewProps) {
         selectedPromptEffort: ctxSelectedPromptEffort,
         selectedModelSelection: ctxSelectedModelSelection,
       } = sendCtx;
+      const submittedDraft = useComposerDraftStore.getState().getComposerDraft(composerDraftTarget);
 
       const threadIdForSend = activeThread.id;
       const messageIdForSend = newMessageId();
@@ -7737,6 +7748,7 @@ export default function ChatView(props: ChatViewProps) {
       }
 
       if (failure === null) {
+        acknowledgeComposerModelSelection(composerDraftTarget, submittedDraft);
         clearUsageLimitsFor(routeThreadKey);
         acknowledgeActiveThreadWoke();
         sendInFlightRef.current = false;
@@ -7760,7 +7772,9 @@ export default function ChatView(props: ChatViewProps) {
       activeThread,
       activeProposedPlan,
       acknowledgeActiveThreadWoke,
+      acknowledgeComposerModelSelection,
       beginLocalDispatch,
+      composerDraftTarget,
       isConnecting,
       isSendBusy,
       isServerThread,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1407,7 +1407,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadEnvironmentId: _activeThreadEnvironmentId,
     activeThread,
     promptHistoryMessages,
-    isServerThread: _isServerThread,
+    isServerThread,
     isLocalDraftThread: _isLocalDraftThread,
     forceExpandedOnMobile,
     projectSelectionRequired,
@@ -1755,8 +1755,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     providers: providerStatuses,
     selectedProvider,
     selectedInstanceId,
-    threadModelSelection: activeThreadModelSelection,
-    projectModelSelection: activeProjectDefaultModelSelection,
+    threadModelSelection: isServerThread ? activeThreadModelSelection : null,
+    projectModelSelection: isServerThread
+      ? activeProjectDefaultModelSelection
+      : activeThreadModelSelection,
     settings,
   });
   const providerSendBlockReason = getAntigravitySendBlockReason(

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -18,6 +18,7 @@ import {
   type ProviderOptionSelection,
 } from "@t3tools/contracts";
 import { createModelSelection } from "@t3tools/shared/model";
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import {
   collectAssistantCitations,
   serializeAssistantCitation,
@@ -67,6 +68,7 @@ import {
   COMPOSER_DRAFT_STORAGE_KEY,
   clearComposerDraftsEnvironment,
   composerDraftHasUserContent,
+  deriveEffectiveComposerModelState,
   finalizePromotedDraftThreadByRef,
   markPromotedDraftThreadByRef,
   type ComposerFileAttachment,
@@ -83,6 +85,7 @@ import {
   type TerminalContextDraft,
 } from "./lib/terminalContext";
 import { createDeferredStorage } from "./lib/storage";
+import { resolveThreadMetadataUpdateForNextTurn } from "./components/ChatView.logic";
 
 function makeImage(input: {
   id: string;
@@ -1721,6 +1724,186 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 });
+
+describe.each([CODEX_INSTANCE, CODEX_SECONDARY_INSTANCE])(
+  "composerDraftStore synchronized thread model (%s)",
+  (instanceId) => {
+    const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, ThreadId.make("thread-model-sync"));
+    const sol = createModelSelection(
+      instanceId,
+      "gpt-5.6-sol",
+      toSelections({ reasoningEffort: "low" }),
+    );
+    const astra = createModelSelection(
+      instanceId,
+      "gpt-6-astra",
+      toSelections({ reasoningEffort: "high" }),
+    );
+
+    beforeEach(resetComposerDraftStore);
+
+    function nextSelection(threadModelSelection: ModelSelection) {
+      const state = deriveEffectiveComposerModelState({
+        draft: useComposerDraftStore.getState().getComposerDraft(threadRef),
+        providers: [
+          {
+            instanceId: threadModelSelection.instanceId,
+            driver: CODEX_DRIVER,
+            enabled: true,
+            installed: true,
+            version: null,
+            status: "ready",
+            auth: { status: "authenticated" },
+            checkedAt: "2026-01-01T00:00:00.000Z",
+            models: ["gpt-5.6-sol", "gpt-6-astra", "gpt-5.6-terra"].map((slug) => ({
+              slug,
+              name: slug,
+              isCustom: false,
+              capabilities: {},
+            })),
+            slashCommands: [],
+            skills: [],
+          },
+        ],
+        selectedProvider: CODEX_DRIVER,
+        selectedInstanceId: threadModelSelection.instanceId,
+        threadModelSelection,
+        projectModelSelection: null,
+        settings: DEFAULT_UNIFIED_SETTINGS,
+      });
+      return createModelSelection(
+        threadModelSelection.instanceId,
+        state.selectedModel,
+        state.modelOptions?.[threadModelSelection.instanceId],
+      );
+    }
+
+    it("uses a remote model change after submitting the desktop selection", () => {
+      const store = useComposerDraftStore.getState();
+      store.setModelSelection(threadRef, sol, { explicit: true });
+      store.setPrompt(threadRef, "First synthetic turn");
+      expect(nextSelection(sol)).toEqual(sol);
+      const submittedDraft = store.getComposerDraft(threadRef);
+      store.clearComposerContent(threadRef);
+      store.acknowledgeModelSelection(threadRef, submittedDraft);
+
+      // The synchronized thread now contains the selection saved by another client.
+      store.setPrompt(threadRef, "Next synthetic turn");
+      const next = nextSelection(astra);
+      expect(next).toEqual(astra);
+      expect(
+        resolveThreadMetadataUpdateForNextTurn({
+          currentModelSelection: astra,
+          nextModelSelection: next,
+          currentBranch: null,
+        }),
+      ).toBeNull();
+    });
+
+    it("keeps unsent content and per-instance caches while following remote model and option changes", () => {
+      const store = useComposerDraftStore.getState();
+      const otherInstance = ProviderInstanceId.make("codex_other");
+      const otherSelection = createModelSelection(
+        otherInstance,
+        "gpt-5.6-terra",
+        toSelections({ reasoningEffort: "xhigh" }),
+      );
+      store.setModelSelection(threadRef, otherSelection, { explicit: true });
+      store.setModelSelection(threadRef, sol, { explicit: true });
+      const submittedDraft = store.getComposerDraft(threadRef);
+      store.clearComposerContent(threadRef);
+      store.setPrompt(threadRef, "Keep this unsent text");
+      store.addImage(threadRef, makeImage({ id: "unsent-image", previewUrl: "blob:unsent-image" }));
+      store.addFiles(threadRef, [makeFile("unsent-file")]);
+      const unsentDraft = store.getComposerDraft(threadRef);
+      store.acknowledgeModelSelection(threadRef, submittedDraft);
+
+      expect(nextSelection(astra)).toEqual(astra);
+      const withoutOptions = createModelSelection(instanceId, astra.model);
+      expect(nextSelection(withoutOptions)).toEqual(withoutOptions);
+      const draft = store.getComposerDraft(threadRef);
+      expect(draft?.prompt).toBe(unsentDraft?.prompt);
+      expect(draft?.images).toBe(unsentDraft?.images);
+      expect(draft?.files).toBe(unsentDraft?.files);
+      expect(draft?.modelSelectionByProvider).toEqual({
+        [instanceId]: sol,
+        [otherInstance]: otherSelection,
+      });
+
+      store.setModelSelection(
+        threadRef,
+        createModelSelection(otherInstance, otherSelection.model),
+        { explicit: true },
+      );
+      expect(nextSelection(createModelSelection(otherInstance, sol.model))).toEqual(otherSelection);
+    });
+
+    it("keeps a new explicit local choice over the synchronized model", () => {
+      const store = useComposerDraftStore.getState();
+      store.setModelSelection(threadRef, astra, { explicit: true });
+      const submittedDraft = store.getComposerDraft(threadRef);
+      store.clearComposerContent(threadRef);
+      store.acknowledgeModelSelection(threadRef, submittedDraft);
+      store.setModelSelection(threadRef, sol, { explicit: true });
+      expect(nextSelection(astra)).toEqual(sol);
+    });
+
+    it("does not consume a model choice made while a send is in flight", () => {
+      const store = useComposerDraftStore.getState();
+      store.setModelSelection(threadRef, sol, { explicit: true });
+      const submittedDraft = store.getComposerDraft(threadRef);
+      store.clearComposerContent(threadRef);
+      store.setModelSelection(threadRef, astra, { explicit: true });
+      store.acknowledgeModelSelection(threadRef, submittedDraft);
+      expect(nextSelection(sol)).toEqual(astra);
+    });
+
+    it.each([{ options: toSelections({ reasoningEffort: "xhigh" }) }, { options: [] }])(
+      "edits traits on the synchronized model without restoring the cached model ($options)",
+      ({ options }) => {
+        const store = useComposerDraftStore.getState();
+        store.setModelSelection(threadRef, sol, { explicit: true });
+        store.acknowledgeModelSelection(threadRef, store.getComposerDraft(threadRef));
+        const current = nextSelection(astra);
+        store.setProviderModelOptions(threadRef, CODEX_DRIVER, options, {
+          instanceId,
+          model: current.model,
+          persistSticky: true,
+        });
+        const expected = createModelSelection(instanceId, astra.model, options);
+        expect(nextSelection(astra)).toEqual(expected);
+        expect(useComposerDraftStore.getState().stickyModelSelectionByProvider[instanceId]).toEqual(
+          expected,
+        );
+      },
+    );
+
+    it("retains an unsent choice after clearing content for a failed submission", () => {
+      const store = useComposerDraftStore.getState();
+      store.setModelSelection(threadRef, sol, { explicit: true });
+      store.clearComposerContent(threadRef);
+      // A failed send restores content without acknowledging the model selection.
+      store.setPrompt(threadRef, "Retry this synthetic turn");
+      expect(nextSelection(astra)).toEqual(sol);
+    });
+
+    it("follows remote selections after persisted draft rehydration", async () => {
+      vi.useFakeTimers();
+      try {
+        const store = useComposerDraftStore.getState();
+        store.setModelSelection(threadRef, sol, { explicit: true });
+        store.clearComposerContent(threadRef);
+        store.acknowledgeModelSelection(threadRef, store.getComposerDraft(threadRef));
+        await vi.advanceTimersByTimeAsync(300);
+        resetComposerDraftStore();
+        await useComposerDraftStore.persist.rehydrate();
+        expect(nextSelection(astra)).toEqual(astra);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  },
+);
 
 describe("composerDraftStore modelSelection", () => {
   const threadId = ThreadId.make("thread-model-options");

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1887,6 +1887,26 @@ describe.each([CODEX_INSTANCE, CODEX_SECONDARY_INSTANCE])(
       expect(nextSelection(astra)).toEqual(sol);
     });
 
+    it("accepts a trait choice that matches the cache but differs from the synchronized options", () => {
+      const store = useComposerDraftStore.getState();
+      const localOptions = toSelections({ reasoningEffort: "low" });
+      store.setProviderModelOptions(threadRef, CODEX_DRIVER, localOptions, {
+        instanceId,
+        model: sol.model,
+        persistSticky: true,
+      });
+      store.acknowledgeModelSelection(threadRef, store.getComposerDraft(threadRef));
+      const remote = createModelSelection(instanceId, sol.model, astra.options);
+      expect(nextSelection(remote)).toEqual(remote);
+
+      store.setProviderModelOptions(threadRef, CODEX_DRIVER, localOptions, {
+        instanceId,
+        model: sol.model,
+        persistSticky: true,
+      });
+      expect(nextSelection(remote)).toEqual(sol);
+    });
+
     it("follows remote selections after persisted draft rehydration", async () => {
       vi.useFakeTimers();
       try {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -684,11 +684,10 @@ export interface EffectiveComposerModelState {
   modelOptions: ProviderOptionSelectionsByProvider | null;
 }
 
-interface ComposerDraftModelState {
-  activeProvider: ProviderInstanceId | null;
-  modelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>>;
-  modelSelectionExplicit?: boolean;
-}
+type ComposerDraftModelState = Pick<
+  ComposerThreadDraftState,
+  "activeProvider" | "modelSelectionByProvider" | "modelSelectionExplicit"
+>;
 
 function providerSelectionsFromModelSelection(
   modelSelection: ModelSelection | null | undefined,
@@ -1237,20 +1236,20 @@ export function deriveEffectiveComposerModelState(input: {
         activeSelection.model,
       ))
     : baseModel;
-  let modelOptions =
+  const baseModelOptions =
     modelSelectionByProviderToOptions(input.draft?.modelSelectionByProvider) ??
     providerSelectionsFromModelSelection(input.threadModelSelection) ??
     providerSelectionsFromModelSelection(input.projectModelSelection) ??
     null;
   const selectedOptionsSource = useThreadSelection ? input.threadModelSelection : activeSelection;
-  if (selectedOptionsSource) {
-    // Replace this instance's options as a complete snapshot, including an
-    // empty selection. Keep the other instances' cached options for switching.
-    modelOptions = {
-      ...modelOptions,
-      [selectedOptionsSource.instanceId]: selectedOptionsSource.options ?? [],
-    };
-  }
+  // Replace this instance's options as a complete snapshot, including an
+  // empty selection. Keep the other instances' cached options for switching.
+  const modelOptions = selectedOptionsSource
+    ? {
+        ...baseModelOptions,
+        [selectedOptionsSource.instanceId]: selectedOptionsSource.options ?? [],
+      }
+    : baseModelOptions;
 
   return {
     selectedModel,
@@ -3171,10 +3170,9 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return;
           }
           const instanceKey = options?.instanceId ?? defaultInstanceIdForDriver(normalizedProvider);
+          const requestedModel = normalizeModelSlug(options?.model, normalizedProvider);
           const fallbackModel =
-            normalizeModelSlug(options?.model, normalizedProvider) ??
-            DEFAULT_MODEL_BY_PROVIDER[normalizedProvider] ??
-            DEFAULT_MODEL;
+            requestedModel ?? DEFAULT_MODEL_BY_PROVIDER[normalizedProvider] ?? DEFAULT_MODEL;
           const providerOpts =
             nextProviderOptions && nextProviderOptions.length > 0 ? nextProviderOptions : undefined;
 
@@ -3185,10 +3183,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             // Update the map entry for this provider
             const nextMap = { ...base.modelSelectionByProvider };
             const currentForProvider = nextMap[instanceKey];
-            const selectedModel =
-              normalizeModelSlug(options?.model, normalizedProvider) ??
-              currentForProvider?.model ??
-              fallbackModel;
+            const selectedModel = requestedModel ?? currentForProvider?.model ?? fallbackModel;
             if (providerOpts || options?.model !== undefined) {
               nextMap[instanceKey] = createModelSelection(instanceKey, selectedModel, providerOpts);
             } else if (currentForProvider && (currentForProvider.options?.length ?? 0) > 0) {
@@ -3215,7 +3210,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 : (base.activeProvider ?? instanceKey);
             }
 
+            const nextActiveProvider = options?.instanceId ?? base.activeProvider;
             if (
+              base.modelSelectionExplicit === true &&
+              base.activeProvider === nextActiveProvider &&
               Equal.equals(base.modelSelectionByProvider, nextMap) &&
               Equal.equals(state.stickyModelSelectionByProvider, nextStickyMap) &&
               state.stickyActiveProvider === nextStickyActiveProvider
@@ -3228,7 +3226,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const { modelSelectionExplicit: _previousExplicit, ...restBase } = base;
             const nextDraft: ComposerThreadDraftState = {
               ...restBase,
-              ...(options?.instanceId ? { activeProvider: instanceKey } : {}),
+              activeProvider: nextActiveProvider,
               modelSelectionByProvider: nextMap,
               modelSelectionExplicit: true,
             };

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -383,12 +383,12 @@ export interface ComposerThreadDraftState {
    * legacy kind-keyed drafts round-trip unchanged.
    */
   modelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>>;
-  /** Routing key of the last picked instance (see `modelSelectionByProvider`). */
+  /** Local instance override, released after a successful submission. */
   activeProvider: ProviderInstanceId | null;
   /**
-   * True only when a human picked the active selection in the composer.
-   * Absent/false means seeded (project default / sticky), so later seeds
-   * may replace it. Legacy entries predate the flag and read as seeded.
+   * True when a human picked a selection that has not been submitted yet.
+   * Otherwise the synchronized thread selection takes precedence over the
+   * cached selection. New drafts can still use project defaults / sticky state.
    */
   modelSelectionExplicit?: boolean;
   runtimeMode: RuntimeMode | null;
@@ -574,6 +574,10 @@ interface ComposerDraftStoreState {
       replaceOptions?: boolean;
     },
   ) => void;
+  acknowledgeModelSelection: (
+    threadRef: ComposerThreadTarget,
+    submittedDraft: ComposerDraftModelState | null,
+  ) => void;
   /** Replace the model options for one or more providers in the draft. */
   setModelOptions: (
     threadRef: ComposerThreadTarget,
@@ -683,6 +687,7 @@ export interface EffectiveComposerModelState {
 interface ComposerDraftModelState {
   activeProvider: ProviderInstanceId | null;
   modelSelectionByProvider: Partial<Record<ProviderInstanceId, ModelSelection>>;
+  modelSelectionExplicit?: boolean;
 }
 
 function providerSelectionsFromModelSelection(
@@ -1154,10 +1159,7 @@ function legacyToModelSelectionByProvider(
 }
 
 export function deriveEffectiveComposerModelState(input: {
-  draft:
-    | Pick<ComposerThreadDraftState, "modelSelectionByProvider" | "activeProvider">
-    | null
-    | undefined;
+  draft: ComposerDraftModelState | null | undefined;
   providers: ReadonlyArray<ServerProvider>;
   selectedProvider: ProviderDriverKind;
   /**
@@ -1211,7 +1213,11 @@ export function deriveEffectiveComposerModelState(input: {
     input.selectedInstanceId !== defaultInstanceIdForDriver(input.selectedProvider)
       ? undefined
       : input.draft?.modelSelectionByProvider?.[ProviderInstanceId.make(input.selectedProvider)];
-  const activeSelection = instanceSelection ?? legacySelection;
+  const useThreadSelection =
+    input.draft?.modelSelectionExplicit !== true &&
+    input.threadModelSelection?.instanceId ===
+      (input.selectedInstanceId ?? ProviderInstanceId.make(input.selectedProvider));
+  const activeSelection = useThreadSelection ? undefined : (instanceSelection ?? legacySelection);
   const activeSelectionInstanceId = instanceSelection
     ? (input.selectedInstanceId ?? ProviderInstanceId.make(input.selectedProvider))
     : ProviderInstanceId.make(input.selectedProvider);
@@ -1231,11 +1237,20 @@ export function deriveEffectiveComposerModelState(input: {
         activeSelection.model,
       ))
     : baseModel;
-  const modelOptions =
+  let modelOptions =
     modelSelectionByProviderToOptions(input.draft?.modelSelectionByProvider) ??
     providerSelectionsFromModelSelection(input.threadModelSelection) ??
     providerSelectionsFromModelSelection(input.projectModelSelection) ??
     null;
+  const selectedOptionsSource = useThreadSelection ? input.threadModelSelection : activeSelection;
+  if (selectedOptionsSource) {
+    // Replace this instance's options as a complete snapshot, including an
+    // empty selection. Keep the other instances' cached options for switching.
+    modelOptions = {
+      ...modelOptions,
+      [selectedOptionsSource.instanceId]: selectedOptionsSource.options ?? [],
+    };
+  }
 
   return {
     selectedModel,
@@ -3021,6 +3036,30 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
+        acknowledgeModelSelection: (threadRef, submittedDraft) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef);
+          if (!threadKey || !submittedDraft) return;
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            // Sending can outlast another model/trait edit. Only consume the
+            // submitted choice, without touching newly typed content or caches.
+            if (
+              !current ||
+              (!current.modelSelectionExplicit && current.activeProvider === null) ||
+              current.modelSelectionByProvider !== submittedDraft.modelSelectionByProvider ||
+              current.activeProvider !== submittedDraft.activeProvider
+            ) {
+              return state;
+            }
+            const { modelSelectionExplicit: _explicit, ...retained } = current;
+            return {
+              draftsByThreadKey: {
+                ...state.draftsByThreadKey,
+                [threadKey]: { ...retained, activeProvider: null },
+              },
+            };
+          });
+        },
         setModelSelection: (threadRef, modelSelection, opts) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
           if (threadKey.length === 0) {
@@ -3146,12 +3185,12 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             // Update the map entry for this provider
             const nextMap = { ...base.modelSelectionByProvider };
             const currentForProvider = nextMap[instanceKey];
-            if (providerOpts) {
-              nextMap[instanceKey] = createModelSelection(
-                instanceKey,
-                currentForProvider?.model ?? fallbackModel,
-                providerOpts,
-              );
+            const selectedModel =
+              normalizeModelSlug(options?.model, normalizedProvider) ??
+              currentForProvider?.model ??
+              fallbackModel;
+            if (providerOpts || options?.model !== undefined) {
+              nextMap[instanceKey] = createModelSelection(instanceKey, selectedModel, providerOpts);
             } else if (currentForProvider && (currentForProvider.options?.length ?? 0) > 0) {
               const { options: _, ...rest } = currentForProvider;
               nextMap[instanceKey] = rest as ModelSelection;
@@ -3166,16 +3205,11 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 nextStickyMap[instanceKey] ??
                 base.modelSelectionByProvider[instanceKey] ??
                 createModelSelection(instanceKey, fallbackModel);
-              if (providerOpts) {
-                nextStickyMap[instanceKey] = createModelSelection(
-                  instanceKey,
-                  stickyBase.model,
-                  providerOpts,
-                );
-              } else if ((stickyBase.options?.length ?? 0) > 0) {
-                const { options: _, ...rest } = stickyBase;
-                nextStickyMap[instanceKey] = rest as ModelSelection;
-              }
+              nextStickyMap[instanceKey] = createModelSelection(
+                instanceKey,
+                options?.model !== undefined ? selectedModel : stickyBase.model,
+                providerOpts,
+              );
               nextStickyActiveProvider = options.instanceId
                 ? instanceKey
                 : (base.activeProvider ?? instanceKey);
@@ -4135,6 +4169,7 @@ function useComposerDraftModelState(threadRef: ComposerThreadTarget): ComposerDr
         ? {
             activeProvider: draft.activeProvider,
             modelSelectionByProvider: draft.modelSelectionByProvider,
+            modelSelectionExplicit: draft.modelSelectionExplicit ?? false,
           }
         : EMPTY_COMPOSER_DRAFT_MODEL_STATE;
     }),
@@ -4147,7 +4182,7 @@ export function useEffectiveComposerModelState(input: {
   providers: ReadonlyArray<ServerProvider>;
   selectedProvider: ProviderDriverKind;
   /**
-   * When supplied, the draft's saved selection for this instance takes
+   * When supplied, the draft's pending selection for this instance takes
    * precedence over the driver-kind bucket — so a custom `codex_personal`
    * instance reads its own model, not the default Codex's.
    */

--- a/apps/web/src/modelSelection.test.ts
+++ b/apps/web/src/modelSelection.test.ts
@@ -748,7 +748,7 @@ describe("instance-scoped model selection", () => {
     ).toEqual(saved);
   });
 
-  it("keeps a custom-instance draft model while dropping unsupported options", () => {
+  it.each([false, true])("keeps custom draft models (server: %s)", (isServerThread) => {
     const instanceId = ProviderInstanceId.make("claude_openrouter");
     const driver = ProviderDriverKind.make("claudeAgent");
     const providers = [
@@ -764,13 +764,14 @@ describe("instance-scoped model selection", () => {
     const state = deriveEffectiveComposerModelState({
       draft: {
         activeProvider: instanceId,
+        modelSelectionExplicit: isServerThread,
         modelSelectionByProvider: { [instanceId]: draftSelection },
       },
       providers,
       selectedProvider: driver,
       selectedInstanceId: instanceId,
-      threadModelSelection: threadSelection,
-      projectModelSelection: null,
+      threadModelSelection: isServerThread ? threadSelection : null,
+      projectModelSelection: isServerThread ? null : threadSelection,
       settings: settingsWithProviderInstances(),
     });
     const dispatch = getComposerProviderState({


### PR DESCRIPTION
After sending with model A on desktop, selecting model B on mobile could be undone by the next desktop send. The composer retained A as a local override; `ChatView` persisted and dispatched it even though the synchronized thread already contained B.

Local model and option edits now override the thread until a successful turn start. Acknowledge only the submitted selection, preserving newer edits and unsent content. Keep per-instance caches, use synchronized model/options together, and apply trait edits to the displayed model. New local intent is respected even when its options match the cache.

Validation:
- Reproduced the Sol → submit → remote Astra → desktop Sol failure on unmodified main, using synthetic data with default and secondary Codex instances.
- 302 focused tests passed across `composerDraftStore`, `modelSelection`, and `ChatView.logic`. Coverage includes explicit edits, attachments, options, persistence, new drafts, and failed/in-flight sends.
- Web typecheck, formatting, and targeted lint passed. Existing lint warnings are in unchanged code.
- Automated verification only; no browser or physical-device testing. No visual layout changes.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved composer model selection across server and draft threads.
  * Preserved custom model choices and provider options more reliably, including when drafts contain unsent content or attachments.
  * Updated selection handling so submitted choices are acknowledged correctly without affecting unrelated pending selections.
  * Improved draft restoration and synchronization when model settings change remotely or submissions are in progress.

* **Tests**
  * Added coverage for model selection, draft persistence, synchronization, failed submissions, and provider option updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->