### PR TITLE
feat(server): show OpenCode subagents in the Agents panel and work log

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3815,6 +3815,309 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("maps task tool metadata and child activity to the shared task lifecycle", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-task-metadata");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const childSessionId = "ses_child_task_metadata";
+      const enqueue = makeOpenCodeEventQueue();
+      const taskEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "task.started" ||
+              event.type === "task.progress" ||
+              event.type === "task.updated"),
+        ),
+        Stream.takeUntil(
+          (event) => event.type === "task.updated" && event.payload.status === "interrupted",
+        ),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Delegate the adapter inspection",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const taskPart = {
+        id: "part-parent-task",
+        sessionID: parentSessionId,
+        messageID: "msg-parent-task",
+        type: "tool",
+        callID: "call-parent-task",
+        tool: "task",
+        state: {
+          status: "completed",
+          input: {
+            description: "Inspect the OpenCode adapter",
+            prompt: "Trace child events",
+            subagent_type: "explore",
+          },
+          output: "Child session started",
+          title: "Delegating",
+          metadata: { parentSessionId, sessionId: childSessionId },
+          time: { start: 1, end: 2 },
+        },
+      } satisfies ToolPart;
+      enqueue({
+        id: "evt-parent-task",
+        type: "message.part.updated",
+        properties: { sessionID: parentSessionId, part: taskPart, time: 1 },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-parent-task-repeat",
+        type: "message.part.updated",
+        properties: { sessionID: parentSessionId, part: taskPart, time: 2 },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-child-tool",
+        type: "message.part.updated",
+        properties: {
+          sessionID: childSessionId,
+          part: {
+            id: "part-child-tool",
+            sessionID: childSessionId,
+            messageID: "msg-child-tool",
+            type: "tool",
+            callID: "call-child-tool",
+            tool: "bash",
+            state: {
+              status: "running",
+              input: { command: "pwd" },
+              title: "Reading the workspace",
+              time: { start: 3 },
+            },
+          },
+        },
+      });
+      for (const status of ["busy", "idle"] as const) {
+        enqueue({
+          id: `evt-child-${status}`,
+          type: "session.status",
+          properties: { sessionID: childSessionId, status: { type: status } },
+        } satisfies OpenCodeEvent);
+      }
+      enqueue({
+        id: "evt-child-deleted",
+        type: "session.deleted",
+        properties: {
+          info: {
+            id: childSessionId,
+            parentID: parentSessionId,
+            title: "Child session",
+          },
+        },
+      });
+
+      const taskEvents = Array.from(
+        yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      const started = taskEvents.filter((event) => event.type === "task.started");
+      NodeAssert.equal(started.length, 1);
+      NodeAssert.partialDeepStrictEqual(started[0], {
+        type: "task.started",
+        turnId: turn.turnId,
+        payload: {
+          taskId: childSessionId,
+          description: "Inspect the OpenCode adapter",
+          title: "Inspect the OpenCode adapter",
+          role: "explore",
+          timelineBypass: true,
+        },
+      });
+      const progress = taskEvents.find((event) => event.type === "task.progress");
+      NodeAssert.partialDeepStrictEqual(progress, {
+        type: "task.progress",
+        turnId: turn.turnId,
+        payload: {
+          taskId: childSessionId,
+          description: "Inspect the OpenCode adapter",
+          lastToolName: "bash",
+          summary: "Reading the workspace",
+          role: "explore",
+          timelineBypass: true,
+        },
+      });
+      NodeAssert.deepEqual(
+        taskEvents.flatMap((event) =>
+          event.type === "task.updated" && event.payload.status ? [event.payload.status] : [],
+        ),
+        ["running", "idle", "interrupted"],
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("keeps parent turn state isolated from child session events", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-turn-isolation");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const childSessionId = "ses_child_turn_isolation";
+      const enqueue = makeOpenCodeEventQueue();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Delegate without ending my turn",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      enqueue({
+        id: "evt-parent-busy",
+        type: "session.status",
+        properties: { sessionID: parentSessionId, status: { type: "busy" } },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-child-created-first",
+        type: "session.created",
+        properties: {
+          info: {
+            id: childSessionId,
+            parentID: parentSessionId,
+            title: "Investigate event routing",
+          },
+        },
+      });
+      enqueue({
+        id: "evt-unrelated-status",
+        type: "session.status",
+        properties: { sessionID: "ses_unrelated", status: { type: "busy" } },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-child-todos",
+        type: "todo.updated",
+        properties: {
+          sessionID: childSessionId,
+          todos: [{ content: "Inspect routing", status: "in_progress", priority: "high" }],
+        },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-child-idle",
+        type: "session.status",
+        properties: { sessionID: childSessionId, status: { type: "idle" } },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-parent-task-after-child",
+        type: "message.part.updated",
+        properties: {
+          sessionID: parentSessionId,
+          time: 1,
+          part: {
+            id: "part-parent-task-after-child",
+            sessionID: parentSessionId,
+            messageID: "msg-parent-task-after-child",
+            type: "tool",
+            callID: "call-parent-task-after-child",
+            tool: "task",
+            state: {
+              status: "completed",
+              input: {
+                description: "Inspect routing deeply",
+                prompt: "Inspect child routing",
+                subagent_type: "librarian",
+              },
+              output: "Child session linked",
+              title: "Delegating",
+              metadata: { parentSessionId, sessionId: childSessionId },
+              time: { start: 1, end: 2 },
+            },
+          } satisfies ToolPart,
+        },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-parent-todos",
+        type: "todo.updated",
+        properties: {
+          sessionID: parentSessionId,
+          todos: [{ content: "Finish parent turn", status: "in_progress", priority: "high" }],
+        },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-parent-idle",
+        type: "session.status",
+        properties: { sessionID: parentSessionId, status: { type: "idle" } },
+      } satisfies OpenCodeEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const started = events.find((event) => event.type === "task.started");
+      NodeAssert.partialDeepStrictEqual(started, {
+        type: "task.started",
+        turnId: turn.turnId,
+        payload: {
+          taskId: childSessionId,
+          description: "Investigate event routing",
+          title: "Investigate event routing",
+          timelineBypass: true,
+        },
+      });
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            (event.type === "task.started" ||
+              event.type === "task.progress" ||
+              event.type === "task.updated") &&
+            event.payload.taskId === "ses_unrelated",
+        ),
+        false,
+      );
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            event.type === "task.updated" &&
+            event.payload.taskId === childSessionId &&
+            event.payload.status === "idle",
+        ),
+        true,
+      );
+      NodeAssert.equal(
+        events.some((event) => event.type === "task.completed"),
+        false,
+      );
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            event.type === "task.updated" &&
+            event.payload.taskId === childSessionId &&
+            event.payload.title === "Inspect routing deeply" &&
+            event.payload.role === "librarian",
+        ),
+        true,
+      );
+      const plans = events.filter((event) => event.type === "turn.plan.updated");
+      NodeAssert.equal(plans.length, 1);
+      NodeAssert.equal(plans[0]?.turnId, turn.turnId);
+      NodeAssert.deepEqual(plans[0]?.payload.plan, [
+        { step: "Finish parent turn", status: "inProgress" },
+      ]);
+      const completions = events.filter((event) => event.type === "turn.completed");
+      NodeAssert.equal(completions.length, 1);
+      NodeAssert.equal(completions[0]?.turnId, turn.turnId);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("routes child-session approval requests and replies through the parent thread", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
@@ -3849,8 +4152,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       ];
 
       const openedEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.take(1),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -4149,8 +4452,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       ];
 
       const requestedEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
