### PR TITLE
fix(server): report Grok context window usage

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -618,6 +618,17 @@ const program = Effect.gen(function* () {
       const requestedSessionId = String(request.sessionId ?? sessionId);
       promptCount += 1;
 
+      if (process.env.T3_ACP_EMIT_USAGE === "1") {
+        yield* agent.client.sessionUpdate({
+          sessionId: requestedSessionId,
+          update: {
+            sessionUpdate: "usage_update",
+            used: promptCount === 1 ? 42_000 : 0,
+            size: promptCount === 1 ? 128_000 : 256_000,
+          },
+        });
+      }
+
       if (completeFirstPromptOnCancel && promptCount === 1) {
         yield* agent.client.sessionUpdate({
           sessionId: requestedSessionId,

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -339,6 +339,52 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
     }),
   );
 
+  it.effect("reports ACP context usage and replaces it with zero on a later turn", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-context-usage");
+      const wrapperPath = yield* Effect.promise(() =>
+        makeMockGrokWrapper({ T3_ACP_EMIT_USAGE: "1" }),
+      );
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const events: ProviderRuntimeEvent[] = [];
+      const completed = yield* Deferred.make<void>();
+      let completedTurns = 0;
+      yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.gen(function* () {
+          events.push(event);
+          if (event.type === "turn.completed" && ++completedTurns === 2) {
+            yield* Deferred.succeed(completed, undefined);
+          }
+        }),
+      ).pipe(Effect.forkChild);
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("grok"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({ threadId, input: "first", attachments: [] });
+      yield* adapter.sendTurn({ threadId, input: "second", attachments: [] });
+      yield* Deferred.await(completed);
+
+      const usageEvents = events.filter((event) => event.type === "thread.token-usage.updated");
+      assert.deepStrictEqual(
+        usageEvents.map((event) => event.payload.usage),
+        [
+          { usedTokens: 42_000, maxTokens: 128_000 },
+          { usedTokens: 0, maxTokens: 256_000 },
+        ],
+      );
+      const turns = events.filter((event) => event.type === "turn.started");
+      assert.lengthOf(turns, 2);
+      assert.deepStrictEqual(
+        usageEvents.map((event) => ({ threadId: event.threadId, turnId: event.turnId })),
+        turns.map((event) => ({ threadId, turnId: event.turnId })),
+      );
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
   it.effect.skipIf(windowsHost)("closes the ACP child process when a session stops", () =>
     Effect.gen(function* () {
       const threadId = ThreadId.make("grok-stop-session-close");

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -1314,6 +1314,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 if (
                   event._tag === "PlanUpdated" ||
                   event._tag === "ToolCallUpdated" ||
+                  event._tag === "UsageUpdated" ||
                   event._tag === "ContentDelta"
                 ) {
                   yield* logNative(ctx.threadId, "session/update", event.rawPayload);
@@ -1324,6 +1325,23 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                 }
 
                 const notificationTurnId = resolveNotificationTurnId(ctx);
+                // Context usage belongs to the session, including updates outside a turn.
+                if (event._tag === "UsageUpdated") {
+                  yield* offerRuntimeEvent({
+                    type: "thread.token-usage.updated",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: ctx.threadId,
+                    turnId: notificationTurnId,
+                    payload: { usage: event.usage },
+                    raw: {
+                      source: "acp.jsonrpc",
+                      method: "session/update",
+                      payload: event.rawPayload,
+                    },
+                  });
+                  return;
+                }
                 if (
                   notificationTurnId === undefined ||
                   ctx.interruptedTurnIds.has(notificationTurnId)

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -282,6 +282,7 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.version).toBeNull();
       expect(snapshot.message).toContain("Checking Grok");
       expect(snapshot.requiresNewThreadForModelChange).toBeUndefined();
+      expect(snapshot.reportsContextWindow).toBe(true);
     }),
   );
 });
@@ -378,6 +379,7 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
       expect(snapshot.status).toBe("ready");
       expect(snapshot.version).toBe("1.0.13");
+      expect(snapshot.reportsContextWindow).toBe(true);
       expect(snapshot.auth).toEqual({
         status: "authenticated",
         type: "cached_token",

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -46,6 +46,7 @@ const GROK_PRESENTATION = {
   displayName: "Grok",
   badgeLabel: "Early Access",
   showInteractionModeToggle: false,
+  reportsContextWindow: true,
 } as const;
 const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [],

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -16,6 +16,35 @@ import {
 } from "./AcpRuntimeModel.ts";
 
 describe("AcpRuntimeModel", () => {
+  it.each([
+    { used: 42_000, size: 128_000, usage: { usedTokens: 42_000, maxTokens: 128_000 } },
+    { used: 0, size: 128_000, usage: { usedTokens: 0, maxTokens: 128_000 } },
+    { used: 100, size: 0, usage: { usedTokens: 100 } },
+  ])("parses ACP context usage: $used / $size", ({ used, size, usage }) => {
+    const notification = {
+      sessionId: "session-1",
+      update: { sessionUpdate: "usage_update", used, size },
+    } satisfies EffectAcpSchema.SessionNotification;
+    expect(parseSessionUpdateEvent(notification).events).toEqual([
+      { _tag: "UsageUpdated", usage, rawPayload: notification },
+    ]);
+  });
+
+  it.each([
+    { used: -1, size: 128_000 },
+    { used: 1.5, size: 128_000 },
+    { used: Number.NaN, size: 128_000 },
+    { used: 100, size: -1 },
+    { used: 100, size: Number.POSITIVE_INFINITY },
+  ])("ignores invalid ACP context usage: $used / $size", ({ used, size }) => {
+    expect(
+      parseSessionUpdateEvent({
+        sessionId: "session-1",
+        update: { sessionUpdate: "usage_update", used, size },
+      }).events,
+    ).toEqual([]);
+  });
+
   it("parses session mode state from typed ACP session setup responses", () => {
     const modeState = parseSessionModeState({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -3,9 +3,12 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { deriveToolActivityPresentation } from "@t3tools/shared/toolActivity";
-import type { ToolLifecycleItemType } from "@t3tools/contracts";
+import { ThreadTokenUsageSnapshot, type ToolLifecycleItemType } from "@t3tools/contracts";
+
+const decodeContextUsage = Schema.decodeUnknownOption(ThreadTokenUsageSnapshot);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -81,6 +84,11 @@ export interface AcpPermissionRequest {
 }
 
 export type AcpParsedSessionEvent =
+  | {
+      readonly _tag: "UsageUpdated";
+      readonly usage: ThreadTokenUsageSnapshot;
+      readonly rawPayload: unknown;
+    }
   | {
       readonly _tag: "ModeChanged";
       readonly modeId: string;
@@ -793,6 +801,16 @@ export function parseSessionUpdateEvent(params: EffectAcpSchema.SessionNotificat
   let modeId: string | undefined;
 
   switch (upd.sessionUpdate) {
+    case "usage_update": {
+      const usage = decodeContextUsage({
+        usedTokens: upd.used,
+        ...(upd.size === 0 ? {} : { maxTokens: upd.size }),
+      });
+      if (Option.isSome(usage)) {
+        events.push({ _tag: "UsageUpdated", usage: usage.value, rawPayload: params });
+      }
+      break;
+    }
     case "config_option_update": {
       events.push({
         _tag: "ConfigOptionsUpdated",


### PR DESCRIPTION
## What Changed

Grok context usage now reaches the existing web/desktop context-window indicator. Parse ACP `usage_update` notifications into validated token snapshots, emit `thread.token-usage.updated` from the Grok adapter, and advertise context-window reporting in Grok provider snapshots.

## Why

The ACP parser previously dropped usage notifications, leaving Grok threads without context-window data. The adapter now forwards session usage even outside an active turn, preserves zero usage, and treats a zero capacity as unknown. Invalid token values are ignored. The existing event contract carries updates across local and remote connections.

## Validation

- 99 tests passed: `vp test run GrokAdapter GrokProvider AcpRuntimeModel`.
- Server typecheck, targeted lint, formatting, and diff checks passed.
- Regression coverage includes successive turns with changed capacity and zero usage, invalid usage values, and provider capability snapshots.
- Live Grok and browser verification are pending; no screenshots captured. Mobile currently has no context-meter UI. Other provider adapters retain their current behavior.

Manual check: start an isolated dev environment, open its pairing URL, enable Grok and Settings → General → Context window indicator (legacy), then send a Grok prompt. Confirm the indicator shows used tokens and capacity when the CLI emits usage, and updates on subsequent turns.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] Live verification and before/after evidence for the existing indicator

Implemented with GPT-6 using the Codex harness.
