### PR TITLE
feat(desktop): fix login-shell environment capture w config

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -245,7 +245,11 @@ const startup = Effect.gen(function* () {
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
-  yield* shellEnvironment.installIntoProcess;
+  const startupSettings = yield* desktopSettings.load;
+  yield* shellEnvironment.installIntoProcess({
+    mode: startupSettings.shellEnvironmentMode,
+    names: startupSettings.shellEnvironmentNames,
+  });
   const hasCommandLinePasswordStore =
     preReadyElectronOptions.linuxPasswordStoreCommandLine !== null;
   const linuxElectronOptions =
@@ -269,7 +273,6 @@ const startup = Effect.gen(function* () {
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
-  yield* desktopSettings.load;
 
   if (linuxElectronOptions !== null) {
     yield* logStartupInfo("linux password store configured", {

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -26,6 +26,8 @@ const DesktopSettingsPatch = Schema.Struct({
   ),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(Schema.Literals(["local-only", "network-accessible"])),
+  shellEnvironmentMode: Schema.optionalKey(Schema.String),
+  shellEnvironmentNames: Schema.optionalKey(Schema.Array(Schema.String)),
   tailscaleServeEnabled: Schema.optionalKey(Schema.Boolean),
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(Schema.Literals(["latest", "nightly"])),
@@ -109,6 +111,8 @@ describe("DesktopSettings", () => {
         mainWindowBounds: null,
         mainWindowMaximized: false,
         serverExposureMode: "local-only",
+        shellEnvironmentMode: "allowlist",
+        shellEnvironmentNames: [],
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
         updateChannel: "nightly",
@@ -127,6 +131,8 @@ describe("DesktopSettings", () => {
         yield* writeSettingsPatch({
           linuxPasswordStore: "gnome-libsecret",
           serverExposureMode: "network-accessible",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
           updateChannel: "latest",
@@ -138,6 +144,8 @@ describe("DesktopSettings", () => {
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
           updateChannel: "latest",
@@ -245,6 +253,8 @@ describe("DesktopSettings", () => {
           mainWindowBounds: { x: 120, y: 80, width: 1280, height: 900 },
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
           updateChannel: "latest",
@@ -301,6 +311,8 @@ describe("DesktopSettings", () => {
             mainWindowBounds: null,
             mainWindowMaximized: false,
             serverExposureMode: "network-accessible",
+            shellEnvironmentMode: "allowlist",
+            shellEnvironmentNames: [],
             tailscaleServeEnabled: true,
             tailscaleServePort: 8443,
             updateChannel: "nightly",
@@ -349,6 +361,8 @@ describe("DesktopSettings", () => {
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
           updateChannel: "nightly",
@@ -377,6 +391,8 @@ describe("DesktopSettings", () => {
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
           updateChannel: "latest",
@@ -404,6 +420,8 @@ describe("DesktopSettings", () => {
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
+          shellEnvironmentMode: "allowlist",
+          shellEnvironmentNames: [],
           tailscaleServeEnabled: true,
           tailscaleServePort: 443,
           updateChannel: "latest",
@@ -487,6 +505,43 @@ describe("DesktopSettings", () => {
         const loaded = yield* settings.load;
         assert.equal(loaded.wslBackendEnabled, true);
         assert.equal(loaded.wslDistro, "Ubuntu-22.04");
+      }),
+    ),
+  );
+
+  it.effect("defaults to the fixed login-shell allowlist", () =>
+    withSettings(
+      Effect.gen(function* () {
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        const loaded = yield* settings.load;
+        assert.equal(loaded.shellEnvironmentMode, "allowlist");
+        assert.deepEqual(loaded.shellEnvironmentNames, []);
+      }),
+    ),
+  );
+
+  it.effect("loads the shell environment harvest and drops unusable names", () =>
+    withSettings(
+      Effect.gen(function* () {
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        yield* writeSettingsPatch({
+          shellEnvironmentMode: "all",
+          shellEnvironmentNames: ["OPENAI_API_KEY", "FOO; rm -rf /", "HOME", "OPENAI_API_KEY"],
+        });
+        const loaded = yield* settings.load;
+        assert.equal(loaded.shellEnvironmentMode, "all");
+        assert.deepEqual(loaded.shellEnvironmentNames, ["OPENAI_API_KEY"]);
+      }),
+    ),
+  );
+
+  it.effect("falls back to the allowlist for an unrecognized harvest mode", () =>
+    withSettings(
+      Effect.gen(function* () {
+        const settings = yield* DesktopAppSettings.DesktopAppSettings;
+        yield* writeSettingsPatch({ shellEnvironmentMode: "everything" });
+        const loaded = yield* settings.load;
+        assert.equal(loaded.shellEnvironmentMode, "allowlist");
       }),
     ),
   );

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -27,7 +27,7 @@ const DesktopSettingsPatch = Schema.Struct({
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(Schema.Literals(["local-only", "network-accessible"])),
   shellEnvironmentMode: Schema.optionalKey(Schema.String),
-  shellEnvironmentNames: Schema.optionalKey(Schema.Array(Schema.String)),
+  shellEnvironmentNames: Schema.optionalKey(Schema.Array(Schema.Unknown)),
   tailscaleServeEnabled: Schema.optionalKey(Schema.Boolean),
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(Schema.Literals(["latest", "nightly"])),
@@ -535,13 +535,19 @@ describe("DesktopSettings", () => {
     ),
   );
 
-  it.effect("falls back to the allowlist for an unrecognized harvest mode", () =>
+  it.effect("keeps unrelated settings when the harvest values are invalid", () =>
     withSettings(
       Effect.gen(function* () {
         const settings = yield* DesktopAppSettings.DesktopAppSettings;
-        yield* writeSettingsPatch({ shellEnvironmentMode: "everything" });
+        yield* writeSettingsPatch({
+          serverExposureMode: "network-accessible",
+          shellEnvironmentMode: "everything",
+          shellEnvironmentNames: [42, "OPENAI_API_KEY"],
+        });
         const loaded = yield* settings.load;
         assert.equal(loaded.shellEnvironmentMode, "allowlist");
+        assert.deepEqual(loaded.shellEnvironmentNames, ["OPENAI_API_KEY"]);
+        assert.equal(loaded.serverExposureMode, "network-accessible");
       }),
     ),
   );

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -21,6 +21,13 @@ import {
   normalizeLinuxPasswordStorePreference,
   type LinuxPasswordStorePreference,
 } from "../linuxSecretStorage.ts";
+import {
+  DEFAULT_SHELL_ENVIRONMENT_HARVEST,
+  normalizeShellEnvironmentMode,
+  normalizeShellEnvironmentNames,
+  ShellEnvironmentModeSchema,
+  type ShellEnvironmentMode,
+} from "../shell/shellEnvironmentHarvest.ts";
 import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts";
 import { isValidDistroName } from "../wsl/wslPathParsing.ts";
 
@@ -29,6 +36,8 @@ export interface DesktopSettings {
   readonly mainWindowBounds: DesktopWindowBounds | null;
   readonly mainWindowMaximized: boolean;
   readonly serverExposureMode: DesktopServerExposureMode;
+  readonly shellEnvironmentMode: ShellEnvironmentMode;
+  readonly shellEnvironmentNames: ReadonlyArray<string>;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
   readonly updateChannel: DesktopUpdateChannel;
@@ -77,6 +86,8 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   mainWindowBounds: null,
   mainWindowMaximized: false,
   serverExposureMode: "local-only",
+  shellEnvironmentMode: DEFAULT_SHELL_ENVIRONMENT_HARVEST.mode,
+  shellEnvironmentNames: DEFAULT_SHELL_ENVIRONMENT_HARVEST.names,
   tailscaleServeEnabled: false,
   tailscaleServePort: DEFAULT_TAILSCALE_SERVE_PORT,
   updateChannel: "latest",
@@ -98,6 +109,8 @@ const DesktopSettingsDocument = Schema.Struct({
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
+  shellEnvironmentMode: Schema.optionalKey(ShellEnvironmentModeSchema),
+  shellEnvironmentNames: Schema.optionalKey(Schema.Array(Schema.String)),
   tailscaleServeEnabled: Schema.optionalKey(Schema.Boolean),
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(DesktopUpdateChannelSchema),
@@ -229,6 +242,8 @@ function normalizeDesktopSettingsDocument(
     mainWindowMaximized: mainWindowBounds !== null && parsed.mainWindowMaximized === true,
     serverExposureMode:
       parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
+    shellEnvironmentMode: normalizeShellEnvironmentMode(parsed.shellEnvironmentMode),
+    shellEnvironmentNames: normalizeShellEnvironmentNames(parsed.shellEnvironmentNames),
     tailscaleServeEnabled: parsed.tailscaleServeEnabled === true,
     tailscaleServePort: normalizeTailscaleServePort(parsed.tailscaleServePort),
     updateChannel: updateChannelConfiguredByUser
@@ -258,6 +273,12 @@ function toDesktopSettingsDocument(
   }
   if (settings.serverExposureMode !== defaults.serverExposureMode) {
     document.serverExposureMode = settings.serverExposureMode;
+  }
+  if (settings.shellEnvironmentMode !== defaults.shellEnvironmentMode) {
+    document.shellEnvironmentMode = settings.shellEnvironmentMode;
+  }
+  if (settings.shellEnvironmentNames.length > 0) {
+    document.shellEnvironmentNames = settings.shellEnvironmentNames;
   }
   if (settings.tailscaleServeEnabled !== defaults.tailscaleServeEnabled) {
     document.tailscaleServeEnabled = settings.tailscaleServeEnabled;

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -25,7 +25,6 @@ import {
   DEFAULT_SHELL_ENVIRONMENT_HARVEST,
   normalizeShellEnvironmentMode,
   normalizeShellEnvironmentNames,
-  ShellEnvironmentModeSchema,
   type ShellEnvironmentMode,
 } from "../shell/shellEnvironmentHarvest.ts";
 import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts";
@@ -109,8 +108,8 @@ const DesktopSettingsDocument = Schema.Struct({
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
-  shellEnvironmentMode: Schema.optionalKey(ShellEnvironmentModeSchema),
-  shellEnvironmentNames: Schema.optionalKey(Schema.Array(Schema.String)),
+  shellEnvironmentMode: Schema.optionalKey(Schema.Unknown),
+  shellEnvironmentNames: Schema.optionalKey(Schema.Unknown),
   tailscaleServeEnabled: Schema.optionalKey(Schema.Boolean),
   tailscaleServePort: Schema.optionalKey(Schema.Number),
   updateChannel: Schema.optionalKey(DesktopUpdateChannelSchema),
@@ -220,6 +219,7 @@ export function normalizeMainWindowBounds(value: unknown): DesktopWindowBounds |
 function normalizeDesktopSettingsDocument(
   parsed: DesktopSettingsDocument,
   appVersion: string,
+  platform: NodeJS.Platform,
 ): DesktopSettings {
   const defaultSettings = resolveDefaultDesktopSettings(appVersion);
   const mainWindowBounds = normalizeMainWindowBounds(parsed.mainWindowBounds);
@@ -243,7 +243,7 @@ function normalizeDesktopSettingsDocument(
     serverExposureMode:
       parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
     shellEnvironmentMode: normalizeShellEnvironmentMode(parsed.shellEnvironmentMode),
-    shellEnvironmentNames: normalizeShellEnvironmentNames(parsed.shellEnvironmentNames),
+    shellEnvironmentNames: normalizeShellEnvironmentNames(parsed.shellEnvironmentNames, platform),
     tailscaleServeEnabled: parsed.tailscaleServeEnabled === true,
     tailscaleServePort: normalizeTailscaleServePort(parsed.tailscaleServePort),
     updateChannel: updateChannelConfiguredByUser
@@ -399,6 +399,7 @@ function readSettings(
   fileSystem: FileSystem.FileSystem,
   settingsPath: string,
   appVersion: string,
+  platform: NodeJS.Platform,
 ): Effect.Effect<DesktopSettings> {
   const defaultSettings = resolveDefaultDesktopSettings(appVersion);
 
@@ -409,7 +410,7 @@ function readSettings(
         onNone: () => Effect.succeed(defaultSettings),
         onSome: (raw) =>
           decodeDesktopSettingsJson(raw).pipe(
-            Effect.map((parsed) => normalizeDesktopSettingsDocument(parsed, appVersion)),
+            Effect.map((parsed) => normalizeDesktopSettingsDocument(parsed, appVersion, platform)),
             Effect.orElseSucceed(() => defaultSettings),
           ),
       }),
@@ -525,6 +526,7 @@ export const make = Effect.gen(function* () {
         fileSystem,
         environment.desktopSettingsPath,
         environment.appVersion,
+        environment.platform,
       );
       return yield* SynchronizedRef.setAndGet(settingsRef, settings);
     }).pipe(Effect.withSpan("desktop.settings.load")),

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -12,6 +12,10 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopShellEnvironment from "./DesktopShellEnvironment.ts";
+import {
+  DEFAULT_SHELL_ENVIRONMENT_HARVEST,
+  type ShellEnvironmentHarvest,
+} from "./shellEnvironmentHarvest.ts";
 
 const textEncoder = new TextEncoder();
 
@@ -27,6 +31,17 @@ function envOutput(values: Readonly<Record<string, string>>): string {
       `__T3CODE_ENV_${name}_END__`,
     ])
     .join("\n");
+}
+
+function fullEnvOutput(values: Readonly<Record<string, string>>, delimiter = "\0"): string {
+  const body = Object.entries(values)
+    .map(([name, value]) => `${name}=${value}`)
+    .join(delimiter);
+  return ["__T3CODE_ENV_*_START__", body, "__T3CODE_ENV_*_END__"].join("\n");
+}
+
+function commandLine(command: ChildProcess.Command): string {
+  return command._tag === "StandardCommand" ? command.args.join(" ") : "";
 }
 
 function makeProcess(output: string): ChildProcessSpawner.ChildProcessHandle {
@@ -69,6 +84,7 @@ function runShellEnvironment(input: {
   readonly platform: NodeJS.Platform;
   readonly handler: (command: ChildProcess.Command) => string;
   readonly failure?: PlatformError.PlatformError;
+  readonly harvest?: ShellEnvironmentHarvest;
 }) {
   const environmentLayer = Layer.succeed(
     DesktopEnvironment.DesktopEnvironment,
@@ -87,7 +103,7 @@ function runShellEnvironment(input: {
 
   const program = Effect.gen(function* () {
     const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
-    yield* shellEnvironment.installIntoProcess;
+    yield* shellEnvironment.installIntoProcess(input.harvest ?? DEFAULT_SHELL_ENVIRONMENT_HARVEST);
   }).pipe(
     Effect.provide(
       DesktopShellEnvironment.layer.pipe(
@@ -394,6 +410,191 @@ describe("DesktopShellEnvironment", () => {
       });
 
       assert.equal(env.DBUS_SESSION_BUS_ADDRESS, "unix:path=/run/user/1000/bus");
+    }),
+  );
+
+  it.effect("leaves the probe untouched when no harvest is configured", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: "/usr/bin" });
+        },
+      });
+
+      const args = commandLine(commands[0] as ChildProcess.Command);
+      assert.equal(args.includes("env -0"), false);
+      assert.equal(args.includes("printenv OPENAI_API_KEY"), false);
+    }),
+  );
+
+  it.effect("restores configured extra names from the login shell", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "allowlist", names: ["OPENAI_API_KEY"] },
+        handler: (command) => {
+          commands.push(command);
+          return envOutput({ PATH: "/usr/bin", OPENAI_API_KEY: "sk-test" });
+        },
+      });
+
+      assert.equal(
+        commandLine(commands[0] as ChildProcess.Command).includes("printenv OPENAI_API_KEY"),
+        true,
+      );
+      assert.equal(env.OPENAI_API_KEY, "sk-test");
+    }),
+  );
+
+  it.effect("lets the login shell win over an inherited value for configured names", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        OPENAI_API_KEY: "sk-stale",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "allowlist", names: ["OPENAI_API_KEY"] },
+        handler: () => envOutput({ PATH: "/usr/bin", OPENAI_API_KEY: "sk-fresh" }),
+      });
+
+      assert.equal(env.OPENAI_API_KEY, "sk-fresh");
+    }),
+  );
+
+  it.effect("restores the whole login shell environment in all mode", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "all", names: [] },
+        handler: (command) => {
+          commands.push(command);
+          return [
+            envOutput({ PATH: "/usr/bin" }),
+            fullEnvOutput({
+              PATH: "/usr/bin",
+              OPENAI_API_KEY: "sk-test",
+              CARGO_HOME: "/home/test/.local/share/cargo",
+              GREETING: "line one\nline two",
+              CONNECTION: "key=value=more",
+            }),
+          ].join("\n");
+        },
+      });
+
+      assert.equal(commandLine(commands[0] as ChildProcess.Command).includes("env -0"), true);
+      assert.equal(env.OPENAI_API_KEY, "sk-test");
+      assert.equal(env.CARGO_HOME, "/home/test/.local/share/cargo");
+      assert.equal(env.GREETING, "line one\nline two");
+      assert.equal(env.CONNECTION, "key=value=more");
+    }),
+  );
+
+  it.effect("does not import process identity names in all mode", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        HOME: "/home/desktop",
+        PWD: "/",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "all", names: [] },
+        handler: () =>
+          [
+            envOutput({ PATH: "/usr/bin" }),
+            fullEnvOutput({
+              HOME: "/home/shell",
+              PWD: "/home/shell/projects",
+              OLDPWD: "/tmp",
+              SHLVL: "3",
+              _: "/usr/bin/env",
+            }),
+          ].join("\n"),
+      });
+
+      assert.equal(env.HOME, "/home/desktop");
+      assert.equal(env.PWD, "/");
+      assert.equal(env.OLDPWD, undefined);
+      assert.equal(env.SHLVL, undefined);
+      assert.equal(env._, undefined);
+    }),
+  );
+
+  it.effect("keeps PATH merging and locale precedence in all mode", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        LANG: "en_US.UTF-8",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "darwin",
+        harvest: { mode: "all", names: [] },
+        handler: () =>
+          [
+            envOutput({ PATH: "/opt/homebrew/bin" }),
+            fullEnvOutput({ PATH: "/only/from/dump", LANG: "de_DE.UTF-8" }),
+          ].join("\n"),
+      });
+
+      assert.equal(env.PATH, "/opt/homebrew/bin:/usr/bin");
+      assert.equal(env.LANG, "en_US.UTF-8");
+    }),
+  );
+
+  it.effect("restores configured extra names from the PowerShell profile on Windows", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32" };
+      const commands: ChildProcess.Command[] = [];
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        harvest: { mode: "all", names: ["OPENAI_API_KEY"] },
+        handler: (command) => {
+          commands.push(command);
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Windows\\System32" })
+            : [
+                envOutput({ PATH: "C:\\Windows\\System32", OPENAI_API_KEY: "sk-test" }),
+                fullEnvOutput({ CARGO_HOME: "C:\\Users\\test\\.cargo" }, "\n"),
+              ].join("\n");
+        },
+      });
+
+      const profileCommand = commands.find(
+        (command) => command._tag === "StandardCommand" && !command.args.includes("-NoProfile"),
+      );
+      assert.equal(
+        commandLine(profileCommand as ChildProcess.Command).includes("Get-ChildItem Env:"),
+        true,
+      );
+      assert.equal(env.OPENAI_API_KEY, "sk-test");
+      assert.equal(env.CARGO_HOME, "C:\\Users\\test\\.cargo");
     }),
   );
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -33,10 +33,10 @@ function envOutput(values: Readonly<Record<string, string>>): string {
     .join("\n");
 }
 
-function fullEnvOutput(values: Readonly<Record<string, string>>, delimiter = "\0"): string {
+function fullEnvOutput(values: Readonly<Record<string, string>>): string {
   const body = Object.entries(values)
     .map(([name, value]) => `${name}=${value}`)
-    .join(delimiter);
+    .join("\0");
   return ["__T3CODE_ENV_*_START__", body, "__T3CODE_ENV_*_END__"].join("\n");
 }
 
@@ -581,7 +581,7 @@ describe("DesktopShellEnvironment", () => {
             ? envOutput({ PATH: "C:\\Windows\\System32" })
             : [
                 envOutput({ PATH: "C:\\Windows\\System32", OPENAI_API_KEY: "sk-test" }),
-                fullEnvOutput({ CARGO_HOME: "C:\\Users\\test\\.cargo" }, "\n"),
+                fullEnvOutput({ CARGO_HOME: "C:\\Users\\test\\.cargo" }),
               ].join("\n");
         },
       });
@@ -594,6 +594,109 @@ describe("DesktopShellEnvironment", () => {
         true,
       );
       assert.equal(env.OPENAI_API_KEY, "sk-test");
+      assert.equal(env.CARGO_HOME, "C:\\Users\\test\\.cargo");
+    }),
+  );
+
+  it.effect("clears an inherited value when the login shell exports it empty", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        OPENAI_API_KEY: "sk-stale",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "all", names: [] },
+        handler: () =>
+          [
+            envOutput({ PATH: "/usr/bin" }),
+            fullEnvOutput({ OPENAI_API_KEY: "", CARGO_HOME: "/home/test/.cargo" }),
+          ].join("\n"),
+      });
+
+      assert.equal(env.OPENAI_API_KEY, "");
+      assert.equal(env.CARGO_HOME, "/home/test/.cargo");
+    }),
+  );
+
+  it.effect("keeps parsing the dump when a value contains the terminator marker", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { SHELL: "/bin/zsh", PATH: "/usr/bin" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        harvest: { mode: "all", names: [] },
+        handler: () =>
+          [
+            envOutput({ PATH: "/usr/bin" }),
+            fullEnvOutput({
+              SNEAKY: "__T3CODE_ENV_*_END__",
+              CARGO_HOME: "/home/test/.cargo",
+              RUSTUP_HOME: "/home/test/.rustup",
+            }),
+          ].join("\n"),
+      });
+
+      assert.equal(env.SNEAKY, "__T3CODE_ENV_*_END__");
+      assert.equal(env.CARGO_HOME, "/home/test/.cargo");
+      assert.equal(env.RUSTUP_HOME, "/home/test/.rustup");
+    }),
+  );
+
+  it.effect("preserves multiline values in the Windows dump", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        harvest: { mode: "all", names: [] },
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Windows\\System32" })
+            : [
+                envOutput({ PATH: "C:\\Windows\\System32" }),
+                fullEnvOutput({
+                  MULTI: "first\nINJECTED=value",
+                  CARGO_HOME: "C:\\Users\\test\\.cargo",
+                }),
+              ].join("\n");
+        },
+      });
+
+      assert.equal(env.MULTI, "first\nINJECTED=value");
+      assert.equal(env.INJECTED, undefined);
+      assert.equal(env.CARGO_HOME, "C:\\Users\\test\\.cargo");
+    }),
+  );
+
+  it.effect("does not let a differently cased Windows PATH clobber the merged one", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32" };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "win32",
+        harvest: { mode: "all", names: [] },
+        handler: (command) => {
+          if (command._tag !== "StandardCommand") return "";
+          return command.args.includes("-NoProfile")
+            ? envOutput({ PATH: "C:\\Windows\\System32" })
+            : [
+                envOutput({ PATH: "C:\\Profile\\Node;C:\\Windows\\System32" }),
+                fullEnvOutput({ Path: "C:\\Injected", CARGO_HOME: "C:\\Users\\test\\.cargo" }),
+              ].join("\n");
+        },
+      });
+
+      assert.equal(env.Path, undefined);
+      assert.equal(env.PATH?.startsWith("C:\\Profile\\Node"), true);
+      assert.equal(env.PATH?.includes("C:\\Injected"), false);
       assert.equal(env.CARGO_HOME, "C:\\Users\\test\\.cargo");
     }),
   );

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -9,6 +9,11 @@ import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import {
+  isImportableEnvironmentName,
+  type ShellEnvironmentHarvest,
+  type ShellEnvironmentMode,
+} from "./shellEnvironmentHarvest.ts";
 
 type EnvironmentPatch = Record<string, string>;
 
