### PR TITLE
fix(test): drain worker broadcasts before restoring browser globals

### DIFF
--- a/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
+++ b/apps/web/src/components/files/fileEditorLanguageReadiness.test.ts
@@ -116,6 +116,8 @@ afterEach(async () => {
   pool?.terminate();
   await Promise.all(terminationPromises);
   await disposeHighlighter();
+  // Drain the pool's final state broadcast before removing the animation frame stubs.
+  await new Promise<void>((resolve) => setImmediate(resolve));
   vi.unstubAllGlobals();
 });
 


### PR DESCRIPTION
ci run [34659051204](https://github.com/pingdotgg/t3code/actions/runs/34659051204) passed all web assertions but failed on an uncaught `cancelAnimationFrame is not defined` from the file editor language readiness suite. the worker pool queues a final state broadcast during teardown; drain that immediate callback before restoring browser globals.

verification: all 7 tests in the affected suite pass, and targeted lint and formatting pass. this changes only test teardown.

model: gpt-6; harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to ensure background processing completes before test environment stubs are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->