### PR TITLE
feat(server): let agents coordinate persistent peer threads

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -41,6 +41,9 @@ import {
   DeviceStandardToolkit,
 } from "./toolkits/device/tools.ts";
 
+import { ThreadsToolkitHandlersLive } from "./toolkits/threads/handlers.ts";
+import { ThreadsToolkit } from "./toolkits/threads/tools.ts";
+
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
     error: "invalid_mcp_credential",
@@ -621,6 +624,10 @@ export const DeviceToolkitRegistrationLive = Layer.mergeAll(
   DeviceScreenshotRegistrationLive,
 );
 
+export const ThreadsToolkitRegistrationLive = McpServer.toolkit(ThreadsToolkit).pipe(
+  Layer.provide(ThreadsToolkitHandlersLive),
+);
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
@@ -632,4 +639,5 @@ export const layer = Layer.mergeAll(
   PreviewToolkitRegistrationLive,
   PullRequestsToolkitRegistrationLive,
   DeviceToolkitRegistrationLive,
+  ThreadsToolkitRegistrationLive,
 ).pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -8,7 +8,7 @@ import {
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
-export type McpCapability = "preview" | "device" | "pull-requests";
+export type McpCapability = "preview" | "device" | "pull-requests" | "threads";
 
 export interface McpInvocationScope {
   readonly environmentId: EnvironmentId;

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -55,7 +55,7 @@ it.effect("stores only a token hash, resolves the bearer token, and revokes by t
   }),
 );
 
