### PR TITLE
fix(desktop): preserve long offscreen text in SnapShots

### DIFF
--- a/apps/desktop/src/snapShot/DesktopSnapShot.test.ts
+++ b/apps/desktop/src/snapShot/DesktopSnapShot.test.ts
@@ -2780,6 +2780,43 @@ it("keeps a truncated element tree when the flat text read fails", async () => {
   );
 });
 
+it("keeps a truncated tree when flat text would not recover any text", async () => {
+  const bounds = { x: 0, y: 0, width: 800, height: 600 };
+  accessibilityByPidMock.mockReset().mockResolvedValue({
+    children: async () => [
+      {
+        role: "window",
+        name: "Editor",
+        bounds,
+        tree: async () => ({ name: "Editor", children: [{ name: "Help", children: [] }] }),
+        children: async () => [
+          {
+            role: "button",
+            name: "Help",
+            description: "Help text ".repeat(250),
+            bounds,
+            children: async () => [],
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = await readAccessibleWindowContext(
+    { title: "Editor", bounds, owner: { processId: 123 } },
+    "darwin",
+    "Editor",
+  );
+  assert.equal(result?.accessibility?.format, "element-tree");
+  assert.isTrue(result?.accessibility?.truncated);
+  assert.include(
+    result?.accessibility?.format === "element-tree"
+      ? result.accessibility.root.children[0]?.description
+      : undefined,
+    "Help text",
+  );
+});
+
 it("times out after three seconds without overlapping the outstanding accessibility read", async () => {
   vi.useFakeTimers();
   accessibilityByPidMock.mockReset();

--- a/apps/desktop/src/snapShot/DesktopSnapShot.test.ts
+++ b/apps/desktop/src/snapShot/DesktopSnapShot.test.ts
@@ -2479,7 +2479,7 @@ it.each(["client", "frame"] as const)(
   },
 );
 
-it.each(["darwin", "win32"] as const)(
+it.each(["darwin", "win32", "linux"] as const)(
   "extracts the same structured accessibility tree on %s",
   async (platform) => {
     const bounds = { x: 100, y: 200, width: 800, height: 600 };
@@ -2487,12 +2487,25 @@ it.each(["darwin", "win32"] as const)(
       role: "window",
       name: "Editor",
       bounds,
-      tree: async () => ({ name: "Editor", children: [{ name: "Save", children: [] }] }),
+      tree: async () => ({
+        name: "Editor",
+        children: [
+          { name: "Save", children: [] },
+          { name: "Below scroll view", children: [] },
+        ],
+      }),
       children: async () => [
         {
           role: "button",
           name: "Save",
           bounds: { x: 300, y: 350, width: 100, height: 50 },
+          children: async () => [],
+        },
+        {
+          role: "static_text",
+          name: "Below scroll view",
+          bounds: { x: 300, y: 1_000, width: 100, height: 50 },
+          visible: false,
           children: async () => [],
         },
       ],
@@ -2515,6 +2528,12 @@ it.each(["darwin", "win32"] as const)(
         ? result.accessibility.root.children[0]?.name
         : undefined,
       "Save",
+    );
+    assert.deepInclude(
+      result?.accessibility?.format === "element-tree"
+        ? result.accessibility.root.children[1]
+        : undefined,
+      { name: "Below scroll view", bounds: null, state: { visible: false } },
     );
     assert.lengthOf(accessibilityByPidMock.mock.calls, platform === "win32" ? 0 : 1);
     assert.lengthOf(accessibilityForegroundMock.mock.calls, platform === "win32" ? 1 : 0);
@@ -2548,6 +2567,48 @@ it.each(["darwin", "win32"] as const)(
         ),
       );
       assert.lengthOf(tree.mock.calls, 0);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  },
+);
+
+it.each([
+  ["darwin", "", "value", 650],
+  ["win32", "", "value", 650],
+  ["linux", "x11", "value", 650],
+  ["linux", "wayland", "value", 650],
+  ["darwin", "", "name", 100],
+] as const)(
+  "preserves long text outside the scroll view on %s %s (%s)",
+  async (platform, session, field, lines) => {
+    const text = `${"Document line\n".repeat(lines)}End of document`;
+    vi.stubEnv("XDG_SESSION_TYPE", session);
+    const bounds = { x: 0, y: 0, width: 800, height: 600 };
+    const window = {
+      role: "window",
+      name: "Editor",
+      bounds,
+      tree: async () => ({ name: "Editor", children: [{ [field]: text, children: [] }] }),
+      children: async () => [
+        { role: "text_area", [field]: text, bounds, children: async () => [] },
+      ],
+    };
+    accessibilityByPidMock.mockReset().mockResolvedValue({ children: async () => [window] });
+    accessibilityForegroundMock
+      .mockReset()
+      .mockResolvedValue({ pid: 123, asElement: () => window });
+    try {
+      const result = await readAccessibleWindowContext(
+        { title: "Editor", bounds, owner: { processId: 123 } },
+        platform,
+        "Editor",
+      );
+      assert.deepEqual(result?.accessibility, {
+        format: "flat-text",
+        text: `Editor\n${text}`,
+        truncated: false,
+      });
     } finally {
       vi.unstubAllEnvs();
     }
@@ -2679,6 +2740,44 @@ it("falls back to completed flat text when rich traversal reaches the deadline",
     await vi.advanceTimersByTimeAsync(0);
     vi.useRealTimers();
   }
+});
+
+it("keeps a truncated element tree when the flat text read fails", async () => {
+  const bounds = { x: 0, y: 0, width: 800, height: 600 };
+  accessibilityByPidMock.mockReset().mockResolvedValue({
+    children: async () => [
+      {
+        role: "window",
+        name: "Editor",
+        bounds,
+        tree: async () => {
+          throw new Error("Text read failed");
+        },
+        children: async () => [
+          {
+            role: "text_area",
+            value: "x".repeat(8_001),
+            bounds: { x: 10, y: 50, width: 700, height: 500 },
+            children: async () => [],
+          },
+        ],
+      },
+    ],
+  });
+
+  const result = await readAccessibleWindowContext(
+    { title: "Editor", bounds, owner: { processId: 123 } },
+    "darwin",
+    "Editor",
+  );
+  assert.equal(result?.accessibility?.format, "element-tree");
+  assert.isTrue(result?.accessibility?.truncated);
+  assert.deepEqual(
+    result?.accessibility?.format === "element-tree"
+      ? result.accessibility.root.children[0]?.bounds
+      : undefined,
+    { x: 10, y: 50, width: 700, height: 500 },
+  );
 });
 
 it("times out after three seconds without overlapping the outstanding accessibility read", async () => {

--- a/apps/desktop/src/snapShot/SnapShotAccessibility.ts
+++ b/apps/desktop/src/snapShot/SnapShotAccessibility.ts
@@ -57,18 +57,20 @@ function accessibilityReadSnapshot(
         descendantLocationsReliable: progress.richLocationsReliable,
       })
     : undefined;
-  const accessibleText =
-    progress.accessibleText ??
-    (richTree
-      ? accessibleWindowText(richTree.root, SNAP_SHOT_ACCESSIBLE_TEXT_MAX_CHARS)
-      : undefined);
+  const richText = richTree
+    ? accessibleWindowText(richTree.root, SNAP_SHOT_ACCESSIBLE_TEXT_MAX_CHARS)
+    : undefined;
+  const accessibleText = progress.accessibleText ?? richText;
+  const richTruncated = progress.richTruncated || richTree?.truncated === true;
   const accessibility: SnapShotAccessibility | undefined =
-    progress.richComplete && richTree && !progress.richTruncated && !richTree.truncated
+    progress.richComplete &&
+    richTree &&
+    (!richTruncated || !progress.accessibleText || progress.accessibleText === richText)
       ? {
           format: "element-tree",
           coordinateSpace: "captured-image",
           imageSize,
-          truncated: false,
+          truncated: richTruncated,
           root: richTree.root,
         }
       : progress.flatComplete && progress.accessibleText

--- a/apps/desktop/src/snapShot/SnapShotAccessibility.ts
+++ b/apps/desktop/src/snapShot/SnapShotAccessibility.ts
@@ -63,19 +63,19 @@ function accessibilityReadSnapshot(
       ? accessibleWindowText(richTree.root, SNAP_SHOT_ACCESSIBLE_TEXT_MAX_CHARS)
       : undefined);
   const accessibility: SnapShotAccessibility | undefined =
-    progress.richComplete && richTree
+    progress.richComplete && richTree && !progress.richTruncated && !richTree.truncated
       ? {
           format: "element-tree",
           coordinateSpace: "captured-image",
           imageSize,
-          truncated: progress.richTruncated || richTree.truncated,
+          truncated: false,
           root: richTree.root,
         }
-      : progress.flatComplete && accessibleText
+      : progress.flatComplete && progress.accessibleText
         ? {
             format: "flat-text",
-            text: accessibleText,
-            truncated: accessibleText.length >= SNAP_SHOT_ACCESSIBLE_TEXT_MAX_CHARS,
+            text: progress.accessibleText,
+            truncated: progress.accessibleText.length >= SNAP_SHOT_ACCESSIBLE_TEXT_MAX_CHARS,
           }
         : richTree
           ? {

--- a/apps/desktop/src/snapShot/snapShot.test.ts
+++ b/apps/desktop/src/snapShot/snapShot.test.ts
@@ -263,6 +263,23 @@ describe("accessibleWindowElementTree", () => {
     expect(tree?.root.children.length).toBeLessThan(10);
     expect(JSON.stringify(tree).length).toBeLessThanOrEqual(32_000);
   });
+
+  it.each(["name", "value", "description"] as const)(
+    "reports clipped %s text in partial trees",
+    async (field) => {
+      const tree = await accessibleWindowElementTree(
+        {
+          role: "window",
+          children: async () => [{ role: "text_area", [field]: "x".repeat(8_001) }],
+        },
+        { x: 0, y: 0, width: 800, height: 600 },
+        { width: 800, height: 600 },
+      );
+
+      expect(tree?.truncated).toBe(true);
+      expect(tree?.root.children[0]?.[field]?.length).toBeLessThan(8_001);
+    },
+  );
 });
 
 describe("compactAccessibilityTree", () => {

--- a/apps/desktop/src/snapShot/snapShot.ts
+++ b/apps/desktop/src/snapShot/snapShot.ts
@@ -155,11 +155,16 @@ function safeProperty<T>(read: () => T): T | undefined {
   }
 }
 
-export function boundedSnapShotString(value: unknown, maxChars: number): string | undefined {
+export function boundedSnapShotString(
+  value: unknown,
+  maxChars: number,
+  onTruncated?: () => void,
+): string | undefined {
   if (typeof value !== "string") return undefined;
   const candidate = value.replaceAll("\0", "").trim();
   if (!candidate) return undefined;
   if (candidate.length <= maxChars) return candidate;
+  onTruncated?.();
   const end = /[\uD800-\uDBFF]/.test(candidate[maxChars - 1] ?? "") ? maxChars - 1 : maxChars;
   return candidate.slice(0, end).trimEnd();
 }
@@ -204,18 +209,22 @@ function accessibilityNode(
   imageSize: CapturedImageSize,
   isRoot: boolean,
   locationsReliable: boolean,
+  onTruncated: () => void,
 ): MutableAccessibilityNode {
   const name = boundedSnapShotString(
     safeProperty(() => element.name),
     1_000,
+    onTruncated,
   );
   const value = boundedSnapShotString(
     safeProperty(() => element.value),
     8_000,
+    onTruncated,
   );
   const description = boundedSnapShotString(
     safeProperty(() => element.description),
     2_000,
+    onTruncated,
   );
   const checked = safeProperty(() => element.checked);
   const expanded = safeProperty(() => element.expanded);
@@ -389,6 +398,9 @@ export async function accessibleWindowElementTree(
       imageSize,
       required,
       options.locationsReliable !== false,
+      () => {
+        truncated = true;
+      },
     );
     nodes += 1;
     root ??= node;


### PR DESCRIPTION
Long text below a scroll view could be collected by SnapShot but missing from the attachment details and the agent prompt. The structured tree silently cut names at 1,000 characters and values at 8,000, then took priority over the fuller plain text read.

This marks clipped text fields as truncated and reuses the existing plain text fallback when the structured tree is incomplete and the fallback recovers text. Complete trees keep their element bounds and state. A truncated tree also stays when plain text contains the same text, preserving useful metadata. If the plain text read fails, the partial tree remains available and is marked truncated.

### Platform findings

| Platform | Finding and verification |
| --- | --- |
| macOS | Reproduced with the real AX reader and an isolated Electron window on this Mac. A 151-line document exposed its final line to the native API, but the selected snapshot stopped at line 132. The same window now returns the final line without scrolling. |
| Windows | The same text limits and selection code apply. Regression tests cover the Windows foreground-window path. Native UI Automation was inspected, but no live Windows desktop was available. |
| Linux | The same code serves X11 and the GNOME, KDE, Hyprland, and Niri capture paths. Tests cover X11 and Wayland, including the existing desktop identity and coordinate cases. No live Linux desktop test was run. Portal/picker captures still omit accessibility data because they lack verified window identity. |

The pinned [xa11y Mac](https://github.com/xa11y/xa11y/blob/v0.13.0/xa11y-macos/src/ax.rs), [Windows](https://github.com/xa11y/xa11y/blob/v0.13.0/xa11y-windows/src/uia.rs), and [Linux](https://github.com/xa11y/xa11y/blob/v0.13.0/xa11y-linux/src/atspi.rs) readers enumerate children without filtering them by screen visibility. The loss fixed here happens after collection in T3's shared reader.

### Verification

- 276 focused tests passed across the snapshot reader, worker lifecycle, attachment details, and provider prompt suites. New regression cases failed before the fix.
- Desktop typecheck, targeted lint, formatting, and diff checks passed.
- Live macOS before/after capture used the same test window and the production snapshot reader. This was a reader integration test, not a full T3 client run.

### Limits

The existing 32,000-character and three-second limits remain. A plain text fallback has no per-element coordinates. This preserves text the app exposes; it cannot recover content absent from the app's accessibility tree, such as unloaded items in a virtualized list. Existing saved snapshots are unchanged.

Implemented with GPT-6 in the native Codex harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Accessibility snapshots now accurately indicate when content or element trees are truncated.
  - Partial accessibility trees are preserved when complete text recovery is unavailable.
  - Long accessibility names, values, and descriptions are safely clipped while retaining useful tree information.
  - Off-screen invisible nodes correctly report unavailable bounds.
  - Long text outside scrollable areas remains represented consistently across platforms and sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->