@@ -16,10 +21,12 @@ interface ShellEnvironmentConfig {
   readonly env: NodeJS.ProcessEnv;
   readonly platform: NodeJS.Platform;
   readonly userShell: Option.Option<string>;
+  readonly harvest: ShellEnvironmentHarvest;
 }
 
 interface WindowsProbeOptions {
   readonly loadProfile: boolean;
+  readonly mode: ShellEnvironmentMode;
 }
 
 const DesktopShellEnvironmentProbe = Schema.Literals([
@@ -63,7 +70,7 @@ export class DesktopShellEnvironmentCommandTimeoutError extends Schema.TaggedErr
 export class DesktopShellEnvironment extends Context.Service<
   DesktopShellEnvironment,
   {
-    readonly installIntoProcess: Effect.Effect<void>;
+    readonly installIntoProcess: (harvest: ShellEnvironmentHarvest) => Effect.Effect<void>;
   }
 >()("@t3tools/desktop/shell/DesktopShellEnvironment") {}
 
@@ -235,18 +242,39 @@ const logShellEnvironmentCommandError = (
     }),
   );
 
-const capturePosixEnvironmentCommand = (names: ReadonlyArray<string>) =>
-  names
-    .map((name) => {
-      return [
-        `printf '%s\\n' '${startMarker(name)}'`,
-        `printenv ${name} || true`,
-        `printf '%s\\n' '${endMarker(name)}'`,
-      ].join("; ");
-    })
-    .join("; ");
+const FULL_ENVIRONMENT_MARKER = "*";
+const POSIX_ENTRY_DELIMITER = "\0";
+const WINDOWS_ENTRY_DELIMITER = "\n";
 