+        Stream.filter(
+          (event) => event.threadId === threadId && event.type === "user-input.requested",
+        ),
+        Stream.take(1),
         Stream.runCollect,
         Effect.forkChild,
       );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3958,6 +3958,288 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("does not adopt a task child whose parent session is unverified", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-unverified-parent");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const foreignSessionId = "ses_foreign_task_child";
+      const enqueue = makeOpenCodeEventQueue();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Delegate to a foreign session",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      enqueue({
+        id: "evt-foreign-task",
+        type: "message.part.updated",
+        properties: {
+          sessionID: parentSessionId,
+          time: 1,
+          part: {
+            id: "part-foreign-task",
+            sessionID: parentSessionId,
+            messageID: "msg-foreign-task",
+            type: "tool",
+            callID: "call-foreign-task",
+            tool: "task",
+            state: {
+              status: "completed",
+              input: { prompt: "Foreign", subagent_type: "explore" },
+              output: "started",
+              title: "Delegating",
+              metadata: { sessionId: foreignSessionId },
+              time: { start: 1, end: 2 },
+            },
+          },
+        },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-foreign-busy",
+        type: "session.status",
+        properties: { sessionID: foreignSessionId, status: { type: "busy" } },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-parent-idle",
+        type: "session.status",
+        properties: { sessionID: parentSessionId, status: { type: "idle" } },
+      } satisfies OpenCodeEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(
+        events.some(
+          (event) =>
+            (event.type === "task.started" ||
+              event.type === "task.progress" ||
+              event.type === "task.updated") &&
+            event.payload.taskId === foreignSessionId,
+        ),
+        false,
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("discovers a resumed child session from its first event", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-resumed-discovery");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const childSessionId = "ses_resumed_child";
+      runtimeMock.state.sessionParentById.set(childSessionId, parentSessionId);
+      const enqueue = makeOpenCodeEventQueue();
+      const taskEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "task.started" || event.type === "task.updated"),
+        ),
+        Stream.takeUntil(
+          (event) => event.type === "task.updated" && event.payload.status === "running",
+        ),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Resume a child",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      enqueue({
+        id: "evt-resumed-busy",
+        type: "session.status",
+        properties: { sessionID: childSessionId, status: { type: "busy" } },
+      } satisfies OpenCodeEvent);
+
+      const events = Array.from(
+        yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("2 seconds")),
+      );
+      NodeAssert.partialDeepStrictEqual(events[0], {
+        type: "task.started",
+        payload: { taskId: childSessionId },
+      });
+      NodeAssert.equal(events[1]?.type, "task.updated");
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("re-admits a child session after it is deleted", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-readmit");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const childSessionId = "ses_child_readmit";
+      const enqueue = makeOpenCodeEventQueue();
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Delegate twice",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      const taskPart = {
+        id: "part-readmit-task",
+        sessionID: parentSessionId,
+        messageID: "msg-readmit-task",
+        type: "tool",
+        callID: "call-readmit-task",
+        tool: "task",
+        state: {
+          status: "completed",
+          input: { description: "Inspect", prompt: "Inspect", subagent_type: "explore" },
+          output: "started",
+          title: "Delegating",
+          metadata: { parentSessionId, sessionId: childSessionId },
+          time: { start: 1, end: 2 },
+        },
+      } satisfies ToolPart;
+      enqueue({
+        id: "evt-readmit-task",
+        type: "message.part.updated",
+        properties: { sessionID: parentSessionId, part: taskPart, time: 1 },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-readmit-deleted",
+        type: "session.deleted",
+        properties: {
+          info: { id: childSessionId, parentID: parentSessionId, title: "Child session" },
+        },
+      });
+      enqueue({
+        id: "evt-readmit-task-again",
+        type: "message.part.updated",
+        properties: { sessionID: parentSessionId, part: taskPart, time: 2 },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-readmit-parent-idle",
+        type: "session.status",
+        properties: { sessionID: parentSessionId, status: { type: "idle" } },
+      } satisfies OpenCodeEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(events.filter((event) => event.type === "task.started").length, 2);
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("publishes a child's real title after it starts on the session-id fallback", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-child-title-refresh");
+      const parentSessionId = "http://127.0.0.1:9999/session";
+      const childSessionId = "ses_child_title_refresh";
+      const enqueue = makeOpenCodeEventQueue();
+      const taskEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter(
+          (event) =>
+            event.threadId === threadId &&
+            (event.type === "task.started" || event.type === "task.updated"),
+        ),
+        Stream.takeUntil(
+          (event) => event.type === "task.updated" && event.payload.title === "Investigate routing",
+        ),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId,
+        input: "Delegate behind a placeholder title",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "opencode/kimi-k3",
+        ),
+      });
+      enqueue({
+        id: "evt-title-task",
+        type: "message.part.updated",
+        properties: {
+          sessionID: parentSessionId,
+          time: 1,
+          part: {
+            id: "part-title-task",
+            sessionID: parentSessionId,
+            messageID: "msg-title-task",
+            type: "tool",
+            callID: "call-title-task",
+            tool: "task",
+            state: {
+              status: "completed",
+              input: { prompt: "Investigate" },
+              output: "started",
+              title: "Delegating",
+              metadata: { parentSessionId, sessionId: childSessionId },
+              time: { start: 1, end: 2 },
+            },
+          },
+        },
+      } satisfies OpenCodeEvent);
+      enqueue({
+        id: "evt-title-updated",
+        type: "session.updated",
+        properties: {
+          sessionID: childSessionId,
+          info: {
+            id: childSessionId,
+            parentID: parentSessionId,
+            title: "Investigate routing",
+          },
+        },
+      });
+
+      const events = Array.from(
+        yield* Fiber.join(taskEventsFiber).pipe(Effect.timeout("1 second")),
+      );
+      NodeAssert.partialDeepStrictEqual(events[0], {
+        type: "task.started",
+        payload: { taskId: childSessionId, title: childSessionId },
+      });
+      NodeAssert.partialDeepStrictEqual(events[1], {
+        type: "task.updated",
+        payload: { taskId: childSessionId, title: "Investigate routing" },
+      });
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect("keeps parent turn state isolated from child session events", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -343,6 +343,13 @@ interface OpenCodeSessionContext {
   readonly relatedSessionIds: Set<string>;
   readonly startedTaskSessionIds: Set<string>;
   readonly childTaskInfoBySessionId: Map<string, OpenCodeChildTaskInfo>;
+  /**
+   * Sessions whose ancestry lookup has already been scheduled. A resumed child
+   * emits events before any `session.created`, so the first one triggers a
+   * one-shot discovery; the id stays here to keep unrelated sessions from
+   * re-triggering a `session.get` walk on every event.
+   */
+  readonly childRelationDiscoverySessionIds: Set<string>;
   readonly resolvedRequestIds: Set<string>;
   readonly autoRepliedRequestIds: Set<string>;
   readonly emittedTerminalRequestIds: Set<string>;
@@ -1660,6 +1667,10 @@ export function makeOpenCodeAdapter(
       }
     };
 
+    /**
+     * Records the display title and subagent role seen for a child session,
+     * preserving the previous value for fields not supplied by this event.
+     */
     const rememberOpenCodeChildTask = (
       context: OpenCodeSessionContext,
       sessionId: string,
@@ -1674,6 +1685,10 @@ export function makeOpenCodeAdapter(
       return next;
     };
 
+    /**
+     * Builds the shared `task.*` linkage for a child, falling back to its session
+     * id when neither a title nor a role is known yet.
+     */
     const openCodeChildTaskLinkage = (context: OpenCodeSessionContext, sessionId: string) => {
       const info = context.childTaskInfoBySessionId.get(sessionId);
       const title = info?.title ?? info?.role ?? sessionId;
@@ -1685,6 +1700,7 @@ export function makeOpenCodeAdapter(
       } as const;
     };
 
+    /** Emits `task.started` once per child session, no matter how it was discovered. */
     const emitOpenCodeChildTaskStarted = Effect.fn("emitOpenCodeChildTaskStarted")(function* (
       context: OpenCodeSessionContext,
       sessionId: string,
@@ -1708,6 +1724,10 @@ export function makeOpenCodeAdapter(
       });
     });
 
+    /**
+     * Translates a known child session's event into `task.progress` / `task.updated`
+     * without touching parent turn state.
+     */
     const handleOpenCodeChildEvent = Effect.fn("handleOpenCodeChildEvent")(function* (
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
@@ -2183,6 +2203,37 @@ export function makeOpenCodeAdapter(
       retry.fiber = yield* run.pipe(Effect.forkIn(context.sessionScope));
     });
 
+    /**
+     * A resumed child session emits events without a preceding `session.created`,
+     * so its first event does not match `relatedSessionIds` and would otherwise be
+     * dropped. Resolve its ancestry once and replay that event as child activity.
+     */
+    const scheduleChildRelationDiscovery = Effect.fn("scheduleChildRelationDiscovery")(function* (
+      context: OpenCodeSessionContext,
+      event: OpenCodeSubscribedEvent,
+      sessionId: string,
+    ) {
+      if (
+        context.relatedSessionIds.has(sessionId) ||
+        context.childRelationDiscoverySessionIds.has(sessionId)
+      ) {
+        return;
+      }
+      context.childRelationDiscoverySessionIds.add(sessionId);
+      const run = Effect.gen(function* () {
+        const related = yield* isRelatedOpenCodeSession(context, sessionId).pipe(
+          Effect.match({
+            onFailure: () => false,
+            onSuccess: (value) => value,
+          }),
+        );
+        if (related) {
+          yield* handleOpenCodeChildEvent(context, event, sessionId);
+        }
+      }).pipe(Effect.catchCause(() => Effect.void));
+      yield* run.pipe(Effect.forkIn(context.sessionScope));
+    });
+
     const schedulePendingRequestRecovery = Effect.fn("schedulePendingRequestRecovery")(function* (
       context: OpenCodeSessionContext,
     ) {
@@ -2353,9 +2404,27 @@ export function makeOpenCodeAdapter(
         if (session.parentID && context.relatedSessionIds.has(session.parentID)) {
           addRelatedOpenCodeSession(context, session.id);
           const title = trimText(session.title);
-          rememberOpenCodeChildTask(context, session.id, {
-            title: title && !isOpenCodeDefaultTitle(title) ? title : undefined,
-          });
+          const nextTitle = title && !isOpenCodeDefaultTitle(title) ? title : undefined;
+          const priorTitle = context.childTaskInfoBySessionId.get(session.id)?.title;
+          const alreadyStarted = context.startedTaskSessionIds.has(session.id);
+          const nextInfo = rememberOpenCodeChildTask(context, session.id, { title: nextTitle });
+          // A child that started on its session-id fallback had no real title to
+          // show. Publish it once it arrives instead of waiting for the next
+          // status event to refresh the linkage.
+          if (alreadyStarted && priorTitle === undefined && nextInfo.title !== undefined) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId: context.activeTurnId,
+                raw: event,
+              })),
+              type: "task.updated",
+              payload: {
+                taskId: RuntimeTaskId.make(session.id),
+                ...openCodeChildTaskLinkage(context, session.id),
+              },
+            });
+          }
         }
       }
 
