### PR TITLE
feat(web): open Usage on the Limits tab by default

### DIFF
--- a/apps/mobile/src/features/usage/UsageRouteScreen.tsx
+++ b/apps/mobile/src/features/usage/UsageRouteScreen.tsx
@@ -67,7 +67,9 @@ const CHART_HEIGHT = 180;
 export function UsageRouteScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  const [tab, setTab] = useState<UsageTab>("usage");
+  // Limits first: remaining quota and reset time are what most people open
+  // the screen for.
+  const [tab, setTab] = useState<UsageTab>("limits");
   const [windowSelection, setWindowSelection] = useState(() => ({
     days: 30,
     window: makeWindow(30),

--- a/apps/web/src/components/usage/usagePagePreferences.test.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
 
 describe("Usage page preferences", () => {
   it("uses defaults when no preference has been saved", () => {
-    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    expect(readUsagePagePreferences()).toEqual({ metric: "limits", windowDays: 30 });
   });
 
   it.each([1, 7, 30, 90] as const)("round-trips every metric with a %i-day range", (windowDays) => {
@@ -41,7 +41,7 @@ describe("Usage page preferences", () => {
     '{"metric":"cost","windowDays":365}',
   ])("replaces invalid preferences on the next save: %s", (value) => {
     values.set(key, value);
-    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    expect(readUsagePagePreferences()).toEqual({ metric: "limits", windowDays: 30 });
     saveUsagePagePreferences({ metric: "tokens", windowDays: 7 });
     expect(readUsagePagePreferences()).toEqual({ metric: "tokens", windowDays: 7 });
   });
@@ -64,7 +64,7 @@ describe("Usage page preferences", () => {
         throw new Error("SecurityError");
       },
     });
-    expect(readUsagePagePreferences()).toEqual({ metric: "cost", windowDays: 30 });
+    expect(readUsagePagePreferences()).toEqual({ metric: "limits", windowDays: 30 });
     expect(() => saveUsagePagePreferences({ metric: "tokens", windowDays: 7 })).not.toThrow();
   });
 });

--- a/apps/web/src/components/usage/usagePagePreferences.ts
+++ b/apps/web/src/components/usage/usagePagePreferences.ts
@@ -9,17 +9,17 @@ const UsagePagePreferencesSchema = Schema.Struct({
 });
 export type UsagePagePreferences = typeof UsagePagePreferencesSchema.Type;
 
+// Limits is what most people open the page for (how much subscription quota is
+// left, and when it resets), so it is the first-visit default; the last picked
+// tab sticks after that.
+const DEFAULT_PREFERENCES: UsagePagePreferences = { metric: "limits", windowDays: 30 };
+
 export function readUsagePagePreferences(): UsagePagePreferences {
   try {
-    return (
-      getLocalStorageItem(STORAGE_KEY, UsagePagePreferencesSchema) ?? {
-        metric: "cost",
-        windowDays: 30,
-      }
-    );
+    return getLocalStorageItem(STORAGE_KEY, UsagePagePreferencesSchema) ?? DEFAULT_PREFERENCES;
   } catch (error) {
     console.error("Could not read Usage page preferences.", error);
-    return { metric: "cost", windowDays: 30 };
+    return DEFAULT_PREFERENCES;
   }
 }
 


### PR DESCRIPTION
## Closes discussions

- https://github.com/pingdotgg/t3code/discussions/11259

The Limits view is what most people open the Usage page for (how much subscription quota is left, and when it resets), but it sat last after Cost and Tokens and was easy to miss.

The first-visit default is now **Limits** on web, desktop, and mobile. The metric toggle stays sticky exactly as before: anyone who already picked Cost or Tokens keeps that, and picking one persists via the existing `usagePagePreferences` localStorage entry. Mobile's Usage/Limits tab has no persistence (unchanged), so it just starts on Limits.

## Before / after

Fresh install, no saved preference, opening `/usage`:

| Before (main) | After |
|---|---|
| ![Before: Usage page opens on Cost tab](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/9c9aa6c2a374c070/before-fresh-cost.png) | ![After: Usage page opens on Limits tab](https://gh-file-drop-api-prod-mi5fy3sowv63ufte.pinglabs.workers.dev/f/a282d218ba630cd8/after-fresh-limits.png) |

Stickiness verified in the same session: pick Cost → reload `/usage` → Cost is still selected and `t3code:usage-page-preferences:v1` holds `{"metric":"cost","windowDays":30}`.

## Verification

- `vp test run apps/web/src/components/usage/usagePagePreferences.test.ts apps/web/src/components/usage/UsagePage.test.tsx` — 15/15 pass. The default-value assertions moved to `limits`; the write-failure case still asserts the previously saved `cost` survives, since that guards stickiness rather than the default.
- Browser check on the worktree dev server with a copy of real usage data (screenshots above).

Made with Claude Fable 5 in Claude Code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/11261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Usage pages now open on the **Limits** view by default across mobile and web.
  - Invalid, missing, or inaccessible saved preferences now consistently fall back to the Limits view.
  - The default reporting window remains 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->