### PR TITLE
fix(web): prevent custom provider metadata overlap

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -160,4 +160,88 @@ describe("deriveProviderModelsForDisplay", () => {
       expect(markup).toContain("is not a symlink");
     }
   });
+
+  it("puts a custom instance's config id on its own line below the name and version", () => {
+    const instanceId = ProviderInstanceId.make("codex_personal");
+    const driver = ProviderDriverKind.make("codex");
+    const liveProvider: ServerProvider = {
+      instanceId,
+      driver,
+      enabled: true,
+      installed: true,
+      version: "0.154.0",
+      status: "ready",
+      auth: { status: "unknown" },
+      checkedAt: "2026-09-11T12:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ProviderInstanceCard, {
+        instanceId,
+        instance: { driver, displayName: "personal" },
+        driverOption: undefined,
+        liveProvider,
+        mode: "list",
+        onUpdate: () => undefined,
+        hiddenModels: [],
+        favoriteModels: [],
+        modelOrder: [],
+        onHiddenModelsChange: () => undefined,
+        onFavoriteModelsChange: () => undefined,
+        onModelOrderChange: () => undefined,
+      }),
+    );
+
+    // The title line holds just the name and version; the config id renders on
+    // the line underneath so the three never compete for one cramped flex line.
+    const nameIndex = markup.indexOf(">personal<");
+    const versionIndex = markup.indexOf("v0.154.0");
+    const configIdIndex = markup.indexOf("codex_personal");
+    expect(nameIndex).toBeGreaterThanOrEqual(0);
+    expect(versionIndex).toBeGreaterThan(nameIndex);
+    expect(configIdIndex).toBeGreaterThan(versionIndex);
+    expect(markup.slice(versionIndex, configIdIndex)).toContain("</span>");
+  });
+
+  it("keeps built-in rows on a single title line without a config id chip", () => {
+    const instanceId = ProviderInstanceId.make("codex");
+    const driver = ProviderDriverKind.make("codex");
+    const liveProvider: ServerProvider = {
+      instanceId,
+      driver,
+      enabled: true,
+      installed: true,
+      version: "0.154.0",
+      status: "ready",
+      auth: { status: "unknown" },
+      checkedAt: "2026-09-11T12:00:00.000Z",
+      models: [],
+      slashCommands: [],
+      skills: [],
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ProviderInstanceCard, {
+        instanceId,
+        instance: { driver },
+        driverOption: undefined,
+        liveProvider,
+        mode: "list",
+        onUpdate: () => undefined,
+        hiddenModels: [],
+        favoriteModels: [],
+        modelOrder: [],
+        onHiddenModelsChange: () => undefined,
+        onFavoriteModelsChange: () => undefined,
+        onModelOrderChange: () => undefined,
+      }),
+    );
+
+    expect(markup).toContain(">codex<");
+    expect(markup).toContain("v0.154.0");
+    expect(markup).not.toContain(">codex</code>");
+  });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -615,12 +615,9 @@ export function ProviderInstanceCard({
           {titleIconNode}
           <span className="min-w-0 flex-1">
             <span className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
-              {String(instanceId) !== String(instance.driver) ? (
-                <code className="min-w-0 truncate rounded bg-muted/60 px-1 py-0.5 text-[10px] text-muted-foreground">
-                  {instanceId}
-                </code>
-              ) : null}
+              <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                {displayName}
+              </span>
               {versionLabel ? (
                 <code className="max-w-24 shrink-0 truncate text-xs text-muted-foreground">
                   {versionLabel}
@@ -654,6 +651,13 @@ export function ProviderInstanceCard({
                 )
               ) : null}
             </span>
+            {String(instanceId) !== String(instance.driver) ? (
+              <span className="mt-0.5 flex min-w-0">
+                <code className="min-w-0 truncate rounded bg-muted/60 px-1 py-0.5 text-[10px] text-muted-foreground">
+                  {instanceId}
+                </code>
+              </span>
+            ) : null}
             <span className="mt-0.5 flex items-start gap-1.5 text-[13px] leading-[1.45] text-muted-foreground/80">
               {statusDotNode ? (
                 <span className="flex h-[1.45em] shrink-0 items-center">{statusDotNode}</span>


### PR DESCRIPTION
## What Changed

In `ProviderInstanceCard` list mode, a custom provider instance put its display name, config-id chip, and version on one non-wrapping flex line inside the 17rem list column. The name and chip both shrank until the name collapsed to a few characters and the chip crowded the version (`pe…  codex_p…  v0.154.0`).

The title line now holds only the display name (`min-w-0 truncate`) and the version (`shrink-0`, unchanged). For custom instances (`instanceId !== driver`), the config-id chip renders on its own line underneath the title, where it can truncate without ever competing with or painting over the version. Built-in provider rows are visually unchanged, and selection, status, the enable switch, and accessibility labels are untouched.

## Why

Fixes #11241 — the custom-instance row was unreadable. Moving the config id out of the title line removes the three-way competition instead of widening the whole list column (which would overlap #8521).

## UI Changes

Before / after at the normal Providers settings width (custom Codex instance `personal` / `codex_personal`):

![Before: name collapses to a few characters, config-id chip crowds the version](https://files.catbox.moe/9twuty.png)

![After: name and version on the title line, config id on its own line](https://files.catbox.moe/v8m9dt.png)

Full panel after the fix:

![Providers settings panel after the fix](https://files.catbox.moe/tox2dz.png)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a — static layout change)

Tests: `vp test run apps/web/src/components/settings/ProviderInstanceCard.test.ts` (6 passing, including a new regression test covering the custom-instance line structure and unchanged built-in rendering), `tsc --noEmit` on apps/web, and `vp lint` / `vp fmt --check` on the changed files. Also verified in the running web app that row selection, status, and the enable switch still work.

SWE-2 High via Devin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Improved provider instance cards in list view by displaying custom instance IDs on a separate line beneath the name and version.
  - Kept built-in provider names and versions together on a single title line.
  - Improved handling of long provider names with truncation to preserve layout clarity.

- **Tests**
  - Added coverage for custom and built-in provider instance card layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->