### PR TITLE
fix(web): use branch wording in commit dialogs

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -303,7 +303,7 @@ function getMenuActionDisabledReason({
 
   if (item.id === "push") {
     if (!hasBranch) {
-      return "Detached HEAD: checkout a refName before pushing.";
+      return "Detached HEAD: check out a branch before pushing.";
     }
     if (hasChanges) {
       return "Commit or stash local changes before pushing.";
@@ -324,7 +324,7 @@ function getMenuActionDisabledReason({
     return `View ${terminology.singular} is currently unavailable.`;
   }
   if (!hasBranch) {
-    return `Detached HEAD: checkout a refName before creating a ${terminology.singular}.`;
+    return `Detached HEAD: check out a branch before creating a ${terminology.singular}.`;
   }
   if (hasChanges) {
     return `Commit local changes before creating a ${terminology.singular}.`;
@@ -1754,7 +1754,7 @@ export default function GitActionsControl({
               ) : null}
               {gitStatusForActions?.refName === null && (
                 <p className="px-2 py-1.5 text-xs text-warning">
-                  Detached HEAD: create and checkout a refName to enable push and pull request
+                  Detached HEAD: create and check out a branch to enable push and pull request
                   actions.
                 </p>
               )}
@@ -1799,9 +1799,7 @@ export default function GitActionsControl({
                   <span className="font-medium">
                     {gitStatusForActions?.refName ?? "(detached HEAD)"}
                   </span>
-                  {isDefaultRef && (
-                    <span className="text-right text-warning">Warning: default refName</span>
-                  )}
+                  {isDefaultRef && <span className="text-right text-warning">Default branch</span>}
                 </span>
               </div>
               <div className="space-y-1">
@@ -1932,7 +1930,7 @@ export default function GitActionsControl({
               disabled={noneSelected}
               onClick={runDialogActionOnNewBranch}
             >
-              Commit on new refName
+              Commit on new branch
             </Button>
             <Button size="sm" disabled={noneSelected} onClick={runDialogAction}>
               Commit
@@ -1960,7 +1958,7 @@ export default function GitActionsControl({
         <DialogPopup className="max-w-xl">
           <DialogHeader>
             <DialogTitle>
-              {pendingDefaultBranchActionCopy?.title ?? "Run action on default refName?"}
+              {pendingDefaultBranchActionCopy?.title ?? "Run action on default branch?"}
             </DialogTitle>
             <DialogDescription>{pendingDefaultBranchActionCopy?.description}</DialogDescription>
           </DialogHeader>

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1984,7 +1984,7 @@ export default function GitActionsControl({
               size="sm"
               onClick={checkoutFeatureBranchAndContinuePendingAction}
             >
-              Checkout feature branch & continue
+              Check out feature branch & continue
             </Button>
           </DialogFooter>
         </DialogPopup>


### PR DESCRIPTION
## What changed

The commit dialog now says "Default branch" and "Commit on new branch". Git action messages use "branch" and "check out" consistently.

## Why

"Warning: default refName" exposed an internal field name and made committing on the default branch look like a Git configuration problem.

Fixes #7649

## UI changes

Before

![Commit dialog before](https://github.com/user-attachments/assets/a939b3cb-855f-4a6c-9383-30b1620d7595)

After

![Commit dialog after](https://github.com/user-attachments/assets/afc6dad1-6276-469a-9c88-c838eacf2787)

## Validation

Verified the dialog in the running web client with a changed file on main. Web typecheck passes. Scoped lint reports two existing React warnings. Desktop shares this component; native desktop was not separately launched. Mobile has a separate Git flow and is unaffected. No Git behavior, contracts, provider handling or connection behavior changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes

Model: GPT-6. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated Git actions messaging with clearer, more consistent “branch” terminology.
  - Improved guidance shown when pushing or creating pull requests from a detached HEAD state.
  - Refined detached-HEAD menu hints to make the required next steps easier to understand.
  - Updated commit dialog labels and default-branch confirmation text for improved clarity.
  - Clarified options for committing on a new branch and checking out a feature branch before continuing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->