@@ -2384,6 +2453,15 @@ export function makeOpenCodeAdapter(
             return;
           }
         }
+      }
+      if (
+        payloadSessionId !== undefined &&
+        payloadSessionId !== context.openCodeSessionId &&
+        !context.relatedSessionIds.has(payloadSessionId) &&
+        !isOpenCodeChildRequestEvent(event)
+      ) {
+        yield* scheduleChildRelationDiscovery(context, event, payloadSessionId);
+        return;
       }
       const isChildEvent =
         payloadSessionId !== undefined &&
@@ -2415,6 +2493,9 @@ export function makeOpenCodeAdapter(
         yield* handleOpenCodeChildEvent(context, event, payloadSessionId);
         if (event.type === "session.deleted") {
           context.relatedSessionIds.delete(payloadSessionId);
+          context.startedTaskSessionIds.delete(payloadSessionId);
+          context.childTaskInfoBySessionId.delete(payloadSessionId);
+          context.childRelationDiscoverySessionIds.delete(payloadSessionId);
         }
         return;
       }
@@ -2640,8 +2721,12 @@ export function makeOpenCodeAdapter(
                 typeof metadata.parentSessionId === "string"
                   ? trimText(metadata.parentSessionId)
                   : undefined;
+              // A spawned session must prove ancestry against a parent session
+              // we already own. Metadata carrying only `sessionId` cannot, so
+              // adopting it would let an unrelated session on a shared server
+              // emit activity under this thread.
               const hasValidParent =
-                metadataParentSessionId === undefined ||
+                metadataParentSessionId !== undefined &&
                 context.relatedSessionIds.has(metadataParentSessionId);
               if (childSessionId && hasValidParent) {
                 const alreadyStarted = context.startedTaskSessionIds.has(childSessionId);
@@ -3206,6 +3291,7 @@ export function makeOpenCodeAdapter(
           relatedSessionIds: new Set([started.openCodeSession.id]),
           startedTaskSessionIds: new Set(),
           childTaskInfoBySessionId: new Map(),
+          childRelationDiscoverySessionIds: new Set(),
           resolvedRequestIds: new Set(),
           autoRepliedRequestIds: new Set(),
           emittedTerminalRequestIds: new Set(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -8,6 +8,7 @@ import {
   type ProviderSession,
   RuntimeItemId,
   RuntimeRequestId,
+  RuntimeTaskId,
   ThreadId,
   type ToolLifecycleItemType,
   type TurnTokenUsage,
@@ -340,6 +341,8 @@ interface OpenCodeSessionContext {
   readonly directory: string;
   readonly openCodeSessionId: string;
   readonly relatedSessionIds: Set<string>;
+  readonly startedTaskSessionIds: Set<string>;
+  readonly childTaskInfoBySessionId: Map<string, OpenCodeChildTaskInfo>;
   readonly resolvedRequestIds: Set<string>;
   readonly autoRepliedRequestIds: Set<string>;
   readonly emittedTerminalRequestIds: Set<string>;
@@ -379,6 +382,11 @@ interface OpenCodeSessionContext {
    *   - tears down the OpenCode server process for scope-owned servers.
    */
   readonly sessionScope: Scope.Closeable;
+}
+
+interface OpenCodeChildTaskInfo {
+  title: string | undefined;
+  role: string | undefined;
 }
 
 interface OpenCodeTurnTokenUsageAccumulator {
@@ -1652,6 +1660,147 @@ export function makeOpenCodeAdapter(
       }
     };
 
+    const rememberOpenCodeChildTask = (
+      context: OpenCodeSessionContext,
+      sessionId: string,
+      update: Partial<OpenCodeChildTaskInfo>,
+    ): OpenCodeChildTaskInfo => {
+      const existing = context.childTaskInfoBySessionId.get(sessionId);
+      const next = {
+        title: update.title ?? existing?.title,
+        role: update.role ?? existing?.role,
+      };
+      context.childTaskInfoBySessionId.set(sessionId, next);
+      return next;
+    };
+
+    const openCodeChildTaskLinkage = (context: OpenCodeSessionContext, sessionId: string) => {
+      const info = context.childTaskInfoBySessionId.get(sessionId);
+      const title = info?.title ?? info?.role ?? sessionId;
+      return {
+        description: title,
+        title,
+        ...(info?.role ? { role: info.role } : {}),
+        timelineBypass: true,
+      } as const;
+    };
+
+    const emitOpenCodeChildTaskStarted = Effect.fn("emitOpenCodeChildTaskStarted")(function* (
+      context: OpenCodeSessionContext,
+      sessionId: string,
+      raw: unknown,
+    ) {
+      if (context.startedTaskSessionIds.has(sessionId)) {
+        return;
+      }
+      context.startedTaskSessionIds.add(sessionId);
+      yield* emit({
+        ...(yield* buildEventBase({
+          threadId: context.session.threadId,
+          turnId: context.activeTurnId,
+          raw,
+        })),
+        type: "task.started",
+        payload: {
+          taskId: RuntimeTaskId.make(sessionId),
+          ...openCodeChildTaskLinkage(context, sessionId),
+        },
+      });
+    });
+
+    const handleOpenCodeChildEvent = Effect.fn("handleOpenCodeChildEvent")(function* (
+      context: OpenCodeSessionContext,
+      event: OpenCodeSubscribedEvent,
+      sessionId: string,
+    ) {
+      yield* emitOpenCodeChildTaskStarted(context, sessionId, event);
+      const taskId = RuntimeTaskId.make(sessionId);
+      const linkage = openCodeChildTaskLinkage(context, sessionId);
+      switch (event.type) {
+        case "message.part.updated": {
+          const part = event.properties.part;
+          if (part.type !== "tool") {
+            return;
+          }
+          const stateTitle =
+            part.state.status === "running" || part.state.status === "completed"
+              ? trimText(part.state.title)
+              : undefined;
+          const command = trimText(
+            typeof part.state.input.command === "string" ? part.state.input.command : undefined,
+          );
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: context.activeTurnId,
+              raw: event,
+            })),
+            type: "task.progress",
+            payload: {
+              taskId,
+              ...linkage,
+              lastToolName: part.tool,
+              summary: stateTitle ?? command ?? part.tool,
+            },
+          });
+          return;
+        }
+        case "session.status": {
+          const status = event.properties.status.type;
+          if (status !== "busy" && status !== "retry" && status !== "idle") {
+            return;
+          }
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: context.activeTurnId,
+              raw: event,
+            })),
+            type: "task.updated",
+            payload: {
+              taskId,
+              status: status === "idle" ? "idle" : "running",
+              ...linkage,
+            },
+          });
+          return;
+        }
+        case "session.deleted": {
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: context.activeTurnId,
+              raw: event,
+            })),
+            type: "task.updated",
+            payload: { taskId, status: "interrupted", ...linkage },
+          });
+          return;
+        }
+        case "todo.updated": {
+          const current = event.properties.todos.find(
+            (todo) => todo.status === "in_progress" || todo.status === "pending",
+          );
+          const summary = trimText(current?.content);
+          if (!summary) {
+            return;
+          }
+          yield* emit({
+            ...(yield* buildEventBase({
+              threadId: context.session.threadId,
+              turnId: context.activeTurnId,
+              raw: event,
+            })),
+            type: "task.progress",
+            payload: { taskId, ...linkage, summary },
+          });
+          return;
+        }
+        default:
+          return;
+      }
+    });
+
     const isRelatedOpenCodeSession = Effect.fn("isRelatedOpenCodeSession")(function* (
       context: OpenCodeSessionContext,
       candidateSessionId: string,
@@ -2203,9 +2352,11 @@ export function makeOpenCodeAdapter(
         const session = event.properties.info;
         if (session.parentID && context.relatedSessionIds.has(session.parentID)) {
           addRelatedOpenCodeSession(context, session.id);
+          const title = trimText(session.title);
+          rememberOpenCodeChildTask(context, session.id, {
+            title: title && !isOpenCodeDefaultTitle(title) ? title : undefined,
+          });
         }
-      } else if (event.type === "session.deleted") {
-        context.relatedSessionIds.delete(event.properties.info.id);
       }
 
       const payloadSessionId = openCodeEventSessionId(event);
@@ -2234,11 +2385,15 @@ export function makeOpenCodeAdapter(
           }
         }
       }
