### PR TITLE
fix(client-runtime): typecheck device hub ticket request on main

### DIFF
--- a/packages/client-runtime/src/state/deviceHubAccess.ts
+++ b/packages/client-runtime/src/state/deviceHubAccess.ts
@@ -50,10 +50,11 @@ export const resolveDeviceHubAccess = Effect.fn("clientRuntime.state.resolveDevi
       prepared: input.prepared,
       signer,
       remoteAuthorization,
+      group: "auth",
       method: "POST",
       url: (httpBaseUrl) => environmentEndpointUrl(httpBaseUrl, "/api/auth/websocket-ticket"),
       timeoutMs: TICKET_TIMEOUT_MS,
-      request: ({ client, headers }) => client.auth.webSocketTicket({ headers }),
+      request: ({ client, headers }) => client.webSocketTicket({ headers }),
     });
     return {
       httpBase,


### PR DESCRIPTION
Main's Check job fails typecheck in \`packages/client-runtime\` ([run](https://github.com/pingdotgg/t3code/actions/runs/34643733799/job/103409414061)). #10677 and #11029 merged back-to-back with no textual conflict, but #11029 changed \`executeAuthenticatedEnvironmentHttpRequest\` to require a \`group\` and hand the callback a group-scoped client, while #10677's new \`deviceHubAccess.ts\` still called the full-API client (\`client.auth.webSocketTicket\`).

Pass \`group: "auth"\` and call \`client.webSocketTicket\` on the group client, matching the other callers. Typecheck for client-runtime, web, and mobile passes locally.

Claude Fable 5 via Claude Code in T3 Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/11304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now request tickets with the correct authentication group, improving access reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->