-const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
+const capturePosixEnvironmentCommand = (
+  names: ReadonlyArray<string>,
+  mode: ShellEnvironmentMode,
+) => {
+  const blocks = names.map((name) => {
+    return [
+      `printf '%s\\n' '${startMarker(name)}'`,
+      `printenv ${name} || true`,
+      `printf '%s\\n' '${endMarker(name)}'`,
+    ].join("; ");
+  });
+
+  if (mode === "all") {
+    blocks.push(
+      [
+        `printf '%s\\n' '${startMarker(FULL_ENVIRONMENT_MARKER)}'`,
+        "env -0 || true",
+        `printf '\\n%s\\n' '${endMarker(FULL_ENVIRONMENT_MARKER)}'`,
+      ].join("; "),
+    );
+  }
+
+  return blocks.join("; ");
+};
+
+const captureWindowsEnvironmentCommand = (
+  names: ReadonlyArray<string>,
+  mode: ShellEnvironmentMode,
+) =>
   [
     "$ErrorActionPreference = 'Stop'",
     ...names.flatMap((name) => {
@@ -257,24 +285,59 @@ const captureWindowsEnvironmentCommand = (names: ReadonlyArray<string>) =>
         `Write-Output '${endMarker(name)}'`,
       ];
     }),
+    ...(mode === "all"
+      ? [
+          `Write-Output '${startMarker(FULL_ENVIRONMENT_MARKER)}'`,
+          "Get-ChildItem Env: | ForEach-Object { Write-Output ($_.Name + '=' + $_.Value) }",
+          `Write-Output '${endMarker(FULL_ENVIRONMENT_MARKER)}'`,
+        ]
+      : []),
   ].join("; ");
 