+      const isChildEvent =
+        payloadSessionId !== undefined &&
+        payloadSessionId !== context.openCodeSessionId &&
+        context.relatedSessionIds.has(payloadSessionId);
       const isChildRequestEvent =
         payloadSessionId !== undefined &&
         isOpenCodeChildRequestEvent(event) &&
         (context.relatedSessionIds.has(payloadSessionId) || isKnownPendingTerminalEvent);
-      if (!isParentEvent && !isChildRequestEvent) {
+      if (!isParentEvent && !isChildEvent && !isChildRequestEvent) {
         return;
       }
 
@@ -2255,6 +2410,14 @@ export function makeOpenCodeAdapter(
           payload: event,
         },
       });
+
+      if (isChildEvent && !isOpenCodeChildRequestEvent(event) && payloadSessionId) {
+        yield* handleOpenCodeChildEvent(context, event, payloadSessionId);
+        if (event.type === "session.deleted") {
+          context.relatedSessionIds.delete(payloadSessionId);
+        }
+        return;
+      }
 
       const suppressInterruptedParentOutput =
         isParentEvent &&
@@ -2460,6 +2623,64 @@ export function makeOpenCodeAdapter(
           }
 
           if (part.type === "tool") {
+            if (part.tool === "task") {
+              const metadata =
+                "metadata" in part.state &&
+                typeof part.state.metadata === "object" &&
+                part.state.metadata !== null
+                  ? part.state.metadata
+                  : undefined;
+              const childSessionId =
+                metadata && "sessionId" in metadata && typeof metadata.sessionId === "string"
+                  ? trimText(metadata.sessionId)
+                  : undefined;
+              const metadataParentSessionId =
+                metadata &&
+                "parentSessionId" in metadata &&
+                typeof metadata.parentSessionId === "string"
+                  ? trimText(metadata.parentSessionId)
+                  : undefined;
+              const hasValidParent =
+                metadataParentSessionId === undefined ||
+                context.relatedSessionIds.has(metadataParentSessionId);
+              if (childSessionId && hasValidParent) {
+                const alreadyStarted = context.startedTaskSessionIds.has(childSessionId);
+                const priorInfo = context.childTaskInfoBySessionId.get(childSessionId);
+                const description = trimText(
+                  typeof part.state.input.description === "string"
+                    ? part.state.input.description
+                    : undefined,
+                );
+                const role = trimText(
+                  typeof part.state.input.subagent_type === "string"
+                    ? part.state.input.subagent_type
+                    : undefined,
+                );
+                addRelatedOpenCodeSession(context, childSessionId);
+                const nextInfo = rememberOpenCodeChildTask(context, childSessionId, {
+                  title: description,
+                  role,
+                });
+                yield* emitOpenCodeChildTaskStarted(context, childSessionId, event);
+                if (
+                  alreadyStarted &&
+                  (priorInfo?.title !== nextInfo.title || priorInfo?.role !== nextInfo.role)
+                ) {
+                  yield* emit({
+                    ...(yield* buildEventBase({
+                      threadId: context.session.threadId,
+                      turnId: context.activeTurnId,
+                      raw: event,
+                    })),
+                    type: "task.updated",
+                    payload: {
+                      taskId: RuntimeTaskId.make(childSessionId),
+                      ...openCodeChildTaskLinkage(context, childSessionId),
+                    },
+                  });
+                }
+              }
+            }
             const itemType = toToolLifecycleItemType(part.tool);
             const title =
               part.state.status === "running" || part.state.status === "completed"
@@ -2983,6 +3204,8 @@ export function makeOpenCodeAdapter(
           directory,
           openCodeSessionId: started.openCodeSession.id,
           relatedSessionIds: new Set([started.openCodeSession.id]),
+          startedTaskSessionIds: new Set(),
+          childTaskInfoBySessionId: new Map(),
           resolvedRequestIds: new Set(),
           autoRepliedRequestIds: new Set(),
           emittedTerminalRequestIds: new Set(),

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -293,3 +293,38 @@ it.effect("falls back to a non-origin remote when origin is not configured", () 
     assert.strictEqual(provider.kind, "azure-devops");
   }),
 );
