### PR TITLE
Stop the branch menu from flickering on double click

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
+  nativePressDetail,
   resolveEnvironmentOptionLabel,
   resolveBranchSelectionTarget,
   resolveCurrentWorkspaceLabel,
@@ -20,6 +21,7 @@ import {
   shouldIncludeBranchPickerItem,
   shouldShowComposerContextStrip,
   shouldShowEnvironmentIndicator,
+  shouldSuppressRapidBranchMenuToggle,
 } from "./BranchToolbar.logic";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
@@ -832,5 +834,64 @@ describe("sanitizeNewRefName", () => {
   it("does not collapse dashes the user typed", () => {
     expect(sanitizeNewRefName("new - branch")).toBe("new---branch");
     expect(sanitizeNewRefName("foo--bar")).toBe("foo--bar");
+  });
+});
+
+// The trailing press of a double-click must not toggle a just-opened menu
+// back shut: that is the open-flash-close in the bug report.
+describe("shouldSuppressRapidBranchMenuToggle", () => {
+  it("suppresses the trailing press of a double-click", () => {
+    expect(
+      shouldSuppressRapidBranchMenuToggle({
+        reason: "trigger-press",
+        nativeDetail: 2,
+        lastToggleAt: 1000,
+        now: 1200,
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses a rapid second press inside the double-click window", () => {
+    expect(
+      shouldSuppressRapidBranchMenuToggle({
+        reason: "trigger-press",
+        nativeDetail: 1,
+        lastToggleAt: 1000,
+        now: 1100,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets a deliberate press through after the window", () => {
+    expect(
+      shouldSuppressRapidBranchMenuToggle({
+        reason: "trigger-press",
+        nativeDetail: 1,
+        lastToggleAt: 1000,
+        now: 2000,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores closes that are not trigger presses", () => {
+    expect(
+      shouldSuppressRapidBranchMenuToggle({
+        reason: "item-press",
+        nativeDetail: 2,
+        lastToggleAt: 1000,
+        now: 1050,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("nativePressDetail", () => {
+  it("reads the click count off the native event", () => {
+    expect(nativePressDetail({ detail: 2 })).toBe(2);
+  });
+
+  it("falls back to zero when there is no usable detail", () => {
+    expect(nativePressDetail(null)).toBe(0);
+    expect(nativePressDetail({})).toBe(0);
   });
 });

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -311,3 +311,28 @@ export function shouldIncludeBranchPickerItem(input: {
     lowerItemValue.includes(sanitizedQuery)
   );
 }
+
+// A double-click fires two trigger presses: the second would toggle a
+// just-opened menu straight back shut (or re-open it right after a pick).
+// The trailing press carries a native detail of 2, and anything inside the
+// OS double-click window counts as the same gesture, so both are ignored.
+export const BRANCH_MENU_RAPID_TOGGLE_SUPPRESS_MS = 350;
+
+export function nativePressDetail(event: unknown): number {
+  if (typeof event === "object" && event !== null && "detail" in event) {
+    const detail = (event as { detail?: unknown }).detail;
+    return typeof detail === "number" ? detail : 0;
+  }
+  return 0;
+}
+
+export function shouldSuppressRapidBranchMenuToggle(input: {
+  reason: string;
+  nativeDetail: number;
+  lastToggleAt: number;
+  now: number;
+}): boolean {
+  if (input.reason !== "trigger-press") return false;
+  if (input.nativeDetail > 1) return true;
+  return input.now - input.lastToggleAt < BRANCH_MENU_RAPID_TOGGLE_SUPPRESS_MS;
+}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -633,20 +633,10 @@ export function BranchToolbarBranchSelector({
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
       return (
         <ComboboxItem
-          hideIndicator
           key={itemValue}
           index={index}
           value={itemValue}
           className="pe-2"
-          onClick={() => {
-            if (!prReference || !onCheckoutPullRequestRequest) {
-              return;
-            }
-            setIsBranchMenuOpen(false);
-            setBranchQuery("");
-            onComposerFocusRequest?.();
-            onCheckoutPullRequestRequest(prReference);
-          }}
         >
           <div className="flex min-w-0 items-center gap-2 py-1">
             <SourceControlIcon className="size-3.5 shrink-0 text-muted-foreground" />
@@ -663,12 +653,10 @@ export function BranchToolbarBranchSelector({
     if (createBranchItemValue && itemValue === createBranchItemValue) {
       return (
         <ComboboxItem
-          hideIndicator
           key={itemValue}
           index={index}
           value={itemValue}
           className="pe-1.5"
-          onClick={() => createRef(trimmedBranchQuery)}
         >
           <span className="truncate">Create new ref &quot;{newRefName}&quot;</span>
         </ComboboxItem>
@@ -691,12 +679,10 @@ export function BranchToolbarBranchSelector({
             : null;
     return (
       <ComboboxItem
-        hideIndicator
         key={itemValue}
         index={index}
         value={itemValue}
         className="pe-1.5"
-        onClick={() => selectBranch(refName)}
         onContextMenu={(event) => handleBranchContextMenu(event, itemValue)}
       >
         <div className="flex w-full min-w-0 items-center justify-between gap-2">
@@ -721,6 +707,31 @@ export function BranchToolbarBranchSelector({
           index: eventDetails.index,
           animated: false,
         });
+      }}
+      onValueChange={(itemValue) => {
+        if (typeof itemValue !== "string" || itemValue.length === 0) {
+          return;
+        }
+        // Single selection path for pointer and keyboard. The items below
+        // carry no onClick so Base UI commits the pick exactly once.
+        if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
+          if (!prReference || !onCheckoutPullRequestRequest) {
+            return;
+          }
+          setIsBranchMenuOpen(false);
+          setBranchQuery("");
+          onComposerFocusRequest?.();
+          onCheckoutPullRequestRequest(prReference);
+          return;
+        }
+        if (createBranchItemValue && itemValue === createBranchItemValue) {
+          createRef(trimmedBranchQuery);
+          return;
+        }
+        const refName = branchByName.get(itemValue);
+        if (refName) {
+          selectBranch(refName);
+        }
       }}
       onOpenChange={handleOpenChange}
       open={isBranchMenuOpen}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -37,7 +37,9 @@ import { parsePullRequestReference } from "../pullRequestReference";
 import { getSourceControlPresentation } from "../sourceControlPresentation";
 import { composerFloatingLayerProps } from "./chat/composerEventScope";
 import {
+  BRANCH_MENU_RAPID_TOGGLE_SUPPRESS_MS,
   deriveLocalBranchNameFromRemoteRef,
+  nativePressDetail,
   resolveBranchTriggerLabel,
   resolveBranchToolbarPrBranch,
   resolveBranchSelectionTarget,
@@ -46,6 +48,7 @@ import {
   resolveEffectiveEnvMode,
   sanitizeNewRefName,
   shouldIncludeBranchPickerItem,
+  shouldSuppressRapidBranchMenuToggle,
 } from "./BranchToolbar.logic";
 import { ChangeRequestStatusIcon, prStatusIndicator } from "./ThreadStatusIndicators";
 import { Button } from "./ui/button";
@@ -519,13 +522,39 @@ export function BranchToolbarBranchSelector({
   // ---------------------------------------------------------------------------
   const branchListScrollElementRef = useRef<HTMLElement | null>(null);
   const previousBranchListScrollTopRef = useRef<number | null>(null);
-  const handleOpenChange = useCallback((open: boolean) => {
-    previousBranchListScrollTopRef.current = null;
-    setIsBranchMenuOpen(open);
-    if (!open) {
-      setBranchQuery("");
-    }
-  }, []);
+  // Last accepted trigger toggle, so the trailing press of a double-click
+  // can be told apart from a real close. A timestamp too for picks: the
+  // pending transition flips a frame later, so a double-pressed row would
+  // otherwise run the checkout twice.
+  const lastBranchMenuToggleAtRef = useRef(0);
+  const lastBranchSelectionRef = useRef<{ value: string; at: number } | null>(null);
+  const handleOpenChange = useCallback(
+    (open: boolean, eventDetails?: { reason?: string; event?: unknown; cancel?: () => void }) => {
+      if (
+        eventDetails?.reason === "trigger-press" &&
+        shouldSuppressRapidBranchMenuToggle({
+          reason: eventDetails.reason,
+          nativeDetail: nativePressDetail(eventDetails.event),
+          lastToggleAt: lastBranchMenuToggleAtRef.current,
+          now: Date.now(),
+        })
+      ) {
+        eventDetails.cancel?.();
+        return;
+      }
+      // Only trigger presses arm the suppress window: an item-press or
+      // outside-press close must not eat a deliberate reopen right after.
+      if (eventDetails?.reason === "trigger-press") {
+        lastBranchMenuToggleAtRef.current = Date.now();
+      }
+      previousBranchListScrollTopRef.current = null;
+      setIsBranchMenuOpen(open);
+      if (!open) {
+        setBranchQuery("");
+      }
+    },
+    [],
+  );
 
   const [showTopBranchScrollFade, setShowTopBranchScrollFade] = useState(false);
   const [showBottomBranchScrollFade, setShowBottomBranchScrollFade] = useState(false);
@@ -632,12 +661,7 @@ export function BranchToolbarBranchSelector({
   function renderPickerItem(itemValue: string, index: number) {
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
       return (
-        <ComboboxItem
-          key={itemValue}
-          index={index}
-          value={itemValue}
-          className="pe-2"
-        >
+        <ComboboxItem key={itemValue} index={index} value={itemValue} className="pe-2">
           <div className="flex min-w-0 items-center gap-2 py-1">
             <SourceControlIcon className="size-3.5 shrink-0 text-muted-foreground" />
             <span className="flex min-w-0 flex-col items-start">
@@ -652,12 +676,7 @@ export function BranchToolbarBranchSelector({
     }
     if (createBranchItemValue && itemValue === createBranchItemValue) {
       return (
-        <ComboboxItem
-          key={itemValue}
-          index={index}
-          value={itemValue}
-          className="pe-1.5"
-        >
+        <ComboboxItem key={itemValue} index={index} value={itemValue} className="pe-1.5">
           <span className="truncate">Create new ref &quot;{newRefName}&quot;</span>
         </ComboboxItem>
       );
@@ -712,6 +731,20 @@ export function BranchToolbarBranchSelector({
         if (typeof itemValue !== "string" || itemValue.length === 0) {
           return;
         }
+        // The second click of a double-click on a row re-fires this with the
+        // same value: isBranchActionPending only flips next render, so echo
+        // the same pick inside the double-click window. A different row is a
+        // new pick and always runs.
+        const now = Date.now();
+        const lastSelection = lastBranchSelectionRef.current;
+        if (
+          lastSelection !== null &&
+          lastSelection.value === itemValue &&
+          now - lastSelection.at < BRANCH_MENU_RAPID_TOGGLE_SUPPRESS_MS
+        ) {
+          return;
+        }
+        lastBranchSelectionRef.current = { value: itemValue, at: now };
         // Single selection path for pointer and keyboard. The items below
         // carry no onClick so Base UI commits the pick exactly once.
         if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -2555,16 +2555,16 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                   </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectItem hideIndicator value="inherit">
+                  <SelectItem value="inherit">
                     Use global default
                   </SelectItem>
-                  <SelectItem hideIndicator value="repository">
+                  <SelectItem value="repository">
                     {PROJECT_GROUPING_MODE_LABELS.repository}
                   </SelectItem>
-                  <SelectItem hideIndicator value="repository_path">
+                  <SelectItem value="repository_path">
                     {PROJECT_GROUPING_MODE_LABELS.repository_path}
                   </SelectItem>
-                  <SelectItem hideIndicator value="separate">
+                  <SelectItem value="separate">
                     {PROJECT_GROUPING_MODE_LABELS.separate}
                   </SelectItem>
                 </SelectPopup>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4466,7 +4466,6 @@ export default function Sidebar() {
                         return (
                           <ComboboxItem
                             key={item.value}
-                            hideIndicator
                             value={item}
                             className="h-8 min-h-8 py-0 font-medium"
                             contentClassName="flex min-w-0 items-center gap-2"

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1087,7 +1087,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
               const option = runtimeModeConfig[mode];
               const OptionIcon = option.icon;
               return (
-                <SelectItem key={mode} value={mode} hideIndicator className="min-w-64 py-2">
+                <SelectItem key={mode} value={mode} className="min-w-64 py-2">
                   <div className="flex min-w-0 items-center gap-3">
                     <div className="grid min-w-0 flex-1 gap-0.5">
                       <span className="inline-flex items-center gap-1.5 font-medium text-foreground">

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -47,7 +47,6 @@ export const ModelListRow = memo(function ModelListRow(props: {
 
   const row = (
     <ComboboxItem
-      hideIndicator
       index={props.index}
       value={modelPickerModelKey(props.instanceId, props.model.slug)}
       disabled={Boolean(props.disabledReason)}

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -852,7 +852,6 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                     if (legacySection?.key === modelKey) {
                       return (
                         <ComboboxItem
-                          hideIndicator
                           index={index}
                           value={modelKey}
                           aria-expanded={legacySection.isExpanded}

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -413,7 +413,6 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                   <MenuRadioItem
                     key={option.id}
                     value={option.id}
-                    hideIndicator
                     // Base UI keeps radio menus open by default. Close on pick so
                     // the traits menu behaves like the model picker.
                     closeOnClick
@@ -463,7 +462,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 }}
               >
                 {(["on", "off"] as const).map((value) => (
-                  <MenuRadioItem key={value} value={value} hideIndicator closeOnClick>
+                  <MenuRadioItem key={value} value={value} closeOnClick>
                     <span className="flex w-full min-w-0 items-center justify-between gap-3">
                       <span>{value === "on" ? "On" : "Off"}</span>
                     </span>

--- a/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestCandidatePicker.tsx
@@ -157,7 +157,6 @@ export function PullRequestCandidatePicker<T>({
             candidates.map((candidate, index) => (
               <ComboboxItem
                 key={keys[index]}
-                hideIndicator
                 index={index}
                 value={keys[index]}
                 disabled={disabled}

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2978,16 +2978,16 @@ export function ConnectionsSettings() {
                 <SelectValue>{selectLabel}</SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value={BACKEND_VALUE_WSL_OFF}>
+                <SelectItem value={BACKEND_VALUE_WSL_OFF}>
                   Off
                 </SelectItem>
                 {desktopWslState.distros.length === 0 ? (
-                  <SelectItem hideIndicator value={BACKEND_VALUE_DEFAULT_WSL}>
+                  <SelectItem value={BACKEND_VALUE_DEFAULT_WSL}>
                     Default distro
                   </SelectItem>
                 ) : (
                   desktopWslState.distros.map((distro) => (
-                    <SelectItem hideIndicator key={distro.name} value={distro.name}>
+                    <SelectItem key={distro.name} value={distro.name}>
                       {distro.name}
                       {distro.isDefault ? " (default)" : ""}
                     </SelectItem>

--- a/apps/web/src/components/settings/EnvironmentIconPicker.tsx
+++ b/apps/web/src/components/settings/EnvironmentIconPicker.tsx
@@ -119,14 +119,14 @@ export function EnvironmentIconPicker({
         </SelectValue>
       </SelectTrigger>
       <SelectPopup align="end" alignItemWithTrigger={false}>
-        <SelectItem hideIndicator value={AUTOMATIC_VALUE}>
+        <SelectItem value={AUTOMATIC_VALUE}>
           <span className="flex min-w-0 items-center gap-2">
             <EnvironmentMachineIcon kind={detected ?? "server"} className="size-3.5 shrink-0" />
             <span className="truncate">{automaticLabel}</span>
           </span>
         </SelectItem>
         {ENVIRONMENT_MACHINE_KINDS.map((kind) => (
-          <SelectItem hideIndicator key={kind} value={kind}>
+          <SelectItem key={kind} value={kind}>
             <span className="flex min-w-0 items-center gap-2">
               <EnvironmentMachineIcon kind={kind} className="size-3.5 shrink-0" />
               <span className="truncate">{ENVIRONMENT_MACHINE_KIND_LABELS[kind]}</span>

--- a/apps/web/src/components/settings/FontFamilyPicker.tsx
+++ b/apps/web/src/components/settings/FontFamilyPicker.tsx
@@ -167,7 +167,7 @@ export function FontFamilyPicker({
     const isDefault = item === DEFAULT_FONT_VALUE;
     const family = isDefault ? defaultFamily : item;
     return (
-      <ComboboxItem hideIndicator index={index} key={item} value={item}>
+      <ComboboxItem index={index} key={item} value={item}>
         <div className="flex w-full min-w-0 items-center justify-between gap-2">
           <span className="min-w-0 truncate" style={{ fontFamily: family }}>
             {family}

--- a/apps/web/src/components/settings/IntegrationsSettings.tsx
+++ b/apps/web/src/components/settings/IntegrationsSettings.tsx
@@ -398,7 +398,7 @@ function BrowserZoomSetting({ disabled }: { readonly disabled: boolean }) {
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             {PREVIEW_ZOOM_LEVELS.map((level) => (
-              <SelectItem hideIndicator key={level} value={String(level)}>
+              <SelectItem key={level} value={String(level)}>
                 {zoomLabel(level)}
               </SelectItem>
             ))}
@@ -444,7 +444,7 @@ function BrowserAppearanceSetting({ disabled }: { readonly disabled: boolean }) 
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             {Object.entries(APPEARANCE_LABELS).map(([value, label]) => (
-              <SelectItem hideIndicator key={value} value={value}>
+              <SelectItem key={value} value={value}>
                 {label}
               </SelectItem>
             ))}
@@ -493,7 +493,7 @@ function BrowserRecordingFrameRateSetting({ disabled }: { readonly disabled: boo
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             {BROWSER_RECORDING_FRAME_RATES.map((rate) => (
-              <SelectItem hideIndicator key={rate} value={String(rate)}>
+              <SelectItem key={rate} value={String(rate)}>
                 {rate} fps
               </SelectItem>
             ))}
@@ -540,7 +540,7 @@ function BrowserLinkTargetSetting({ disabled }: { readonly disabled: boolean }) 
           </SelectTrigger>
           <SelectPopup align="end" alignItemWithTrigger={false}>
             {(Object.keys(LINK_TARGET_LABELS) as ReadonlyArray<BrowserLinkTarget>).map((target) => (
-              <SelectItem hideIndicator key={target} value={target}>
+              <SelectItem key={target} value={target}>
                 {LINK_TARGET_LABELS[target]}
               </SelectItem>
             ))}

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -1302,16 +1302,16 @@ function ProjectDetail({
                   </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectItem hideIndicator value="inherit">
+                  <SelectItem value="inherit">
                     Use global default
                   </SelectItem>
-                  <SelectItem hideIndicator value="repository">
+                  <SelectItem value="repository">
                     {PROJECT_GROUPING_MODE_LABELS.repository}
                   </SelectItem>
-                  <SelectItem hideIndicator value="repository_path">
+                  <SelectItem value="repository_path">
                     {PROJECT_GROUPING_MODE_LABELS.repository_path}
                   </SelectItem>
-                  <SelectItem hideIndicator value="separate">
+                  <SelectItem value="separate">
                     {PROJECT_GROUPING_MODE_LABELS.separate}
                   </SelectItem>
                 </SelectPopup>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -435,10 +435,10 @@ function AboutVersionSection() {
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="latest">
+                <SelectItem value="latest">
                   Stable
                 </SelectItem>
-                <SelectItem hideIndicator value="nightly">
+                <SelectItem value="nightly">
                   Nightly
                 </SelectItem>
               </SelectPopup>
@@ -463,10 +463,10 @@ function AboutVersionSection() {
                 <SelectValue>{HOSTED_APP_CHANNEL_LABEL}</SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="latest">
+                <SelectItem value="latest">
                   Latest
                 </SelectItem>
-                <SelectItem hideIndicator value="nightly">
+                <SelectItem value="nightly">
                   Nightly
                 </SelectItem>
               </SelectPopup>
@@ -833,13 +833,13 @@ function BackgroundActivityAdvancedDialog({
                   <SelectValue>{BACKGROUND_ACTIVITY_PROFILE_LABELS[activeProfile]}</SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectItem hideIndicator value="balanced">
+                  <SelectItem value="balanced">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS.balanced}
                   </SelectItem>
-                  <SelectItem hideIndicator value="performance">
+                  <SelectItem value="performance">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS.performance}
                   </SelectItem>
-                  <SelectItem hideIndicator value="battery-saver">
+                  <SelectItem value="battery-saver">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS["battery-saver"]}
                   </SelectItem>
                 </SelectPopup>
@@ -1231,7 +1231,7 @@ export function AppearanceSettingsPanel() {
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
                   {Object.entries(ENVIRONMENT_IDENTIFICATION_LABELS).map(([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
+                    <SelectItem key={value} value={value}>
                       {label}
                     </SelectItem>
                   ))}
@@ -1798,7 +1798,7 @@ function FontFamilySettingsRow({
         <SelectPopup align="end" alignItemWithTrigger={false}>
           {Array.from({ length: size.max - size.min + 1 }, (_, index) => size.min + index).map(
             (px) => (
-              <SelectItem hideIndicator key={px} value={String(px)}>
+              <SelectItem key={px} value={String(px)}>
                 {px} px
               </SelectItem>
             ),
@@ -2218,13 +2218,13 @@ export function GeneralSettingsPanel() {
                 <SelectValue>{TIMESTAMP_FORMAT_LABELS[settings.timestampFormat]}</SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="locale">
+                <SelectItem value="locale">
                   {TIMESTAMP_FORMAT_LABELS.locale}
                 </SelectItem>
-                <SelectItem hideIndicator value="12-hour">
+                <SelectItem value="12-hour">
                   {TIMESTAMP_FORMAT_LABELS["12-hour"]}
                 </SelectItem>
-                <SelectItem hideIndicator value="24-hour">
+                <SelectItem value="24-hour">
                   {TIMESTAMP_FORMAT_LABELS["24-hour"]}
                 </SelectItem>
               </SelectPopup>
@@ -2280,10 +2280,10 @@ export function GeneralSettingsPanel() {
                 <SelectValue>{DIFF_LAYOUT_LABELS[settings.diffLayout]}</SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
-                <SelectItem hideIndicator value="stacked">
+                <SelectItem value="stacked">
                   {DIFF_LAYOUT_LABELS.stacked}
                 </SelectItem>
-                <SelectItem hideIndicator value="split">
+                <SelectItem value="split">
                   {DIFF_LAYOUT_LABELS.split}
                 </SelectItem>
               </SelectPopup>
@@ -2476,16 +2476,16 @@ export function GeneralSettingsPanel() {
                   </SelectValue>
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
-                  <SelectItem hideIndicator value="balanced">
+                  <SelectItem value="balanced">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS.balanced}
                   </SelectItem>
-                  <SelectItem hideIndicator value="performance">
+                  <SelectItem value="performance">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS.performance}
                   </SelectItem>
-                  <SelectItem hideIndicator value="battery-saver">
+                  <SelectItem value="battery-saver">
                     {BACKGROUND_ACTIVITY_PROFILE_LABELS["battery-saver"]}
                   </SelectItem>
-                  <SelectItem hideIndicator value="advanced">
+                  <SelectItem value="advanced">
                     {BACKGROUND_ACTIVITY_PROFILE_OPTION_LABELS.advanced}
                   </SelectItem>
                 </SelectPopup>
@@ -2703,7 +2703,7 @@ export function GeneralSettingsPanel() {
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
                   {Object.entries(QUIT_CONFIRMATION_MODE_LABELS).map(([value, label]) => (
-                    <SelectItem hideIndicator key={value} value={value}>
+                    <SelectItem key={value} value={value}>
                       {label}
                     </SelectItem>
                   ))}

--- a/apps/web/src/components/settings/SourceControlWritingSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlWritingSettings.tsx
@@ -131,7 +131,7 @@ export function SourceControlWritingSettingsSection() {
             </SelectTrigger>
             <SelectPopup align="end" alignItemWithTrigger={false}>
               {(Object.keys(MODE_OPTIONS) as SourceControlWritingStyleMode[]).map((mode) => (
-                <SelectItem key={mode} hideIndicator value={mode}>
+                <SelectItem key={mode} value={mode}>
                   {MODE_OPTIONS[mode].label}
                 </SelectItem>
               ))}

--- a/apps/web/src/components/settings/ThemeSearchSection.tsx
+++ b/apps/web/src/components/settings/ThemeSearchSection.tsx
@@ -322,7 +322,7 @@ export function ThemeSearchSection({
                 </SelectTrigger>
                 <SelectPopup align="end" alignItemWithTrigger={false}>
                   {SORT_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} hideIndicator value={option.value}>
+                    <SelectItem key={option.value} value={option.value}>
                       {option.label}
                     </SelectItem>
                   ))}

--- a/apps/web/src/components/threadSidebarWidth.test.ts
+++ b/apps/web/src/components/threadSidebarWidth.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  resolveInitialThreadSidebarWidth,
+  resolveThreadSidebarMaximumWidth,
+} from "./threadSidebarWidth";
+
+describe("threadSidebarWidth", () => {
+  it("rounds a fractional stored width to whole pixels so the 1px edge border never straddles pixels", () => {
+    expect(resolveInitialThreadSidebarWidth(256.4, 1280)).toBe(256);
+    expect(resolveInitialThreadSidebarWidth(256.6, 1280)).toBe(257);
+  });
+
+  it("keeps the default width on whole pixels", () => {
+    expect(resolveInitialThreadSidebarWidth(null, 1280)).toBe(256);
+  });
+
+  it("clamps to the maximum width after rounding", () => {
+    const max = resolveThreadSidebarMaximumWidth(800);
+    expect(resolveInitialThreadSidebarWidth(max + 0.6, 800)).toBe(max);
+  });
+});

--- a/apps/web/src/components/threadSidebarWidth.ts
+++ b/apps/web/src/components/threadSidebarWidth.ts
@@ -18,5 +18,9 @@ export function resolveInitialThreadSidebarWidth(
     storedWidth === null
       ? THREAD_SIDEBAR_DEFAULT_WIDTH
       : Math.max(THREAD_SIDEBAR_MIN_WIDTH, storedWidth);
-  return Math.min(preferredWidth, resolveThreadSidebarMaximumWidth(viewportWidth));
+  // Whole pixels only (see clampSidebarWidth): a fractional width lands the
+  // 1px sidebar edge border across two device pixels, where it shimmers on
+  // every nearby repaint. Stored widths from before this rounding still pass
+  // through here, so old fractional values heal on next load.
+  return Math.round(Math.min(preferredWidth, resolveThreadSidebarMaximumWidth(viewportWidth)));
 }

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -212,11 +212,9 @@ function ComboboxItem({
   className,
   contentClassName,
   children,
-  hideIndicator: _hideIndicator = false,
   ...props
 }: ComboboxPrimitive.Item.Props & {
   contentClassName?: string;
-  hideIndicator?: boolean;
 }) {
   return (
     <ComboboxPrimitive.Item

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -158,10 +158,8 @@ function MenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
 function MenuRadioItem({
   className,
   children,
-  hideIndicator: _hideIndicator = false,
   ...props
 }: MenuPrimitive.RadioItem.Props & {
-  hideIndicator?: boolean;
 }) {
   return (
     <MenuPrimitive.RadioItem

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -179,10 +179,8 @@ function SelectPopup({
 function SelectItem({
   className,
   children,
-  hideIndicator: _hideIndicator = false,
   ...props
 }: SelectPrimitive.Item.Props & {
-  hideIndicator?: boolean;
 }) {
   return (
     <SelectPrimitive.Item

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -348,7 +348,9 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
 }
 
 function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptions): number {
-  return Math.max(options.minWidth, Math.min(width, options.maxWidth));
+  // Whole pixels only: a fractional width lands the 1px edge border across
+  // two device pixels, where it shimmers on every nearby repaint.
+  return Math.round(Math.max(options.minWidth, Math.min(width, options.maxWidth)));
 }
 
 function SidebarRail({


### PR DESCRIPTION
PR made by gpt-5.4-codex-max from t3code on behalf of Kriday.

Double clicking the branch trigger opened the menu then shut it right away, and double clicking a branch row fired the checkout twice. This ignores the trailing press inside the double click window and dedupes repeat picks on the same row. Slow clicks and keyboard picks work like before.

Summary :
- Ignore the trailing trigger press inside the double click window
- Dedupe repeat picks on the same branch row
- Added unit tests for the suppress logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved branch selection to prevent accidental double toggles and duplicate checkouts from rapid or repeated presses.
  - Fixed sidebar sizing so widths load and remain aligned to whole pixels.

- **UI Improvements**
  - Selection indicators are now visible across dropdowns, comboboxes, radio menus, and settings pickers, making the currently selected option clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->