### PR TITLE
feat(web): pin a skill as a composer mode with option+enter

### DIFF
--- a/apps/mobile/src/components/ComposerSkillModeChip.tsx
+++ b/apps/mobile/src/components/ComposerSkillModeChip.tsx
@@ -1,0 +1,45 @@
+import { composerSkillModeMention, type ComposerSkillMode } from "@t3tools/shared/composerTrigger";
+import { memo } from "react";
+import { Pressable, View } from "react-native";
+
+import { SymbolView } from "./AppSymbol";
+import { AppText as Text } from "./AppText";
+
+/**
+ * Sits above the editor rather than in the toolbar, which is hidden while the
+ * composer is collapsed. A pinned mode that vanishes on collapse would be a
+ * setting the user cannot see or undo.
+ */
+export const ComposerSkillModeChip = memo(function ComposerSkillModeChip(props: {
+  readonly skillMode: ComposerSkillMode;
+  readonly onRemove: () => void;
+}) {
+  return (
+    <View className="flex-row">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Remove pinned mode ${props.skillMode.label}`}
+        accessibilityHint={`Every message starts with ${composerSkillModeMention(props.skillMode)}`}
+        onPress={props.onRemove}
+        hitSlop={6}
+        className="max-w-full flex-row items-center gap-1.5 rounded-lg bg-subtle px-2 py-1 active:opacity-60"
+      >
+        <SymbolView
+          name="cube"
+          size={12}
+          tintColorClassName="accent-icon-muted"
+          type="monochrome"
+        />
+        <Text className="shrink text-xs font-t3-medium text-foreground-muted" numberOfLines={1}>
+          {props.skillMode.label}
+        </Text>
+        <SymbolView
+          name="xmark"
+          size={10}
+          tintColorClassName="accent-icon-subtle"
+          type="monochrome"
+        />
+      </Pressable>
+    </View>
+  );
+});

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -42,11 +42,26 @@ export type ComposerCommandItem =
       readonly description: string;
     };
 
+export type ComposerPinnableItem = Extract<
+  ComposerCommandItem,
+  { type: "skill" | "provider-slash-command" }
+>;
+
+/**
+ * Whether a row names a provider entry point a mode can repeat. Skills qualify,
+ * and so do provider slash commands, because Claude Code lists plugin skills
+ * only under `/`. The client's own `/model` and a path do not.
+ */
+export function isComposerPinnableItem(item: ComposerCommandItem): item is ComposerPinnableItem {
+  return item.type === "skill" || item.type === "provider-slash-command";
+}
+
 interface ComposerCommandPopoverProps {
   readonly items: ReadonlyArray<ComposerCommandItem>;
   readonly triggerKind: ComposerTriggerKind | null;
   readonly isLoading: boolean;
   readonly onSelect: (item: ComposerCommandItem) => void;
+  readonly onPinMode?: (item: ComposerPinnableItem) => void;
 }
 
 function PopoverSurface(props: { readonly children: React.ReactNode; readonly style?: ViewStyle }) {
@@ -120,6 +135,7 @@ function emptyText(triggerKind: ComposerTriggerKind | null, isLoading: boolean):
 const CommandRow = memo(function CommandRow(props: {
   readonly item: ComposerCommandItem;
   readonly onPress: () => void;
+  readonly onPinMode?: () => void;
   readonly isLast: boolean;
   readonly isSlashSkill: boolean;
 }) {
@@ -157,6 +173,23 @@ const CommandRow = memo(function CommandRow(props: {
           {props.item.description}
         </Text>
       ) : null}
+      {props.onPinMode ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={`Use ${props.item.label} as a mode`}
+          accessibilityHint="Starts every message in this thread with it"
+          // The row is the outer press target, so the pill has to claim the
+          // touch before it bubbles or tapping Mode would insert instead.
+          onPress={(event) => {
+            event.stopPropagation();
+            props.onPinMode?.();
+          }}
+          hitSlop={8}
+          className="ml-auto shrink-0 rounded-md bg-subtle px-2 py-1 active:opacity-60"
+        >
+          <Text className="text-2xs font-t3-medium text-foreground-muted">Mode</Text>
+        </Pressable>
+      ) : null}
     </Pressable>
   );
 });
@@ -181,15 +214,21 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
           keyboardShouldPersistTaps="always"
           showsVerticalScrollIndicator={false}
         >
-          {props.items.map((item, index) => (
-            <CommandRow
-              key={item.id}
-              item={item}
-              onPress={() => props.onSelect(item)}
-              isLast={index === props.items.length - 1}
-              isSlashSkill={props.triggerKind === "slash-command" && item.type === "skill"}
-            />
-          ))}
+          {props.items.map((item, index) => {
+            const onPinMode = props.onPinMode;
+            return (
+              <CommandRow
+                key={item.id}
+                item={item}
+                onPress={() => props.onSelect(item)}
+                {...(onPinMode && isComposerPinnableItem(item)
+                  ? { onPinMode: () => onPinMode(item) }
+                  : {})}
+                isLast={index === props.items.length - 1}
+                isSlashSkill={props.triggerKind === "slash-command" && item.type === "skill"}
+              />
+            );
+          })}
         </ScrollView>
       ) : (
         <View className="px-3.5 py-2.5">

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -74,6 +74,9 @@ import {
 import { useScaledTextRole } from "../settings/appearance/useScaledTextRole";
 import type { RemoteClientConnectionState } from "../../lib/connection";
 import { resolveProviderOptionDescriptors } from "../../lib/providerOptions";
+import type { ComposerSkillMode } from "@t3tools/shared/composerTrigger";
+
+import { ComposerSkillModeChip } from "../../components/ComposerSkillModeChip";
 import { ComposerCommandPopover } from "./ComposerCommandPopover";
 import { useComposerCommandMenu } from "./use-composer-command-menu";
 import {
@@ -136,6 +139,9 @@ export interface ThreadComposerProps {
   readonly onUpdateModelSelection: (modelSelection: ModelSelection) => void;
   readonly onUpdateRuntimeMode: (runtimeMode: RuntimeMode) => void;
   readonly onUpdateInteractionMode: (interactionMode: ProviderInteractionMode) => void;
+  readonly skillMode: ComposerSkillMode | null;
+  readonly onPinSkillMode: (skillMode: ComposerSkillMode) => void;
+  readonly onClearSkillMode: () => void;
   readonly onExpandedChange?: (expanded: boolean) => void;
   /** Fires on editor focus/blur; hosts use it to vet stale keyboard state. */
   readonly onEditorFocusChange?: (focused: boolean) => void;
@@ -359,6 +365,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     // With attachments aboard the pick just inserts the text, so it sends as a prompt.
     onUsageLimits:
       usageLimitsOffered && props.draftAttachments.length === 0 ? openUsageLimits : undefined,
+    onPinSkillMode: props.onPinSkillMode,
   });
   const voiceInput = useVoiceInputController({
     ownerKey: composerOwnerKey,
@@ -605,6 +612,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               triggerKind={composerMenu.trigger.kind}
               isLoading={composerMenu.isLoading}
               onSelect={composerMenu.onSelect}
+              {...(composerMenu.onPinMode ? { onPinMode: composerMenu.onPinMode } : {})}
             />
           </View>
         ) : null}
@@ -647,6 +655,14 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                 onPickMedia={props.onPickDraftMedia}
                 onPickFiles={props.onPickDraftFiles}
               />
+            ) : null}
+            {props.skillMode ? (
+              <View className={isExpanded ? "px-[14px] pb-2" : "px-[6px] pb-1.5"}>
+                <ComposerSkillModeChip
+                  skillMode={props.skillMode}
+                  onRemove={props.onClearSkillMode}
+                />
+              </View>
             ) : null}
             {isExpanded && props.draftAttachments.length > 0 ? (
               <Animated.View

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -1,3 +1,4 @@
+import type { ComposerSkillMode } from "@t3tools/shared/composerTrigger";
 import { type EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import {
   appendCodexArtifactTemplateUsePrompt,
@@ -162,6 +163,9 @@ export interface ThreadDetailScreenProps {
   readonly onUpdateThreadModelSelection: (modelSelection: ModelSelection) => void;
   readonly onUpdateThreadRuntimeMode: (runtimeMode: RuntimeMode) => void;
   readonly onUpdateThreadInteractionMode: (interactionMode: ProviderInteractionMode) => void;
+  readonly skillMode: ComposerSkillMode | null;
+  readonly onPinSkillMode: (skillMode: ComposerSkillMode) => void;
+  readonly onClearSkillMode: () => void;
   readonly onRespondToApproval: (
     requestId: ApprovalRequestId,
     decision: ProviderApprovalDecision,
@@ -1056,6 +1060,9 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
                     onUpdateModelSelection={props.onUpdateThreadModelSelection}
                     onUpdateRuntimeMode={props.onUpdateThreadRuntimeMode}
                     onUpdateInteractionMode={props.onUpdateThreadInteractionMode}
+                    skillMode={props.skillMode}
+                    onPinSkillMode={props.onPinSkillMode}
+                    onClearSkillMode={props.onClearSkillMode}
                     onExpandedChange={setComposerExpanded}
                     onEditorFocusChange={handleComposerFocusChange}
                   />

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -899,6 +899,9 @@ function ThreadRouteContent(
           onUpdateThreadModelSelection={composer.onUpdateModelSelection}
           onUpdateThreadRuntimeMode={composer.onUpdateRuntimeMode}
           onUpdateThreadInteractionMode={composer.onUpdateInteractionMode}
+          skillMode={composer.skillMode}
+          onPinSkillMode={composer.onPinSkillMode}
+          onClearSkillMode={composer.onClearSkillMode}
           onRespondToApproval={requests.onRespondToApproval}
           onSelectUserInputOption={requests.onSelectUserInputOption}
           onChangeUserInputCustomAnswer={requests.onChangeUserInputCustomAnswer}

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -4,6 +4,7 @@ import {
   detectComposerTrigger,
   replaceTextRange,
   serializeComposerFileLink,
+  type ComposerSkillMode,
   type ComposerTrigger,
 } from "@t3tools/shared/composerTrigger";
 import {
@@ -15,6 +16,8 @@ import {
   dedupeProviderSkillsByName,
   getProviderSkillsForSlashMenu,
   isProviderSkillUserInvocable,
+  providerSkillComposerMode,
+  providerSlashCommandComposerMode,
   resolveProviderSkillsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -23,7 +26,7 @@ import type { ComposerEditorSelection } from "../../components/ComposerEditor";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useComposerPathSearch } from "../../state/queries";
-import type { ComposerCommandItem } from "./ComposerCommandPopover";
+import type { ComposerCommandItem, ComposerPinnableItem } from "./ComposerCommandPopover";
 import { matchesSlashSkillQuery } from "./composerSlashSkillSearch";
 
 const WORKSPACE_SNAPSHOT_RETRY_COOLDOWN_MS = 10_000;
@@ -156,6 +159,7 @@ export function useComposerCommandMenu({
   onChangeDraftMessage,
   onUpdateInteractionMode,
   onUsageLimits,
+  onPinSkillMode,
 }: {
   readonly draftMessage: string;
   readonly ownerKey: string | null;
@@ -171,6 +175,7 @@ export function useComposerCommandMenu({
   readonly onUpdateInteractionMode?: (mode: ProviderInteractionMode) => void;
   /** Picking /usage-limits is the action itself; the draft keeps nothing of it. */
   readonly onUsageLimits?: () => void;
+  readonly onPinSkillMode?: (mode: ComposerSkillMode) => void;
 }) {
   const [selection, setSelection] = useState(() => composerSelectionAtEnd(draftMessage));
   const previousOwnerKeyRef = useRef(ownerKey);
@@ -448,6 +453,23 @@ export function useComposerCommandMenu({
     ],
   );
 
+  const onPinMode = useCallback(
+    (item: ComposerPinnableItem) => {
+      if (!trigger || !onPinSkillMode) return;
+      onPinSkillMode(
+        item.type === "skill"
+          ? providerSkillComposerMode(item.skill)
+          : providerSlashCommandComposerMode(item.command),
+      );
+      // The trigger text did its job once the mode is pinned, so it comes out
+      // the same way a pick would have consumed it.
+      const cleared = replaceTextRange(draftMessage, trigger.rangeStart, trigger.rangeEnd, "");
+      setSelection({ start: cleared.cursor, end: cleared.cursor });
+      onChangeDraftMessage(cleared.text);
+    },
+    [draftMessage, onChangeDraftMessage, onPinSkillMode, trigger],
+  );
+
   return {
     selection,
     onSelectionChange,
@@ -456,5 +478,6 @@ export function useComposerCommandMenu({
     skills,
     isLoading: pathSearch.isPending,
     onSelect,
+    ...(onPinSkillMode ? { onPinMode } : {}),
   };
 }

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -1451,6 +1451,27 @@ describe("mobile composer drafts", () => {
     });
   });
 
+  it("keeps a pinned skill mode when the sent content is cleared", () => {
+    const draftKey = "environment-1:thread-1";
+    const draft: ComposerDraft = {
+      text: "send this",
+      attachments: [],
+      skillMode: {
+        kind: "slash-command",
+        name: "pstack:poteto-mode",
+        label: "/pstack:poteto-mode",
+      },
+    };
+
+    expect(clearComposerDraftContentState({ [draftKey]: draft }, draftKey)).toEqual({
+      [draftKey]: {
+        skillMode: draft.skillMode,
+        text: "",
+        attachments: [],
+      },
+    });
+  });
+
   it("drops draft-local model and workspace selections after sending a new task", () => {
     const draftKey = "new-task:environment-1:project-1";
     const draft: ComposerDraft = {

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -16,6 +16,8 @@ import * as Schema from "effect/Schema";
 import { useEffect } from "react";
 import { Atom } from "effect/unstable/reactivity";
 
+import type { ComposerSkillMode } from "@t3tools/shared/composerTrigger";
+
 import { writeFileAtomically } from "../lib/atomic-file";
 import { DraftComposerAttachmentSchema } from "../lib/composer-image-schema";
 import {
@@ -66,6 +68,8 @@ export interface ComposerDraft {
   readonly modelSelection?: ModelSelection;
   readonly runtimeMode?: RuntimeMode;
   readonly interactionMode?: ProviderInteractionMode;
+  /** Provider entry point that leads every message sent from this draft. */
+  readonly skillMode?: ComposerSkillMode;
   readonly workspaceSelection?: ComposerDraftWorkspaceSelection;
   /**
    * Set on new-task drafts only. The project is stored here rather than in
@@ -97,13 +101,22 @@ export interface ComposerDraftWorkspaceSelection {
 export type ComposerDraftSettingsUpdate = Pick<
   ComposerDraft,
   "modelSelection" | "runtimeMode" | "interactionMode" | "workspaceSelection" | "project"
->;
+> & {
+  /** Undefined clears the pin, so the key is present but the value optional. */
+  readonly skillMode: ComposerSkillMode | undefined;
+};
 
 const ComposerDraftWorkspaceSelectionSchema = Schema.Struct({
   mode: Schema.Literals(["local", "worktree"]),
   branch: Schema.NullOr(Schema.String),
   worktreePath: Schema.NullOr(Schema.String),
   startFromOrigin: Schema.optional(Schema.Boolean),
+});
+
+const ComposerSkillModeSchema = Schema.Struct({
+  kind: Schema.Literals(["skill", "slash-command"]),
+  name: Schema.String,
+  label: Schema.String,
 });
 
 const ComposerDraftProjectSchema = Schema.Struct({
@@ -119,6 +132,7 @@ const ComposerDraftSchema = Schema.Struct({
   modelSelection: Schema.optional(ModelSelectionSchema),
   runtimeMode: Schema.optional(RuntimeModeSchema),
   interactionMode: Schema.optional(ProviderInteractionModeSchema),
+  skillMode: Schema.optional(ComposerSkillModeSchema),
   workspaceSelection: Schema.optional(ComposerDraftWorkspaceSelectionSchema),
   project: Schema.optional(ComposerDraftProjectSchema),
 });
@@ -212,6 +226,7 @@ function isEmptyDraft(draft: ComposerDraft): boolean {
     draft.modelSelection === undefined &&
     draft.runtimeMode === undefined &&
     draft.interactionMode === undefined &&
+    draft.skillMode === undefined &&
     draft.workspaceSelection === undefined
   );
 }
@@ -295,6 +310,7 @@ export function decodePersistedComposerState(value: unknown): {
               draft.attachments.length === 0 &&
               draft.runtimeMode === undefined &&
               draft.interactionMode === undefined &&
+              draft.skillMode === undefined &&
               draft.workspaceSelection === undefined
               ? { ...draft, modelSelection: undefined }
               : draft,
@@ -1233,6 +1249,7 @@ export function sameComposerDraftState(a: ComposerDraft, b: ComposerDraft): bool
     a.modelSelection === b.modelSelection &&
     a.runtimeMode === b.runtimeMode &&
     a.interactionMode === b.interactionMode &&
+    a.skillMode === b.skillMode &&
     a.workspaceSelection === b.workspaceSelection
   );
 }
@@ -1266,7 +1283,12 @@ export function undoComposerDraftMergeState(
   // A setting still holding the merge's value is the merge's doing: restore
   // the snapshot's. One the user changed since the merge stays theirs.
   const undoSetting = <
-    K extends "modelSelection" | "runtimeMode" | "interactionMode" | "workspaceSelection",
+    K extends
+      | "modelSelection"
+      | "runtimeMode"
+      | "interactionMode"
+      | "skillMode"
+      | "workspaceSelection",
   >(
     key: K,
   ): ComposerDraft[K] => (existing[key] === merged[key] ? snapshot[key] : existing[key]);
@@ -1285,6 +1307,7 @@ export function undoComposerDraftMergeState(
     modelSelection: undoSetting("modelSelection"),
     runtimeMode: undoSetting("runtimeMode"),
     interactionMode: undoSetting("interactionMode"),
+    skillMode: undoSetting("skillMode"),
     workspaceSelection: undoSetting("workspaceSelection"),
   };
   return withComposerDraft(current, draftKey, draft);

--- a/apps/mobile/src/state/use-thread-composer-state.ts
+++ b/apps/mobile/src/state/use-thread-composer-state.ts
@@ -20,6 +20,10 @@ import {
   type CodexFeedbackSubmission,
 } from "@t3tools/client-runtime/state/threads";
 import { deriveActiveWorkStartedAt } from "@t3tools/shared/orchestrationTiming";
+import {
+  applyComposerSkillModePrefix,
+  type ComposerSkillMode,
+} from "@t3tools/shared/composerTrigger";
 
 import { makeQueuedMessageMetadata } from "../lib/commandMetadata";
 import { isModelSelectionUnavailable } from "../lib/modelOptions";
@@ -207,6 +211,7 @@ export function useThreadComposerState() {
   const selectedThread = selectedThreadDetail ?? selectedThreadShell;
   const modelSelection = selectedDraft?.modelSelection ?? selectedThread?.modelSelection ?? null;
   const runtimeMode = selectedDraft?.runtimeMode ?? selectedThread?.runtimeMode ?? null;
+  const skillMode = selectedDraft?.skillMode ?? null;
   const selectedProvider = selectedEnvironmentRuntime?.serverConfig?.providers.find(
     (provider) => provider.instanceId === modelSelection?.instanceId,
   );
@@ -395,7 +400,7 @@ export function useThreadComposerState() {
       threadId: selectedThreadShell.id,
       messageId,
       commandId: CommandId.make(metadata.commandId),
-      text,
+      text: applyComposerSkillModePrefix(text, draft.skillMode),
       attachments,
       modelSelection,
       runtimeMode: draft.runtimeMode ?? thread.runtimeMode,
@@ -584,6 +589,23 @@ export function useThreadComposerState() {
     [selectedEnvironmentRuntime?.serverConfig, selectedThreadKey],
   );
 
+  const onPinSkillMode = useCallback(
+    (value: ComposerSkillMode) => {
+      if (!selectedThreadKey) {
+        return;
+      }
+      updateComposerDraftSettings(selectedThreadKey, { skillMode: value });
+    },
+    [selectedThreadKey],
+  );
+
+  const onClearSkillMode = useCallback(() => {
+    if (!selectedThreadKey) {
+      return;
+    }
+    updateComposerDraftSettings(selectedThreadKey, { skillMode: undefined });
+  }, [selectedThreadKey]);
+
   const onUpdateRuntimeMode = useCallback(
     (value: RuntimeMode) => {
       if (!selectedThreadKey) {
@@ -636,5 +658,8 @@ export function useThreadComposerState() {
     onUpdateModelSelection,
     onUpdateRuntimeMode,
     onUpdateInteractionMode,
+    skillMode,
+    onPinSkillMode,
+    onClearSkillMode,
   };
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -59,6 +59,10 @@ import {
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
 import {
+  type ComposerSkillMode,
+  applyComposerSkillModePrefix,
+} from "@t3tools/shared/composerTrigger";
+import {
   applyClaudePromptEffortPrefix,
   createModelSelection,
   resolvePromptInjectedEffort,
@@ -669,11 +673,17 @@ function formatOutgoingPrompt(params: {
   model: string | null;
   models: ReadonlyArray<ServerProvider["models"][number]>;
   effort: string | null;
+  skillMode: ComposerSkillMode | null;
   text: string;
 }): string {
   const caps = getProviderModelCapabilities(params.models, params.model, params.provider);
   const promptEffort = resolvePromptInjectedEffort(caps, params.effort);
-  return applyClaudePromptEffortPrefix(params.text, promptEffort);
+  // The effort prefix has to stay at the very start for Claude to honour it,
+  // so the skill mention goes underneath it.
+  return applyClaudePromptEffortPrefix(
+    applyComposerSkillModePrefix(params.text, params.skillMode),
+    promptEffort,
+  );
 }
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
@@ -6752,6 +6762,7 @@ export default function ChatView(props: ChatViewProps) {
       selectedProviderModels: ctxSelectedProviderModels,
       selectedPromptEffort: ctxSelectedPromptEffort,
       selectedModelSelection: ctxSelectedModelSelection,
+      skillMode: ctxSkillMode,
       interactionMode: sendInteractionMode,
       interactionModeEnabled: sendInteractionModeEnabled,
     } = sendCtx;
@@ -6878,6 +6889,7 @@ export default function ChatView(props: ChatViewProps) {
         model: ctxSelectedModel,
         models: ctxSelectedProviderModels,
         effort: ctxSelectedPromptEffort,
+        skillMode: ctxSkillMode,
         text: followUp.text.trim(),
       });
       if (composerRef.current?.validateProviderInput(outgoingFollowUpText) === false) {
@@ -6976,6 +6988,7 @@ export default function ChatView(props: ChatViewProps) {
       model: ctxSelectedModel,
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
+      skillMode: ctxSkillMode,
       text: messageTextForSend || ATTACHMENT_ONLY_BOOTSTRAP_PROMPT,
     });
     if (composerRef.current?.validateProviderInput(outgoingMessageText) === false) {
@@ -7704,6 +7717,7 @@ export default function ChatView(props: ChatViewProps) {
         selectedProviderModels: ctxSelectedProviderModels,
         selectedPromptEffort: ctxSelectedPromptEffort,
         selectedModelSelection: ctxSelectedModelSelection,
+        skillMode: ctxSkillMode,
       } = sendCtx;
 
       const threadIdForSend = activeThread.id;
@@ -7714,6 +7728,7 @@ export default function ChatView(props: ChatViewProps) {
         model: ctxSelectedModel,
         models: ctxSelectedProviderModels,
         effort: ctxSelectedPromptEffort,
+        skillMode: ctxSkillMode,
         text: trimmed,
       });
 
@@ -7852,6 +7867,7 @@ export default function ChatView(props: ChatViewProps) {
       selectedProviderModels: ctxSelectedProviderModels,
       selectedPromptEffort: ctxSelectedPromptEffort,
       selectedModelSelection: ctxSelectedModelSelection,
+      skillMode: ctxSkillMode,
     } = sendCtx;
 
     const createdAt = new Date().toISOString();
@@ -7863,6 +7879,7 @@ export default function ChatView(props: ChatViewProps) {
       model: ctxSelectedModel,
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
+      skillMode: ctxSkillMode,
       text: implementationPrompt,
     });
     if (composerRef.current?.validateProviderInput(outgoingImplementationPrompt) === false) {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -27,7 +27,10 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
-import { serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  type ComposerSkillMode,
+  serializeComposerFileLink,
+} from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import { USAGE_LIMITS_COMMAND } from "@t3tools/shared/usageLimits";
 import {
@@ -188,6 +191,7 @@ import {
   ComposerControlSeparator,
   ComposerSelectControl,
 } from "./ComposerControl";
+import { resolveComposerMenuKeyAction } from "./composerMenuKeyAction";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
 import {
   searchSlashCommandItems,
@@ -1229,6 +1233,7 @@ export interface ChatComposerHandle {
     selectedProviderModels: ReadonlyArray<ServerProvider["models"][number]>;
     interactionMode: ProviderInteractionMode;
     interactionModeEnabled: boolean;
+    skillMode: ComposerSkillMode | null;
   };
   /** Validate the fully composed text immediately before a provider turn starts. */
   validateProviderInput: (providerInput: string) => boolean;
@@ -1603,7 +1608,11 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const syncComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.syncPersistedAttachments,
   );
+  const setComposerDraftSkillMode = useComposerDraftStore((store) => store.setSkillMode);
   const getComposerDraft = useComposerDraftStore((store) => store.getComposerDraft);
+  const composerSkillMode = useComposerDraftStore(
+    (store) => store.getComposerDraft(composerDraftTarget)?.skillMode ?? null,
+  );
 
   useEffect(() => {
     if (!attachmentUploadsCapabilityKnown) {
@@ -2850,6 +2859,29 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     };
   }, [readComposerSnapshot]);
 
+  const pinComposerSkillMode = useCallback(
+    (item: Extract<ComposerCommandItem, { type: "skill" }>) => {
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      if (!trigger) return;
+      setComposerDraftSkillMode(composerDraftTarget, {
+        name: item.skill.name,
+        label: formatProviderSkillDisplayName(item.skill),
+      });
+      const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+        expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+      });
+      if (applied) {
+        setComposerHighlightedItemId(null);
+      }
+    },
+    [
+      applyPromptReplacement,
+      composerDraftTarget,
+      resolveActiveComposerTrigger,
+      setComposerDraftSkillMode,
+    ],
+  );
+
   const { onUsageLimitsCommand } = props;
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {
@@ -3230,15 +3262,21 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (menuIsActive) {
       const currentItems = composerMenuItemsRef.current;
       const selectedItem = activeComposerMenuItemRef.current ?? currentItems[0];
-      if (key === "ArrowDown" && currentItems.length > 0) {
-        nudgeComposerMenuHighlight("ArrowDown");
+      const action = resolveComposerMenuKeyAction({
+        key,
+        altKey: event.altKey,
+        itemCount: currentItems.length,
+        activeItemType: selectedItem?.type ?? null,
+      });
+      if (action?.kind === "highlight") {
+        nudgeComposerMenuHighlight(action.direction);
         return true;
       }
-      if (key === "ArrowUp" && currentItems.length > 0) {
-        nudgeComposerMenuHighlight("ArrowUp");
+      if (action?.kind === "pin-mode" && selectedItem?.type === "skill") {
+        pinComposerSkillMode(selectedItem);
         return true;
       }
-      if ((key === "Enter" || key === "Tab") && selectedItem) {
+      if (action?.kind === "select" && selectedItem) {
         onSelectComposerItem(selectedItem);
         return true;
       }
@@ -4835,6 +4873,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         selectedProviderModels,
         interactionMode,
         interactionModeEnabled: planModeUiEnabled,
+        skillMode: composerSkillMode,
       }),
       validateProviderInput: (providerInput: string) => {
         const validationMessage = getComposerSubmissionValidationMessage({
@@ -4883,6 +4922,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       selectedProviderModels,
       interactionMode,
       planModeUiEnabled,
+      composerSkillMode,
       compactThreadContext,
       restoreAfterTimelineReachedEnd,
       getTimelineScrollableNode,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1018,6 +1018,7 @@ const ComposerSkillModeChip = memo(function ComposerSkillModeChip(props: {
             type="button"
             onClick={props.onRemove}
             aria-label={removeLabel}
+            data-composer-skill-mode-chip="true"
           />
         }
       >

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -850,6 +850,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { toastManager } from "../ui/toast";
 import {
   BotIcon,
+  BoxIcon,
   CircleAlertIcon,
   PaperclipIcon,
   PencilRulerIcon,
@@ -1000,6 +1001,36 @@ function useRestingComposerControlsLayout(host: HTMLDivElement | null) {
 
   return { controlsRef, hiddenBlockCount: layout.hiddenCount, controlsVisible: layout.visible };
 }
+
+const ComposerSkillModeChip = memo(function ComposerSkillModeChip(props: {
+  skillMode: ComposerSkillMode;
+  size: "sm" | "xs";
+  onRemove: () => void;
+}) {
+  const removeLabel = `Remove ${props.skillMode.label} skill mode`;
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <ComposerControl
+            size={props.size}
+            className="shrink-0 whitespace-nowrap"
+            type="button"
+            onClick={props.onRemove}
+            aria-label={removeLabel}
+          />
+        }
+      >
+        <ComposerControlIcon icon={BoxIcon} size={props.size} />
+        <span className="max-w-32 truncate">{props.skillMode.label}</span>
+        <ComposerControlIcon icon={XIcon} size={props.size} className="opacity-60" />
+      </TooltipTrigger>
+      <TooltipPopup side="top">
+        {`Every message starts with $${props.skillMode.name}. Click to remove.`}
+      </TooltipPopup>
+    </Tooltip>
+  );
+});
 
 const ComposerFooterModeControls = memo(function ComposerFooterModeControls(props: {
   showInteractionModeToggle: boolean;
@@ -2882,6 +2913,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     ],
   );
 
+  const clearComposerSkillMode = useCallback(() => {
+    setComposerDraftSkillMode(composerDraftTarget, null);
+  }, [composerDraftTarget, setComposerDraftSkillMode]);
+
   const { onUsageLimitsCommand } = props;
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {
@@ -4157,6 +4192,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           size="xs"
           className="@max-[400px]/composer-surface:hidden"
           data-resting-controls-separator="true"
+        />
+      ) : null}
+      {composerSkillMode ? (
+        <ComposerSkillModeChip
+          skillMode={composerSkillMode}
+          size={composerControlsInStrip ? "xs" : "sm"}
+          onRemove={clearComposerSkillMode}
         />
       ) : null}
       <ProviderModelPicker

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -898,6 +898,8 @@ import {
   formatProviderSkillDisplayName,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
+  providerSkillComposerMode,
+  providerSlashCommandComposerMode,
   resolveProviderSkillsForCwd,
   resolveProviderSlashCommandsForCwd,
 } from "@t3tools/client-runtime/providerSkills";
@@ -2902,12 +2904,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       setComposerDraftSkillMode(
         composerDraftTarget,
         item.type === "skill"
-          ? {
-              kind: "skill",
-              name: item.skill.name,
-              label: formatProviderSkillDisplayName(item.skill),
-            }
-          : { kind: "slash-command", name: item.command.name, label: `/${item.command.name}` },
+          ? providerSkillComposerMode(item.skill)
+          : providerSlashCommandComposerMode(item.command),
       );
       const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
         expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -27,7 +27,11 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
-import { type ComposerSkillMode, serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
+import {
+  type ComposerSkillMode,
+  composerSkillModeMention,
+  serializeComposerFileLink,
+} from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import { USAGE_LIMITS_COMMAND } from "@t3tools/shared/usageLimits";
 import {
@@ -175,7 +179,12 @@ import { measureRestingComposerControls } from "./restingComposerControlsMeasure
 import { observeResponsiveBreakpointFade, usePanelAnimationSettings } from "../../panelAnimations";
 import { type ComposerPromptEditorHandle, ComposerPromptEditor } from "../ComposerPromptEditor";
 import { ProviderModelPicker } from "./ProviderModelPicker";
-import { type ComposerCommandItem, ComposerCommandMenu } from "./ComposerCommandMenu";
+import {
+  type ComposerCommandItem,
+  ComposerCommandMenu,
+  type ComposerPinnableItem,
+  isComposerPinnableItem,
+} from "./ComposerCommandMenu";
 import { ComposerPendingApprovalActions } from "./ComposerPendingApprovalActions";
 import { CompactComposerControlsMenu } from "./CompactComposerControlsMenu";
 import { ComposerPrimaryActions } from "./ComposerPrimaryActions";
@@ -1004,7 +1013,7 @@ const ComposerSkillModeChip = memo(function ComposerSkillModeChip(props: {
   size: "sm" | "xs";
   onRemove: () => void;
 }) {
-  const removeLabel = `Remove ${props.skillMode.label} skill mode`;
+  const removeLabel = `Remove pinned mode ${props.skillMode.label}`;
   return (
     <Tooltip>
       <TooltipTrigger
@@ -1024,7 +1033,7 @@ const ComposerSkillModeChip = memo(function ComposerSkillModeChip(props: {
         <ComposerControlIcon icon={XIcon} size={props.size} className="opacity-60" />
       </TooltipTrigger>
       <TooltipPopup side="top">
-        {`Every message starts with $${props.skillMode.name}. Click to remove.`}
+        {`Every message starts with ${composerSkillModeMention(props.skillMode)}. Click to remove.`}
       </TooltipPopup>
     </Tooltip>
   );
@@ -2887,13 +2896,19 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   }, [readComposerSnapshot]);
 
   const pinComposerSkillMode = useCallback(
-    (item: Extract<ComposerCommandItem, { type: "skill" }>) => {
+    (item: ComposerPinnableItem) => {
       const { snapshot, trigger } = resolveActiveComposerTrigger();
       if (!trigger) return;
-      setComposerDraftSkillMode(composerDraftTarget, {
-        name: item.skill.name,
-        label: formatProviderSkillDisplayName(item.skill),
-      });
+      setComposerDraftSkillMode(
+        composerDraftTarget,
+        item.type === "skill"
+          ? {
+              kind: "skill",
+              name: item.skill.name,
+              label: formatProviderSkillDisplayName(item.skill),
+            }
+          : { kind: "slash-command", name: item.command.name, label: `/${item.command.name}` },
+      );
       const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
         expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
       });
@@ -3303,7 +3318,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         nudgeComposerMenuHighlight(action.direction);
         return true;
       }
-      if (action?.kind === "pin-mode" && selectedItem?.type === "skill") {
+      if (action?.kind === "pin-mode" && isComposerPinnableItem(selectedItem)) {
         pinComposerSkillMode(selectedItem);
         return true;
       }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -27,10 +27,7 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
 import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
-import {
-  type ComposerSkillMode,
-  serializeComposerFileLink,
-} from "@t3tools/shared/composerTrigger";
+import { type ComposerSkillMode, serializeComposerFileLink } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import { USAGE_LIMITS_COMMAND } from "@t3tools/shared/usageLimits";
 import {
@@ -1642,9 +1639,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   );
   const setComposerDraftSkillMode = useComposerDraftStore((store) => store.setSkillMode);
   const getComposerDraft = useComposerDraftStore((store) => store.getComposerDraft);
-  const composerSkillMode = useComposerDraftStore(
-    (store) => store.getComposerDraft(composerDraftTarget)?.skillMode ?? null,
-  );
+  const composerSkillMode = composerDraft.skillMode;
 
   useEffect(() => {
     if (!attachmentUploadsCapabilityKnown) {

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -129,6 +129,7 @@ describe("ComposerCommandMenu", () => {
     expect(markup).toContain("Mode");
     // The modifier glyph is platform-dependent; the key name is not.
     expect(markup).toContain("Enter");
+    expect(markup).not.toContain(">App Skill</span>");
     expect(markup).not.toContain('data-slot="badge"');
   });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.test.tsx
@@ -51,7 +51,7 @@ describe("ComposerCommandMenu", () => {
         resolvedTheme="dark"
         isLoading={false}
         triggerKind="skill"
-        activeItemId="skill:codex:browser"
+        activeItemId={null}
         onHighlightedItemChange={() => {}}
         onSelect={() => {}}
       />,
@@ -86,7 +86,7 @@ describe("ComposerCommandMenu", () => {
         resolvedTheme="dark"
         isLoading={false}
         triggerKind="slash-command"
-        activeItemId="skill:codex:ask-matt"
+        activeItemId={null}
         onHighlightedItemChange={() => {}}
         onSelect={() => {}}
       />,
@@ -97,5 +97,38 @@ describe("ComposerCommandMenu", () => {
     expect(markup).toContain("lucide-folder");
     expect(markup).toContain(">Repo</span>");
     expect(markup).toContain("Find the right skill or workflow");
+  });
+
+  it("swaps the source badge for the mode hint on the highlighted skill", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerCommandMenu
+        items={[
+          {
+            id: "skill:codex:browser",
+            type: "skill",
+            provider: ProviderDriverKind.make("codex"),
+            skill: {
+              name: "browser",
+              path: "/Users/maria/.codex/plugins/browser/skills/browser/SKILL.md",
+              scope: "user",
+              enabled: true,
+            },
+            label: "Browser",
+            description: "Open and control the in-app browser",
+          },
+        ]}
+        resolvedTheme="dark"
+        isLoading={false}
+        triggerKind="skill"
+        activeItemId="skill:codex:browser"
+        onHighlightedItemChange={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(markup).toContain("Mode");
+    // The modifier glyph is platform-dependent; the key name is not.
+    expect(markup).toContain("Enter");
+    expect(markup).not.toContain('data-slot="badge"');
   });
 });

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -70,6 +70,22 @@ export type ComposerCommandItem =
       description: string;
     };
 
+export type ComposerPinnableItem = Extract<
+  ComposerCommandItem,
+  { type: "skill" | "provider-slash-command" }
+>;
+
+/**
+ * Whether a menu row names a provider entry point a mode can repeat. Skills
+ * qualify, and so do provider slash commands, because Claude Code lists plugin
+ * skills only under `/`. The client's own `/model` and a path do not.
+ */
+export function isComposerPinnableItem(
+  item: ComposerCommandItem | null | undefined,
+): item is ComposerPinnableItem {
+  return item?.type === "skill" || item?.type === "provider-slash-command";
+}
+
 export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
   items: ComposerCommandItem[];
   resolvedTheme: "light" | "dark";
@@ -194,7 +210,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <span className="min-w-0 max-w-[48ch] flex-1 truncate text-left text-secondary-label text-xs">
           {props.item.description}
         </span>
-        {props.isActive && props.item.type === "skill" ? (
+        {props.isActive && isComposerPinnableItem(props.item) ? (
           <span className="ms-auto flex shrink-0 items-center gap-1.5 text-secondary-label text-xs">
             Mode
             <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -20,11 +20,22 @@ import {
 import { memo, useLayoutEffect, useRef } from "react";
 
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
+import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
 import { Command, CommandGroup, CommandItem, CommandList } from "../ui/command";
+import { Kbd } from "../ui/kbd";
 import { PierreEntryIcon } from "./PierreEntryIcon";
 import { ComposerBanner } from "./ComposerBanner";
+
+const PIN_SKILL_MODE_SHORTCUT_LABEL = formatShortcutLabel({
+  key: "enter",
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: true,
+  modKey: false,
+});
 
 export type ComposerCommandItem =
   | {
@@ -183,7 +194,14 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <span className="min-w-0 max-w-[48ch] flex-1 truncate text-left text-secondary-label text-xs">
           {props.item.description}
         </span>
-        {skillSourceKind ? (
+        {props.isActive && props.item.type === "skill" ? (
+          <span className="ms-auto flex shrink-0 items-center gap-1.5 text-secondary-label text-xs">
+            Mode
+            <Kbd className="h-4 min-w-0 rounded-sm px-1.5 text-[10px]">
+              {PIN_SKILL_MODE_SHORTCUT_LABEL}
+            </Kbd>
+          </span>
+        ) : skillSourceKind ? (
           <SkillSourceBadge
             kind={skillSourceKind}
             showSkillSuffix={props.triggerKind === "skill"}

--- a/apps/web/src/components/chat/composerMenuKeyAction.test.ts
+++ b/apps/web/src/components/chat/composerMenuKeyAction.test.ts
@@ -42,9 +42,9 @@ describe("resolveComposerMenuKeyAction", () => {
       { kind: "select" },
     ],
     [
-      "Alt+Enter on a provider slash command selects",
+      "Alt+Enter on a provider slash command pins the mode",
       { key: "Enter", altKey: true, itemCount: 1, activeItemType: "provider-slash-command" },
-      { kind: "select" },
+      { kind: "pin-mode" },
     ],
     [
       "plain Enter on a skill selects",

--- a/apps/web/src/components/chat/composerMenuKeyAction.test.ts
+++ b/apps/web/src/components/chat/composerMenuKeyAction.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveComposerMenuKeyAction, type ComposerMenuKeyAction } from "./composerMenuKeyAction";
+
+type Params = Parameters<typeof resolveComposerMenuKeyAction>[0];
+
+describe("resolveComposerMenuKeyAction", () => {
+  it.each<[string, Params, ComposerMenuKeyAction | null]>([
+    [
+      "ArrowDown with items highlights down",
+      { key: "ArrowDown", altKey: false, itemCount: 3, activeItemType: null },
+      { kind: "highlight", direction: "ArrowDown" },
+    ],
+    [
+      "ArrowUp with items highlights up",
+      { key: "ArrowUp", altKey: false, itemCount: 3, activeItemType: null },
+      { kind: "highlight", direction: "ArrowUp" },
+    ],
+    [
+      "ArrowDown with no items does nothing",
+      { key: "ArrowDown", altKey: false, itemCount: 0, activeItemType: null },
+      null,
+    ],
+    [
+      "ArrowUp with no items does nothing",
+      { key: "ArrowUp", altKey: false, itemCount: 0, activeItemType: null },
+      null,
+    ],
+    [
+      "Alt+Enter on a skill pins the mode",
+      { key: "Enter", altKey: true, itemCount: 1, activeItemType: "skill" },
+      { kind: "pin-mode" },
+    ],
+    [
+      "Alt+Enter on a path selects",
+      { key: "Enter", altKey: true, itemCount: 1, activeItemType: "path" },
+      { kind: "select" },
+    ],
+    [
+      "Alt+Enter on a slash command selects",
+      { key: "Enter", altKey: true, itemCount: 1, activeItemType: "slash-command" },
+      { kind: "select" },
+    ],
+    [
+      "Alt+Enter on a provider slash command selects",
+      { key: "Enter", altKey: true, itemCount: 1, activeItemType: "provider-slash-command" },
+      { kind: "select" },
+    ],
+    [
+      "plain Enter on a skill selects",
+      { key: "Enter", altKey: false, itemCount: 1, activeItemType: "skill" },
+      { kind: "select" },
+    ],
+    [
+      "Alt+Tab on a skill selects because only Enter pins",
+      { key: "Tab", altKey: true, itemCount: 1, activeItemType: "skill" },
+      { kind: "select" },
+    ],
+    [
+      "Enter with no active item does nothing",
+      { key: "Enter", altKey: false, itemCount: 0, activeItemType: null },
+      null,
+    ],
+    [
+      "Tab with no active item does nothing",
+      { key: "Tab", altKey: false, itemCount: 0, activeItemType: null },
+      null,
+    ],
+  ])("%s", (_name, params, expected) => {
+    const action = resolveComposerMenuKeyAction(params);
+
+    if (expected === null) {
+      expect(action).toBeNull();
+    } else {
+      expect(action).toEqual(expected);
+    }
+  });
+});

--- a/apps/web/src/components/chat/composerMenuKeyAction.ts
+++ b/apps/web/src/components/chat/composerMenuKeyAction.ts
@@ -15,12 +15,16 @@ export function resolveComposerMenuKeyAction(params: {
     return { kind: "highlight", direction: params.key };
   }
 
-  if (params.key === "Enter" && params.altKey && params.activeItemType === "skill") {
+  if (
+    params.key === "Enter" &&
+    params.altKey &&
+    (params.activeItemType === "skill" || params.activeItemType === "provider-slash-command")
+  ) {
     return { kind: "pin-mode" };
   }
 
-  // Alt+Enter on any other row still selects, because only a skill row has
-  // something to pin.
+  // Alt+Enter on any other row still selects, because only a provider entry
+  // point has something to pin.
   if ((params.key === "Enter" || params.key === "Tab") && params.activeItemType !== null) {
     return { kind: "select" };
   }

--- a/apps/web/src/components/chat/composerMenuKeyAction.ts
+++ b/apps/web/src/components/chat/composerMenuKeyAction.ts
@@ -1,0 +1,29 @@
+import type { ComposerCommandItem } from "./ComposerCommandMenu";
+
+export type ComposerMenuKeyAction =
+  | { kind: "highlight"; direction: "ArrowDown" | "ArrowUp" }
+  | { kind: "select" }
+  | { kind: "pin-mode" };
+
+export function resolveComposerMenuKeyAction(params: {
+  key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab";
+  altKey: boolean;
+  itemCount: number;
+  activeItemType: ComposerCommandItem["type"] | null;
+}): ComposerMenuKeyAction | null {
+  if ((params.key === "ArrowDown" || params.key === "ArrowUp") && params.itemCount > 0) {
+    return { kind: "highlight", direction: params.key };
+  }
+
+  if (params.key === "Enter" && params.altKey && params.activeItemType === "skill") {
+    return { kind: "pin-mode" };
+  }
+
+  // Alt+Enter on any other row still selects, because only a skill row has
+  // something to pin.
+  if ((params.key === "Enter" || params.key === "Tab") && params.activeItemType !== null) {
+    return { kind: "select" };
+  }
+
+  return null;
+}

--- a/apps/web/src/components/chat/restingComposerControlsMeasurement.test.ts
+++ b/apps/web/src/components/chat/restingComposerControlsMeasurement.test.ts
@@ -6,17 +6,26 @@ import {
 } from "../composerFooterLayout";
 import { measureRestingComposerControls } from "./restingComposerControlsMeasurement";
 
-function measurePicker(input: { clientWidth: number; flexGrow: string; maxWidth?: string }) {
+function measurePicker(input: {
+  clientWidth: number;
+  flexGrow: string;
+  maxWidth?: string;
+  skillModeChipWidth?: number;
+}) {
   const label = { clientWidth: input.clientWidth, scrollWidth: 160 };
   const picker = {
     getBoundingClientRect: () => ({ width: 52 }),
     querySelector: () => label,
   };
+  const skillModeChipWidth = input.skillModeChipWidth;
   const controls = {
     querySelector: (selector: string) => {
       if (selector === "[data-chat-provider-model-picker]") return picker;
       if (selector === "[data-resting-controls-overflow]") {
         return { getBoundingClientRect: () => ({ width: 24 }) };
+      }
+      if (selector === "[data-composer-skill-mode-chip]" && skillModeChipWidth !== undefined) {
+        return { getBoundingClientRect: () => ({ width: skillModeChipWidth }) };
       }
       return null;
     },
@@ -59,6 +68,21 @@ describe("measureRestingComposerControls", () => {
 
     expect(measurement.naturalFixedWidth).toBe(212);
     expect(resolveRestingComposerControlsLayout({ ...measurement, hostWidth: 200 })).toEqual({
+      hiddenCount: 1,
+      visible: true,
+    });
+  });
+
+  it("reserves room for the pinned skill mode chip", () => {
+    const withoutChip = measurePicker({ clientWidth: 0, flexGrow: "0" });
+    const withChip = measurePicker({ clientWidth: 0, flexGrow: "0", skillModeChipWidth: 96 });
+
+    expect(withChip.naturalFixedWidth).toBe(withoutChip.naturalFixedWidth + 100);
+    expect(resolveRestingComposerControlsLayout({ ...withoutChip, hostWidth: 200 })).toEqual({
+      hiddenCount: 0,
+      visible: true,
+    });
+    expect(resolveRestingComposerControlsLayout({ ...withChip, hostWidth: 200 })).toEqual({
       hiddenCount: 1,
       visible: true,
     });

--- a/apps/web/src/components/chat/restingComposerControlsMeasurement.ts
+++ b/apps/web/src/components/chat/restingComposerControlsMeasurement.ts
@@ -66,15 +66,22 @@ export function measureRestingComposerControls(
   const separatorWidth = separator ? elementOuterWidth(separator) : 0;
   const overflow = controls.querySelector<HTMLElement>("[data-resting-controls-overflow]");
   const separatorAndGapWidth = separatorWidth > 0 ? separatorWidth + gap : 0;
+  // A pinned skill mode leads the cluster and never moves into overflow, so
+  // its width belongs with the picker rather than the hideable blocks.
+  const skillModeChip = controls.querySelector<HTMLElement>("[data-composer-skill-mode-chip]");
+  const skillModeChipWidth = skillModeChip ? elementOuterWidth(skillModeChip) : 0;
+  const skillModeChipAndGapWidth = skillModeChipWidth > 0 ? skillModeChipWidth + gap : 0;
   const blocks = Array.from(controls.querySelectorAll<HTMLElement>("[data-resting-block]"));
   return {
     gap,
     naturalFixedWidth:
       (picker ? providerModelPickerNaturalWidth(picker) : elementOuterWidth(leadingControl)) +
-      separatorAndGapWidth,
+      separatorAndGapWidth +
+      skillModeChipAndGapWidth,
     minimumFixedWidth:
       (picker ? providerModelPickerMinimumWidth(picker) : elementOuterWidth(leadingControl)) +
-      separatorAndGapWidth,
+      separatorAndGapWidth +
+      skillModeChipAndGapWidth,
     blockWidths: blocks.map(elementOuterWidth),
     overflowWidth: overflow ? elementOuterWidth(overflow) : 0,
   };

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -2788,6 +2788,7 @@ describe("composerDraftStore skill mode", () => {
     vi.useFakeTimers();
     try {
       useComposerDraftStore.getState().setSkillMode(threadRef, {
+        kind: "skill",
         name: "review",
         label: "Review",
       });
@@ -2796,6 +2797,7 @@ describe("composerDraftStore skill mode", () => {
       resetComposerDraftStore();
       await useComposerDraftStore.persist.rehydrate();
       expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.skillMode).toEqual({
+        kind: "skill",
         name: "review",
         label: "Review",
       });
@@ -2812,10 +2814,61 @@ describe("composerDraftStore skill mode", () => {
     }
   });
 
+  it("round-trips a slash-command mode and reads a kindless legacy mode as a skill", async () => {
+    await useComposerDraftStore.persist.clearStorage();
+    vi.useFakeTimers();
+    try {
+      const storage = useComposerDraftStore.persist.getOptions().storage;
+      expect(storage).toBeDefined();
+      const reseed = async (mutate: (skillMode: Record<string, string>) => void) => {
+        useComposerDraftStore.getState().setSkillMode(threadRef, {
+          kind: "skill",
+          name: "review",
+          label: "Review",
+        });
+        await vi.advanceTimersByTimeAsync(300);
+        const persisted = (await storage?.getItem(COMPOSER_DRAFT_STORAGE_KEY)) as {
+          version: number;
+          state: { draftsByThreadKey: Record<string, { skillMode?: Record<string, string> }> };
+        } | null;
+        expect(persisted).not.toBeNull();
+        for (const draft of Object.values(persisted!.state.draftsByThreadKey)) {
+          if (draft.skillMode) mutate(draft.skillMode);
+        }
+        storage?.setItem(COMPOSER_DRAFT_STORAGE_KEY, persisted as never);
+        await vi.advanceTimersByTimeAsync(300);
+        resetComposerDraftStore();
+        await useComposerDraftStore.persist.rehydrate();
+      };
+
+      await reseed((skillMode) => {
+        skillMode.kind = "slash-command";
+      });
+      expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.skillMode).toEqual({
+        kind: "slash-command",
+        name: "review",
+        label: "Review",
+      });
+
+      await reseed((skillMode) => {
+        delete skillMode.kind;
+      });
+      expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.skillMode).toEqual({
+        kind: "skill",
+        name: "review",
+        label: "Review",
+      });
+    } finally {
+      vi.useRealTimers();
+      await useComposerDraftStore.persist.clearStorage();
+    }
+  });
+
   it("does not count a skill mode as user content", async () => {
     vi.useFakeTimers();
     try {
       useComposerDraftStore.getState().setSkillMode(threadRef, {
+        kind: "skill",
         name: "review",
         label: "Review",
       });

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -2774,3 +2774,58 @@ describe("createDeferredStorage", () => {
     expect(base.setItem).toHaveBeenCalledWith("key", "s:v2");
   });
 });
+
+describe("composerDraftStore skill mode", () => {
+  const threadId = ThreadId.make("thread-skill-mode");
+  const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("persists and clears skill mode through storage round-trips", async () => {
+    await useComposerDraftStore.persist.clearStorage();
+    vi.useFakeTimers();
+    try {
+      useComposerDraftStore.getState().setSkillMode(threadRef, {
+        name: "review",
+        label: "Review",
+      });
+      await vi.advanceTimersByTimeAsync(300);
+
+      resetComposerDraftStore();
+      await useComposerDraftStore.persist.rehydrate();
+      expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.skillMode).toEqual({
+        name: "review",
+        label: "Review",
+      });
+
+      useComposerDraftStore.getState().setSkillMode(threadRef, null);
+      await vi.advanceTimersByTimeAsync(300);
+
+      resetComposerDraftStore();
+      await useComposerDraftStore.persist.rehydrate();
+      expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+      await useComposerDraftStore.persist.clearStorage();
+    }
+  });
+
+  it("does not count a skill mode as user content", async () => {
+    vi.useFakeTimers();
+    try {
+      useComposerDraftStore.getState().setSkillMode(threadRef, {
+        name: "review",
+        label: "Review",
+      });
+
+      expect(
+        composerDraftHasUserContent(useComposerDraftStore.getState().getComposerDraft(threadRef)),
+      ).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      await useComposerDraftStore.persist.clearStorage();
+    }
+  });
+});

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -32,6 +32,7 @@ import * as Equal from "effect/Equal";
 import * as Effect from "effect/Effect";
 import { DeepMutable } from "effect/Types";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
+import type { ComposerSkillMode } from "@t3tools/shared/composerTrigger";
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
@@ -256,6 +257,7 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   modelSelectionExplicit: Schema.optionalKey(Schema.Boolean),
   runtimeMode: Schema.optionalKey(RuntimeMode),
   interactionMode: Schema.optionalKey(ProviderInteractionMode),
+  skillMode: Schema.optionalKey(Schema.Struct({ name: Schema.String, label: Schema.String })),
 });
 type PersistedComposerThreadDraftState = typeof PersistedComposerThreadDraftState.Type;
 
@@ -393,6 +395,7 @@ export interface ComposerThreadDraftState {
   modelSelectionExplicit?: boolean;
   runtimeMode: RuntimeMode | null;
   interactionMode: ProviderInteractionMode | null;
+  skillMode: ComposerSkillMode | null;
 }
 
 /**
@@ -601,6 +604,10 @@ interface ComposerDraftStoreState {
     threadRef: ComposerThreadTarget,
     interactionMode: ProviderInteractionMode | null | undefined,
   ) => void;
+  setSkillMode: (
+    threadRef: ComposerThreadTarget,
+    skillMode: ComposerSkillMode | null | undefined,
+  ) => void;
   addImage: (threadRef: ComposerThreadTarget, image: ComposerImageAttachment) => boolean;
   addImages: (threadRef: ComposerThreadTarget, images: ComposerImageAttachment[]) => void;
   removeImage: (threadRef: ComposerThreadTarget, imageId: string) => void;
@@ -774,6 +781,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   activeProvider: null,
   runtimeMode: null,
   interactionMode: null,
+  skillMode: null,
 });
 
 /**
@@ -797,6 +805,7 @@ function createEmptyThreadDraft(): ComposerThreadDraftState {
     activeProvider: null,
     runtimeMode: null,
     interactionMode: null,
+    skillMode: null,
   };
 }
 
@@ -890,7 +899,8 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     Object.keys(draft.modelSelectionByProvider).length === 0 &&
     draft.activeProvider === null &&
     draft.runtimeMode === null &&
-    draft.interactionMode === null
+    draft.interactionMode === null &&
+    draft.skillMode === null
   );
 }
 
@@ -1930,6 +1940,12 @@ function normalizePersistedDraftsByThreadId(
       draftCandidate.interactionMode === "plan" || draftCandidate.interactionMode === "default"
         ? draftCandidate.interactionMode
         : null;
+    const skillMode =
+      draftCandidate.skillMode &&
+      typeof draftCandidate.skillMode.name === "string" &&
+      typeof draftCandidate.skillMode.label === "string"
+        ? { name: draftCandidate.skillMode.name, label: draftCandidate.skillMode.label }
+        : null;
     const prompt = ensureInlineTerminalContextPlaceholders(
       promptCandidate,
       terminalContexts.length,
@@ -1993,7 +2009,8 @@ function normalizePersistedDraftsByThreadId(
       reviewComments.length === 0 &&
       !hasModelData &&
       !runtimeMode &&
-      !interactionMode
+      !interactionMode &&
+      !skillMode
     ) {
       continue;
     }
@@ -2025,6 +2042,7 @@ function normalizePersistedDraftsByThreadId(
         : {}),
       ...(runtimeMode ? { runtimeMode } : {}),
       ...(interactionMode ? { interactionMode } : {}),
+      ...(skillMode ? { skillMode } : {}),
     };
   }
 
@@ -2063,7 +2081,9 @@ function stripLegacyModelSeedsFromEmptyDraftSessions(
         modelSelectionExplicit: _modelSelectionExplicit,
         ...retained
       } = draft;
-      return retained.runtimeMode || retained.interactionMode ? [[threadKey, retained]] : [];
+      return retained.runtimeMode || retained.interactionMode || retained.skillMode
+        ? [[threadKey, retained]]
+        : [];
     }),
   );
 }
@@ -2127,7 +2147,8 @@ export function partializeComposerDraftStoreState(
       draft.reviewComments.length === 0 &&
       !hasModelData &&
       draft.runtimeMode === null &&
-      draft.interactionMode === null
+      draft.interactionMode === null &&
+      draft.skillMode === null
     ) {
       continue;
     }
@@ -2206,6 +2227,7 @@ export function partializeComposerDraftStoreState(
         : {}),
       ...(draft.runtimeMode ? { runtimeMode: draft.runtimeMode } : {}),
       ...(draft.interactionMode ? { interactionMode: draft.interactionMode } : {}),
+      ...(draft.skillMode ? { skillMode: { ...draft.skillMode } } : {}),
     };
     persistedDraftsByThreadKey[threadKey] = persistedDraft;
   }
@@ -2469,6 +2491,7 @@ function toHydratedThreadDraft(
     ...(persistedDraft.modelSelectionExplicit ? { modelSelectionExplicit: true } : {}),
     runtimeMode: persistedDraft.runtimeMode ?? null,
     interactionMode: persistedDraft.interactionMode ?? null,
+    skillMode: persistedDraft.skillMode ? { ...persistedDraft.skillMode } : null,
   };
 }
 
@@ -3263,6 +3286,45 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             const nextDraft: ComposerThreadDraftState = {
               ...base,
               interactionMode: nextInteractionMode,
+            };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) {
+              delete nextDraftsByThreadKey[threadKey];
+            } else {
+              nextDraftsByThreadKey[threadKey] = nextDraft;
+            }
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
+        setSkillMode: (threadRef, skillMode) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return;
+          }
+          const nextSkillMode =
+            typeof skillMode?.name === "string" && skillMode.name.trim().length > 0
+              ? skillMode
+              : null;
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey];
+            if (!existing && nextSkillMode === null) {
+              return state;
+            }
+            const base = existing ?? createEmptyThreadDraft();
+            // The picker hands over a fresh object on every pick, so identity
+            // would report a change even when the same skill is re-pinned.
+            const skillModeUnchanged =
+              (base.skillMode === null && nextSkillMode === null) ||
+              (base.skillMode !== null &&
+                nextSkillMode !== null &&
+                base.skillMode.name === nextSkillMode.name &&
+                base.skillMode.label === nextSkillMode.label);
+            if (skillModeUnchanged) {
+              return state;
+            }
+            const nextDraft: ComposerThreadDraftState = {
+              ...base,
+              skillMode: nextSkillMode,
             };
             const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
             if (shouldRemoveDraft(nextDraft)) {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -257,7 +257,13 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   modelSelectionExplicit: Schema.optionalKey(Schema.Boolean),
   runtimeMode: Schema.optionalKey(RuntimeMode),
   interactionMode: Schema.optionalKey(ProviderInteractionMode),
-  skillMode: Schema.optionalKey(Schema.Struct({ name: Schema.String, label: Schema.String })),
+  skillMode: Schema.optionalKey(
+    Schema.Struct({
+      kind: Schema.Literals(["skill", "slash-command"]),
+      name: Schema.String,
+      label: Schema.String,
+    }),
+  ),
 });
 type PersistedComposerThreadDraftState = typeof PersistedComposerThreadDraftState.Type;
 
@@ -1944,7 +1950,16 @@ function normalizePersistedDraftsByThreadId(
       draftCandidate.skillMode &&
       typeof draftCandidate.skillMode.name === "string" &&
       typeof draftCandidate.skillMode.label === "string"
-        ? { name: draftCandidate.skillMode.name, label: draftCandidate.skillMode.label }
+        ? {
+            // A draft pinned before slash commands could be modes carries no
+            // kind, and could only ever have held a skill.
+            kind:
+              draftCandidate.skillMode.kind === "slash-command"
+                ? ("slash-command" as const)
+                : ("skill" as const),
+            name: draftCandidate.skillMode.name,
+            label: draftCandidate.skillMode.label,
+          }
         : null;
     const prompt = ensureInlineTerminalContextPlaceholders(
       promptCandidate,
@@ -3317,6 +3332,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               (base.skillMode === null && nextSkillMode === null) ||
               (base.skillMode !== null &&
                 nextSkillMode !== null &&
+                base.skillMode.kind === nextSkillMode.kind &&
                 base.skillMode.name === nextSkillMode.name &&
                 base.skillMode.label === nextSkillMode.label);
             if (skillModeUnchanged) {

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -106,6 +106,11 @@ Show skills in slash menu**. Only skills enabled for the provider are listed.
 Provider commands must start the message to run. T3 Code commands such as
 `/model` and `/plan`, and skill mentions, work on any line.
 
+On web and desktop, press `Option+Enter` on macOS or `Alt+Enter` on Windows and
+Linux while a skill is highlighted in either menu to pin it as a mode. A pinned
+skill appears as a chip in the composer and starts every message in that thread
+with its mention, until you click the chip to remove it.
+
 Send `/compact` in an existing conversation to reduce context usage when the
 provider supports it. Web and desktop also offer compaction from the context meter.
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -113,6 +113,11 @@ message in that thread with it, until you click the chip to remove it. Skills
 lead with `$name` and provider commands with `/name`, so a command mode runs on
 every message the way it would if you typed it.
 
+On mobile, tap **Mode** on a skill or provider command in the menu to pin it.
+The chip sits above the message field and stays there while the composer is
+collapsed; tap it to remove the mode. Pinning a mode is not available on
+**New task**, since that draft ends when the thread starts.
+
 Send `/compact` in an existing conversation to reduce context usage when the
 provider supports it. Web and desktop also offer compaction from the context meter.
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -107,9 +107,11 @@ Provider commands must start the message to run. T3 Code commands such as
 `/model` and `/plan`, and skill mentions, work on any line.
 
 On web and desktop, press `Option+Enter` on macOS or `Alt+Enter` on Windows and
-Linux while a skill is highlighted in either menu to pin it as a mode. A pinned
-skill appears as a chip in the composer and starts every message in that thread
-with its mention, until you click the chip to remove it.
+Linux while a skill or a provider command is highlighted in either menu to pin
+it as a mode. A pinned mode appears as a chip in the composer and starts every
+message in that thread with it, until you click the chip to remove it. Skills
+lead with `$name` and provider commands with `/name`, so a command mode runs on
+every message the way it would if you typed it.
 
 Send `/compact` in an existing conversation to reduce context usage when the
 provider supports it. Web and desktop also offer compaction from the context meter.

--- a/packages/client-runtime/src/providerSkills.test.ts
+++ b/packages/client-runtime/src/providerSkills.test.ts
@@ -1,9 +1,13 @@
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
+import { applyComposerSkillModePrefix } from "@t3tools/shared/composerTrigger";
+
 import {
   dedupeProviderSkillsByName,
   formatProviderSkillDisplayName,
+  providerSkillComposerMode,
+  providerSlashCommandComposerMode,
   getProviderSlashCommandsForSlashMenu,
   getProviderSkillsForSlashMenu,
   resolveProviderSkillsForCwd,
@@ -250,5 +254,21 @@ describe("workspace provider snapshots", () => {
   it("keeps the machine snapshot before this cwd has a provider snapshot", () => {
     expect(resolveProviderSkillsForCwd(provider, "/workspace/project-b")).toEqual(provider.skills);
     expect(resolveProviderSlashCommandsForCwd(provider, null)).toEqual(provider.slashCommands);
+  });
+});
+
+describe("composer modes built from picker rows", () => {
+  it("sends a skill as a mention and shows its display name", () => {
+    const mode = providerSkillComposerMode({ name: "poteto-mode", displayName: "Poteto Mode" });
+
+    expect(mode.label).toBe("Poteto Mode");
+    expect(applyComposerSkillModePrefix("ship it", mode)).toBe("$poteto-mode ship it");
+  });
+
+  it("sends a provider slash command as the command that runs it", () => {
+    const mode = providerSlashCommandComposerMode({ name: "pstack:poteto-mode" });
+
+    expect(mode.label).toBe("/pstack:poteto-mode");
+    expect(applyComposerSkillModePrefix("ship it", mode)).toBe("/pstack:poteto-mode ship it");
   });
 });

--- a/packages/client-runtime/src/providerSkills.ts
+++ b/packages/client-runtime/src/providerSkills.ts
@@ -3,6 +3,7 @@ import type {
   ServerProviderSkill,
   ServerProviderSlashCommand,
 } from "@t3tools/contracts";
+import type { ComposerSkillMode } from "@t3tools/shared/composerTrigger";
 
 export type ProviderSkillSourceKind = "app" | "repo" | "project" | "personal" | "system" | "other";
 
@@ -54,6 +55,22 @@ export function isProviderSkillUserInvocable(
   skill: Pick<ServerProviderSkill, "enabled" | "userInvocable">,
 ): boolean {
   return skill.enabled && skill.userInvocable !== false;
+}
+
+/**
+ * The composer mode a picker row pins. Both surfaces build it here so the chip
+ * label and the mention they send cannot drift apart.
+ */
+export function providerSkillComposerMode(
+  skill: Pick<ServerProviderSkill, "name" | "displayName">,
+): ComposerSkillMode {
+  return { kind: "skill", name: skill.name, label: formatProviderSkillDisplayName(skill) };
+}
+
+export function providerSlashCommandComposerMode(
+  command: Pick<ServerProviderSlashCommand, "name">,
+): ComposerSkillMode {
+  return { kind: "slash-command", name: command.name, label: `/${command.name}` };
 }
 
 export function getProviderSkillsForSlashMenu(

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -39,51 +39,72 @@ describe("applyComposerSkillModePrefix", () => {
 
   it("returns the text unchanged when the mode name is blank", () => {
     expect(
-      applyComposerSkillModePrefix("fix the flaky test", { name: "   ", label: "Review" }),
+      applyComposerSkillModePrefix("fix the flaky test", {
+        kind: "skill",
+        name: "   ",
+        label: "Review",
+      }),
     ).toBe("fix the flaky test");
   });
 
   it("returns empty text unchanged", () => {
-    expect(applyComposerSkillModePrefix("", { name: "review", label: "Review" })).toBe("");
+    expect(
+      applyComposerSkillModePrefix("", { kind: "skill", name: "review", label: "Review" }),
+    ).toBe("");
   });
 
   it("returns whitespace-only text unchanged, preserving the original whitespace", () => {
-    expect(applyComposerSkillModePrefix("   ", { name: "review", label: "Review" })).toBe("   ");
+    expect(
+      applyComposerSkillModePrefix("   ", { kind: "skill", name: "review", label: "Review" }),
+    ).toBe("   ");
   });
 
   it("does not double-prefix text that already starts with the mention", () => {
     expect(
-      applyComposerSkillModePrefix("$review the diff", { name: "review", label: "Review" }),
+      applyComposerSkillModePrefix("$review the diff", {
+        kind: "skill",
+        name: "review",
+        label: "Review",
+      }),
     ).toBe("$review the diff");
   });
 
   it("does not double-prefix an exact, standalone mention token", () => {
-    expect(applyComposerSkillModePrefix("$review", { name: "review", label: "Review" })).toBe(
-      "$review",
-    );
+    expect(
+      applyComposerSkillModePrefix("$review", { kind: "skill", name: "review", label: "Review" }),
+    ).toBe("$review");
   });
 
   it("prefixes text that merely shares the mention as a prefix of a longer token", () => {
     expect(
-      applyComposerSkillModePrefix("$reviewer look", { name: "review", label: "Review" }),
+      applyComposerSkillModePrefix("$reviewer look", {
+        kind: "skill",
+        name: "review",
+        label: "Review",
+      }),
     ).toBe("$review $reviewer look");
   });
 
   it("does not prefix a provider slash command", () => {
-    expect(applyComposerSkillModePrefix("/compact", { name: "review", label: "Review" })).toBe(
-      "/compact",
-    );
+    expect(
+      applyComposerSkillModePrefix("/compact", { kind: "skill", name: "review", label: "Review" }),
+    ).toBe("/compact");
   });
 
   it("does not prefix a slash command surrounded by whitespace, preserving the original", () => {
     expect(
-      applyComposerSkillModePrefix(" /review src/x.ts ", { name: "review", label: "Review" }),
+      applyComposerSkillModePrefix(" /review src/x.ts ", {
+        kind: "skill",
+        name: "review",
+        label: "Review",
+      }),
     ).toBe(" /review src/x.ts ");
   });
 
   it("prefixes an absolute path that is not a slash command", () => {
     expect(
       applyComposerSkillModePrefix("/home/theo/app.ts crashed", {
+        kind: "skill",
         name: "review",
         label: "Review",
       }),
@@ -92,8 +113,42 @@ describe("applyComposerSkillModePrefix", () => {
 
   it("prefixes a plain prompt", () => {
     expect(
-      applyComposerSkillModePrefix("fix the flaky test", { name: "review", label: "Review" }),
+      applyComposerSkillModePrefix("fix the flaky test", {
+        kind: "skill",
+        name: "review",
+        label: "Review",
+      }),
     ).toBe("$review fix the flaky test");
+  });
+
+  it("opens a prompt with the command when the mode is a slash command", () => {
+    expect(
+      applyComposerSkillModePrefix("fix the flaky test", {
+        kind: "slash-command",
+        name: "pstack:poteto-mode",
+        label: "/pstack:poteto-mode",
+      }),
+    ).toBe("/pstack:poteto-mode fix the flaky test");
+  });
+
+  it("does not double-prefix a prompt that already opens with the pinned command", () => {
+    expect(
+      applyComposerSkillModePrefix("/pstack:poteto-mode ship it", {
+        kind: "slash-command",
+        name: "pstack:poteto-mode",
+        label: "/pstack:poteto-mode",
+      }),
+    ).toBe("/pstack:poteto-mode ship it");
+  });
+
+  it("yields to a different command the prompt already opens with", () => {
+    expect(
+      applyComposerSkillModePrefix("/compact", {
+        kind: "slash-command",
+        name: "pstack:poteto-mode",
+        label: "/pstack:poteto-mode",
+      }),
+    ).toBe("/compact");
   });
 });
 

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { serializeComposerFileLink } from "./composerTrigger.ts";
+import { applyComposerSkillModePrefix, serializeComposerFileLink } from "./composerTrigger.ts";
 
 describe("serializeComposerFileLink", () => {
   it("uses the basename as the markdown label", () => {
@@ -25,5 +25,70 @@ describe("serializeComposerFileLink", () => {
     expect(serializeComposerFileLink("@scope/package.json")).toBe(
       "[package.json](@scope/package.json)",
     );
+  });
+});
+
+describe("applyComposerSkillModePrefix", () => {
+  it("returns the text unchanged when there is no mode", () => {
+    expect(applyComposerSkillModePrefix("fix the flaky test", null)).toBe("fix the flaky test");
+  });
+
+  it("returns the text unchanged when the mode name is blank", () => {
+    expect(
+      applyComposerSkillModePrefix("fix the flaky test", { name: "   ", label: "Review" }),
+    ).toBe("fix the flaky test");
+  });
+
+  it("returns empty text unchanged", () => {
+    expect(applyComposerSkillModePrefix("", { name: "review", label: "Review" })).toBe("");
+  });
+
+  it("returns whitespace-only text unchanged, preserving the original whitespace", () => {
+    expect(applyComposerSkillModePrefix("   ", { name: "review", label: "Review" })).toBe("   ");
+  });
+
+  it("does not double-prefix text that already starts with the mention", () => {
+    expect(
+      applyComposerSkillModePrefix("$review the diff", { name: "review", label: "Review" }),
+    ).toBe("$review the diff");
+  });
+
+  it("does not double-prefix an exact, standalone mention token", () => {
+    expect(applyComposerSkillModePrefix("$review", { name: "review", label: "Review" })).toBe(
+      "$review",
+    );
+  });
+
+  it("prefixes text that merely shares the mention as a prefix of a longer token", () => {
+    expect(
+      applyComposerSkillModePrefix("$reviewer look", { name: "review", label: "Review" }),
+    ).toBe("$review $reviewer look");
+  });
+
+  it("does not prefix a provider slash command", () => {
+    expect(applyComposerSkillModePrefix("/compact", { name: "review", label: "Review" })).toBe(
+      "/compact",
+    );
+  });
+
+  it("does not prefix a slash command surrounded by whitespace, preserving the original", () => {
+    expect(
+      applyComposerSkillModePrefix(" /review src/x.ts ", { name: "review", label: "Review" }),
+    ).toBe(" /review src/x.ts ");
+  });
+
+  it("prefixes an absolute path that is not a slash command", () => {
+    expect(
+      applyComposerSkillModePrefix("/home/theo/app.ts crashed", {
+        name: "review",
+        label: "Review",
+      }),
+    ).toBe("$review /home/theo/app.ts crashed");
+  });
+
+  it("prefixes a plain prompt", () => {
+    expect(
+      applyComposerSkillModePrefix("fix the flaky test", { name: "review", label: "Review" }),
+    ).toBe("$review fix the flaky test");
   });
 });

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { applyComposerSkillModePrefix, serializeComposerFileLink } from "./composerTrigger.ts";
+import {
+  applyComposerSkillModePrefix,
+  serializeComposerFileLink,
+  startsWithProviderSlashCommand,
+} from "./composerTrigger.ts";
 
 describe("serializeComposerFileLink", () => {
   it("uses the basename as the markdown label", () => {
@@ -90,5 +94,23 @@ describe("applyComposerSkillModePrefix", () => {
     expect(
       applyComposerSkillModePrefix("fix the flaky test", { name: "review", label: "Review" }),
     ).toBe("$review fix the flaky test");
+  });
+});
+
+describe("startsWithProviderSlashCommand", () => {
+  it("recognizes a bare command", () => {
+    expect(startsWithProviderSlashCommand("/compact")).toBe(true);
+  });
+
+  it("recognizes a command carrying arguments", () => {
+    expect(startsWithProviderSlashCommand("/plugin:skill do the thing")).toBe(true);
+  });
+
+  it("ignores an absolute path", () => {
+    expect(startsWithProviderSlashCommand("/home/theo/app.ts crashed")).toBe(false);
+  });
+
+  it("ignores prose", () => {
+    expect(startsWithProviderSlashCommand("fix the flaky test")).toBe(false);
   });
 });

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -115,6 +115,45 @@ export function detectComposerTrigger(
   };
 }
 
+export interface ComposerSkillMode {
+  /** Provider skill name — the token body of the `$name` mention. */
+  name: string;
+  /** Display label shown on the composer chip. */
+  label: string;
+}
+
+export function applyComposerSkillModePrefix(
+  text: string,
+  mode: ComposerSkillMode | null | undefined,
+): string {
+  const name = mode?.name.trim();
+  if (!name) {
+    return text;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return text;
+  }
+  // A recalled or resent prompt already carries the mention, so prefixing it
+  // again would double it. The token has to end at a boundary, since
+  // "$reviewer" names a different skill than "$review".
+  const mention = `$${name}`;
+  if (text.startsWith(mention)) {
+    const next = text.charAt(mention.length);
+    if (next === "" || isWhitespace(next)) {
+      return text;
+    }
+  }
+  // Command names come from arbitrary file names ("/deploy.prod",
+  // "/plugin:skill"), so any first token without a second slash counts as
+  // one, and prefixing it would leave prose the provider never runs. An
+  // absolute path like "/home/theo/app.ts" is not a command and keeps it.
+  if (/^\/[^\s/]+(?:\s|$)/u.test(trimmed)) {
+    return text;
+  }
+  return `$${name} ${text}`;
+}
+
 export function replaceTextRange(
   text: string,
   rangeStart: number,

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -115,11 +115,23 @@ export function detectComposerTrigger(
   };
 }
 
+/**
+ * How the provider starts the pinned entry point. A skill answers to a `$name`
+ * mention in prose; a provider slash command only answers to `/name`, which is
+ * how Claude Code exposes plugin commands that never reach its skill list.
+ */
+export type ComposerSkillModeKind = "skill" | "slash-command";
+
 export interface ComposerSkillMode {
-  /** Provider skill name — the token body of the `$name` mention. */
+  kind: ComposerSkillModeKind;
+  /** Provider skill or slash command name, without its sigil. */
   name: string;
   /** Display label shown on the composer chip. */
   label: string;
+}
+
+export function composerSkillModeMention(mode: ComposerSkillMode): string {
+  return `${mode.kind === "slash-command" ? "/" : "$"}${mode.name.trim()}`;
 }
 
 /**
@@ -137,8 +149,7 @@ export function applyComposerSkillModePrefix(
   text: string,
   mode: ComposerSkillMode | null | undefined,
 ): string {
-  const name = mode?.name.trim();
-  if (!name) {
+  if (!mode?.name.trim()) {
     return text;
   }
   const trimmed = text.trim();
@@ -148,17 +159,19 @@ export function applyComposerSkillModePrefix(
   // A recalled or resent prompt already carries the mention, so prefixing it
   // again would double it. The token has to end at a boundary, since
   // "$reviewer" names a different skill than "$review".
-  const mention = `$${name}`;
+  const mention = composerSkillModeMention(mode);
   if (trimmed.startsWith(mention)) {
     const next = trimmed.charAt(mention.length);
     if (next === "" || isWhitespace(next)) {
       return text;
     }
   }
+  // Only one command can lead a message, so a slash-command mode yields to
+  // whichever one the prompt was typed with.
   if (startsWithProviderSlashCommand(trimmed)) {
     return text;
   }
-  return `$${name} ${text}`;
+  return `${mention} ${text}`;
 }
 
 export function replaceTextRange(

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -122,6 +122,17 @@ export interface ComposerSkillMode {
   label: string;
 }
 
+/**
+ * Whether the text opens with a `/command` the provider expands itself.
+ * Anything prepended to one leaves prose the provider never runs, so every
+ * prompt prefix has to skip it. Command names come from arbitrary file names
+ * ("/deploy.prod", "/plugin:skill"), so any first token without a second
+ * slash counts; an absolute path like "/home/theo/app.ts" does not.
+ */
+export function startsWithProviderSlashCommand(text: string): boolean {
+  return /^\/[^\s/]+(?:\s|$)/u.test(text.trim());
+}
+
 export function applyComposerSkillModePrefix(
   text: string,
   mode: ComposerSkillMode | null | undefined,
@@ -138,17 +149,13 @@ export function applyComposerSkillModePrefix(
   // again would double it. The token has to end at a boundary, since
   // "$reviewer" names a different skill than "$review".
   const mention = `$${name}`;
-  if (text.startsWith(mention)) {
-    const next = text.charAt(mention.length);
+  if (trimmed.startsWith(mention)) {
+    const next = trimmed.charAt(mention.length);
     if (next === "" || isWhitespace(next)) {
       return text;
     }
   }
-  // Command names come from arbitrary file names ("/deploy.prod",
-  // "/plugin:skill"), so any first token without a second slash counts as
-  // one, and prefixing it would leave prose the provider never runs. An
-  // absolute path like "/home/theo/app.ts" is not a command and keeps it.
-  if (/^\/[^\s/]+(?:\s|$)/u.test(trimmed)) {
+  if (startsWithProviderSlashCommand(trimmed)) {
     return text;
   }
   return `$${name} ${text}`;

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -11,6 +11,8 @@ import {
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
+import { startsWithProviderSlashCommand } from "./composerTrigger.ts";
+
 const DEFAULT_PROVIDER_DRIVER_KIND = ProviderDriverKind.make("codex");
 
 export interface SelectableModelOption {
@@ -412,11 +414,7 @@ export function applyClaudePromptEffortPrefix(
   if (!trimmed) {
     return trimmed;
   }
-  // Prefixing a slash command turns it into plain prose, so Claude never
-  // runs it. Command names come from arbitrary file names ("/deploy.prod",
-  // "/plugin:skill"), so accept any first token without a second slash;
-  // absolute paths like "/home/theo/app.ts" keep the prefix.
-  if (effort !== "ultrathink" || /^\/[^\s/]+(?:\s|$)/u.test(trimmed)) {
+  if (effort !== "ultrathink" || startsWithProviderSlashCommand(trimmed)) {
     return trimmed;
   }
   if (trimmed.startsWith("Ultrathink:")) {


### PR DESCRIPTION
Proposed first in Ideas: https://github.com/pingdotgg/t3code/discussions/11342. Opening the PR alongside it so there is something concrete to look at. Close it freely if the idea is not wanted; nothing here is load-bearing for anything else.

## The problem

A skill mention is a one-shot insert. `$review` goes into one message and is gone on the next, so keeping a skill in play across a stretch of a conversation means retyping the mention every turn, and the turn where you forget quietly behaves differently.

## What changed

Option+Enter on macOS, Alt+Enter elsewhere, on a highlighted skill row in either the `$` or the `/` picker pins that skill for the thread instead of inserting it once. The pinned skill leads the composer's control row as a chip, and every message goes out with `$<name>` in front of it until the chip is clicked.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/matheustimbo/t3code/pr-assets/composer-skill-mode/composer-skill-mode/pr-before.png) | ![after](https://raw.githubusercontent.com/matheustimbo/t3code/pr-assets/composer-skill-mode/composer-skill-mode/pr-after.png) |

The highlighted skill row trades its source badge for the shortcut hint, so the row keeps one right-aligned element. Every other row is unchanged.

Interaction video, pin through send through clear: https://raw.githubusercontent.com/matheustimbo/t3code/pr-assets/composer-skill-mode/composer-skill-mode/skill-mode.mp4

## Why it should exist

The mode is fully expressed in the text it produces. `applyComposerSkillModePrefix` prepends `$<name>` to the prompt at send time, in `formatOutgoingPrompt`, next to the `Ultrathink:` prefix that already works this way. So there is no contract change, no new command, no event, no projector work, and the server, the provider, and every other client see the prefix because it is literally in `message.text`. The prefix is also visible in the thread exactly as sent, which is what makes the chip honest rather than a hidden setting.

Two guards on the prefix. It is idempotent, so a recalled prompt never takes the mention twice. It leaves a leading provider slash command alone, because prefixing one turns it into prose the provider never runs. `applyClaudePromptEffortPrefix` already carried that second rule, so rather than ship a second copy of a subtle regex the two prefixes now share `startsWithProviderSlashCommand`.

`onComposerCommandKey` was modifier-blind: Enter, Tab, Cmd+Enter, and Alt+Enter on a highlighted row all selected. Rather than add a fourth branch to a 5900-line component, the key table moved to `resolveComposerMenuKeyAction`, which is pure and has its own test. Existing highlight and select behavior is unchanged.

The pinned mode lives on the composer draft beside `runtimeMode` and `interactionMode`, so it is scoped per environment and thread and survives a reload. It is not user content, so it never gives an empty draft a sidebar row.

## Scope

Web and desktop. **Mobile is deliberately untouched.** It has no modifier keys and its picker is a separate implementation, so the touch affordance is a design question of its own rather than something to guess at here. The prefix helper is in `packages/shared` so mobile can adopt it unchanged if you want it there.

One rough edge left in on purpose: in the provider-unavailable composer state the control row is replaced by a single button, so a pinned chip is not in the DOM and cannot be cleared until a provider is back. Sending is blocked in that state anyway and the mode persists, so fixing it meant widening the diff for a state you cannot send from.

## Verification

`vp test run` over the six touched test files, 158 passing. `vp lint` and `vp run --filter @t3tools/web --filter @t3tools/shared typecheck` clean, no new warnings or errors.

Driven end to end against a real environment with a headless browser, nine checks: the hint shows only on the highlighted skill row and other rows keep their badge, pinning clears the trigger text and closes the menu, the chip survives a reload, clicking it clears the mode. The outgoing frame was captured at the WebSocket boundary and `message.text` read exactly `"$pstack:poteto-mode reply with exactly: OK"`.

The resting-strip width fix is its own commit: `restingComposerControlsMeasurement` sums three specific selectors rather than the cluster's children, so the chip had to be added to it or the strip measured narrower than it renders. Its test was confirmed non-tautological by reverting only the production change, which fails it.

Implemented with Claude Opus 5 through T3 Code and the Claude Code harness.

## Closes discussions

- https://github.com/pingdotgg/t3code/discussions/11342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin skills or provider commands as composer modes with Alt/Option+Enter, including on mobile.
  * Pinned modes appear as removable chips and automatically prefix messages in threads and plan follow-ups.
  * Modes persist between drafts and remain available when clearing sent message content.
  * Command menus show pinning hints for supported items.

* **Bug Fixes**
  * Prevented duplicate prefixes and preserved provider slash-command behavior.

* **Documentation**
  * Added instructions for pinning and removing composer modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->