-const extractEnvironment = (output: string, names: ReadonlyArray<string>): EnvironmentPatch => {
+const extractMarkedSection = (output: string, name: string): string | null => {
+  const start = output.indexOf(startMarker(name));
+  if (start === -1) return null;
+
+  const valueStart = start + startMarker(name).length;
+  const end = output.indexOf(endMarker(name), valueStart);
+  if (end === -1) return null;
+
+  return output
+    .slice(valueStart, end)
+    .replace(/^\r?\n/, "")
+    .replace(/\r?\n$/, "");
+};
+
+const extractFullEnvironment = (output: string, delimiter: string): EnvironmentPatch => {
+  const section = extractMarkedSection(output, FULL_ENVIRONMENT_MARKER);
+  if (section === null) return {};
+
   const environment: EnvironmentPatch = {};
+  for (const entry of section.split(delimiter)) {
+    const separator = entry.indexOf("=");
+    if (separator <= 0) continue;
+
+    const value = entry.slice(separator + 1).replace(/\r$/, "");
+    if (value.length > 0) {
+      environment[entry.slice(0, separator)] = value;
+    }
+  }
+
+  return environment;
+};
+
+const extractEnvironment = (
+  output: string,
+  names: ReadonlyArray<string>,
+  mode: ShellEnvironmentMode,
+  delimiter: string,
+): EnvironmentPatch => {
+  const environment: EnvironmentPatch =
+    mode === "all" ? extractFullEnvironment(output, delimiter) : {};
 
   for (const name of names) {
-    const start = output.indexOf(startMarker(name));
-    if (start === -1) continue;
-
-    const valueStart = start + startMarker(name).length;
-    const end = output.indexOf(endMarker(name), valueStart);
-    if (end === -1) continue;
-
-    const value = output
-      .slice(valueStart, end)
-      .replace(/^\r?\n/, "")
-      .replace(/\r?\n$/, "");
-    if (value.length > 0) {
+    const value = extractMarkedSection(output, name);
+    if (value !== null && value.length > 0) {
       environment[name] = value;
     }
   }
@@ -334,15 +397,18 @@ const runCommandOutput = Effect.fn("desktop.shellEnvironment.runCommandOutput")(
 const readLoginShellEnvironment = (
   shell: string,
   names: ReadonlyArray<string>,
+  mode: ShellEnvironmentMode,
 ): Effect.Effect<EnvironmentPatch, never, ChildProcessSpawner.ChildProcessSpawner> =>
   names.length === 0
     ? Effect.succeed({})
     : runCommandOutput({
         probe: "login-shell",
         command: shell,
-        args: ["-ilc", capturePosixEnvironmentCommand(names)],
+        args: ["-ilc", capturePosixEnvironmentCommand(names, mode)],
         timeout: LOGIN_SHELL_TIMEOUT,
-      }).pipe(Effect.map((output) => extractEnvironment(output, names)));
+      }).pipe(
+        Effect.map((output) => extractEnvironment(output, names, mode, POSIX_ENTRY_DELIMITER)),
+      );
 
 const readLaunchctlPath = runCommandOutput({
   probe: "launchctl-path",
@@ -363,7 +429,7 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
       ...(options.loadProfile ? ([] as const) : (["-NoProfile"] as const)),
       "-NonInteractive",
       "-Command",
-      captureWindowsEnvironmentCommand(names),
+      captureWindowsEnvironmentCommand(names, options.mode),
     ];
 
     for (const command of WINDOWS_SHELL_CANDIDATES) {
@@ -373,7 +439,7 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
         args,
         timeout: LOGIN_SHELL_TIMEOUT,
       });
-      const environment = extractEnvironment(output, names);
+      const environment = extractEnvironment(output, names, options.mode, WINDOWS_ENTRY_DELIMITER);
       if (Object.keys(environment).length > 0) {
         return environment;
       }
@@ -382,6 +448,18 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
     return {};
   },
 );
