### PR TITLE
fix(web): show pointer cursors on pull request controls

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestRow.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestRow.tsx
@@ -104,7 +104,7 @@ function PullRequestRowImpl({
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelect(entry)}
       className={cn(
-        "@container/pr-row grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        "@container/pr-row grid w-full cursor-pointer grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         // Offscreen rows are skipped for style, layout and paint: a long list costs what the
         // viewport shows, not what the pages have loaded. The intrinsic size keeps the
         // scrollbar honest while a row is skipped.

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -806,7 +806,7 @@ export function PullRequestSummaryTab({
                       onClick={() => check.url && openCheck(check.url)}
                       className={cn(
                         "flex min-w-0 flex-1 items-start gap-2 rounded-md px-2 py-2 text-left text-xs leading-5 [&>svg]:mt-0.5",
-                        check.url ? undefined : "cursor-default",
+                        check.url ? "cursor-pointer" : "cursor-default",
                       )}
                     >
                       <PullRequestCheckStatusIcon status={check.status} />

--- a/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestTimelineTab.tsx
@@ -385,7 +385,7 @@ function CommitEvent({
   return (
     <button
       type="button"
-      className="group relative mb-5 block w-full rounded-sm pl-12 text-left outline-none [contain-intrinsic-block-size:48px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring"
+      className="group relative mb-5 block w-full cursor-pointer rounded-sm pl-12 text-left outline-none [contain-intrinsic-block-size:48px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`View commit ${event.id}`}
       onClick={() => onOpen(event.id)}
     >


### PR DESCRIPTION
## What changed

Pull request rows, linked CI checks and timeline commits now show a pointer cursor when hovered. Checks without a URL keep the default cursor. The Summary, Timeline and Code tabs already inherit pointer styling from Toggle.

## Why

These controls opened a review, check or commit while displaying the ordinary cursor, making their click targets harder to recognize.

Fixes #7606

## UI changes

Before

![PR row with the default cursor](https://github.com/user-attachments/assets/75feca1a-a0c1-4820-bc11-27ca5c77ffb7)

After

![PR row with the pointer cursor](https://github.com/user-attachments/assets/8f1b86e3-da72-4a03-9111-1bc64bd58327)

## Validation

Verified the live PR row changes from computed cursor `default` to `pointer`; screenshots include the actual cursor in an isolated Linux window. Web typecheck passes. Scoped lint has one existing array-index-key warning.

The detail panel returned a GitHub CLI error in this environment, so linked-check and timeline cursor changes were inspected in source but not exercised in that panel. Web and desktop share these components. Mobile uses a separate touch UI. No action handlers, contracts, provider behavior or connection handling changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes

Model: GPT-6. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated hover cursors across pull request rows, checks with available links, and timeline commit events to clearly indicate clickable elements.
  * Preserved the default cursor for checks without links.
  * Improved pull request title-row indicators by displaying approval status and check details alongside the title.
  * Approved pull requests now use the approval glyph, while “Changes requested” remains highlighted in amber.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->