+
+it.effect("resolves an SSH host alias before classifying the remote", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "git@github-personal:noueii/t3code.git" }],
+      process: {
+        run: (input) =>
+          Effect.succeed(
+            input.command === "ssh" && input.args.includes("github-personal")
+              ? processOutput("hostname github.com\n")
+              : processOutput(""),
+          ),
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "github");
+  }),
+);
+
+it.effect("keeps a remote unknown when its SSH host alias cannot be resolved", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "git@github-personal:noueii/t3code.git" }],
+      process: {
+        run: () => Effect.succeed(processOutput("")),
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "unknown");
+  }),
+);

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -328,3 +328,23 @@ it.effect("keeps a remote unknown when its SSH host alias cannot be resolved", (
     assert.strictEqual(provider.kind, "unknown");
   }),
 );
+
+it.effect("resolves an SSH host alias carrying an explicit port", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "ssh://git@github-personal:2222/noueii/t3code.git" }],
+      process: {
+        run: (input) =>
+          Effect.succeed(
+            input.command === "ssh" && input.args.includes("github-personal")
+              ? processOutput("hostname github.com\n")
+              : processOutput(""),
+          ),
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "github");
+  }),
+);

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -135,6 +135,10 @@ interface SourceControlRemoteCandidate {
   readonly provider: SourceControlProviderInfo | null;
 }
 