+
+const applyHarvestedEnvironment = (input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly shellEnvironment: EnvironmentPatch;
+  readonly governed: ReadonlyArray<string>;
+}): void => {
+  const governed = new Set(input.governed);
+  for (const [name, value] of Object.entries(input.shellEnvironment)) {
+    if (governed.has(name) || !isImportableEnvironmentName(name) || value.length === 0) continue;
+    input.env[name] = value;
+  }
+};
 
 const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWindowsEnvironment")(
   function* (
@@ -394,8 +472,11 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     // startup span, of which desktop.bootstrap is ~30ms.
     const [noProfile, profile] = yield* Effect.all(
       [
-        readWindowsEnvironment(["PATH"], { loadProfile: false }),
-        readWindowsEnvironment(WINDOWS_PROFILE_ENV_NAMES, { loadProfile: true }),
+        readWindowsEnvironment(["PATH"], { loadProfile: false, mode: "allowlist" }),
+        readWindowsEnvironment([...WINDOWS_PROFILE_ENV_NAMES, ...config.harvest.names], {
+          loadProfile: true,
+          mode: config.harvest.mode,
+        }),
       ],
       { concurrency: 2 },
     );
@@ -415,6 +496,12 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
     if (!config.env.FNM_MULTISHELL_PATH && profile.FNM_MULTISHELL_PATH) {
       config.env.FNM_MULTISHELL_PATH = profile.FNM_MULTISHELL_PATH;
     }
+
+    applyHarvestedEnvironment({
+      env: config.env,
+      shellEnvironment: profile,
+      governed: WINDOWS_PROFILE_ENV_NAMES,
+    });
   },
 );
 
@@ -429,10 +516,11 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     const fileSystem = yield* FileSystem.FileSystem;
     const shellEnvironment: EnvironmentPatch = {};
 
+    const probeNames = [...LOGIN_SHELL_ENV_NAMES, ...config.harvest.names];
     for (const shell of listLoginShellCandidates(config)) {
       Object.assign(
         shellEnvironment,
-        yield* readLoginShellEnvironment(shell, LOGIN_SHELL_ENV_NAMES),
+        yield* readLoginShellEnvironment(shell, probeNames, config.harvest.mode),
       );
       if (shellEnvironment.PATH) break;
     }
@@ -518,6 +606,12 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
         }
       }
     }
+
+    applyHarvestedEnvironment({
+      env: config.env,
+      shellEnvironment,
+      governed: LOGIN_SHELL_ENV_NAMES,
+    });
   },
 );
 