-it.effect("always grants pull-requests and gates browser and device access independently", () =>
+it.effect("grants thread and PR tools independently of browser and device access", () =>
   Effect.gen(function* () {
     const registry = yield* makeRegistry(() => 1_000);
     const withPreview = yield* registry.issue({
@@ -78,9 +78,9 @@ it.effect("always grants pull-requests and gates browser and device access indep
         .resolve(issued.config.authorizationHeader.replace(/^Bearer\s+/, ""))
         .pipe(Effect.map((scope) => [...(scope?.capabilities ?? [])].sort()));
 
-    expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests"]);
-    expect(yield* capabilitiesOf(withoutPreview)).toEqual(["pull-requests"]);
-    expect(yield* capabilitiesOf(withDevice)).toEqual(["device", "pull-requests"]);
+    expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests", "threads"]);
+    expect(yield* capabilitiesOf(withoutPreview)).toEqual(["pull-requests", "threads"]);
+    expect(yield* capabilitiesOf(withDevice)).toEqual(["device", "pull-requests", "threads"]);
   }),
 );
 

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -131,6 +131,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         providerInstanceId: ProviderInstanceId.make(request.providerInstanceId),
         capabilities: new Set<McpInvocationContext.McpCapability>([
           "pull-requests",
+          "threads",
           ...request.capabilities,
         ]),
         issuedAt,

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -123,6 +123,51 @@ const seed = Effect.gen(function* () {
 });
 
 describe("peer thread MCP", () => {
+  it.effect("keeps retry IDs distinct across caller IDs containing delimiters", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-peer-retry-" });
+        yield* Effect.gen(function* () {
+          yield* seed;
+          const engine = yield* OrchestrationEngineService;
+          const secondCaller = ThreadId.make("caller:b");
+          yield* engine.dispatch({
+            type: "thread.create",
+            commandId: CommandId.make("seed-second-caller"),
+            threadId: secondCaller,
+            projectId,
+            title: "Second caller",
+            modelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt,
+          });
+          const first = result(yield* call("create_thread", { title: "First", commandId: "b:c" }));
+          const second = result(
+            yield* call(
+              "create_thread",
+              { title: "Second", commandId: "c" },
+              { ...scope, threadId: secondCaller },
+            ),
+          );
+          expect(second.threadId).not.toBe(first.threadId);
+          expect(
+            result(yield* call("read_thread", { threadId: first.threadId })).thread.title,
+          ).toBe("First");
+          expect(
+            result(yield* call("read_thread", { threadId: second.threadId })).thread.title,
+          ).toBe("Second");
+          expect(
+            result(yield* call("create_thread", { title: "First", commandId: "b:c" })),
+          ).toEqual(first);
+        }).pipe(Effect.provide(makeLayer(`${directory}/state.sqlite`)));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
   it.effect(
     "persists commands across service restart and deduplicates caller retry IDs through MCP",
     () =>

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import {
+  CommandId,
+  EnvironmentId,
+  EventId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as FileSystem from "effect/FileSystem";
+import { TestClock } from "effect/testing";
+import { McpSchema, McpServer } from "effect/unstable/ai";
+import { ServerConfig } from "../../../config.ts";
+import { OrchestrationEngineLive } from "../../../orchestration/Layers/OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "../../../orchestration/Layers/ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "../../../orchestration/Layers/ProjectionSnapshotQuery.ts";
+import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
+import * as ThreadBackgroundLiveness from "../../../orchestration/ThreadBackgroundLiveness.ts";
+import * as ThreadPlanProgress from "../../../orchestration/ThreadPlanProgress.ts";
+import { OrchestrationCommandReceiptRepositoryLive } from "../../../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../../../persistence/Layers/OrchestrationEventStore.ts";
+import { makeSqlitePersistenceLive } from "../../../persistence/Layers/Sqlite.ts";
+import * as RepositoryIdentityResolver from "../../../project/RepositoryIdentityResolver.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ThreadsToolkitRegistrationLive } from "../../McpHttpServer.ts";
+
+const callerId = ThreadId.make("caller");
+const projectId = ProjectId.make("project");
+const createdAt = "2026-09-11T00:00:00.000Z";
+const modelSelection = { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" };
+const client = McpSchema.McpServerClient.of({
+  clientId: 1,
+  clientCapabilities: {},
+  clientInfo: { name: "test", version: "1" },
+  protocolVersion: "2025-06-18",
+  initializePayload: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "test", version: "1" },
+  },
+  getClient: Effect.die("unused"),
+});
+const scope: McpInvocationContext.McpInvocationScope = {
+  environmentId: EnvironmentId.make("test"),
+  threadId: callerId,
+  providerSessionId: "test",
+  providerInstanceId: modelSelection.instanceId,
+  capabilities: new Set(["threads"]),
+  issuedAt: 1,
+};
+function makeLayer(db: string) {
+  const orchestration = Layer.mergeAll(
+    OrchestrationEngineLive.pipe(
+      Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+      Layer.provide(OrchestrationProjectionPipelineLive),
+    ),
+    OrchestrationProjectionSnapshotQueryLive,
+  ).pipe(
+    Layer.provideMerge(ThreadBackgroundLiveness.layer),
+    Layer.provide(ThreadPlanProgress.layer),
+    Layer.provide(OrchestrationEventStoreLive),
+    Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+    Layer.provide(RepositoryIdentityResolver.layer),
+    Layer.provide(makeSqlitePersistenceLive(db)),
+  );
+  return ThreadsToolkitRegistrationLive.pipe(
+    Layer.provideMerge(McpServer.McpServer.layer),
+    Layer.provideMerge(orchestration),
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), { prefix: "t3-peer-tools-" })),
+    Layer.provideMerge(NodeServices.layer),
+  );
+}
+const call = Effect.fn("test.callThreadTool")(function* (
+  name: string,
+  args: Record<string, unknown>,
+  invocation = scope,
+) {
+  const server = yield* McpServer.McpServer;
+  return yield* server
+    .callTool({ name, arguments: args })
+    .pipe(
+      Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+      Effect.provideService(McpSchema.McpServerClient, client),
+    );
+});
+function result(response: McpSchema.CallToolResult) {
+  expect(response.isError).not.toBe(true);
+  const content = response.content?.find((entry) => entry.type === "text");
+  if (!content || content.type !== "text") throw new Error("Missing MCP text result");
+  return JSON.parse(content.text);
+}
+const seed = Effect.gen(function* () {
+  const engine = yield* OrchestrationEngineService;
+  for (const id of [projectId, ProjectId.make("other-project")]) {
+    yield* engine.dispatch({
+      type: "project.create",
+      commandId: CommandId.make(id),
+      projectId: id,
+      title: id,
+      workspaceRoot: `/tmp/${id}`,
+      createdAt,
+    });
+    const threadId = id === projectId ? callerId : ThreadId.make("other-thread");
+    yield* engine.dispatch({
+      type: "thread.create",
+      commandId: CommandId.make(threadId),
+      threadId,
+      projectId: id,
+      title: "Caller",
+      modelSelection,
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      branch: null,
+      worktreePath: null,
+      createdAt,
+    });
+  }
+});
+
+describe("peer thread MCP", () => {
+  it.effect(
+    "persists commands across service restart and deduplicates caller retry IDs through MCP",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-peer-persistence-" });
+          const db = `${directory}/state.sqlite`;
+          const created = yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* seed;
+              const created = result(
+                yield* call("create_thread", { title: "Worker", commandId: "create-worker" }),
+              );
+              expect(
+                result(
+                  yield* call("create_thread", { title: "Worker", commandId: "create-worker" }),
+                ),
+              ).toEqual(created);
+              const args = {
+                threadId: created.threadId,
+                message: "Fix issue",
+                commandId: "first-message",
+                replyToSource: false,
+              };
+              const sent = result(yield* call("send_message_to_thread", args));
+              expect(result(yield* call("send_message_to_thread", args))).toEqual(sent);
+              expect(
+                (yield* call("set_thread_settled", { threadId: created.threadId, settled: true }))
+                  .isError,
+              ).toBe(true);
+              const engine = yield* OrchestrationEngineService;
+              const timestamp = DateTime.formatIso(yield* DateTime.now);
+              for (const status of ["running", "ready"] as const)
+                yield* engine.dispatch({
+                  type: "thread.session.set",
+                  commandId: CommandId.make(`session-${status}`),
+                  threadId: ThreadId.make(created.threadId),
+                  createdAt: timestamp,
+                  session: {
+                    threadId: ThreadId.make(created.threadId),
+                    status,
+                    providerName: "codex",
+                    runtimeMode: "full-access",
+                    activeTurnId: status === "running" ? TurnId.make("turn-1") : null,
+                    lastError: null,
+                    updatedAt: timestamp,
+                  },
+                });
+              const completed = result(
+                yield* call("wait_threads", {
+                  targets: [{ threadId: created.threadId }],
+                  timeoutSeconds: 0,
+                }),
+              );
+              expect(completed.timedOut).toBe(false);
+              expect(
+                result(
+                  yield* call("wait_threads", {
+                    targets: [{ threadId: created.threadId, cursor: completed.threads[0].cursor }],
+                    timeoutSeconds: 0,
+                  }),
+                ).timedOut,
+              ).toBe(true);
+              result(
+                yield* call("set_thread_settled", { threadId: created.threadId, settled: true }),
+              );
+              return created;
+            }).pipe(Effect.provide(makeLayer(db))),
+          );
+          // The first scope has closed its SQLite connection and orchestration workers.
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const read = result(yield* call("read_thread", { threadId: created.threadId }));
+              expect(read.thread.title).toBe("Worker");
+              expect(read.thread.settledOverride).toBe("settled");
+              expect(read.messages).toHaveLength(1);
+              expect(read.messages[0].text).toBe(
+                `Message from T3 thread ${callerId}.\n\nFix issue`,
+              );
+              expect(
+                result(
+                  yield* call("create_thread", { title: "Worker", commandId: "create-worker" }),
+                ),
+              ).toEqual(created);
+              expect(result(yield* call("list_threads", {})).threads).toHaveLength(2);
+              result(
+                yield* call("set_thread_settled", { threadId: created.threadId, settled: false }),
+              );
+              expect(
+                result(yield* call("read_thread", { threadId: created.threadId })).thread
+                  .settledOverride,
+              ).toBe("active");
+            }).pipe(Effect.provide(makeLayer(db))),
+          );
+        }).pipe(Effect.provide(NodeServices.layer)),
+      ),
+  );
+
+  it.effect("rejects cross-project, malformed and null optional arguments", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-peer-scope-" });
+        yield* Effect.gen(function* () {
+          yield* seed;
+          for (const [name, args] of [
+            ["read_thread", { threadId: "other-thread" }],
+            ["send_message_to_thread", { threadId: "other-thread", message: "hello" }],
+            ["set_thread_settled", { threadId: "other-thread", settled: true }],
+            ["interrupt_thread", { threadId: "other-thread" }],
+            ["wait_threads", { targets: [{ threadId: "other-thread" }], timeoutSeconds: 0 }],
+          ] as const)
+            expect((yield* call(name, args)).isError).toBe(true);
+          expect(
+            (yield* call("list_threads", {}, { ...scope, capabilities: new Set() })).isError,
+          ).toBe(true);
+          yield* call("wait_threads", { targets: [], timeoutSeconds: 0 }).pipe(Effect.flip);
+          yield* call("read_thread", { threadId: callerId, turnLimit: 101 }).pipe(Effect.flip);
+          expect(
+            result(
+              yield* call("wait_threads", { targets: [{ threadId: callerId }], timeoutSeconds: 0 }),
+            ).timedOut,
+          ).toBe(true);
+          yield* call("create_thread", { title: "Nullable A", commandId: null }).pipe(Effect.flip);
+          yield* call("list_threads", { beforeThreadId: null }).pipe(Effect.flip);
+        }).pipe(Effect.provide(makeLayer(`${directory}/state.sqlite`)));
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+  it.effect(
+    "wait observes new attention requests within one turn without waking on commentary",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-peer-attention-" });
+          yield* Effect.gen(function* () {
+            yield* seed;
+            const engine = yield* OrchestrationEngineService;
+            const timestamp = DateTime.formatIso(yield* DateTime.now);
+            for (const status of ["running", "ready"] as const)
+              yield* engine.dispatch({
+                type: "thread.session.set",
+                commandId: CommandId.make(`initial-${status}`),
+                threadId: callerId,
+                createdAt: timestamp,
+                session: {
+                  threadId: callerId,
+                  status,
+                  providerName: "codex",
+                  runtimeMode: "full-access",
+                  activeTurnId: status === "running" ? TurnId.make("initial-turn") : null,
+                  lastError: null,
+                  updatedAt: timestamp,
+                },
+              });
+            yield* TestClock.adjust("1 second");
+            result(
+              yield* call("send_message_to_thread", {
+                threadId: callerId,
+                message: "Queued work",
+                replyToSource: false,
+              }),
+            );
+            expect(
+              result(
+                yield* call("wait_threads", {
+                  targets: [{ threadId: callerId }],
+                  timeoutSeconds: 0,
+                }),
+              ).timedOut,
+            ).toBe(true);
+            const append = (id: string, kind: string, requestId: string) =>
+              engine.dispatch({
+                type: "thread.activity.append",
+                commandId: CommandId.make(id),
+                threadId: callerId,
+                createdAt,
+                activity: {
+                  id: EventId.make(id),
+                  kind,
+                  summary: kind,
+                  tone: "info",
+                  createdAt,
+                  turnId: TurnId.make("same-turn"),
+                  payload: { requestId, requestType: "command" },
+                },
+              });
+            yield* append("request-a", "approval.requested", "a");
+            const first = result(
+              yield* call("wait_threads", { targets: [{ threadId: callerId }], timeoutSeconds: 0 }),
+            );
+            expect(first.timedOut).toBe(false);
+            yield* append("resolve-a", "approval.resolved", "a");
+            yield* append("request-b", "approval.requested", "b");
+            const second = result(
+              yield* call("wait_threads", {
+                targets: [{ threadId: callerId, cursor: first.threads[0].cursor }],
+                timeoutSeconds: 0,
+              }),
+            );
+            expect(second.timedOut).toBe(false);
+            expect(second.threads[0].cursor).not.toBe(first.threads[0].cursor);
+            yield* append("commentary", "tool.started", "unrelated");
+            expect(
+              result(
+                yield* call("wait_threads", {
+                  targets: [{ threadId: callerId, cursor: second.threads[0].cursor }],
+                  timeoutSeconds: 0,
+                }),
+              ).timedOut,
+            ).toBe(true);
+          }).pipe(Effect.provide(makeLayer(`${directory}/state.sqlite`)));
+        }).pipe(Effect.provide(NodeServices.layer)),
+      ),
+  );
+});

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -12,6 +12,7 @@ import {
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as FileSystem from "effect/FileSystem";
 import { TestClock } from "effect/testing";
 import { McpSchema, McpServer } from "effect/unstable/ai";
@@ -53,7 +54,10 @@ const scope: McpInvocationContext.McpInvocationScope = {
   capabilities: new Set(["threads"]),
   issuedAt: 1,
 };
-function makeLayer(db: string) {
+function makeLayer(
+  db: string,
+  wrapQuery = (query: ProjectionSnapshotQuery.ProjectionSnapshotQueryShape) => query,
+) {
   const orchestration = Layer.mergeAll(
     OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionSnapshotQueryLive),
@@ -70,7 +74,12 @@ function makeLayer(db: string) {
   );
   return ThreadsToolkitRegistrationLive.pipe(
     Layer.provideMerge(McpServer.McpServer.layer),
-    Layer.provideMerge(orchestration),
+    Layer.provideMerge(
+      Layer.effect(
+        ProjectionSnapshotQuery.ProjectionSnapshotQuery,
+        Effect.map(ProjectionSnapshotQuery.ProjectionSnapshotQuery, wrapQuery),
+      ).pipe(Layer.provideMerge(orchestration)),
+    ),
     Layer.provideMerge(ServerConfig.layerTest(process.cwd(), { prefix: "t3-peer-tools-" })),
     Layer.provideMerge(NodeServices.layer),
   );
@@ -123,6 +132,44 @@ const seed = Effect.gen(function* () {
 });
 
 describe("peer thread MCP", () => {
+  it.effect("retries a read when projection changes between shell and detail", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const directory = yield* fs.makeTempDirectoryScoped({ prefix: "t3-peer-detail-" });
+        let detailReads = 0;
+        let rename = Effect.void;
+        yield* Effect.gen(function* () {
+          yield* seed;
+          const engine = yield* OrchestrationEngineService;
+          rename = engine
+            .dispatch({
+              type: "thread.meta.update",
+              threadId: callerId,
+              commandId: CommandId.make("rename-during-read"),
+              title: "New title",
+            })
+            .pipe(Effect.asVoid, Effect.orDie);
+          const read = result(yield* call("read_thread", { threadId: callerId }));
+          expect(read.thread.title).toBe("New title");
+          expect(read.thread.hasPendingApprovals).toBe(false);
+          expect(detailReads).toBe(2);
+        }).pipe(
+          Effect.provide(
+            makeLayer(`${directory}/state.sqlite`, (query) => ({
+              ...query,
+              getThreadDetailSnapshot: (...args) =>
+                Effect.gen(function* () {
+                  if (++detailReads === 1) yield* rename;
+                  return yield* query.getThreadDetailSnapshot(...args);
+                }),
+            })),
+          ),
+        );
+      }).pipe(Effect.provide(NodeServices.layer)),
+    ),
+  );
+
   it.effect("keeps retry IDs distinct across caller IDs containing delimiters", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -132,7 +132,7 @@ const seed = Effect.gen(function* () {
 });
 
 describe("peer thread MCP", () => {
-  it.effect("retries a read when projection changes between shell and detail", () =>
+  it.effect("reads shell and detail together after a concurrent projection change", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
@@ -153,7 +153,7 @@ describe("peer thread MCP", () => {
           const read = result(yield* call("read_thread", { threadId: callerId }));
           expect(read.thread.title).toBe("New title");
           expect(read.thread.hasPendingApprovals).toBe(false);
-          expect(detailReads).toBe(2);
+          expect(detailReads).toBe(1);
         }).pipe(
           Effect.provide(
             makeLayer(`${directory}/state.sqlite`, (query) => ({

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -156,27 +156,45 @@ const make = Effect.gen(function* () {
     read_thread: (input) =>
       Effect.gen(function* () {
         const caller = yield* source();
-        const thread = yield* target(input.threadId, caller);
-        const detail = yield* snapshots
-          .getThreadDetailSnapshot(thread.id, {
-            turnLimit: input.turnLimit ?? 10,
-            ...(input.beforeCursor === undefined ? {} : { beforeCursor: input.beforeCursor }),
-          })
-          .pipe(Effect.mapError(failed));
-        if (Option.isNone(detail)) return yield* failed();
-        return {
-          thread: yield* summarize(thread),
-          snapshotSequence: detail.value.snapshotSequence,
-          ...(detail.value.page === undefined ? {} : { page: detail.value.page }),
-          messages: detail.value.thread.messages.map((message) => ({
-            id: message.id,
-            role: message.role,
-            text: message.text.slice(0, 8000),
-            truncated: message.text.length > 8000,
-            createdAt: message.createdAt,
-          })),
-        };
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const before = yield* snapshots.getSnapshotSequence().pipe(Effect.mapError(failed));
+          const thread = yield* target(input.threadId, caller);
+          const detail = yield* snapshots
+            .getThreadDetailSnapshot(thread.id, {
+              turnLimit: input.turnLimit ?? 10,
+              ...(input.beforeCursor === undefined ? {} : { beforeCursor: input.beforeCursor }),
+            })
+            .pipe(Effect.mapError(failed));
+          if (Option.isNone(detail)) return yield* failed();
+          // Detail pages omit shell-only attention/liveness fields. A matching sequence
+          // keeps those fields and the paginated history on the same projection version.
+          if (before.snapshotSequence !== detail.value.snapshotSequence) continue;
+          return {
+            thread: summary(
+              thread,
+              detail.value.thread.activities
+                .filter(
+                  (activity) =>
+                    activity.kind === "approval.requested" ||
+                    activity.kind === "user-input.requested",
+                )
+                .map((activity) => activity.id)
+                .sort(),
+            ),
+            snapshotSequence: detail.value.snapshotSequence,
+            ...(detail.value.page === undefined ? {} : { page: detail.value.page }),
+            messages: detail.value.thread.messages.map((message) => ({
+              id: message.id,
+              role: message.role,
+              text: message.text.slice(0, 8000),
+              truncated: message.text.length > 8000,
+              createdAt: message.createdAt,
+            })),
+          };
+        }
+        return yield* failed();
       }),
+
     send_message_to_thread: (input) =>
       Effect.gen(function* () {
         const caller = yield* source();

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -66,7 +66,9 @@ const make = Effect.gen(function* () {
   const commandId = (caller: OrchestrationThreadShell, id?: CommandId) =>
     id === undefined
       ? uuid.pipe(Effect.map(CommandId.make))
-      : Effect.succeed(CommandId.make(`mcp:${caller.id}:${id}`));
+      : Effect.succeed(
+          CommandId.make(`mcp:${encodeURIComponent(caller.id)}:${encodeURIComponent(id)}`),
+        );
   const now = DateTime.now.pipe(Effect.map(DateTime.formatIso));
   const failed = () => new ThreadToolError({ message: "Thread operation failed." });
   const load = Effect.fn("ThreadsToolkit.load")(function* (threadId: ThreadId) {

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -156,43 +156,43 @@ const make = Effect.gen(function* () {
     read_thread: (input) =>
       Effect.gen(function* () {
         const caller = yield* source();
-        for (let attempt = 0; attempt < 3; attempt++) {
-          const before = yield* snapshots.getSnapshotSequence().pipe(Effect.mapError(failed));
-          const thread = yield* target(input.threadId, caller);
-          const detail = yield* snapshots
-            .getThreadDetailSnapshot(thread.id, {
+        const detail = yield* snapshots
+          .getThreadDetailSnapshot(
+            input.threadId,
+            {
               turnLimit: input.turnLimit ?? 10,
               ...(input.beforeCursor === undefined ? {} : { beforeCursor: input.beforeCursor }),
-            })
-            .pipe(Effect.mapError(failed));
-          if (Option.isNone(detail)) return yield* failed();
-          // Detail pages omit shell-only attention/liveness fields. A matching sequence
-          // keeps those fields and the paginated history on the same projection version.
-          if (before.snapshotSequence !== detail.value.snapshotSequence) continue;
-          return {
-            thread: summary(
-              thread,
-              detail.value.thread.activities
-                .filter(
-                  (activity) =>
-                    activity.kind === "approval.requested" ||
-                    activity.kind === "user-input.requested",
-                )
-                .map((activity) => activity.id)
-                .sort(),
-            ),
-            snapshotSequence: detail.value.snapshotSequence,
-            ...(detail.value.page === undefined ? {} : { page: detail.value.page }),
-            messages: detail.value.thread.messages.map((message) => ({
-              id: message.id,
-              role: message.role,
-              text: message.text.slice(0, 8000),
-              truncated: message.text.length > 8000,
-              createdAt: message.createdAt,
-            })),
-          };
+            },
+            true,
+          )
+          .pipe(Effect.mapError(failed));
+        if (Option.isNone(detail) || detail.value.shell === undefined) return yield* failed();
+        const thread = detail.value.shell;
+        if (thread.projectId !== caller.projectId || thread.archivedAt !== null) {
+          return yield* new ThreadToolError({ message: "Thread is unavailable in this project." });
         }
-        return yield* failed();
+        return {
+          thread: summary(
+            thread,
+            detail.value.thread.activities
+              .filter(
+                (activity) =>
+                  activity.kind === "approval.requested" ||
+                  activity.kind === "user-input.requested",
+              )
+              .map((activity) => activity.id)
+              .sort(),
+          ),
+          snapshotSequence: detail.value.snapshotSequence,
+          ...(detail.value.page === undefined ? {} : { page: detail.value.page }),
+          messages: detail.value.thread.messages.map((message) => ({
+            id: message.id,
+            role: message.role,
+            text: message.text.slice(0, 8000),
+            truncated: message.text.length > 8000,
+            createdAt: message.createdAt,
+          })),
+        };
       }),
 
     send_message_to_thread: (input) =>

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -1,0 +1,257 @@
+import { CommandId, MessageId, ThreadId, type OrchestrationThreadShell } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+
+import * as OrchestrationEngine from "../../../orchestration/Services/OrchestrationEngine.ts";
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ThreadToolError, ThreadsToolkit } from "./tools.ts";
+
+const summary = (thread: OrchestrationThreadShell, attentionIds: ReadonlyArray<string> = []) => ({
+  id: thread.id,
+  projectId: thread.projectId,
+  title: thread.title,
+  modelSelection: thread.modelSelection,
+  runtimeMode: thread.runtimeMode,
+  interactionMode: thread.interactionMode,
+  createdAt: thread.createdAt,
+  updatedAt: thread.updatedAt,
+  settledAt: thread.settledAt,
+  settledOverride: thread.settledOverride,
+  session: thread.session,
+  latestTurn: thread.latestTurn,
+  latestUserMessageAt: thread.latestUserMessageAt,
+  hasPendingApprovals: thread.hasPendingApprovals,
+  hasPendingUserInput: thread.hasPendingUserInput,
+  backgroundLiveness: thread.backgroundLiveness,
+  // Exclude commentary and timestamps: they must not repeat a completion notification.
+  cursor: JSON.stringify([
+    thread.latestTurn?.turnId ?? null,
+    thread.latestTurn?.state ?? null,
+    thread.session?.status ?? null,
+    thread.hasPendingApprovals,
+    thread.hasPendingUserInput,
+    thread.settledAt,
+    thread.backgroundLiveness ?? null,
+    attentionIds,
+  ]),
+});
+
+const needsAttention = (thread: ReturnType<typeof summary>) =>
+  thread.hasPendingApprovals ||
+  thread.hasPendingUserInput ||
+  (thread.session?.status === "error" &&
+    (thread.latestUserMessageAt === null ||
+      thread.session.updatedAt >= thread.latestUserMessageAt)) ||
+  ((thread.latestUserMessageAt === null ||
+    [
+      thread.latestTurn?.requestedAt,
+      thread.latestTurn?.startedAt,
+      thread.latestTurn?.completedAt,
+    ].some((at) => at != null && at >= thread.latestUserMessageAt!)) &&
+    thread.session?.status !== "starting" &&
+    thread.session?.status !== "running" &&
+    thread.backgroundLiveness !== "working" &&
+    thread.latestTurn !== null &&
+    thread.latestTurn.state !== "running");
+
+const make = Effect.gen(function* () {
+  const engine = yield* OrchestrationEngine.OrchestrationEngineService;
+  const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+  const crypto = yield* Crypto.Crypto;
+  const uuid = crypto.randomUUIDv4.pipe(Effect.orDie);
+  const commandId = (caller: OrchestrationThreadShell, id?: CommandId) =>
+    id === undefined
+      ? uuid.pipe(Effect.map(CommandId.make))
+      : Effect.succeed(CommandId.make(`mcp:${caller.id}:${id}`));
+  const now = DateTime.now.pipe(Effect.map(DateTime.formatIso));
+  const failed = () => new ThreadToolError({ message: "Thread operation failed." });
+  const load = Effect.fn("ThreadsToolkit.load")(function* (threadId: ThreadId) {
+    const thread = yield* snapshots.getThreadShellById(threadId).pipe(Effect.mapError(failed));
+    if (Option.isNone(thread) || thread.value.archivedAt !== null) {
+      return yield* new ThreadToolError({ message: "Thread is unavailable in this project." });
+    }
+    return thread.value;
+  });
+  const source = Effect.fn("ThreadsToolkit.source")(function* () {
+    const scope = yield* McpInvocationContext.requireMcpCapability("threads");
+    return yield* load(scope.threadId);
+  });
+  const target = Effect.fn("ThreadsToolkit.target")(function* (
+    threadId: ThreadId,
+    caller: OrchestrationThreadShell,
+  ) {
+    const thread = yield* load(threadId);
+    if (thread.projectId !== caller.projectId) {
+      return yield* new ThreadToolError({ message: "Thread is unavailable in this project." });
+    }
+    return thread;
+  });
+  const summarize = Effect.fn("ThreadsToolkit.summarize")(function* (
+    thread: OrchestrationThreadShell,
+  ) {
+    if (!thread.hasPendingApprovals && !thread.hasPendingUserInput) return summary(thread);
+    const detail = yield* snapshots
+      .getThreadDetailSnapshot(thread.id, { turnLimit: 1 })
+      .pipe(Effect.mapError(failed));
+    if (Option.isNone(detail)) return yield* failed();
+    const attentionIds = detail.value.thread.activities
+      .filter(
+        (activity) =>
+          activity.kind === "approval.requested" || activity.kind === "user-input.requested",
+      )
+      .map((activity) => activity.id)
+      .sort();
+    return summary(thread, attentionIds);
+  });
+  const dispatch = Effect.fn("ThreadsToolkit.dispatch")(function* (
+    command: Extract<Parameters<typeof engine.dispatch>[0], { readonly threadId: ThreadId }>,
+  ) {
+    const receipt = yield* engine.dispatch(command).pipe(Effect.mapError(failed));
+    return { threadId: command.threadId, ...receipt };
+  });
+
+  return ThreadsToolkit.of({
+    create_thread: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const id = yield* commandId(caller, input.commandId);
+        return yield* dispatch({
+          type: "thread.create",
+          commandId: id,
+          threadId: ThreadId.make(`mcp-thread:${id}`),
+          projectId: caller.projectId,
+          title: input.title,
+          modelSelection: input.modelSelection ?? caller.modelSelection,
+          runtimeMode: caller.runtimeMode,
+          interactionMode: caller.interactionMode,
+          branch: null,
+          worktreePath: null,
+          createdAt: yield* now,
+        });
+      }),
+    list_threads: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const snapshot = yield* snapshots.getShellSnapshot().pipe(Effect.mapError(failed));
+        const threads = snapshot.threads
+          .filter(
+            (thread) =>
+              thread.projectId === caller.projectId &&
+              thread.archivedAt === null &&
+              (input.beforeThreadId === undefined || thread.id < input.beforeThreadId),
+          )
+          .sort((a, b) => (a.id < b.id ? 1 : a.id > b.id ? -1 : 0));
+        const page = threads.slice(0, input.limit ?? 20);
+        return {
+          threads: yield* Effect.forEach(page, summarize),
+          nextBeforeThreadId: threads.length > page.length ? page.at(-1)!.id : null,
+        };
+      }),
+    read_thread: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const thread = yield* target(input.threadId, caller);
+        const detail = yield* snapshots
+          .getThreadDetailSnapshot(thread.id, {
+            turnLimit: input.turnLimit ?? 10,
+            ...(input.beforeCursor === undefined ? {} : { beforeCursor: input.beforeCursor }),
+          })
+          .pipe(Effect.mapError(failed));
+        if (Option.isNone(detail)) return yield* failed();
+        return {
+          thread: yield* summarize(thread),
+          snapshotSequence: detail.value.snapshotSequence,
+          ...(detail.value.page === undefined ? {} : { page: detail.value.page }),
+          messages: detail.value.thread.messages.map((message) => ({
+            id: message.id,
+            role: message.role,
+            text: message.text.slice(0, 8000),
+            truncated: message.text.length > 8000,
+            createdAt: message.createdAt,
+          })),
+        };
+      }),
+    send_message_to_thread: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const thread = yield* target(input.threadId, caller);
+        const id = yield* commandId(caller, input.commandId);
+        return yield* dispatch({
+          type: "thread.turn.start",
+          commandId: id,
+          threadId: thread.id,
+          message: {
+            messageId: MessageId.make(`mcp-message:${id}`),
+            role: "user",
+            attachments: [],
+            text: `Message from T3 thread ${caller.id}.${input.replyToSource === false ? "" : " Reply with send_message_to_thread using that thread ID."}\n\n${input.message}`,
+          },
+          ...(input.modelSelection === undefined ? {} : { modelSelection: input.modelSelection }),
+          runtimeMode: thread.runtimeMode,
+          interactionMode: thread.interactionMode,
+          createdAt: yield* now,
+        });
+      }),
+    wait_threads: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const read = Effect.forEach(input.targets, (entry) =>
+          target(entry.threadId, caller).pipe(Effect.flatMap(summarize)),
+        );
+        const ready = (threads: ReadonlyArray<ReturnType<typeof summary>>) =>
+          threads.some(
+            (thread, index) =>
+              needsAttention(thread) && thread.cursor !== input.targets[index]?.cursor,
+          );
+        return yield* Effect.scoped(
+          Effect.gen(function* () {
+            // Subscribe before reading so a completion between the read and wait is not lost.
+            const events = yield* engine.subscribeDomainEvents;
+            const initial = yield* read;
+            if (ready(initial)) return { threads: initial, timedOut: false };
+            const result = yield* events.pipe(
+              Stream.filter((event) =>
+                input.targets.some((entry) => entry.threadId === event.aggregateId),
+              ),
+              Stream.mapEffect(() => read),
+              Stream.filter(ready),
+              Stream.runHead,
+              Effect.timeoutOption((input.timeoutSeconds ?? 60) * 1000),
+            );
+            const completed = Option.flatMap(result, (value) => value);
+            return Option.isSome(completed)
+              ? { threads: completed.value, timedOut: false }
+              : { threads: yield* read, timedOut: true };
+          }),
+        );
+      }),
+    set_thread_settled: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const thread = yield* target(input.threadId, caller);
+        const id = yield* commandId(caller, input.commandId);
+        return yield* dispatch(
+          input.settled
+            ? { type: "thread.settle", commandId: id, threadId: thread.id }
+            : { type: "thread.unsettle", commandId: id, threadId: thread.id, reason: "user" },
+        );
+      }),
+    interrupt_thread: (input) =>
+      Effect.gen(function* () {
+        const caller = yield* source();
+        const thread = yield* target(input.threadId, caller);
+        return yield* dispatch({
+          type: "thread.turn.interrupt",
+          commandId: yield* commandId(caller, input.commandId),
+          threadId: thread.id,
+          createdAt: yield* now,
+        });
+      }),
+  });
+});
+
+export const ThreadsToolkitHandlersLive = ThreadsToolkit.toLayer(make);

--- a/apps/server/src/mcp/toolkits/threads/tools.ts
+++ b/apps/server/src/mcp/toolkits/threads/tools.ts
@@ -67,10 +67,11 @@ const makeTool = <const N extends string, P extends Schema.Top, S extends Schema
   parameters: P,
   success: S,
   readonly: boolean,
+  destructive = false,
 ) =>
   Tool.make(name, { description, parameters, success, failure, dependencies })
     .annotate(Tool.Readonly, readonly)
-    .annotate(Tool.Destructive, false)
+    .annotate(Tool.Destructive, destructive)
     .annotate(Tool.Idempotent, readonly)
     .annotate(Tool.OpenWorld, false);
 
@@ -158,6 +159,7 @@ export const ThreadsToolkit = Toolkit.make(
     Schema.Struct({ ...mutation, ...target, settled: Schema.Boolean }),
     receipt,
     false,
+    true,
   ),
   makeTool(
     "interrupt_thread",
@@ -165,5 +167,6 @@ export const ThreadsToolkit = Toolkit.make(
     Schema.Struct({ ...mutation, ...target }),
     receipt,
     false,
+    true,
   ),
 );

--- a/apps/server/src/mcp/toolkits/threads/tools.ts
+++ b/apps/server/src/mcp/toolkits/threads/tools.ts
@@ -1,0 +1,169 @@
+import {
+  CommandId,
+  McpCapabilityUnavailableError,
+  ModelSelection,
+  OrchestrationMessage,
+  OrchestrationThreadDetailPage,
+  OrchestrationThreadShell,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import * as Struct from "effect/Struct";
+import * as Tool from "effect/unstable/ai/Tool";
+import * as Toolkit from "effect/unstable/ai/Toolkit";
+
+import * as OrchestrationEngine from "../../../orchestration/Services/OrchestrationEngine.ts";
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+
+export class ThreadToolError extends Schema.TaggedError<ThreadToolError>()("ThreadToolError", {
+  message: Schema.String,
+}) {}
+
+const dependencies = [
+  McpInvocationContext.McpInvocationContext,
+  OrchestrationEngine.OrchestrationEngineService,
+  ProjectionSnapshotQuery.ProjectionSnapshotQuery,
+];
+const failure = Schema.Union([McpCapabilityUnavailableError, ThreadToolError]);
+const target = { threadId: ThreadId };
+const mutation = {
+  commandId: Schema.optionalKey(
+    CommandId.annotate({
+      description:
+        "Stable retry ID. Reuse only for the identical operation and arguments; scoped to your source thread.",
+    }),
+  ),
+};
+const receipt = Schema.Struct({ ...target, sequence: Schema.Finite });
+const limit = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 100 }));
+
+export const ThreadSummary = Schema.Struct({
+  ...Struct.pick(OrchestrationThreadShell.fields, [
+    "id",
+    "projectId",
+    "title",
+    "modelSelection",
+    "runtimeMode",
+    "interactionMode",
+    "createdAt",
+    "updatedAt",
+    "settledAt",
+    "settledOverride",
+    "session",
+    "latestTurn",
+    "latestUserMessageAt",
+    "hasPendingApprovals",
+    "hasPendingUserInput",
+    "backgroundLiveness",
+  ]),
+  cursor: Schema.String,
+});
+
+const makeTool = <const N extends string, P extends Schema.Top, S extends Schema.Top>(
+  name: N,
+  description: string,
+  parameters: P,
+  success: S,
+  readonly: boolean,
+) =>
+  Tool.make(name, { description, parameters, success, failure, dependencies })
+    .annotate(Tool.Readonly, readonly)
+    .annotate(Tool.Destructive, false)
+    .annotate(Tool.Idempotent, readonly)
+    .annotate(Tool.OpenWorld, false);
+
+export const ThreadsToolkit = Toolkit.make(
+  makeTool(
+    "create_thread",
+    "Create an empty persistent peer thread in this project, at its workspace root. Inherits this thread's model and permission mode unless modelSelection is supplied. Returns its ID; use send_message_to_thread to start work. Does not copy history or create a worktree.",
+    Schema.Struct({
+      ...mutation,
+      title: TrimmedNonEmptyString,
+      modelSelection: Schema.optionalKey(ModelSelection),
+    }),
+    receipt,
+    false,
+  ),
+  makeTool(
+    "list_threads",
+    "List persistent peer threads in this project, including settled threads. Archived threads are excluded. Results sort by ID; pass nextBeforeThreadId to fetch the next page.",
+    Schema.Struct({
+      limit: Schema.optionalKey(limit),
+      beforeThreadId: Schema.optionalKey(ThreadId),
+    }),
+    Schema.Struct({
+      threads: Schema.Array(ThreadSummary),
+      nextBeforeThreadId: Schema.NullOr(ThreadId),
+    }),
+    true,
+  ),
+  makeTool(
+    "read_thread",
+    "Read a peer thread's state and a page of conversation messages in this project. Tool output and attachments are omitted; message text is capped at 8000 characters. Use the returned page.beforeCursor for older turns.",
+    Schema.Struct({
+      ...target,
+      turnLimit: Schema.optionalKey(limit),
+      beforeCursor: Schema.optionalKey(TrimmedNonEmptyString),
+    }),
+    Schema.Struct({
+      thread: ThreadSummary,
+      messages: Schema.Array(
+        Schema.Struct({
+          ...Struct.pick(OrchestrationMessage.fields, ["id", "role", "text", "createdAt"]),
+          truncated: Schema.Boolean,
+        }),
+      ),
+      page: Schema.optionalKey(OrchestrationThreadDetailPage),
+      snapshotSequence: Schema.Finite,
+    }),
+    true,
+  ),
+  makeTool(
+    "send_message_to_thread",
+    "Send a visible follow-up to a peer thread in this project, starting or queuing work and reviving settled threads. Includes your thread ID so the recipient can reply. Optional modelSelection changes the model. T3 can reject changing the provider of an already-bound thread.",
+    Schema.Struct({
+      ...mutation,
+      ...target,
+      message: TrimmedNonEmptyString,
+      replyToSource: Schema.optionalKey(
+        Schema.Boolean.annotate({
+          description:
+            "Include instructions to reply to your source thread. Defaults true. Set false when an external controller watches completion instead.",
+        }),
+      ),
+      modelSelection: Schema.optionalKey(ModelSelection),
+    }),
+    receipt,
+    false,
+  ),
+  makeTool(
+    "wait_threads",
+    "Wait for any peer thread to finish or need attention. Pass each last returned cursor to avoid repeated notifications. Returns current state on timeout; commentary does not wake this tool. Maximum wait is 60 seconds.",
+    Schema.Struct({
+      targets: Schema.Array(
+        Schema.Struct({ ...target, cursor: Schema.optionalKey(Schema.String) }),
+      ).check(Schema.isMinLength(1), Schema.isMaxLength(8)),
+      timeoutSeconds: Schema.optionalKey(
+        Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 60 })),
+      ),
+    }),
+    Schema.Struct({ threads: Schema.Array(ThreadSummary), timedOut: Schema.Boolean }),
+    true,
+  ),
+  makeTool(
+    "set_thread_settled",
+    "Settle or reactivate a peer thread in this project. Settling is rejected while work is running or queued, or blocking approvals are pending. Use interrupt_thread to stop a turn first.",
+    Schema.Struct({ ...mutation, ...target, settled: Schema.Boolean }),
+    receipt,
+    false,
+  ),
+  makeTool(
+    "interrupt_thread",
+    "Request interruption of a peer thread's current turn in this project. History remains available for a follow-up.",
+    Schema.Struct({ ...mutation, ...target }),
+    receipt,
+    false,
+  ),
+);

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -3496,6 +3496,7 @@ pending_approval_requests AS (
   const getThreadDetailSnapshot: ProjectionSnapshotQueryShape["getThreadDetailSnapshot"] = (
     threadId,
     window,
+    includeShell = false,
   ) =>
     // Read the thread detail and the snapshot sequence within a single
     // transaction so the sequence is consistent with the returned state; a
@@ -3506,6 +3507,9 @@ pending_approval_requests AS (
     sql
       .withTransaction(
         Effect.gen(function* () {
+          const shell = includeShell ? yield* getThreadShellById(threadId) : Option.none();
+          if (includeShell && Option.isNone(shell)) return Option.none();
+          const shellFields = Option.isSome(shell) ? { shell: shell.value } : {};
           if (window?.turnLimit === undefined) {
             const thread = yield* getThreadDetailByIdBounded(threadId, undefined, {
               mode: "client",
@@ -3514,7 +3518,7 @@ pending_approval_requests AS (
               return Option.none<OrchestrationThreadDetailSnapshot>();
             }
             const { snapshotSequence } = yield* getSnapshotSequence();
-            return Option.some({ snapshotSequence, thread: thread.value });
+            return Option.some({ snapshotSequence, thread: thread.value, ...shellFields });
           }
 
           // A malformed or foreign-thread cursor falls back to the first page
@@ -3606,6 +3610,7 @@ pending_approval_requests AS (
           return Option.some({
             snapshotSequence,
             thread: thread.value,
+            ...shellFields,
             page: {
               beforeCursor:
                 hasMore && oldest !== undefined

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -248,6 +248,9 @@ export interface ProjectionSnapshotQueryShape {
    * Without a window the full thread is returned with no `page` field —
    * pagination is strictly opt-in.
    *
+   * `includeShell` reads shell-only attention and liveness fields in the same
+   * transaction for callers that combine history with a thread summary.
+   *
    * Activity payloads are projected for clients as they are read in small
    * sequential batches. Callers still apply the full snapshot projector for
    * collection-level activity pruning.
@@ -255,7 +258,13 @@ export interface ProjectionSnapshotQueryShape {
   readonly getThreadDetailSnapshot: (
     threadId: ThreadId,
     window?: OrchestrationThreadDetailWindow,
-  ) => Effect.Effect<Option.Option<OrchestrationThreadDetailSnapshot>, ProjectionRepositoryError>;
+    includeShell?: boolean,
+  ) => Effect.Effect<
+    Option.Option<
+      OrchestrationThreadDetailSnapshot & { readonly shell?: OrchestrationThreadShell }
+    >,
+    ProjectionRepositoryError
+  >;
 }
 
 /**

--- a/docs/user/thread-sidebar.md
+++ b/docs/user/thread-sidebar.md
@@ -20,6 +20,19 @@ on Windows and Linux to start a new thread and immediately open another draft. T
 next draft keeps the workspace mode and base branch you selected. With **New
 worktree**, each background submission creates its own worktree.
 
+## Delegate work between threads
+
+Ask an agent connected to T3 Code's built-in tools to create a peer thread for a
+separate task, send it work, and check its result. Peers are ordinary persistent
+threads in the same project. You can open their history and manage them from any
+connected client. Agents can exchange messages across providers.
+
+Creating a peer leaves it empty at the project's workspace root. The agent sends
+a follow-up to start work. It can choose another model, wait for completion or
+attention, interrupt a turn, and settle or reactivate a thread. Sending new work
+to a settled thread revives it. These tools do not copy history or create isolated
+worktrees; use a new worktree when concurrent code changes need separate files.
+
 ## Pin and reorder threads
 
 Pin a thread from its menu to keep it above your active work.


### PR DESCRIPTION
Agents can delegate to persistent peer threads and resume old work through T3's existing MCP connection. This adds project-scoped create, list, read, send, wait, interrupt, and settle/reactivate tools. Peers remain ordinary T3 threads, including when the two agents use different providers.

The tools reuse orchestration commands and stored command receipts. Optional retry IDs prevent duplicate creation or execution after reconnects. Outgoing messages identify their source; external coordinators can omit the reply instruction. Waits subscribe before reading state, distinguish successive attention requests, and avoid reporting an old completion while new work awaits adoption. Creation leaves an empty thread at the project root; it does not copy history or create a worktree.

A standalone [compatibility MCP server](https://github.com/samdickson22/t3code-thread-mcp) works with unmodified T3 0.0.40 while this is reviewed. Its tool contract is generated from this implementation. It uses existing authenticated HTTP routes and polls for waits. [Validation notes and remote-browser screenshots](https://github.com/samdickson22/t3code-thread-mcp/releases/tag/v0.1.0) are attached to its release.

Validation:

- 26 focused server tests pass, including actual MCP calls backed by SQLite, restart/receipt replay, scope/capability denial, null/invalid arguments, settlement, queued work, successive approval requests, retry-ID delimiter collisions, and concurrent snapshot reads.
- Server typecheck, targeted lint, and exact native/standalone contract comparison pass.
- Real GPT-6 Astra with low reasoning created and messaged a Claude Fable 5.1 peer. Claude read and replied to Codex through these native tools. Both directions were settled/revived and retained conversation context.
- The standalone stdio server passed its tests and a live test against released 0.0.40 with both requested models.
- A real remote HTTPS browser displayed the exchanged messages. At a 390×844 viewport, settling the Claude thread through its menu updated the server state. This was responsive web validation, not a native mobile-app run.

T3 0.0.40 rejects changing an already-bound thread from Codex to Claude; this change does not add driver migration. Cross-provider peer communication works. Related work: #10627 includes a broader agent-workflow and MCP gateway proposal.

Model/harness: GPT-6 via Codex. Adversarial review: GPT-6 Astra, low reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP tools to create, list, read, message, wait on, settle, and interrupt persistent peer threads.
  - Added thread capabilities to MCP sessions, including project-scoped access, pagination, retries, attention-aware waiting, and model selection.
  - Enabled persistent thread collaboration across connected clients and providers.
  - Improved thread reads to provide consistent details during concurrent updates.

- **Documentation**
  - Documented peer-thread workflows, including delegation, monitoring, model selection, interruption, settlement, revival, and workspace considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