+/**
+ * Picks the provider context for a repository: the `origin` remote wins, then the
+ * first recognized provider, then the first remote with any provider.
+ */
 function selectProviderContext(
   remotes: ReadonlyArray<SourceControlRemoteCandidate>,
 ): SourceControlProvider.SourceControlProviderContext | null {
@@ -286,10 +290,12 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
           Effect.gen(function* () {
             let provider = detectSourceControlProviderFromRemoteUrl(remote.url);
             if ((provider === null || provider.kind === "unknown") && isSshRemoteUrl(remote.url)) {
-              const host = parseRemoteHost(remote.url);
-              if (host !== null) {
-                const canonicalHost = yield* resolveSshHostAlias({ process, cwd, host });
-                if (canonicalHost !== null && canonicalHost !== host) {
+              // `parseRemoteHost` keeps an explicit port (`host:2222`), which is
+              // not a valid ssh alias, so resolve the bare hostname.
+              const hostname = parseRemoteHost(remote.url)?.replace(/:\d+$/u, "");
+              if (hostname) {
+                const canonicalHost = yield* resolveSshHostAlias({ process, cwd, host: hostname });
+                if (canonicalHost !== null && canonicalHost !== hostname) {
                   provider = detectSourceControlProviderFromHost(canonicalHost) ?? provider;
                 }
               }

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -8,8 +8,13 @@ import {
   SourceControlProviderError,
   type SourceControlProviderDiscoveryItem,
 } from "@t3tools/contracts";
-import type { SourceControlProviderKind } from "@t3tools/contracts";
-import { detectSourceControlProviderFromRemoteUrl } from "@t3tools/shared/sourceControl";
+import type { SourceControlProviderInfo, SourceControlProviderKind } from "@t3tools/contracts";
+import {
+  detectSourceControlProviderFromHost,
+  detectSourceControlProviderFromRemoteUrl,
+  isSshRemoteUrl,
+  parseRemoteHost,
+} from "@t3tools/shared/sourceControl";
 
 import * as AzureDevOpsSourceControlProvider from "./AzureDevOpsSourceControlProvider.ts";
 import * as BitbucketSourceControlProvider from "./BitbucketSourceControlProvider.ts";
@@ -124,18 +129,20 @@ function unsupportedProvider(
   });
 }
 
+interface SourceControlRemoteCandidate {
+  readonly name: string;
+  readonly url: string;
+  readonly provider: SourceControlProviderInfo | null;
+}
+
 function selectProviderContext(
-  remotes: ReadonlyArray<{
-    readonly name: string;
-    readonly url: string;
-  }>,
+  remotes: ReadonlyArray<SourceControlRemoteCandidate>,
 ): SourceControlProvider.SourceControlProviderContext | null {
   const candidates: Array<SourceControlProvider.SourceControlProviderContext> = [];
   for (const remote of remotes) {
-    const provider = detectSourceControlProviderFromRemoteUrl(remote.url);
-    if (provider) {
+    if (remote.provider) {
       candidates.push({
-        provider,
+        provider: remote.provider,
         remoteName: remote.name,
         remoteUrl: remote.url,
       });
@@ -149,6 +156,46 @@ function selectProviderContext(
     null
   );
 }
+
+// `ssh -G` prints the effective configuration for a host, which is how a
+// ~/.ssh/config `Host` alias (e.g. `github-personal`) maps back to its canonical
+// hostname. Only a hostname-shaped host is passed through, so an alias can never
+// smuggle an option into the command.
+const SSH_HOST_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+const SSH_CONFIG_HOSTNAME_PATTERN = /^hostname\s+(\S+)\s*$/im;
+const SSH_HOST_RESOLUTION_TIMEOUT_MS = 5_000;
+
+const resolveSshHostAlias = Effect.fn("SourceControlProviderRegistry.resolveSshHostAlias")(
+  function* (input: {
+    readonly process: VcsProcess.VcsProcess["Service"];
+    readonly cwd: string;
+    readonly host: string;
+  }): Effect.fn.Return<string | null> {
+    if (!SSH_HOST_PATTERN.test(input.host)) {
+      return null;
+    }
+
+    const output = yield* input.process
+      .run({
+        operation: "source-control.detect.resolve-ssh-host",
+        command: "ssh",
+        args: ["-G", input.host],
+        cwd: input.cwd,
+        allowNonZeroExit: true,
+        timeoutMs: SSH_HOST_RESOLUTION_TIMEOUT_MS,
+        maxOutputBytes: 16_000,
+        appendTruncationMarker: true,
+      })
+      .pipe(Effect.orElseSucceed(() => null));
+
+    if (output === null || output.exitCode !== 0) {
+      return null;
+    }
+
+    const hostname = SSH_CONFIG_HOSTNAME_PATTERN.exec(output.stdout)?.[1]?.toLowerCase();
+    return hostname && hostname.length > 0 ? hostname : null;
+  },
+);
 
 function bindProviderContext(
   provider: SourceControlProvider.SourceControlProvider["Service"],
@@ -235,7 +282,26 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
               }),
           ),
         );
-        const context = selectProviderContext(remotes.remotes);
+        const candidates = yield* Effect.forEach(remotes.remotes, (remote) =>
+          Effect.gen(function* () {
+            let provider = detectSourceControlProviderFromRemoteUrl(remote.url);
+            if ((provider === null || provider.kind === "unknown") && isSshRemoteUrl(remote.url)) {
+              const host = parseRemoteHost(remote.url);
+              if (host !== null) {
+                const canonicalHost = yield* resolveSshHostAlias({ process, cwd, host });
+                if (canonicalHost !== null && canonicalHost !== host) {
+                  provider = detectSourceControlProviderFromHost(canonicalHost) ?? provider;
+                }
+              }
+            }
+            return {
+              name: remote.name,
+              url: remote.url,
+              provider,
+            } satisfies SourceControlRemoteCandidate;
+          }),
+        );
+        const context = selectProviderContext(candidates);
 
         return yield* refineUnknownRemoteProvider({
           specs: discoverySpecs,

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   sourceControlRepositorySelector,
+  detectSourceControlProviderFromHost,
   detectSourceControlProviderFromRemoteUrl,
   getChangeRequestTerminologyForKind,
   isSshRemoteUrl,
@@ -137,6 +138,17 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
     expect(
       detectSourceControlProviderFromRemoteUrl("git@bitbucket.org:workspace/repo.git")?.kind,
     ).toBe("bitbucket");
+  });
+});
+
+describe("detectSourceControlProviderFromHost", () => {
+  it("classifies canonical and self-hosted hosts", () => {
+    expect(detectSourceControlProviderFromHost("github.com")?.kind).toBe("github");
+    expect(detectSourceControlProviderFromHost("gitlab.example.com")?.kind).toBe("gitlab");
+  });
+
+  it("leaves SSH aliases unknown, because upstream resolves them first", () => {
+    expect(detectSourceControlProviderFromHost("github-personal")?.kind).toBe("unknown");
   });
 });
 

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -133,7 +133,7 @@ export function isSshRemoteUrl(remoteUrl: string): boolean {
   return SCP_SSH_REMOTE_PATTERN.test(trimmed) || trimmed.toLowerCase().startsWith("ssh://");
 }
 
-function parseRemoteHost(remoteUrl: string): string | null {
+export function parseRemoteHost(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim();
   if (trimmed.length === 0) {
     return null;
@@ -191,13 +191,9 @@ function isBitbucketHost(host: string): boolean {
   return host === "bitbucket.org" || hasDnsLabel(host, "bitbucket");
 }
 
-export function detectSourceControlProviderFromRemoteUrl(
-  remoteUrl: string,
+export function detectSourceControlProviderFromHost(
+  host: string,
 ): SourceControlProviderInfo | null {
-  const host = parseRemoteHost(remoteUrl);
-  if (!host) {
-    return null;
-  }
   const hostname = parseHostName(host);
 
   if (isGitHubHost(hostname)) {
@@ -237,6 +233,16 @@ export function detectSourceControlProviderFromRemoteUrl(
     name: host,
     baseUrl: toBaseUrl(host),
   };
+}
+
+export function detectSourceControlProviderFromRemoteUrl(
+  remoteUrl: string,
+): SourceControlProviderInfo | null {
+  const host = parseRemoteHost(remoteUrl);
+  if (!host) {
+    return null;
+  }
+  return detectSourceControlProviderFromHost(host);
 }
 
 /**

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -133,6 +133,10 @@ export function isSshRemoteUrl(remoteUrl: string): boolean {
   return SCP_SSH_REMOTE_PATTERN.test(trimmed) || trimmed.toLowerCase().startsWith("ssh://");
 }
 
+/**
+ * Returns the lowercased host of a git remote URL (including any explicit port),
+ * or null when the URL cannot be parsed.
+ */
 export function parseRemoteHost(remoteUrl: string): string | null {
   const trimmed = remoteUrl.trim();
   if (trimmed.length === 0) {
@@ -191,6 +195,12 @@ function isBitbucketHost(host: string): boolean {
   return host === "bitbucket.org" || hasDnsLabel(host, "bitbucket");
 }
 
+/**
+ * Classifies a git remote host (for example `github.com` or
+ * `github.example.com`) as a source control provider. Matching is by exact name
+ * or DNS label, so an SSH alias such as `github-personal` must be resolved to
+ * its canonical hostname before calling this.
+ */
 export function detectSourceControlProviderFromHost(
   host: string,
 ): SourceControlProviderInfo | null {
@@ -235,6 +245,10 @@ export function detectSourceControlProviderFromHost(
   };
 }
 
+/**
+ * Classifies a git remote URL by its parsed host. SSH aliases and `insteadOf`
+ * rewrites are not resolved here; callers resolve them before re-classifying.
+ */
 export function detectSourceControlProviderFromRemoteUrl(
   remoteUrl: string,
 ): SourceControlProviderInfo | null {


### PR DESCRIPTION
## What Changed

OpenCode sub-agent activity is now surfaced through T3's shared `task.*` runtime
events, at the adapter boundary.

- Correlate a parent `task` tool call to its child session via
  `part.state.metadata.sessionId` (validated against `metadata.parentSessionId`),
  falling back to `Session.parentID` ancestry so event order doesn't matter.
- Emit a deduplicated `task.started` per child (taskId = child session id,
  title/role from the task input, `timelineBypass: true`).
- Route child-session events through a separate branch that never touches parent
  turn state: child tool parts → `task.progress` (summary + last tool), child
  `session.status` busy/idle → `task.updated` running/idle, child
  `session.deleted` → `interrupted`, child `todo.updated` → progress.
- Accept child events only when their ancestry resolves to the thread, so a
  shared OpenCode server cannot leak another thread's activity.

No contract or UI changes — the Agents panel and work log already consume
`task.*` for the other providers.

## Why

T3 already renders sub-agents for Claude, Codex, and Antigravity through `task.*`
events, but the OpenCode adapter dropped all child-session activity. OpenCode's
`task` tool appeared only as a bare `collab_agent_tool_call` with no roster entry
or live status, even though the adapter already tracked child sessions for
permission routing and teardown. Users could see a sub-agent was spawned, but not
what it was doing. This maps OpenCode child sessions onto the existing lifecycle
instead of adding new machinery; a completed child turn is `idle` (resumable),
not terminal, matching the Codex adapter.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

https://github.com/user-attachments/assets/64660253-5d3f-4da3-88d2-8baa81d86575

## Before
<img width="1721" height="1038" alt="Screenshot 2026-09-12 020926" src="https://github.com/user-attachments/assets/ed2af125-83bd-4338-9fe8-9bee9de4b55f" />

## AFTER
<img width="1685" height="1012" alt="Screenshot 2026-09-12 021040" src="https://github.com/user-attachments/assets/c6cc032a-e67b-49fb-b230-d726c0b10073" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Child sessions are now represented as tasks, with clearer started, progress, completion, and title updates.
  - Resumed and previously removed child sessions can be rediscovered and restored to task tracking.

- **Bug Fixes**
  - Improved source control provider detection for SSH aliases, including aliases with explicit ports.
  - Improved validation when associating child activity with parent sessions.
  - Improved handling of child-session lifecycle and status updates.
  - Refined approval and question event handling for more reliable user prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->