@@ -538,15 +632,18 @@ export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const fileSystem = yield* FileSystem.FileSystem;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const installIntoProcess: DesktopShellEnvironment["Service"]["installIntoProcess"] =
+  const installIntoProcess: DesktopShellEnvironment["Service"]["installIntoProcess"] = (harvest) =>
     installShellEnvironment({
       env: process.env,
       platform: environment.platform,
       userShell: Option.none(),
+      harvest,
     }).pipe(
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-      Effect.withSpan("desktop.shellEnvironment.installIntoProcess"),
+      Effect.withSpan("desktop.shellEnvironment.installIntoProcess", {
+        attributes: { mode: harvest.mode, extraNameCount: harvest.names.length },
+      }),
     );
 
   return DesktopShellEnvironment.of({ installIntoProcess });

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -10,6 +10,7 @@ import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawne
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import {
+  environmentNameKey,
   isImportableEnvironmentName,
   type ShellEnvironmentHarvest,
   type ShellEnvironmentMode,
@@ -243,8 +244,7 @@ const logShellEnvironmentCommandError = (
   );
 
 const FULL_ENVIRONMENT_MARKER = "*";
-const POSIX_ENTRY_DELIMITER = "\0";
-const WINDOWS_ENTRY_DELIMITER = "\n";
+const ENTRY_DELIMITER = "\0";
 
 const capturePosixEnvironmentCommand = (
   names: ReadonlyArray<string>,
@@ -288,7 +288,7 @@ const captureWindowsEnvironmentCommand = (
     ...(mode === "all"
       ? [
           `Write-Output '${startMarker(FULL_ENVIRONMENT_MARKER)}'`,
-          "Get-ChildItem Env: | ForEach-Object { Write-Output ($_.Name + '=' + $_.Value) }",
+          "Get-ChildItem Env: | ForEach-Object { [Console]::Out.Write($_.Name + '=' + $_.Value + [char]0) }",
           `Write-Output '${endMarker(FULL_ENVIRONMENT_MARKER)}'`,
         ]
       : []),
@@ -308,19 +308,25 @@ const extractMarkedSection = (output: string, name: string): string | null => {
     .replace(/\r?\n$/, "");
 };
 
-const extractFullEnvironment = (output: string, delimiter: string): EnvironmentPatch => {
-  const section = extractMarkedSection(output, FULL_ENVIRONMENT_MARKER);
-  if (section === null) return {};
+const extractFullEnvironment = (output: string): EnvironmentPatch => {
+  const opening = startMarker(FULL_ENVIRONMENT_MARKER);
+  const start = output.indexOf(opening);
+  if (start === -1) return {};
+
+  const end = output.lastIndexOf(endMarker(FULL_ENVIRONMENT_MARKER));
+  if (end <= start) return {};
+
+  const section = output
+    .slice(start + opening.length, end)
+    .replace(/^\r?\n/, "")
+    .replace(/\r?\n$/, "");
 
   const environment: EnvironmentPatch = {};
-  for (const entry of section.split(delimiter)) {
+  for (const entry of section.split(ENTRY_DELIMITER)) {
     const separator = entry.indexOf("=");
     if (separator <= 0) continue;
 
-    const value = entry.slice(separator + 1).replace(/\r$/, "");
-    if (value.length > 0) {
-      environment[entry.slice(0, separator)] = value;
-    }
+    environment[entry.slice(0, separator)] = entry.slice(separator + 1);
   }
 
   return environment;
@@ -330,10 +336,8 @@ const extractEnvironment = (
   output: string,
   names: ReadonlyArray<string>,
   mode: ShellEnvironmentMode,
-  delimiter: string,
 ): EnvironmentPatch => {
-  const environment: EnvironmentPatch =
-    mode === "all" ? extractFullEnvironment(output, delimiter) : {};
+  const environment: EnvironmentPatch = mode === "all" ? extractFullEnvironment(output) : {};
 
   for (const name of names) {
     const value = extractMarkedSection(output, name);
@@ -406,9 +410,7 @@ const readLoginShellEnvironment = (
         command: shell,
         args: ["-ilc", capturePosixEnvironmentCommand(names, mode)],
         timeout: LOGIN_SHELL_TIMEOUT,
-      }).pipe(
-        Effect.map((output) => extractEnvironment(output, names, mode, POSIX_ENTRY_DELIMITER)),
-      );
+      }).pipe(Effect.map((output) => extractEnvironment(output, names, mode)));
 
 const readLaunchctlPath = runCommandOutput({
   probe: "launchctl-path",
@@ -439,7 +441,7 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
         args,
         timeout: LOGIN_SHELL_TIMEOUT,
       });
-      const environment = extractEnvironment(output, names, options.mode, WINDOWS_ENTRY_DELIMITER);
+      const environment = extractEnvironment(output, names, options.mode);
       if (Object.keys(environment).length > 0) {
         return environment;
       }
@@ -453,10 +455,16 @@ const applyHarvestedEnvironment = (input: {
   readonly env: NodeJS.ProcessEnv;
   readonly shellEnvironment: EnvironmentPatch;
   readonly governed: ReadonlyArray<string>;
+  readonly platform: NodeJS.Platform;
 }): void => {
-  const governed = new Set(input.governed);
+  const governed = new Set(input.governed.map((name) => environmentNameKey(name, input.platform)));
   for (const [name, value] of Object.entries(input.shellEnvironment)) {
-    if (governed.has(name) || !isImportableEnvironmentName(name) || value.length === 0) continue;
+    if (
+      governed.has(environmentNameKey(name, input.platform)) ||
+      !isImportableEnvironmentName(name, input.platform)
+    ) {
+      continue;
+    }
     input.env[name] = value;
   }
 };
@@ -501,6 +509,7 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
       env: config.env,
       shellEnvironment: profile,
       governed: WINDOWS_PROFILE_ENV_NAMES,
+      platform: "win32",
     });
   },
 );
@@ -611,6 +620,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       env: config.env,
       shellEnvironment,
       governed: LOGIN_SHELL_ENV_NAMES,
+      platform: config.platform,
     });
   },
 );

