### PR TITLE
fix(client): restore authenticated device stream tickets

### DIFF
--- a/packages/client-runtime/src/state/deviceHubAccess.ts
+++ b/packages/client-runtime/src/state/deviceHubAccess.ts
@@ -47,13 +47,14 @@ export const resolveDeviceHubAccess = Effect.fn("clientRuntime.state.resolveDevi
     const signer = yield* Effect.serviceOption(ManagedRelayDpopSigner);
     const remoteAuthorization = yield* Effect.serviceOption(RemoteEnvironmentAuthorization);
     const ticket = yield* executeAuthenticatedEnvironmentHttpRequest({
+      group: "auth",
       prepared: input.prepared,
       signer,
       remoteAuthorization,
       method: "POST",
       url: (httpBaseUrl) => environmentEndpointUrl(httpBaseUrl, "/api/auth/websocket-ticket"),
       timeoutMs: TICKET_TIMEOUT_MS,
-      request: ({ client, headers }) => client.auth.webSocketTicket({ headers }),
+      request: ({ client, headers }) => client.webSocketTicket({ headers }),
     });
     return {
       httpBase,


### PR DESCRIPTION
The grouped HTTP client change in #11029 left device stream ticket requests on the old interface. This breaks the client-runtime typecheck and the bearer/DPoP ticket path used by the Device panel.

Select the `auth` group and call its `webSocketTicket` method directly, matching the other migrated request sites.

Client-runtime typecheck, 23 authenticated HTTP tests, scoped lint and formatting pass. Cookie access keeps its existing early return. Native device streams were not separately exercised.

Model: GPT-6. Harness: Codex in T3 Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket ticket requests by using the correct access method, helping device hub connections authenticate reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->