### PR TITLE
fix(web): align attached composer drawer shadows

### DIFF
--- a/apps/web/src/components/chat/ComposerBanner.test.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ComposerBanner } from "./ComposerBanner";
+
+describe("ComposerBanner.Surface", () => {
+  it("casts attached drawer shadows away from the composer seam", () => {
+    const markup = renderToStaticMarkup(<ComposerBanner.Surface />);
+
+    expect(markup).toContain("before:shadow-[0_-8px_24px_-18px_rgb(0_0_0/45%)]");
+    expect(markup).not.toContain("before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)]");
+  });
+
+  it("keeps the downward shadow on floating surfaces", () => {
+    const markup = renderToStaticMarkup(<ComposerBanner.Surface placement="floating" />);
+
+    expect(markup).toContain("before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)]");
+  });
+});

--- a/apps/web/src/components/chat/ComposerBanner.tsx
+++ b/apps/web/src/components/chat/ComposerBanner.tsx
@@ -52,15 +52,15 @@ function Surface({
         "relative isolate border-0 bg-transparent shadow-none [--chat-composer-attached-tint:transparent]",
         variantColors[variant],
         placement === "attached"
-          ? "[--chat-composer-attachment-overlap:calc(1rem+1px)] before:rounded-t-[16px]"
-          : "[--chat-composer-attachment-overlap:0px] before:rounded-[1rem]",
+          ? "[--chat-composer-attachment-overlap:calc(1rem+1px)] before:rounded-t-[16px] before:shadow-[0_-8px_24px_-18px_rgb(0_0_0/45%)] dark:before:shadow-[0_-10px_28px_-18px_rgb(0_0_0/80%)]"
+          : "[--chat-composer-attachment-overlap:0px] before:rounded-[1rem] before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)] dark:before:shadow-[0_14px_32px_-18px_rgb(0_0_0/75%)]",
         "before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:border before:border-(--chat-composer-attached-outline)",
         "before:bg-[color-mix(in_srgb,var(--chat-composer-attached-surface)_var(--glass-opacity),transparent)] before:bg-[linear-gradient(var(--chat-composer-attached-tint),var(--chat-composer-attached-tint))] before:backdrop-blur-(--glass-blur) before:backdrop-saturate-(--glass-saturation)",
         // The mask cut-off bleeds one pixel past the seam: Chromium drops the last
         // device-pixel row of a filtered backdrop when the cut-off lands off the
         // device-pixel grid, and the composer's surface starts exactly there. The
         // composer's own glass covers the extra row, so the overlap never shows.
-        "before:mask-[linear-gradient(to_top,transparent_0_calc(var(--chat-composer-attachment-overlap)-1px),black_calc(var(--chat-composer-attachment-overlap)-1px))] before:shadow-[0_12px_28px_-18px_rgb(0_0_0/40%)] dark:before:shadow-[0_14px_32px_-18px_rgb(0_0_0/75%)]",
+        "before:mask-[linear-gradient(to_top,transparent_0_calc(var(--chat-composer-attachment-overlap)-1px),black_calc(var(--chat-composer-attachment-overlap)-1px))]",
         "dark:supports-[(backdrop-filter:blur(1px))_or_(-webkit-backdrop-filter:blur(1px))]:before:bg-[linear-gradient(var(--chat-composer-attached-tint),var(--chat-composer-attached-tint)),linear-gradient(to_top,transparent_0_var(--chat-composer-attachment-overlap),rgb(0_0_0/18%)_var(--chat-composer-attachment-overlap),transparent_calc(var(--chat-composer-attachment-overlap)+10px))]",
         "not-supports-[((backdrop-filter:blur(1px))_or_(-webkit-backdrop-filter:blur(1px)))]:before:bg-(--chat-composer-attached-surface)",
         className,


### PR DESCRIPTION
Attached composer drawers inherited the same downward shadow as floating banners, leaving a dark, inset seam where the narrower drawer meets the composer.

This gives attached surfaces their original upward-facing shadow while preserving the downward shadow for floating surfaces, with focused regression coverage for both placements.

### Before
![Zoomed composer drawer before](https://raw.githubusercontent.com/gsimone/t3code/pr-assets/fix-composer-drawer-shadow/.github/pr-assets/composer-drawer-shadow-before.png)

### After
![Zoomed composer drawer after](https://raw.githubusercontent.com/gsimone/t3code/pr-assets/fix-composer-drawer-shadow/.github/pr-assets/composer-drawer-shadow-after.png)

### Verification
- `vp test run apps/web/src/components/chat/ComposerBanner.test.tsx`
- `vp check apps/web/src/components/chat/ComposerBanner.tsx apps/web/src/components/chat/ComposerBanner.test.tsx`
- `vp run --filter @t3tools/web typecheck`

Created with GPT-5.6 Sol via the Cursor harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated chat composer banner surfaces with placement-specific shadows and rounded corners.
  - Attached banners now cast their shadow upward, while floating banners retain a downward shadow.
  - Adjusted mask clipping behavior for each placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->