--- a/apps/desktop/src/shell/shellEnvironmentHarvest.test.ts
+++ b/apps/desktop/src/shell/shellEnvironmentHarvest.test.ts
@@ -8,37 +8,32 @@ import {
 
 describe("shellEnvironmentHarvest", () => {
   it("rejects names that would escape the probe command", () => {
-    assert.equal(isImportableEnvironmentName("OPENAI_API_KEY"), true);
-    assert.equal(isImportableEnvironmentName("_PRIVATE"), true);
-    assert.equal(isImportableEnvironmentName("FOO; rm -rf /"), false);
-    assert.equal(isImportableEnvironmentName("FOO'"), false);
-    assert.equal(isImportableEnvironmentName("$(id)"), false);
-    assert.equal(isImportableEnvironmentName("FOO=BAR"), false);
-    assert.equal(isImportableEnvironmentName("1FOO"), false);
-    assert.equal(isImportableEnvironmentName(""), false);
+    assert.equal(isImportableEnvironmentName("OPENAI_API_KEY", "linux"), true);
+    assert.equal(isImportableEnvironmentName("_PRIVATE", "linux"), true);
+    assert.equal(isImportableEnvironmentName("FOO; rm -rf /", "linux"), false);
+    assert.equal(isImportableEnvironmentName("FOO'", "linux"), false);
+    assert.equal(isImportableEnvironmentName("$(id)", "linux"), false);
+    assert.equal(isImportableEnvironmentName("FOO=BAR", "linux"), false);
+    assert.equal(isImportableEnvironmentName("1FOO", "linux"), false);
+    assert.equal(isImportableEnvironmentName("", "linux"), false);
   });
 
   it("rejects names that describe the running process", () => {
     for (const name of ["HOME", "PWD", "OLDPWD", "SHLVL", "_"]) {
-      assert.equal(isImportableEnvironmentName(name), false);
+      assert.equal(isImportableEnvironmentName(name, "linux"), false);
     }
   });
 
   it("normalizes configured names and drops unusable entries", () => {
     assert.deepEqual(
-      normalizeShellEnvironmentNames([
-        " OPENAI_API_KEY ",
-        "OPENAI_API_KEY",
-        "FOO; rm -rf /",
-        "HOME",
-        42,
-        "",
-        "CARGO_HOME",
-      ]),
+      normalizeShellEnvironmentNames(
+        [" OPENAI_API_KEY ", "OPENAI_API_KEY", "FOO; rm -rf /", "HOME", 42, "", "CARGO_HOME"],
+        "linux",
+      ),
       ["OPENAI_API_KEY", "CARGO_HOME"],
     );
-    assert.deepEqual(normalizeShellEnvironmentNames("OPENAI_API_KEY"), []);
-    assert.deepEqual(normalizeShellEnvironmentNames(undefined), []);
+    assert.deepEqual(normalizeShellEnvironmentNames("OPENAI_API_KEY", "linux"), []);
+    assert.deepEqual(normalizeShellEnvironmentNames(undefined, "linux"), []);
   });
 
   it("falls back to the allowlist for unrecognized modes", () => {
@@ -46,5 +41,19 @@ describe("shellEnvironmentHarvest", () => {
     assert.equal(normalizeShellEnvironmentMode("allowlist"), "allowlist");
     assert.equal(normalizeShellEnvironmentMode("everything"), "allowlist");
     assert.equal(normalizeShellEnvironmentMode(undefined), "allowlist");
+  });
+
+  it("rejects reserved names case-insensitively on Windows only", () => {
+    assert.equal(isImportableEnvironmentName("pwd", "win32"), false);
+    assert.equal(isImportableEnvironmentName("Path", "win32"), true);
+    assert.equal(isImportableEnvironmentName("home", "win32"), false);
+    assert.equal(isImportableEnvironmentName("pwd", "linux"), true);
+    assert.equal(isImportableEnvironmentName("home", "linux"), true);
+  });
+
+  it("deduplicates configured names by their Windows casing", () => {
+    assert.deepEqual(normalizeShellEnvironmentNames(["Path", "PATH"], "win32"), ["Path"]);
+    assert.deepEqual(normalizeShellEnvironmentNames(["Path", "PATH"], "linux"), ["Path", "PATH"]);
+    assert.deepEqual(normalizeShellEnvironmentNames(["pwd"], "win32"), []);
   });
 });

--- a/apps/desktop/src/shell/shellEnvironmentHarvest.test.ts
+++ b/apps/desktop/src/shell/shellEnvironmentHarvest.test.ts
@@ -1,0 +1,50 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  isImportableEnvironmentName,
+  normalizeShellEnvironmentMode,
+  normalizeShellEnvironmentNames,
+} from "./shellEnvironmentHarvest.ts";
+
+describe("shellEnvironmentHarvest", () => {
+  it("rejects names that would escape the probe command", () => {
+    assert.equal(isImportableEnvironmentName("OPENAI_API_KEY"), true);
+    assert.equal(isImportableEnvironmentName("_PRIVATE"), true);
+    assert.equal(isImportableEnvironmentName("FOO; rm -rf /"), false);
+    assert.equal(isImportableEnvironmentName("FOO'"), false);
+    assert.equal(isImportableEnvironmentName("$(id)"), false);
+    assert.equal(isImportableEnvironmentName("FOO=BAR"), false);
+    assert.equal(isImportableEnvironmentName("1FOO"), false);
+    assert.equal(isImportableEnvironmentName(""), false);
+  });
+
+  it("rejects names that describe the running process", () => {
+    for (const name of ["HOME", "PWD", "OLDPWD", "SHLVL", "_"]) {
+      assert.equal(isImportableEnvironmentName(name), false);
+    }
+  });
+
+  it("normalizes configured names and drops unusable entries", () => {
+    assert.deepEqual(
+      normalizeShellEnvironmentNames([
+        " OPENAI_API_KEY ",
+        "OPENAI_API_KEY",
+        "FOO; rm -rf /",
+        "HOME",
+        42,
+        "",
+        "CARGO_HOME",
+      ]),
+      ["OPENAI_API_KEY", "CARGO_HOME"],
+    );
+    assert.deepEqual(normalizeShellEnvironmentNames("OPENAI_API_KEY"), []);
+    assert.deepEqual(normalizeShellEnvironmentNames(undefined), []);
+  });
+
+  it("falls back to the allowlist for unrecognized modes", () => {
+    assert.equal(normalizeShellEnvironmentMode("all"), "all");
+    assert.equal(normalizeShellEnvironmentMode("allowlist"), "allowlist");
+    assert.equal(normalizeShellEnvironmentMode("everything"), "allowlist");
+    assert.equal(normalizeShellEnvironmentMode(undefined), "allowlist");
+  });
+});

--- a/apps/desktop/src/shell/shellEnvironmentHarvest.ts
+++ b/apps/desktop/src/shell/shellEnvironmentHarvest.ts
@@ -1,0 +1,48 @@
+import * as Schema from "effect/Schema";
+
+export const ShellEnvironmentModeSchema = Schema.Literals(["allowlist", "all"]);
+export type ShellEnvironmentMode = typeof ShellEnvironmentModeSchema.Type;
+
+export interface ShellEnvironmentHarvest {
+  readonly mode: ShellEnvironmentMode;
+  readonly names: ReadonlyArray<string>;
+}
+
+export const DEFAULT_SHELL_ENVIRONMENT_HARVEST: ShellEnvironmentHarvest = {
+  mode: "allowlist",
+  names: [],
+};
+
+const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+const RESERVED_ENVIRONMENT_NAMES: ReadonlySet<string> = new Set([
+  "HOME",
+  "OLDPWD",
+  "PWD",
+  "SHLVL",
+  "_",
+]);
+
+export function isImportableEnvironmentName(name: string): boolean {
+  return ENVIRONMENT_NAME_PATTERN.test(name) && !RESERVED_ENVIRONMENT_NAMES.has(name);
+}
+
+export function normalizeShellEnvironmentMode(value: unknown): ShellEnvironmentMode {
+  return value === "all" ? "all" : "allowlist";
+}
+
+export function normalizeShellEnvironmentNames(value: unknown): ReadonlyArray<string> {
+  if (!Array.isArray(value)) return [];
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const name = entry.trim();
+    if (!isImportableEnvironmentName(name) || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+
+  return names;
+}

--- a/apps/desktop/src/shell/shellEnvironmentHarvest.ts
+++ b/apps/desktop/src/shell/shellEnvironmentHarvest.ts
@@ -23,15 +23,25 @@ const RESERVED_ENVIRONMENT_NAMES: ReadonlySet<string> = new Set([
   "_",
 ]);
 
-export function isImportableEnvironmentName(name: string): boolean {
-  return ENVIRONMENT_NAME_PATTERN.test(name) && !RESERVED_ENVIRONMENT_NAMES.has(name);
+export function environmentNameKey(name: string, platform: NodeJS.Platform): string {
+  return platform === "win32" ? name.toUpperCase() : name;
+}
+
+export function isImportableEnvironmentName(name: string, platform: NodeJS.Platform): boolean {
+  return (
+    ENVIRONMENT_NAME_PATTERN.test(name) &&
+    !RESERVED_ENVIRONMENT_NAMES.has(environmentNameKey(name, platform))
+  );
 }
 
 export function normalizeShellEnvironmentMode(value: unknown): ShellEnvironmentMode {
   return value === "all" ? "all" : "allowlist";
 }
 
-export function normalizeShellEnvironmentNames(value: unknown): ReadonlyArray<string> {
+export function normalizeShellEnvironmentNames(
+  value: unknown,
+  platform: NodeJS.Platform,
+): ReadonlyArray<string> {
   if (!Array.isArray(value)) return [];
 
   const names: string[] = [];
@@ -39,8 +49,11 @@ export function normalizeShellEnvironmentNames(value: unknown): ReadonlyArray<st
   for (const entry of value) {
     if (typeof entry !== "string") continue;
     const name = entry.trim();
-    if (!isImportableEnvironmentName(name) || seen.has(name)) continue;
-    seen.add(name);
+    if (!isImportableEnvironmentName(name, platform)) continue;
+
+    const key = environmentNameKey(name, platform);
+    if (seen.has(key)) continue;
+    seen.add(key);
     names.push(name);
   }
 


### PR DESCRIPTION
this is debatabley a fix() rather than a feat because it completely breaks agents' ability to use the tooling i have installed on my system.

## What Changed

adds shellEnvironmentMode` and `shellEnvironmentNames` to desktop-settings.json so you can configure what gets passed from the login shell.

```json
{
  "shellEnvironmentMode": "allowlist" | "all",
  "shellEnvironmentNames": ["RUSTUP_HOME", "CARGO_HOME"]
}
```

defaults to current behavior.

## Why

depending on whether t3code was launched from `npx t3` or the desktop app, agents may end up with a completely different set of environment variables. `DesktopShellEnvironment` seeds `$PATH` and 16 others, but things like `$BUN_INSTALL`, `$CARGO_HOME`, and `$RUSTUP_HOME` that i have configured in `.zshrc` don't make it into the agents' shells, confusing the hell out of them. perpetually recovering specific env vars from the login shell is not a solution (#10312 for example).

<details>
<summary>claude's slop reasoning for all the review bots</summary>

## Problem

On the same machine, as the same user, agents get different environments depending on how T3 Code started:

- `npx t3` from a terminal: the shell already sourced `~/.zshrc`, so the server and every agent it spawns inherit the user's full environment.
- Desktop app launched from a session manager: it inherits almost nothing, so `DesktopShellEnvironment` probes the login shell to recover it.

Nothing filters the environment on the way to an agent. `mergeProviderInstanceEnvironment` spreads all of `process.env` into every provider spawn. The loss happens earlier, at capture: `capturePosixEnvironmentCommand` issues one `printenv` per name in `LOGIN_SHELL_ENV_NAMES`, and `extractEnvironment` filters by the same 17 names. Anything else the user exported is evaluated by that shell and thrown away.

The allowlist is being extended one variable at a time, and the queue is not keeping up:

| PR | Variable(s) |
| --- | --- |
| #7363 | AWS Bedrock credentials and region (#4928) |
| #9022 | `T3CODE_BITBUCKET_*` (#5840) |
| #7620 | the same, forwarded to WSL |
| #10312 | login-shell `SSH_AUTH_SOCK` |

Each is correct in isolation. This generalizes them.

## Fix

Two keys in `<stateDir>/desktop-settings.json`, both defaulting to today's

```json
{
  "shellEnvironmentMode": "allowlist" | "all",
  "shellEnvironmentNames": ["OPENAI_API_KEY", "CARGO_HOME"]
}
```

- `shellEnvironmentNames` appends to the names the probe asks for.
- `shellEnvironmentMode: "all"` appends a marker-wrapped `env -0` block (`s) to the **same** probe command, so widening the capture never costs anextra login shell. This matters because #10972 is actively trying to remove a redundant shell probe from Linux boot.

No Settings control, deliberately. linuxPasswordStore sets the precedent for a startup-only escape hatch with no IPC surface, and adding one here would pull web and mobile into a desktop-only change. Happy to add it if you'd rather it be discoverable.

Precedence, which is the part worth reviewing:

- User-supplied values win over the inherited process environment. Copy-if-absent would be useless here, since the whole problem is that the GUI-launched process's environment is
the impoverished one.
- User configuration cannot touch the 17 names the existing logic governs. `PATH` keeps its merge, the locale keeps its group rule, XDG keeps its rules. The blast radius on
current behavior is provably zero.
- `"all"` additionally skips `HOME`, `PWD`, `OLDPWD`, `SHLVL` and `_`, which describe the running process rather than the user's environment.

Probe names reach a shell command line, so they are validated against `^[A-Za-z_][A-Za-z0-9_]*$` at both settings load and apply time rather than escaped. The full-dump marker is `*`, which can never be a legal variable name, so a configured name cannot

Follows `linuxPasswordStore`: read at startup, no setter, no IPC, no UI. Npackages/contracts`, web and mobile are untouched.

One ordering change worth a close look: `desktopSettings.load` moves abovektopApp.startup`. The probe cannot move later, because Linux password-store selection reads the `XDG_*` values it hydrates. Loading settings earlier is safe because `desktopSettingsPath` hangs off the resolved state dir, not off Electron's `userData`
path, which is set further down.

## Deliberately not included

- **Per-project environments.** The probe still runs once at startup in thmise and `nix develop` are unaffected. That is #523, closed as not planned, and this does not reopen it.
- **WSL forwarding.** `WSLENV` propagation is #7620's concern.
- **Docs.** `desktop-settings.json` has no existing documented surface to extend.

## Why this is not the AppImage leak class

#10966, #5059, #1699 and #1162 were all runtime environment leaking *outward* from the packaged app into child processes, breaking `PHP_BINARY`, `XDG_DATA_DIRS` and other Electron apps. This reads the login shell, which is the clean user environdesktop process. It overwrites packaging junk with correct values ratherthan propagating it. In `"all"` mode a GUI launch ends up environment-equivalent to a terminal launch, which is the property to check.

## Verification

- `vp run --filter @t3tools/desktop typecheck` — clean
- `vp test run` on the three touched test files — 45 passing, covering defnames, precedence, full-mode parsing (values containing `=` and newlines),the reserved-name skip, `PATH` merge and locale precedence preserved under `"all"`, the Windows profile path, and rejection of names like `FOO; rm -rf /`
- `vp lint` and `vp fmt --check` on the changed paths — clean

Repo-wide checks not run; CI owns those.

Model: Claude Opus 5, harness: Claude Code.
</details>

## workarounds for anyone that lands on this

add the vars to `.zshenv` instead, or wrap the `.desktop` invocation with a shell script that sources the login shell and launch the desktop app under that

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable shell environment harvesting, including disabled, allowlisted, and full-environment modes.
  - Added support for harvesting environment variables from Windows PowerShell profiles.

- **Bug Fixes**
  - Improved handling of empty, multiline, and special-character environment values.
  - Prevented protected process variables from being overwritten.
  - Improved Windows handling for variable-name casing, duplicates, reserved names, and `PATH`.
  - Preserved valid desktop settings when unrelated environment configuration is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->