### PR TITLE
fix(mobile): sheet action buttons text alignment

### DIFF
--- a/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
+++ b/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
@@ -24,7 +24,7 @@ export function SheetActionButton(props: {
   return (
     <Pressable
       className={cn(
-        "min-h-[48px] flex-1 flex-row items-center justify-center gap-2 rounded-[18px] px-4 py-3 disabled:opacity-[0.45]",
+        "min-h-[48px] flex-1 items-center justify-center rounded-[18px] px-3 py-3 disabled:opacity-[0.45]",
         tone === "primary"
           ? "bg-primary"
           : tone === "danger"
@@ -34,24 +34,26 @@ export function SheetActionButton(props: {
       disabled={props.disabled}
       onPress={props.onPress}
     >
-      <SymbolView
-        name={props.icon}
-        size={16}
-        tintColorClassName={textColorClassName}
-        type="monochrome"
-      />
-      <Text
-        className={cn(
-          "text-xs font-t3-bold tracking-[0.9px] uppercase",
-          tone === "primary"
-            ? "text-primary-foreground"
-            : tone === "danger"
-              ? "text-danger-foreground"
-              : "text-secondary-foreground",
-        )}
-      >
-        {props.label}
-      </Text>
+      <View className="max-w-full flex-row items-center justify-center gap-1.5">
+        <SymbolView
+          name={props.icon}
+          size={16}
+          tintColorClassName={textColorClassName}
+          type="monochrome"
+        />
+        <Text
+          className={cn(
+            "shrink text-center text-xs font-t3-bold tracking-[0.9px] uppercase",
+            tone === "primary"
+              ? "text-primary-foreground"
+              : tone === "danger"
+                ? "text-danger-foreground"
+                : "text-secondary-foreground",
+          )}
+        >
+          {props.label}
+        </Text>
+      </View>
     </Pressable>
   );
 }


### PR DESCRIPTION
## What changed

`SheetActionButton` now centres its icon and label as one group. Wrapped labels use `text-center` and `shrink` so multi-line text stays centered inside narrow git sheet buttons.

This shared component is used on the commit, confirm, and branches sheets.

## Why

On the commit sheet, **Commit on new branch** wraps to two lines in a half-width button. The old layout left-aligned the wrapped text next to the icon, so it looked misaligned compared with the single-line **Commit** button beside it.

| Before | After |
| --- | --- |
| ![Before: left-aligned wrapped label](https://github.com/user-attachments/assets/e6a016fc-e885-4154-9f3a-af5f40972417) | ![After: centred icon and wrapped label](https://github.com/user-attachments/assets/5ecf9227-e4ee-4bd5-b076-8c735fdd1129) |

## Validation

- Verified on the git commit sheet (before/after screenshots above).
- Change is limited to `apps/mobile/src/features/threads/git/gitSheetComponents.tsx`.

## Checklist

- [x] Small, focused bug fix
- [x] Explained what changed and why
- [x] Included before/after UI evidence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the layout and spacing of sheet action buttons.
  * Improved alignment and text wrapping for action button labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->