### PR TITLE
fix(desktop): keep preview keystrokes out of the composer

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3926,28 +3926,20 @@ describe("PreviewManager", () => {
       Effect.gen(function* () {
         let failKeyDown = false;
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
-        const sendCommand = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-          if (
-            failKeyDown &&
-            method === "Input.dispatchKeyEvent" &&
-            (params?.["type"] === "keyDown" || params?.["type"] === "rawKeyDown")
-          ) {
-            throw new Error("key dispatch failed");
-          }
-          if (
-            method === "Input.dispatchKeyEvent" &&
-            (params?.["type"] === "keyDown" || params?.["type"] === "rawKeyDown")
-          ) {
-            humanInput?.(
-              {},
-              {
-                kind: "key",
-                key: params["key"],
-                code: params["code"] ?? "Digit1",
-              },
-            );
-          }
-          return method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined;
+        const sendCommand = vi.fn(async (method: string, _params?: Record<string, unknown>) =>
+          method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined,
+        );
+        const sendInputEvent = vi.fn((input: Electron.KeyboardInputEvent) => {
+          if (input.type !== "keyDown") return;
+          if (failKeyDown) throw new Error("key dispatch failed");
+          humanInput?.(
+            {},
+            {
+              kind: "key",
+              key: input.keyCode,
+              code: input.keyCode === "!" ? "Digit1" : `Key${input.keyCode.toUpperCase()}`,
+            },
+          );
         });
         const restoreFocus = vi.fn();
         const focus = vi.fn();
@@ -3965,6 +3957,7 @@ describe("PreviewManager", () => {
           isLoading: () => false,
           isDevToolsOpened: () => false,
           focus,
+          sendInputEvent,
           getZoomFactor: () => 1,
           setZoomFactor: vi.fn(),
           setAudioMuted: vi.fn(),
@@ -4003,13 +3996,6 @@ describe("PreviewManager", () => {
           ([method, params]) =>
             method === "Emulation.setFocusEmulationEnabled" && params?.["enabled"] === true,
         );
-        const keyDownIndex = calls.findIndex(
-          ([method, params]) =>
-            method === "Input.dispatchKeyEvent" && params?.["type"] === "keyDown",
-        );
-        const keyUpIndex = calls.findIndex(
-          ([method, params]) => method === "Input.dispatchKeyEvent" && params?.["type"] === "keyUp",
-        );
         const focusOffIndex = calls.findIndex(
           ([method, params]) =>
             method === "Emulation.setFocusEmulationEnabled" && params?.["enabled"] === false,
@@ -4037,61 +4023,54 @@ describe("PreviewManager", () => {
         expect(clearOnlyEvaluation).toBeDefined();
         expect(methods).not.toContain("Input.insertText");
         expect(enableIndex).toBeGreaterThanOrEqual(0);
-        expect(focus).toHaveBeenCalledOnce();
-        expect(restoreFocus).toHaveBeenCalledOnce();
-        expect(methods).toContain("Page.bringToFront");
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
+        expect(methods).not.toContain("Page.bringToFront");
+        expect(methods).not.toContain("Input.dispatchKeyEvent");
         expect(enableIndex).toBeLessThan(focusOnIndex);
-        expect(focusOnIndex).toBeLessThan(keyDownIndex);
-        expect(keyDownIndex).toBeLessThan(keyUpIndex);
-        expect(keyUpIndex).toBeLessThan(focusOffIndex);
-        expect(
-          calls.filter(
-            ([method, params]) =>
-              method === "Input.dispatchKeyEvent" && params?.["type"] === "keyUp",
-          ),
-        ).toHaveLength(1);
+        expect(sendCommand.mock.invocationCallOrder[focusOnIndex]).toBeLessThan(
+          sendInputEvent.mock.invocationCallOrder[0]!,
+        );
+        expect(sendInputEvent.mock.invocationCallOrder[2]).toBeLessThan(
+          sendCommand.mock.invocationCallOrder[focusOffIndex]!,
+        );
+        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
+          { type: "keyDown", keyCode: "x", modifiers: [], skipIfUnhandled: true },
+          { type: "char", keyCode: "x", modifiers: [], skipIfUnhandled: true },
+          { type: "keyUp", keyCode: "x", modifiers: [], skipIfUnhandled: true },
+        ]);
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
 
         sendCommand.mockClear();
+        sendInputEvent.mockClear();
         failKeyDown = true;
         const failedPress = yield* Effect.exit(manager.automationPress("tab_input", { key: "y" }));
 
         expect(Exit.isFailure(failedPress)).toBe(true);
-        expect(sendCommand).toHaveBeenCalledWith("Input.dispatchKeyEvent", {
-          type: "keyUp",
-          key: "y",
-          code: "KeyY",
-          modifiers: 0,
-          windowsVirtualKeyCode: 89,
-          location: 0,
-          isKeypad: false,
-        });
+        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
+          { type: "keyDown", keyCode: "y", modifiers: [], skipIfUnhandled: true },
+          { type: "keyUp", keyCode: "y", modifiers: [], skipIfUnhandled: true },
+        ]);
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
-        expect(restoreFocus).toHaveBeenCalledTimes(2);
-        expect(
-          sendCommand.mock.calls.filter(
-            ([method, params]) =>
-              method === "Input.dispatchKeyEvent" && params?.["type"] === "keyUp",
-          ),
-        ).toHaveLength(1);
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
 
         sendCommand.mockClear();
+        sendInputEvent.mockClear();
         failKeyDown = false;
         yield* manager.automationPress("tab_input", { key: "!" });
-        expect(sendCommand).toHaveBeenCalledWith("Input.dispatchKeyEvent", {
-          type: "keyDown",
-          key: "!",
-          code: "Digit1",
-          modifiers: 0,
-          windowsVirtualKeyCode: 49,
-          location: 0,
-          isKeypad: false,
-          text: "!",
-          unmodifiedText: "!",
+        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
+          { type: "keyDown", keyCode: "!", modifiers: [], skipIfUnhandled: true },
+          { type: "char", keyCode: "!", modifiers: [], skipIfUnhandled: true },
+          { type: "keyUp", keyCode: "!", modifiers: [], skipIfUnhandled: true },
+        ]);
+        expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+          enabled: false,
         });
-        expect(restoreFocus).toHaveBeenCalledTimes(3);
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
       }),
     ),
   );

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -4096,8 +4096,6 @@ describe("PreviewManager", () => {
         expect(clearOnlyEvaluation).toBeDefined();
         expect(methods).not.toContain("Input.insertText");
         expect(enableIndex).toBeGreaterThanOrEqual(0);
-        expect(focus).not.toHaveBeenCalled();
-        expect(restoreFocus).not.toHaveBeenCalled();
         expect(methods).not.toContain("Page.bringToFront");
         expect(methods).not.toContain("Input.dispatchKeyEvent");
         expect(enableIndex).toBeLessThan(focusOnIndex);
@@ -4107,10 +4105,10 @@ describe("PreviewManager", () => {
         expect(sendInputEvent.mock.invocationCallOrder[2]).toBeLessThan(
           sendCommand.mock.invocationCallOrder[focusOffIndex]!,
         );
-        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
-          { type: "keyDown", keyCode: "x", modifiers: [], skipIfUnhandled: true },
-          { type: "char", keyCode: "x", modifiers: [], skipIfUnhandled: true },
-          { type: "keyUp", keyCode: "x", modifiers: [], skipIfUnhandled: true },
+        expect(sendInputEvent.mock.calls.map(([input]) => input.type)).toEqual([
+          "keyDown",
+          "char",
+          "keyUp",
         ]);
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
         expect(listeners.size).toBe(0);
@@ -4136,110 +4134,62 @@ describe("PreviewManager", () => {
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
-        expect(focus).not.toHaveBeenCalled();
-        expect(restoreFocus).not.toHaveBeenCalled();
         holdKeyUp = false;
 
-        sendCommand.mockClear();
-        sendInputEvent.mockClear();
-        failKeyDown = true;
-        const failedPress = yield* Effect.exit(manager.automationPress("tab_input", { key: "y" }));
+        // Both native failures and expected-input matching must leave focus emulation off.
+        for (const key of ["y", "!"]) {
+          sendCommand.mockClear();
+          sendInputEvent.mockClear();
+          failKeyDown = key === "y";
+          const exit = yield* Effect.exit(manager.automationPress("tab_input", { key }));
+          expect(Exit.isFailure(exit)).toBe(failKeyDown);
+          expect(sendInputEvent.mock.calls.map(([input]) => input.type)).toEqual(
+            failKeyDown ? ["keyDown", "keyUp"] : ["keyDown", "char", "keyUp"],
+          );
+          expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+            enabled: false,
+          });
+        }
 
-        expect(Exit.isFailure(failedPress)).toBe(true);
-        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
-          { type: "keyDown", keyCode: "y", modifiers: [], skipIfUnhandled: true },
-          { type: "keyUp", keyCode: "y", modifiers: [], skipIfUnhandled: true },
-        ]);
-        expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
-          enabled: false,
-        });
-        expect(focus).not.toHaveBeenCalled();
-        expect(restoreFocus).not.toHaveBeenCalled();
-
-        sendCommand.mockClear();
-        sendInputEvent.mockClear();
-        failKeyDown = false;
-        yield* manager.automationPress("tab_input", { key: "!" });
-        expect(sendInputEvent.mock.calls.map(([input]) => input)).toEqual([
-          { type: "keyDown", keyCode: "!", modifiers: [], skipIfUnhandled: true },
-          { type: "char", keyCode: "!", modifiers: [], skipIfUnhandled: true },
-          { type: "keyUp", keyCode: "!", modifiers: [], skipIfUnhandled: true },
-        ]);
-        expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
-          enabled: false,
-        });
-        expect(focus).not.toHaveBeenCalled();
-        expect(restoreFocus).not.toHaveBeenCalled();
-
-        sendCommand.mockClear();
-        sendInputEvent.mockClear();
         routeToIframe = true;
-        yield* manager.automationPress("tab_input", { key: "Enter" });
-        expect(sendInputEvent).not.toHaveBeenCalled();
-        expect(sendCommand).toHaveBeenCalledWith("Target.attachToTarget", {
-          targetId: "focused-frame",
-          flatten: true,
-        });
-        const childKeys = sendCommand.mock.calls.filter(
-          ([method]) => method === "Input.dispatchKeyEvent",
-        );
-        expect(
-          childKeys.map(([, params, sessionId]) => ({ type: params?.["type"], sessionId })),
-        ).toEqual([
-          { type: "keyDown", sessionId: "child-session" },
-          { type: "keyUp", sessionId: "child-session" },
-        ]);
-        expect(sendCommand).toHaveBeenCalledWith(
-          "Emulation.setFocusEmulationEnabled",
-          { enabled: false },
-          "child-session",
-        );
-        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
-          sessionId: "child-session",
-        });
-
-        sendCommand.mockClear();
-        failKeyDown = true;
-        const failedFramePress = yield* Effect.exit(
-          manager.automationPress("tab_input", { key: "x" }),
-        );
-        expect(Exit.isFailure(failedFramePress)).toBe(true);
-        expect(sendInputEvent).not.toHaveBeenCalled();
-        expect(sendCommand).toHaveBeenCalledWith(
-          "Input.dispatchKeyEvent",
-          expect.objectContaining({ type: "keyUp" }),
-          "child-session",
-        );
-        expect(sendCommand).toHaveBeenCalledWith(
-          "Emulation.setFocusEmulationEnabled",
-          { enabled: false },
-          "child-session",
-        );
-        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
-          sessionId: "child-session",
-        });
-
-        sendCommand.mockClear();
-        failKeyDown = false;
-        interruptFrameKeyDown = true;
-        const interruptedFramePress = yield* Effect.exit(
-          manager.automationPress("tab_input", { key: "x" }),
-        );
-        expect(Exit.isFailure(interruptedFramePress)).toBe(true);
-        if (Exit.isSuccess(interruptedFramePress)) return;
-        expect(Option.getOrThrow(Cause.findErrorOption(interruptedFramePress.cause))).toMatchObject(
-          {
-            _tag: "PreviewAutomationControlInterruptedError",
-          },
-        );
-        expect(sendCommand).toHaveBeenCalledWith(
-          "Input.dispatchKeyEvent",
-          expect.objectContaining({ type: "keyUp" }),
-          "child-session",
-        );
-        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
-          sessionId: "child-session",
-        });
+        sendInputEvent.mockClear();
+        for (const outcome of ["success", "failure", "interrupted"]) {
+          sendCommand.mockClear();
+          failKeyDown = outcome === "failure";
+          interruptFrameKeyDown = outcome === "interrupted";
+          const exit = yield* Effect.exit(
+            manager.automationPress("tab_input", {
+              key: outcome === "success" ? "Enter" : "x",
+            }),
+          );
+          expect(Exit.isSuccess(exit)).toBe(outcome === "success");
+          if (outcome === "interrupted" && Exit.isFailure(exit)) {
+            expect(Option.getOrThrow(Cause.findErrorOption(exit.cause))).toMatchObject({
+              _tag: "PreviewAutomationControlInterruptedError",
+            });
+          }
+          expect(sendInputEvent).not.toHaveBeenCalled();
+          expect(sendCommand).toHaveBeenCalledWith("Target.attachToTarget", {
+            targetId: "focused-frame",
+            flatten: true,
+          });
+          expect(
+            sendCommand.mock.calls
+              .filter(([method]) => method === "Input.dispatchKeyEvent")
+              .map(([, params, sessionId]) => ({ type: params?.["type"], sessionId })),
+          ).toEqual([
+            { type: "keyDown", sessionId: "child-session" },
+            { type: "keyUp", sessionId: "child-session" },
+          ]);
+          expect(sendCommand).toHaveBeenCalledWith(
+            "Emulation.setFocusEmulationEnabled",
+            { enabled: false },
+            "child-session",
+          );
+          expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
+            sessionId: "child-session",
+          });
+        }
         expect(focus).not.toHaveBeenCalled();
         expect(restoreFocus).not.toHaveBeenCalled();
       }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -3935,7 +3935,22 @@ describe("PreviewManager", () => {
           notifyKeyUpQueued = resolve;
         });
         const listeners = new Map<string, (event: unknown) => void>();
+        const eventCounts = new Map<string, number>();
+        const animationFrames = new Map<number, () => void>();
+        let animationFrameId = 0;
+        const renderFrame = () => {
+          const callbacks = [...animationFrames.values()];
+          animationFrames.clear();
+          callbacks.forEach((callback) => callback());
+        };
         const frameContext = NodeVM.createContext({
+          performance: { eventCounts },
+          requestAnimationFrame: (callback: () => void) => {
+            const id = ++animationFrameId;
+            animationFrames.set(id, callback);
+            return id;
+          },
+          cancelAnimationFrame: (id: number) => animationFrames.delete(id),
           window: {
             addEventListener: (type: string, listener: (event: unknown) => void) =>
               listeners.set(type, listener),
@@ -3983,7 +3998,10 @@ describe("PreviewManager", () => {
             code: input.keyCode === "!" ? "Digit1" : `Key${input.keyCode.toUpperCase()}`,
           };
           if (input.type === "keyUp") {
-            const deliver = () => listeners.get("keyup")?.({ ...signal, isTrusted: true });
+            const deliver = () => {
+              eventCounts.set("keyup", (eventCounts.get("keyup") ?? 0) + 1);
+              renderFrame();
+            };
             if (holdKeyUp) {
               releaseKeyUp = deliver;
               notifyKeyUpQueued?.();
@@ -4096,6 +4114,7 @@ describe("PreviewManager", () => {
         ]);
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
         expect(listeners.size).toBe(0);
+        expect(animationFrames.size).toBe(0);
 
         sendCommand.mockClear();
         sendInputEvent.mockClear();
@@ -4108,11 +4127,12 @@ describe("PreviewManager", () => {
         expect(sendCommand).not.toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
-        listeners.get("keyup")?.({ isTrusted: false, key: "x", code: "KeyX" });
-        expect(listeners.has("keyup")).toBe(true);
+        renderFrame();
+        expect(animationFrames.size).toBe(1);
         releaseKeyUp?.();
         yield* Fiber.join(backgroundPress);
         expect(listeners.size).toBe(0);
+        expect(animationFrames.size).toBe(0);
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -177,6 +177,7 @@ describe("previewWindowOpenAction", () => {
 
 const {
   browserWindowConstructor,
+  browserWindowFromWebContents,
   clipboardItemConstructor,
   createFromPath,
   fromId,
@@ -188,6 +189,7 @@ const {
   writeClipboard,
 } = vi.hoisted(() => ({
   browserWindowConstructor: vi.fn(),
+  browserWindowFromWebContents: vi.fn(),
   clipboardItemConstructor: vi.fn(),
   createFromPath: vi.fn((): { readonly isEmpty: () => boolean; readonly toPNG: () => Buffer } => ({
     isEmpty: () => false,
@@ -203,7 +205,9 @@ const {
 }));
 
 vi.mock("electron", () => ({
-  BrowserWindow: browserWindowConstructor,
+  BrowserWindow: Object.assign(browserWindowConstructor, {
+    fromWebContents: browserWindowFromWebContents,
+  }),
   ClipboardItem: class {
     constructor(data: Record<string, unknown>) {
       clipboardItemConstructor(data);
@@ -539,6 +543,8 @@ const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () 
 describe("PreviewManager", () => {
   beforeEach(() => {
     browserWindowConstructor.mockReset();
+    browserWindowFromWebContents.mockReset();
+    browserWindowFromWebContents.mockReturnValue({ isFocused: () => true });
     fromId.mockClear();
     getFocusedWebContents.mockReset();
     getFocusedWebContents.mockReturnValue(null);
@@ -3925,6 +3931,7 @@ describe("PreviewManager", () => {
     withManager((manager) =>
       Effect.gen(function* () {
         let failKeyDown = false;
+        const hostWebContents = { id: 7 };
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
         const sendCommand = vi.fn(async (method: string, _params?: Record<string, unknown>) =>
           method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined,
@@ -3950,6 +3957,7 @@ describe("PreviewManager", () => {
         } as never);
         fromId.mockReturnValue({
           id: 42,
+          hostWebContents,
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => "https://example.com",
@@ -4040,6 +4048,34 @@ describe("PreviewManager", () => {
           { type: "keyUp", keyCode: "x", modifiers: [], skipIfUnhandled: true },
         ]);
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
+        expect(browserWindowFromWebContents).toHaveBeenLastCalledWith(hostWebContents);
+
+        sendCommand.mockClear();
+        sendInputEvent.mockClear();
+        const windowFocus = vi.fn();
+        browserWindowFromWebContents.mockReturnValue({
+          isFocused: () => false,
+          focus: windowFocus,
+        });
+        const unfocusedPress = yield* Effect.exit(
+          manager.automationPress("tab_input", { key: "x" }),
+        );
+        expect(Exit.isFailure(unfocusedPress)).toBe(true);
+        if (Exit.isSuccess(unfocusedPress)) return;
+        const unfocusedError = Option.getOrThrow(Cause.findErrorOption(unfocusedPress.cause));
+        expect(unfocusedError).toMatchObject({
+          _tag: "PreviewAutomationWindowNotFocusedError",
+          tabId: "tab_input",
+        });
+        expect(unfocusedError.message).toContain("Focus the window");
+        expect(sendInputEvent).not.toHaveBeenCalled();
+        expect(windowFocus).not.toHaveBeenCalled();
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
+        expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+          enabled: false,
+        });
+        browserWindowFromWebContents.mockReturnValue({ isFocused: () => true });
 
         sendCommand.mockClear();
         sendInputEvent.mockClear();
@@ -4069,6 +4105,9 @@ describe("PreviewManager", () => {
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
+        const popupWebContents = Object.assign(fromId(42)!, { hostWebContents: undefined });
+        yield* manager.automationPress("tab_input", { key: "x" });
+        expect(browserWindowFromWebContents).toHaveBeenLastCalledWith(popupWebContents);
         expect(focus).not.toHaveBeenCalled();
         expect(restoreFocus).not.toHaveBeenCalled();
       }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1,3 +1,4 @@
+import { createContext, runInContext } from "node:vm";
 import { it as effectIt } from "@effect/vitest";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type { DesktopPreviewRecordingFrame } from "@t3tools/contracts";
@@ -177,7 +178,6 @@ describe("previewWindowOpenAction", () => {
 
 const {
   browserWindowConstructor,
-  browserWindowFromWebContents,
   clipboardItemConstructor,
   createFromPath,
   fromId,
@@ -189,7 +189,6 @@ const {
   writeClipboard,
 } = vi.hoisted(() => ({
   browserWindowConstructor: vi.fn(),
-  browserWindowFromWebContents: vi.fn(),
   clipboardItemConstructor: vi.fn(),
   createFromPath: vi.fn((): { readonly isEmpty: () => boolean; readonly toPNG: () => Buffer } => ({
     isEmpty: () => false,
@@ -205,9 +204,7 @@ const {
 }));
 
 vi.mock("electron", () => ({
-  BrowserWindow: Object.assign(browserWindowConstructor, {
-    fromWebContents: browserWindowFromWebContents,
-  }),
+  BrowserWindow: browserWindowConstructor,
   ClipboardItem: class {
     constructor(data: Record<string, unknown>) {
       clipboardItemConstructor(data);
@@ -543,8 +540,6 @@ const makeTestPictureInPictureWindow = (loadURL: () => Promise<void> = async () 
 describe("PreviewManager", () => {
   beforeEach(() => {
     browserWindowConstructor.mockReset();
-    browserWindowFromWebContents.mockReset();
-    browserWindowFromWebContents.mockReturnValue({ isFocused: () => true });
     fromId.mockClear();
     getFocusedWebContents.mockReset();
     getFocusedWebContents.mockReturnValue(null);
@@ -3931,22 +3926,71 @@ describe("PreviewManager", () => {
     withManager((manager) =>
       Effect.gen(function* () {
         let failKeyDown = false;
-        const hostWebContents = { id: 7 };
+        let routeToIframe = false;
+        let interruptFrameKeyDown = false;
+        let holdKeyUp = false;
+        let releaseKeyUp: (() => void) | undefined;
+        const keyUpQueued = yield* Deferred.make<void>();
+        const listeners = new Map<string, (event: unknown) => void>();
+        const frameContext = createContext({
+          window: {
+            addEventListener: (type: string, listener: (event: unknown) => void) =>
+              listeners.set(type, listener),
+            removeEventListener: (type: string) => listeners.delete(type),
+          },
+        });
+        const frame = {
+          executeJavaScript: vi.fn(async (expression: string) =>
+            runInContext(expression, frameContext),
+          ),
+        };
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
-        const sendCommand = vi.fn(async (method: string, _params?: Record<string, unknown>) =>
-          method === "Runtime.evaluate" ? { result: { value: { ok: true } } } : undefined,
+        const sendCommand = vi.fn(
+          async (method: string, params?: Record<string, unknown>, sessionId?: string) => {
+            if (method === "Runtime.evaluate") {
+              if (params?.["returnByValue"] === true) return { result: { value: { ok: true } } };
+              return {
+                result:
+                  routeToIframe && !sessionId
+                    ? { objectId: "focused-iframe-object" }
+                    : { subtype: "null" },
+              };
+            }
+            if (method === "DOM.describeNode") return { node: { frameId: "focused-frame" } };
+            if (method === "Target.getTargets")
+              return {
+                targetInfos: [
+                  { targetId: "unrelated-frame", type: "iframe" },
+                  { targetId: "focused-frame", type: "iframe" },
+                ],
+              };
+            if (method === "Target.attachToTarget") return { sessionId: "child-session" };
+            if (method === "Input.dispatchKeyEvent" && params?.["type"] !== "keyUp") {
+              if (failKeyDown) throw new Error("key dispatch failed");
+              if (interruptFrameKeyDown)
+                humanInput?.({}, { kind: "pointer", x: 80, y: 40, button: 0 });
+            }
+            return undefined;
+          },
         );
         const sendInputEvent = vi.fn((input: Electron.KeyboardInputEvent) => {
+          const signal = {
+            kind: "key",
+            key: input.keyCode,
+            code: input.keyCode === "!" ? "Digit1" : `Key${input.keyCode.toUpperCase()}`,
+          };
+          if (input.type === "keyUp") {
+            const deliver = () => listeners.get("keyup")?.({ ...signal, isTrusted: true });
+            if (holdKeyUp) {
+              releaseKeyUp = deliver;
+              Effect.runSync(Deferred.succeed(keyUpQueued, undefined));
+            } else {
+              queueMicrotask(deliver);
+            }
+          }
           if (input.type !== "keyDown") return;
           if (failKeyDown) throw new Error("key dispatch failed");
-          humanInput?.(
-            {},
-            {
-              kind: "key",
-              key: input.keyCode,
-              code: input.keyCode === "!" ? "Digit1" : `Key${input.keyCode.toUpperCase()}`,
-            },
-          );
+          humanInput?.({}, signal);
         });
         const restoreFocus = vi.fn();
         const focus = vi.fn();
@@ -3957,7 +4001,7 @@ describe("PreviewManager", () => {
         } as never);
         fromId.mockReturnValue({
           id: 42,
-          hostWebContents,
+          mainFrame: { framesInSubtree: [frame] },
           isDestroyed: () => false,
           getType: () => "webview",
           getURL: () => "https://example.com",
@@ -4048,34 +4092,30 @@ describe("PreviewManager", () => {
           { type: "keyUp", keyCode: "x", modifiers: [], skipIfUnhandled: true },
         ]);
         expect(sendCommand).toHaveBeenCalledWith("Input.setIgnoreInputEvents", { ignore: false });
-        expect(browserWindowFromWebContents).toHaveBeenLastCalledWith(hostWebContents);
+        expect(listeners.size).toBe(0);
 
         sendCommand.mockClear();
         sendInputEvent.mockClear();
-        const windowFocus = vi.fn();
-        browserWindowFromWebContents.mockReturnValue({
-          isFocused: () => false,
-          focus: windowFocus,
+        getFocusedWebContents.mockReturnValue(null);
+        holdKeyUp = true;
+        const backgroundPress = yield* manager
+          .automationPress("tab_input", { key: "x" })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(keyUpQueued);
+        expect(sendCommand).not.toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
+          enabled: false,
         });
-        const unfocusedPress = yield* Effect.exit(
-          manager.automationPress("tab_input", { key: "x" }),
-        );
-        expect(Exit.isFailure(unfocusedPress)).toBe(true);
-        if (Exit.isSuccess(unfocusedPress)) return;
-        const unfocusedError = Option.getOrThrow(Cause.findErrorOption(unfocusedPress.cause));
-        expect(unfocusedError).toMatchObject({
-          _tag: "PreviewAutomationWindowNotFocusedError",
-          tabId: "tab_input",
-        });
-        expect(unfocusedError.message).toContain("Focus the window");
-        expect(sendInputEvent).not.toHaveBeenCalled();
-        expect(windowFocus).not.toHaveBeenCalled();
-        expect(focus).not.toHaveBeenCalled();
-        expect(restoreFocus).not.toHaveBeenCalled();
+        listeners.get("keyup")?.({ isTrusted: false, key: "x", code: "KeyX" });
+        expect(listeners.has("keyup")).toBe(true);
+        releaseKeyUp?.();
+        yield* Fiber.join(backgroundPress);
+        expect(listeners.size).toBe(0);
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
-        browserWindowFromWebContents.mockReturnValue({ isFocused: () => true });
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
+        holdKeyUp = false;
 
         sendCommand.mockClear();
         sendInputEvent.mockClear();
@@ -4105,9 +4145,78 @@ describe("PreviewManager", () => {
         expect(sendCommand).toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });
-        const popupWebContents = Object.assign(fromId(42)!, { hostWebContents: undefined });
-        yield* manager.automationPress("tab_input", { key: "x" });
-        expect(browserWindowFromWebContents).toHaveBeenLastCalledWith(popupWebContents);
+        expect(focus).not.toHaveBeenCalled();
+        expect(restoreFocus).not.toHaveBeenCalled();
+
+        sendCommand.mockClear();
+        sendInputEvent.mockClear();
+        routeToIframe = true;
+        yield* manager.automationPress("tab_input", { key: "Enter" });
+        expect(sendInputEvent).not.toHaveBeenCalled();
+        expect(sendCommand).toHaveBeenCalledWith("Target.attachToTarget", {
+          targetId: "focused-frame",
+          flatten: true,
+        });
+        const childKeys = sendCommand.mock.calls.filter(
+          ([method]) => method === "Input.dispatchKeyEvent",
+        );
+        expect(
+          childKeys.map(([, params, sessionId]) => ({ type: params?.["type"], sessionId })),
+        ).toEqual([
+          { type: "keyDown", sessionId: "child-session" },
+          { type: "keyUp", sessionId: "child-session" },
+        ]);
+        expect(sendCommand).toHaveBeenCalledWith(
+          "Emulation.setFocusEmulationEnabled",
+          { enabled: false },
+          "child-session",
+        );
+        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
+          sessionId: "child-session",
+        });
+
+        sendCommand.mockClear();
+        failKeyDown = true;
+        const failedFramePress = yield* Effect.exit(
+          manager.automationPress("tab_input", { key: "x" }),
+        );
+        expect(Exit.isFailure(failedFramePress)).toBe(true);
+        expect(sendInputEvent).not.toHaveBeenCalled();
+        expect(sendCommand).toHaveBeenCalledWith(
+          "Input.dispatchKeyEvent",
+          expect.objectContaining({ type: "keyUp" }),
+          "child-session",
+        );
+        expect(sendCommand).toHaveBeenCalledWith(
+          "Emulation.setFocusEmulationEnabled",
+          { enabled: false },
+          "child-session",
+        );
+        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
+          sessionId: "child-session",
+        });
+
+        sendCommand.mockClear();
+        failKeyDown = false;
+        interruptFrameKeyDown = true;
+        const interruptedFramePress = yield* Effect.exit(
+          manager.automationPress("tab_input", { key: "x" }),
+        );
+        expect(Exit.isFailure(interruptedFramePress)).toBe(true);
+        if (Exit.isSuccess(interruptedFramePress)) return;
+        expect(Option.getOrThrow(Cause.findErrorOption(interruptedFramePress.cause))).toMatchObject(
+          {
+            _tag: "PreviewAutomationControlInterruptedError",
+          },
+        );
+        expect(sendCommand).toHaveBeenCalledWith(
+          "Input.dispatchKeyEvent",
+          expect.objectContaining({ type: "keyUp" }),
+          "child-session",
+        );
+        expect(sendCommand).toHaveBeenCalledWith("Target.detachFromTarget", {
+          sessionId: "child-session",
+        });
         expect(focus).not.toHaveBeenCalled();
         expect(restoreFocus).not.toHaveBeenCalled();
       }),

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1,4 +1,4 @@
-import { createContext, runInContext } from "node:vm";
+import * as NodeVM from "node:vm";
 import { it as effectIt } from "@effect/vitest";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type { DesktopPreviewRecordingFrame } from "@t3tools/contracts";
@@ -3930,9 +3930,12 @@ describe("PreviewManager", () => {
         let interruptFrameKeyDown = false;
         let holdKeyUp = false;
         let releaseKeyUp: (() => void) | undefined;
-        const keyUpQueued = yield* Deferred.make<void>();
+        let notifyKeyUpQueued: (() => void) | undefined;
+        const keyUpQueued = new Promise<void>((resolve) => {
+          notifyKeyUpQueued = resolve;
+        });
         const listeners = new Map<string, (event: unknown) => void>();
-        const frameContext = createContext({
+        const frameContext = NodeVM.createContext({
           window: {
             addEventListener: (type: string, listener: (event: unknown) => void) =>
               listeners.set(type, listener),
@@ -3941,7 +3944,7 @@ describe("PreviewManager", () => {
         });
         const frame = {
           executeJavaScript: vi.fn(async (expression: string) =>
-            runInContext(expression, frameContext),
+            NodeVM.runInContext(expression, frameContext),
           ),
         };
         let humanInput: ((_event: unknown, signal: unknown) => void) | undefined;
@@ -3983,7 +3986,7 @@ describe("PreviewManager", () => {
             const deliver = () => listeners.get("keyup")?.({ ...signal, isTrusted: true });
             if (holdKeyUp) {
               releaseKeyUp = deliver;
-              Effect.runSync(Deferred.succeed(keyUpQueued, undefined));
+              notifyKeyUpQueued?.();
             } else {
               queueMicrotask(deliver);
             }
@@ -4101,7 +4104,7 @@ describe("PreviewManager", () => {
         const backgroundPress = yield* manager
           .automationPress("tab_input", { key: "x" })
           .pipe(Effect.forkChild({ startImmediately: true }));
-        yield* Deferred.await(keyUpQueued);
+        yield* Effect.promise(() => keyUpQueued);
         expect(sendCommand).not.toHaveBeenCalledWith("Emulation.setFocusEmulationEnabled", {
           enabled: false,
         });

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -5,7 +5,7 @@
  * elements live in the renderer; we only attach listeners and forward state
  * here). Single layer-scoped browser session partition.
  */
-import { randomUUID } from "node:crypto";
+import * as NodeCrypto from "node:crypto";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type {
   DesktopPreviewAnnotationTheme,
@@ -3937,7 +3937,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const { frames, receiptKey } = yield* Effect.acquireRelease(
       attempt(context, () => ({
         frames: wc.mainFrame.framesInSubtree,
-        receiptKey: JSON.stringify(`__t3NativeKey_${randomUUID()}`),
+        receiptKey: JSON.stringify(`__t3NativeKey_${NodeCrypto.randomUUID()}`),
       })),
       ({ frames, receiptKey }) =>
         Effect.all(

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -4199,40 +4199,34 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               keySequence,
               clipboardData,
             );
-            if (
-              keySequence.commands.some((command) => ["copy", "cut", "paste"].includes(command))
-            ) {
-              const selectionKey = yield* encodeJson(
-                context,
-                `__t3ClipboardSelection_${NodeCrypto.randomUUID()}`,
-              );
-              // Clipboard editing requires an active document. Preserve the target
-              // and selection across focus handlers without focusing the desktop.
-              yield* Effect.acquireUseRelease(
-                evaluate(`(() => {
-                  let element = document.activeElement;
-                  while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
-                  const selection = document.getSelection();
-                  const ranges = Array.from({ length: selection?.rangeCount ?? 0 }, (_, i) => selection.getRangeAt(i).cloneRange());
-                  const start = element?.selectionStart;
-                  const end = element?.selectionEnd;
-                  const direction = element?.selectionDirection;
-                  globalThis[${selectionKey}] = () => {
-                    element?.focus({ preventScroll: true });
-                    if (typeof start === "number") element.setSelectionRange(start, end, direction);
-                    else { selection?.removeAllRanges(); ranges.forEach(range => selection?.addRange(range)); }
-                  };
-                })()`),
-                () =>
-                  Effect.gen(function* () {
-                    yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
-                    yield* evaluate(`globalThis[${selectionKey}]();${expression}`);
-                  }),
-                () => evaluate(`delete globalThis[${selectionKey}]`).pipe(Effect.ignore),
-              );
-            } else {
-              yield* evaluate(expression);
-            }
+            const selectionKey = yield* encodeJson(
+              context,
+              `__t3EditingSelection_${NodeCrypto.randomUUID()}`,
+            );
+            // Editing requires an active document. Preserve the target
+            // and selection across focus handlers without focusing the desktop.
+            yield* Effect.acquireUseRelease(
+              evaluate(`(() => {
+                let element = document.activeElement;
+                while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+                const selection = document.getSelection();
+                const ranges = Array.from({ length: selection?.rangeCount ?? 0 }, (_, i) => selection.getRangeAt(i).cloneRange());
+                const start = element?.selectionStart;
+                const end = element?.selectionEnd;
+                const direction = element?.selectionDirection;
+                globalThis[${selectionKey}] = () => {
+                  element?.focus({ preventScroll: true });
+                  if (typeof start === "number") element.setSelectionRange(start, end, direction);
+                  else { selection?.removeAllRanges(); ranges.forEach(range => selection?.addRange(range)); }
+                };
+              })()`),
+              () =>
+                Effect.gen(function* () {
+                  yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
+                  yield* evaluate(`globalThis[${selectionKey}]();${expression}`);
+                }),
+              () => evaluate(`delete globalThis[${selectionKey}]`).pipe(Effect.ignore),
+            );
             yield* checkControl;
             return;
           }

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -4127,6 +4127,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     // WebContents.focus() is a no-op for webview guests. Native input targets
     // this guest's widget directly, so Enter cannot submit the host composer.
     yield* Effect.gen(function* () {
+      if (yield* dispatchNativeFrameKey(tabId, input, send, sendCleanup, checkControl)) return;
       if (keySequence.commands?.length) {
         // Follow active iframe WindowProxy identities, which remain comparable
         // across origins even when the host holds native focus.
@@ -4156,14 +4157,48 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
           yield* checkControl;
           if (childIndex === -1) {
-            yield* attemptPromise(
-              { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-              () =>
-                frame.executeJavaScript(
-                  previewAutomationEditingCommandExpression(input, keySequence),
-                  true,
-                ),
-            );
+            const context = {
+              operation: "automationPress.editFocusedFrame",
+              tabId,
+              webContentsId: wc.id,
+            };
+            const evaluate = (expression: string) =>
+              attemptPromise(context, () => frame.executeJavaScript(expression, true));
+            const expression = previewAutomationEditingCommandExpression(input, keySequence);
+            if (
+              keySequence.commands.some((command) => ["copy", "cut", "paste"].includes(command))
+            ) {
+              const selectionKey = yield* encodeJson(
+                context,
+                `__t3ClipboardSelection_${NodeCrypto.randomUUID()}`,
+              );
+              // Clipboard editing requires an active document. Preserve the target
+              // and selection across focus handlers without focusing the desktop.
+              yield* Effect.acquireUseRelease(
+                evaluate(`(() => {
+                  let element = document.activeElement;
+                  while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+                  const selection = document.getSelection();
+                  const ranges = Array.from({ length: selection?.rangeCount ?? 0 }, (_, i) => selection.getRangeAt(i).cloneRange());
+                  const start = element?.selectionStart;
+                  const end = element?.selectionEnd;
+                  const direction = element?.selectionDirection;
+                  globalThis[${selectionKey}] = () => {
+                    element?.focus({ preventScroll: true });
+                    if (typeof start === "number") element.setSelectionRange(start, end, direction);
+                    else { selection?.removeAllRanges(); ranges.forEach(range => selection?.addRange(range)); }
+                  };
+                })()`),
+                () =>
+                  Effect.gen(function* () {
+                    yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
+                    yield* evaluate(`globalThis[${selectionKey}]();${expression}`);
+                  }),
+                () => evaluate(`delete globalThis[${selectionKey}]`).pipe(Effect.ignore),
+              );
+            } else {
+              yield* evaluate(expression);
+            }
             yield* checkControl;
             return;
           }
@@ -4193,7 +4228,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
         }
       }
-      if (yield* dispatchNativeFrameKey(tabId, input, send, sendCleanup, checkControl)) return;
       yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
       yield* withNativeKeyReceipt(
         tabId,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -77,7 +77,7 @@ import { isPreviewAnnotationPayload } from "./PickedElementPayload.ts";
 import { playwrightInjectedRuntimeInstallExpression } from "./PlaywrightInjectedRuntime.ts";
 import {
   makePreviewAutomationKeySequence,
-  makePreviewAutomationFrameKeySequence,
+  makePreviewAutomationNativeKeySequence,
   previewAutomationEditingCommandExpression,
 } from "./PreviewKeyboard.ts";
 import { captureFavicon, safeHttpOrigin, selectFaviconCandidates } from "./FaviconCapture.ts";
@@ -3931,6 +3931,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     checkControl: Effect.Effect<void, PreviewManagerError>,
   ) {
     const context = { operation: "automationPress.awaitNativeKey", tabId, webContentsId: wc.id };
+    const evaluate = (frame: Electron.WebFrameMain, expression: string) =>
+      attemptPromise(context, () => frame.executeJavaScript(expression));
     const { frames, receiptKey } = yield* Effect.acquireRelease(
       attempt(context, () => ({
         frames: wc.mainFrame.framesInSubtree,
@@ -3939,10 +3941,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       ({ frames, receiptKey }) =>
         Effect.all(
           frames.map((frame) =>
-            Effect.tryPromise({
-              try: (_signal) => frame.executeJavaScript(`globalThis[${receiptKey}]?.dispose()`),
-              catch: (cause) => new PreviewOperationError({ ...context, cause }),
-            }).pipe(Effect.timeoutOption(1_000), Effect.ignore),
+            evaluate(frame, `globalThis[${receiptKey}]?.dispose()`).pipe(
+              Effect.timeoutOption(1_000),
+              Effect.ignore,
+            ),
           ),
           { concurrency: "unbounded", discard: true },
         ),
@@ -3950,9 +3952,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     yield* Effect.gen(function* () {
       for (const frame of frames) {
         yield* checkControl;
-        yield* Effect.tryPromise({
-          try: (_signal) =>
-            frame.executeJavaScript(`(() => {
+        yield* evaluate(
+          frame,
+          `(() => {
               const receiptKey = ${receiptKey};
               const counts = performance.eventCounts;
               if (!counts) throw new Error("Native key delivery counters are unavailable.");
@@ -3960,11 +3962,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               const keyDownsBefore = counts.get("keydown") ?? 0;
               let settle;
               let animationFrame = 0;
-              let finished = false;
               const promise = new Promise(resolve => { settle = resolve; });
               const finish = delivered => {
-                if (finished) return;
-                finished = true;
                 cancelAnimationFrame(animationFrame);
                 window.removeEventListener("pagehide", onPageHide, true);
                 settle(delivered);
@@ -3973,7 +3972,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               // so stopImmediatePropagation cannot hide completed input.
               const observe = () => {
                 if ((counts.get("keyup") ?? 0) > keyUpsBefore) finish(true);
-                else if (!finished) animationFrame = requestAnimationFrame(observe);
+                else animationFrame = requestAnimationFrame(observe);
               };
               const onPageHide = () => finish(
                 (counts.get("keyup") ?? 0) > keyUpsBefore ||
@@ -3985,27 +3984,24 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
               }};
               window.addEventListener("pagehide", onPageHide, true);
               animationFrame = requestAnimationFrame(observe);
-            })()`),
-          catch: (cause) => new PreviewOperationError({ ...context, cause }),
-        });
+            })()`,
+        );
       }
       yield* checkControl;
       yield* dispatch;
-      yield* Effect.tryPromise({
-        try: (_signal) =>
-          Promise.any(
-            frames.map(async (frame) => {
-              const delivered: unknown = await frame.executeJavaScript(
-                `globalThis[${receiptKey}]?.promise`,
+      yield* attemptPromise(context, () =>
+        Promise.any(
+          frames.map(async (frame) => {
+            const delivered: unknown = await frame.executeJavaScript(
+              `globalThis[${receiptKey}]?.promise`,
+            );
+            if (delivered !== true)
+              throw new Error(
+                "The preview document changed before native key delivery was confirmed.",
               );
-              if (delivered !== true)
-                throw new Error(
-                  "The preview document changed before native key delivery was confirmed.",
-                );
-            }),
-          ),
-        catch: (cause) => new PreviewOperationError({ ...context, cause }),
-      });
+          }),
+        ),
+      );
       yield* checkControl;
     }).pipe(
       Effect.timeout(5_000),
@@ -4016,9 +4012,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     );
   }, Effect.scoped);
 
-  const dispatchNativeFrameKey = Effect.fn("PreviewManager.dispatchNativeFrameKey")(function* (
+  const resolveKeyboardTarget = Effect.fn("PreviewManager.resolveKeyboardTarget")(function* (
     tabId: string,
-    input: PreviewAutomationPressInput,
     send: SendCommand,
     sendCleanup: SendCommand,
     checkControl: Effect.Effect<void, PreviewManagerError>,
@@ -4103,23 +4098,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         contextId = world.executionContextId;
       }
     }
-    // Main-frame CDP keyboard input can retarget to the desktop. Only an
-    // explicitly attached descendant renderer may receive these packets.
-    if (!sessionId) return false;
-    const targetSessionId = sessionId;
-    const keys = makePreviewAutomationFrameKeySequence(input, { isMac: hostPlatform === "darwin" });
-    yield* Effect.acquireRelease(Effect.void, () =>
-      sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }, targetSessionId).pipe(
-        Effect.ignore,
-      ),
-    );
-    yield* send("Emulation.setFocusEmulationEnabled", { enabled: true }, targetSessionId);
-    yield* Effect.acquireRelease(Effect.void, () =>
-      sendCleanup("Input.dispatchKeyEvent", keys.keyUp, targetSessionId).pipe(Effect.ignore),
-    );
-    yield* send("Input.dispatchKeyEvent", keys.keyDown, targetSessionId);
-    return true;
-  }, Effect.scoped);
+    return { sessionId, contextId };
+  });
 
   const performAutomationPress = Effect.fn("PreviewManager.performAutomationPress")(function* (
     tabId: string,
@@ -4130,138 +4110,113 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     checkControl: Effect.Effect<void, PreviewManagerError>,
   ) {
     yield* prepareAutomationInput(send, false);
-    const keySequence = makePreviewAutomationKeySequence(input, {
+    const keySequence = makePreviewAutomationNativeKeySequence(input, {
       isMac: hostPlatform === "darwin",
     });
     // CDP keyboard dispatch follows the embedder's focused renderer, and
     // WebContents.focus() is a no-op for webview guests. Native input targets
     // this guest's widget directly, so Enter cannot submit the host composer.
     yield* Effect.gen(function* () {
-      if (yield* dispatchNativeFrameKey(tabId, input, send, sendCleanup, checkControl)) return;
-      if (keySequence.commands?.length) {
-        // Follow active iframe WindowProxy identities, which remain comparable
-        // across origins even when the host holds native focus.
-        let frame = yield* attempt(
-          { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-          () => wc.mainFrame,
+      const { sessionId, contextId } = yield* resolveKeyboardTarget(
+        tabId,
+        send,
+        sendCleanup,
+        checkControl,
+      );
+      // Only descendant renderer sessions bypass Chromium's desktop focus lookup.
+      if (sessionId) {
+        const keys = makePreviewAutomationKeySequence(input, { isMac: hostPlatform === "darwin" });
+        yield* Effect.acquireRelease(Effect.void, () =>
+          sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }, sessionId).pipe(
+            Effect.ignore,
+          ),
         );
-        while (true) {
-          yield* checkControl;
-          const childIndex = yield* attemptPromise(
-            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-            async () => {
-              const index: unknown = await frame.executeJavaScript(`(() => {
-                let element = document.activeElement;
-                while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
-                if (element?.tagName !== "IFRAME") return -1;
-                for (let index = 0; index < window.length; index++) {
-                  if (window[index] === element.contentWindow) return index;
+        yield* send("Emulation.setFocusEmulationEnabled", { enabled: true }, sessionId);
+        yield* Effect.acquireRelease(Effect.void, () =>
+          sendCleanup("Input.dispatchKeyEvent", keys.keyUp, sessionId).pipe(Effect.ignore),
+        );
+        yield* send("Input.dispatchKeyEvent", keys.keyDown, sessionId);
+        return;
+      }
+      if (keySequence.commands?.length) {
+        const context = {
+          operation: "automationPress.editFocusedFrame",
+          tabId,
+          webContentsId: wc.id,
+        };
+        const evaluate = (expression: string, cleanup = false) =>
+          evaluateWithDebugger(
+            tabId,
+            (method, params) =>
+              (cleanup ? sendCleanup : send)(method, {
+                ...params,
+                ...(contextId === undefined ? {} : { contextId }),
+              }),
+            expression,
+            true,
+          );
+        const clipboardData = keySequence.commands.includes("paste")
+          ? yield* attemptPromise(context, async () => {
+              const formats: Array<{ type: string; data: string }> = [];
+              for (const item of await clipboard.read()) {
+                for (const type of item.types) {
+                  if (type.startsWith("electron ")) continue;
+                  const blob = await item.getType(type);
+                  if (!("arrayBuffer" in blob)) continue;
+                  formats.push({
+                    type,
+                    data: type.startsWith("text/")
+                      ? await blob.text()
+                      : Buffer.from(await blob.arrayBuffer()).toString("base64"),
+                  });
                 }
-                throw new Error("The focused preview iframe is unavailable.");
-              })()`);
-              if (typeof index !== "number" || !Number.isInteger(index)) {
-                throw new Error("The focused preview iframe index is invalid.");
               }
-              return index;
-            },
-          );
-          yield* checkControl;
-          if (childIndex === -1) {
-            const context = {
-              operation: "automationPress.editFocusedFrame",
-              tabId,
-              webContentsId: wc.id,
+              return formats;
+            })
+          : [];
+        yield* checkControl;
+        const expression = previewAutomationEditingCommandExpression(
+          input,
+          keySequence,
+          clipboardData,
+        );
+        const selectionKey = yield* encodeJson(
+          context,
+          `__t3EditingSelection_${NodeCrypto.randomUUID()}`,
+        );
+        // Editing requires an active document. Preserve the target
+        // and selection across focus handlers without focusing the desktop.
+        yield* Effect.acquireUseRelease(
+          evaluate(`(() => {
+            let element = document.activeElement;
+            while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+            const selection = document.getSelection();
+            const range = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+            const backward = selection?.direction === "backward";
+            const start = element?.selectionStart;
+            const end = element?.selectionEnd;
+            const direction = element?.selectionDirection;
+            globalThis[${selectionKey}] = () => {
+              element?.focus({ preventScroll: true });
+              if (typeof start === "number") element.setSelectionRange(start, end, direction);
+              else {
+                selection?.removeAllRanges();
+                if (range && backward) selection.setBaseAndExtent(
+                  range.endContainer, range.endOffset, range.startContainer, range.startOffset,
+                );
+                else if (range) selection.addRange(range);
+              }
             };
-            const evaluate = (expression: string) =>
-              attemptPromise(context, () => frame.executeJavaScript(expression, true));
-            const clipboardData = keySequence.commands.includes("paste")
-              ? yield* attemptPromise(context, async () => {
-                  const formats: Array<{ type: string; data: string }> = [];
-                  for (const item of await clipboard.read()) {
-                    for (const type of item.types) {
-                      if (type.startsWith("electron ")) continue;
-                      const blob = await item.getType(type);
-                      if (!("arrayBuffer" in blob)) continue;
-                      formats.push({
-                        type,
-                        data: type.startsWith("text/")
-                          ? await blob.text()
-                          : Buffer.from(await blob.arrayBuffer()).toString("base64"),
-                      });
-                    }
-                  }
-                  return formats;
-                })
-              : [];
-            yield* checkControl;
-            const expression = previewAutomationEditingCommandExpression(
-              input,
-              keySequence,
-              clipboardData,
-            );
-            const selectionKey = yield* encodeJson(
-              context,
-              `__t3EditingSelection_${NodeCrypto.randomUUID()}`,
-            );
-            // Editing requires an active document. Preserve the target
-            // and selection across focus handlers without focusing the desktop.
-            yield* Effect.acquireUseRelease(
-              evaluate(`(() => {
-                let element = document.activeElement;
-                while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
-                const selection = document.getSelection();
-                const range = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
-                const backward = selection?.direction === "backward";
-                const start = element?.selectionStart;
-                const end = element?.selectionEnd;
-                const direction = element?.selectionDirection;
-                globalThis[${selectionKey}] = () => {
-                  element?.focus({ preventScroll: true });
-                  if (typeof start === "number") element.setSelectionRange(start, end, direction);
-                  else {
-                    selection?.removeAllRanges();
-                    if (range && backward) selection.setBaseAndExtent(
-                      range.endContainer, range.endOffset, range.startContainer, range.startOffset,
-                    );
-                    else if (range) selection.addRange(range);
-                  }
-                };
-              })()`),
-              () =>
-                Effect.gen(function* () {
-                  yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
-                  yield* evaluate(`globalThis[${selectionKey}]();${expression}`);
-                }),
-              () => evaluate(`delete globalThis[${selectionKey}]`).pipe(Effect.ignore),
-            );
-            yield* checkControl;
-            return;
-          }
-          const children = yield* attempt(
-            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-            () => frame.frames,
-          );
-          let activeChild: Electron.WebFrameMain | undefined;
-          for (const child of children) {
-            yield* checkControl;
-            const matches = yield* attemptPromise(
-              { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-              () => child.executeJavaScript(`window.parent[${childIndex}] === window`),
-            );
-            yield* checkControl;
-            if (matches) {
-              activeChild = child;
-              break;
-            }
-          }
-          frame = yield* attempt(
-            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
-            () => {
-              if (!activeChild) throw new Error("The focused preview iframe is unavailable.");
-              return activeChild;
-            },
-          );
-        }
+          })()`),
+          () =>
+            Effect.gen(function* () {
+              yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
+              yield* evaluate(`globalThis[${selectionKey}]();${expression}`);
+            }),
+          () => evaluate(`delete globalThis[${selectionKey}]`, true).pipe(Effect.ignore),
+        );
+        yield* checkControl;
+        return;
       }
       yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
       yield* withNativeKeyReceipt(
@@ -4284,6 +4239,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         checkControl,
       );
     }).pipe(
+      Effect.scoped,
       Effect.ensuring(
         sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(Effect.ignore),
       ),

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -5,6 +5,7 @@
  * elements live in the renderer; we only attach listeners and forward state
  * here). Single layer-scoped browser session partition.
  */
+import { randomUUID } from "node:crypto";
 import { DESKTOP_PREVIEW_RECORDING_CAPTURE_TRIGGER } from "@t3tools/contracts";
 import type {
   DesktopPreviewAnnotationTheme,
@@ -76,7 +77,9 @@ import { isPreviewAnnotationPayload } from "./PickedElementPayload.ts";
 import { playwrightInjectedRuntimeInstallExpression } from "./PlaywrightInjectedRuntime.ts";
 import {
   makePreviewAutomationKeySequence,
+  makePreviewAutomationFrameKeySequence,
   previewAutomationEditingCommandExpression,
+  type PreviewAutomationKeySequence,
 } from "./PreviewKeyboard.ts";
 import { captureFavicon, safeHttpOrigin, selectFaviconCandidates } from "./FaviconCapture.ts";
 
@@ -1394,6 +1397,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   type SendCommand = (
     method: string,
     commandParams?: Record<string, unknown>,
+    sessionId?: string,
   ) => Effect.Effect<unknown, PreviewManagerError>;
 
   const prepareAutomationInput = Effect.fn("PreviewManager.prepareAutomationInput")(function* (
@@ -1444,11 +1448,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         }
       });
       const send: SendCommand = Effect.fn("PreviewManager.sendCommand")(
-        function* (method, commandParams) {
+        function* (method, commandParams, sessionId) {
           yield* checkControl;
           const result = yield* attemptPromise(
             { operation: `${action}.${method}`, tabId, webContentsId: wc.id },
-            () => control.debugger.sendCommand(method, commandParams),
+            () =>
+              sessionId === undefined
+                ? control.debugger.sendCommand(method, commandParams)
+                : control.debugger.sendCommand(method, commandParams, sessionId),
           );
           yield* checkControl;
           return result;
@@ -1458,14 +1465,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       // control epoch. Otherwise a partially dispatched input can leave Chromium
       // with a held key or focus emulation enabled for subsequent actions.
       const sendCleanup: SendCommand = Effect.fn("PreviewManager.sendCleanupCommand")(
-        function* (method, commandParams) {
+        function* (method, commandParams, sessionId) {
           return yield* attemptPromise(
             {
               operation: `${action}.cleanup.${method}`,
               tabId,
               webContentsId: wc.id,
             },
-            () => control.debugger.sendCommand(method, commandParams),
+            () =>
+              sessionId === undefined
+                ? control.debugger.sendCommand(method, commandParams)
+                : control.debugger.sendCommand(method, commandParams, sessionId),
           );
         },
       );
@@ -3915,6 +3925,192 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     );
   });
 
+  const withNativeKeyReceipt = Effect.fn("PreviewManager.withNativeKeyReceipt")(function* (
+    tabId: string,
+    wc: Electron.WebContents,
+    signal: PreviewAutomationKeySequence["signal"],
+    dispatch: Effect.Effect<void, PreviewManagerError>,
+    checkControl: Effect.Effect<void, PreviewManagerError>,
+  ) {
+    const context = { operation: "automationPress.awaitNativeKey", tabId, webContentsId: wc.id };
+    const signalJson = yield* encodeJson(context, signal);
+    const { frames, receiptKey } = yield* Effect.acquireRelease(
+      attempt(context, () => ({
+        frames: wc.mainFrame.framesInSubtree,
+        receiptKey: JSON.stringify(`__t3NativeKey_${randomUUID()}`),
+      })),
+      ({ frames, receiptKey }) =>
+        Effect.all(
+          frames.map((frame) =>
+            Effect.tryPromise({
+              try: (_signal) => frame.executeJavaScript(`globalThis[${receiptKey}]?.dispose()`),
+              catch: (cause) => new PreviewOperationError({ ...context, cause }),
+            }).pipe(Effect.timeoutOption(1_000), Effect.ignore),
+          ),
+          { concurrency: "unbounded", discard: true },
+        ),
+    );
+    yield* Effect.gen(function* () {
+      for (const frame of frames) {
+        yield* checkControl;
+        yield* Effect.tryPromise({
+          try: (_signal) =>
+            frame.executeJavaScript(`(() => {
+              const receiptKey = ${receiptKey};
+              const signal = ${signalJson};
+              let settle;
+              const promise = new Promise(resolve => { settle = resolve; });
+              const finish = delivered => {
+                window.removeEventListener("keyup", onKeyUp, true);
+                window.removeEventListener("pagehide", onPageHide, true);
+                settle(delivered);
+              };
+              const onKeyUp = event => {
+                if (event.isTrusted && event.key === signal.key && event.code === signal.code) finish(true);
+              };
+              const onPageHide = () => finish(false);
+              globalThis[receiptKey] = { promise, dispose: () => {
+                finish(false);
+                delete globalThis[receiptKey];
+              }};
+              window.addEventListener("keyup", onKeyUp, true);
+              window.addEventListener("pagehide", onPageHide, true);
+            })()`),
+          catch: (cause) => new PreviewOperationError({ ...context, cause }),
+        });
+      }
+      yield* checkControl;
+      yield* dispatch;
+      yield* Effect.tryPromise({
+        try: (_signal) =>
+          Promise.any(
+            frames.map(async (frame) => {
+              const delivered: unknown = await frame.executeJavaScript(
+                `globalThis[${receiptKey}]?.promise`,
+              );
+              if (delivered !== true)
+                throw new Error(
+                  "The preview document changed before native key delivery was confirmed.",
+                );
+            }),
+          ),
+        catch: (cause) => new PreviewOperationError({ ...context, cause }),
+      });
+      yield* checkControl;
+    }).pipe(
+      Effect.timeout(5_000),
+      Effect.catchTags({
+        TimeoutError: () =>
+          Effect.fail(new PreviewAutomationTimeoutError({ tabId, timeoutMs: 5_000 })),
+      }),
+    );
+  }, Effect.scoped);
+
+  const dispatchNativeFrameKey = Effect.fn("PreviewManager.dispatchNativeFrameKey")(function* (
+    tabId: string,
+    input: PreviewAutomationPressInput,
+    send: SendCommand,
+    sendCleanup: SendCommand,
+    checkControl: Effect.Effect<void, PreviewManagerError>,
+  ) {
+    const context = { operation: "automationPress.resolveFocusedFrame", tabId };
+    let sessionId: string | undefined;
+    let contextId: number | undefined;
+    while (true) {
+      const evaluated = (yield* send(
+        "Runtime.evaluate",
+        {
+          expression: `(() => {
+            let element = document.activeElement;
+            while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+            return element?.tagName === "IFRAME" ? element : null;
+          })()`,
+          ...(contextId === undefined ? {} : { contextId }),
+        },
+        sessionId,
+      )) as { result?: { objectId?: string; subtype?: string } };
+      if (evaluated.result?.subtype === "null") break;
+      const objectId = evaluated.result?.objectId;
+      if (!objectId)
+        return yield* new PreviewOperationError({
+          ...context,
+          cause: new Error("The focused preview frame could not be resolved."),
+        });
+      const described = (yield* send("DOM.describeNode", { objectId }, sessionId).pipe(
+        Effect.ensuring(
+          sendCleanup("Runtime.releaseObject", { objectId }, sessionId).pipe(Effect.ignore),
+        ),
+      )) as { node?: { frameId?: string } };
+      const frameId = described.node?.frameId;
+      if (!frameId)
+        return yield* new PreviewOperationError({
+          ...context,
+          cause: new Error("The focused preview iframe is unavailable."),
+        });
+      const targets = (yield* send("Target.getTargets")) as {
+        targetInfos?: ReadonlyArray<{ targetId: string; type: string }>;
+      };
+      if (
+        targets.targetInfos?.some(
+          (target) => target.type === "iframe" && target.targetId === frameId,
+        )
+      ) {
+        yield* checkControl;
+        // Register cleanup before checking the epoch again: a successful
+        // attach must be released even when human input interrupts its reply.
+        sessionId = yield* Effect.acquireRelease(
+          sendCleanup("Target.attachToTarget", { targetId: frameId, flatten: true }).pipe(
+            Effect.flatMap((response) =>
+              attempt(context, () => {
+                const attached = response as { sessionId?: string };
+                if (!attached.sessionId)
+                  throw new Error("The focused preview iframe could not be attached.");
+                return attached.sessionId;
+              }),
+            ),
+          ),
+          (attachedSessionId) =>
+            sendCleanup("Target.detachFromTarget", { sessionId: attachedSessionId }).pipe(
+              Effect.ignore,
+            ),
+        );
+        yield* checkControl;
+        contextId = undefined;
+      } else {
+        const world = (yield* send(
+          "Page.createIsolatedWorld",
+          {
+            frameId,
+            worldName: "t3-preview-key-target",
+          },
+          sessionId,
+        )) as { executionContextId?: number };
+        if (typeof world.executionContextId !== "number")
+          return yield* new PreviewOperationError({
+            ...context,
+            cause: new Error("The focused preview iframe context is unavailable."),
+          });
+        contextId = world.executionContextId;
+      }
+    }
+    // Main-frame CDP keyboard input can retarget to the desktop. Only an
+    // explicitly attached descendant renderer may receive these packets.
+    if (!sessionId) return false;
+    const targetSessionId = sessionId;
+    const keys = makePreviewAutomationFrameKeySequence(input, { isMac: hostPlatform === "darwin" });
+    yield* Effect.acquireRelease(Effect.void, () =>
+      sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }, targetSessionId).pipe(
+        Effect.ignore,
+      ),
+    );
+    yield* send("Emulation.setFocusEmulationEnabled", { enabled: true }, targetSessionId);
+    yield* Effect.acquireRelease(Effect.void, () =>
+      sendCleanup("Input.dispatchKeyEvent", keys.keyUp, targetSessionId).pipe(Effect.ignore),
+    );
+    yield* send("Input.dispatchKeyEvent", keys.keyDown, targetSessionId);
+    return true;
+  }, Effect.scoped);
+
   const performAutomationPress = Effect.fn("PreviewManager.performAutomationPress")(function* (
     tabId: string,
     wc: Electron.WebContents,
@@ -3997,27 +4193,28 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
         }
       }
+      if (yield* dispatchNativeFrameKey(tabId, input, send, sendCleanup, checkControl)) return;
       yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
-      yield* checkControl;
-      yield* expectAgentInput(tabId, keySequence.signal);
-      const dispatched = yield* attempt(
-        { operation: "automationPress.sendInputEvent", tabId, webContentsId: wc.id },
-        () => {
-          if (!BrowserWindow.fromWebContents(wc.hostWebContents ?? wc)?.isFocused()) return false;
-          try {
-            wc.sendInputEvent(keySequence.keyDown);
-            if (keySequence.char) wc.sendInputEvent(keySequence.char);
-          } finally {
-            wc.sendInputEvent(keySequence.keyUp);
-          }
-          return true;
-        },
+      yield* withNativeKeyReceipt(
+        tabId,
+        wc,
+        keySequence.signal,
+        Effect.gen(function* () {
+          yield* expectAgentInput(tabId, keySequence.signal);
+          yield* attempt(
+            { operation: "automationPress.sendInputEvent", tabId, webContentsId: wc.id },
+            () => {
+              try {
+                wc.sendInputEvent(keySequence.keyDown);
+                if (keySequence.char) wc.sendInputEvent(keySequence.char);
+              } finally {
+                wc.sendInputEvent(keySequence.keyUp);
+              }
+            },
+          );
+        }),
+        checkControl,
       );
-      if (!dispatched) {
-        yield* consumeExpectedAgentInput(tabId, keySequence.signal);
-        return yield* new PreviewAutomationWindowNotFocusedError({ tabId });
-      }
-      yield* checkControl;
     }).pipe(
       Effect.ensuring(
         sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(Effect.ignore),
@@ -4429,15 +4626,6 @@ export class PreviewAutomationDebuggerAttachedError extends Schema.TaggedError<P
   }
 }
 
-export class PreviewAutomationWindowNotFocusedError extends Schema.TaggedError<PreviewAutomationWindowNotFocusedError>()(
-  "PreviewAutomationWindowNotFocusedError",
-  { tabId: Schema.String },
-) {
-  override get message(): string {
-    return `Focus the window containing preview tab ${this.tabId} and retry the key press, or use preview_type for background text entry. No keys were sent.`;
-  }
-}
-
 export class PreviewAutomationEvaluationError extends Schema.TaggedError<PreviewAutomationEvaluationError>()(
   "PreviewAutomationEvaluationError",
   {
@@ -4587,7 +4775,6 @@ export const PreviewManagerError = Schema.Union([
   PreviewArtifactImageLoadError,
   PreviewAutomationDevToolsOpenError,
   PreviewAutomationDebuggerAttachedError,
-  PreviewAutomationWindowNotFocusedError,
   PreviewAutomationEvaluationError,
   PreviewAutomationTargetNotFoundError,
   PreviewAutomationTargetNotEditableError,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -79,7 +79,6 @@ import {
   makePreviewAutomationKeySequence,
   makePreviewAutomationFrameKeySequence,
   previewAutomationEditingCommandExpression,
-  type PreviewAutomationKeySequence,
 } from "./PreviewKeyboard.ts";
 import { captureFavicon, safeHttpOrigin, selectFaviconCandidates } from "./FaviconCapture.ts";
 
@@ -3928,12 +3927,10 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   const withNativeKeyReceipt = Effect.fn("PreviewManager.withNativeKeyReceipt")(function* (
     tabId: string,
     wc: Electron.WebContents,
-    signal: PreviewAutomationKeySequence["signal"],
     dispatch: Effect.Effect<void, PreviewManagerError>,
     checkControl: Effect.Effect<void, PreviewManagerError>,
   ) {
     const context = { operation: "automationPress.awaitNativeKey", tabId, webContentsId: wc.id };
-    const signalJson = yield* encodeJson(context, signal);
     const { frames, receiptKey } = yield* Effect.acquireRelease(
       attempt(context, () => ({
         frames: wc.mainFrame.framesInSubtree,
@@ -3957,24 +3954,37 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           try: (_signal) =>
             frame.executeJavaScript(`(() => {
               const receiptKey = ${receiptKey};
-              const signal = ${signalJson};
+              const counts = performance.eventCounts;
+              if (!counts) throw new Error("Native key delivery counters are unavailable.");
+              const keyUpsBefore = counts.get("keyup") ?? 0;
+              const keyDownsBefore = counts.get("keydown") ?? 0;
               let settle;
+              let animationFrame = 0;
+              let finished = false;
               const promise = new Promise(resolve => { settle = resolve; });
               const finish = delivered => {
-                window.removeEventListener("keyup", onKeyUp, true);
+                if (finished) return;
+                finished = true;
+                cancelAnimationFrame(animationFrame);
                 window.removeEventListener("pagehide", onPageHide, true);
                 settle(delivered);
               };
-              const onKeyUp = event => {
-                if (event.isTrusted && event.key === signal.key && event.code === signal.code) finish(true);
+              // Chromium counts trusted keys before dispatching page listeners,
+              // so stopImmediatePropagation cannot hide completed input.
+              const observe = () => {
+                if ((counts.get("keyup") ?? 0) > keyUpsBefore) finish(true);
+                else if (!finished) animationFrame = requestAnimationFrame(observe);
               };
-              const onPageHide = () => finish(false);
+              const onPageHide = () => finish(
+                (counts.get("keyup") ?? 0) > keyUpsBefore ||
+                (counts.get("keydown") ?? 0) > keyDownsBefore,
+              );
               globalThis[receiptKey] = { promise, dispose: () => {
                 finish(false);
                 delete globalThis[receiptKey];
               }};
-              window.addEventListener("keyup", onKeyUp, true);
               window.addEventListener("pagehide", onPageHide, true);
+              animationFrame = requestAnimationFrame(observe);
             })()`),
           catch: (cause) => new PreviewOperationError({ ...context, cause }),
         });
@@ -4164,7 +4174,31 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
             };
             const evaluate = (expression: string) =>
               attemptPromise(context, () => frame.executeJavaScript(expression, true));
-            const expression = previewAutomationEditingCommandExpression(input, keySequence);
+            const clipboardData = keySequence.commands.includes("paste")
+              ? yield* attemptPromise(context, async () => {
+                  const formats: Array<{ type: string; data: string }> = [];
+                  for (const item of await clipboard.read()) {
+                    for (const type of item.types) {
+                      if (type.startsWith("electron ")) continue;
+                      const blob = await item.getType(type);
+                      if (!("arrayBuffer" in blob)) continue;
+                      formats.push({
+                        type,
+                        data: type.startsWith("text/")
+                          ? await blob.text()
+                          : Buffer.from(await blob.arrayBuffer()).toString("base64"),
+                      });
+                    }
+                  }
+                  return formats;
+                })
+              : [];
+            yield* checkControl;
+            const expression = previewAutomationEditingCommandExpression(
+              input,
+              keySequence,
+              clipboardData,
+            );
             if (
               keySequence.commands.some((command) => ["copy", "cut", "paste"].includes(command))
             ) {
@@ -4232,7 +4266,6 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       yield* withNativeKeyReceipt(
         tabId,
         wc,
-        keySequence.signal,
         Effect.gen(function* () {
           yield* expectAgentInput(tabId, keySequence.signal);
           yield* attempt(

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -4210,14 +4210,21 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                 let element = document.activeElement;
                 while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
                 const selection = document.getSelection();
-                const ranges = Array.from({ length: selection?.rangeCount ?? 0 }, (_, i) => selection.getRangeAt(i).cloneRange());
+                const range = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+                const backward = selection?.direction === "backward";
                 const start = element?.selectionStart;
                 const end = element?.selectionEnd;
                 const direction = element?.selectionDirection;
                 globalThis[${selectionKey}] = () => {
                   element?.focus({ preventScroll: true });
                   if (typeof start === "number") element.setSelectionRange(start, end, direction);
-                  else { selection?.removeAllRanges(); ranges.forEach(range => selection?.addRange(range)); }
+                  else {
+                    selection?.removeAllRanges();
+                    if (range && backward) selection.setBaseAndExtent(
+                      range.endContainer, range.endOffset, range.startContainer, range.startOffset,
+                    );
+                    else if (range) selection.addRange(range);
+                  }
                 };
               })()`),
               () =>

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1413,7 +1413,11 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     tabId: string,
     wc: Electron.WebContents,
     action: string,
-    use: (send: SendCommand, sendCleanup: SendCommand) => Effect.Effect<A, PreviewManagerError>,
+    use: (
+      send: SendCommand,
+      sendCleanup: SendCommand,
+      checkControl: Effect.Effect<void, PreviewManagerError>,
+    ) => Effect.Effect<A, PreviewManagerError>,
   ) {
     const sequence = yield* nextCounter(actionSequenceRef);
     const startedAt = yield* currentIso;
@@ -1429,28 +1433,24 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const control = yield* ensureControlSession(wc);
     const execute = Effect.fn("PreviewManager.executeControlAction")(function* () {
       yield* update(tabId, { controller: "agent" });
+      const checkControl = Effect.gen(function* () {
+        const currentEpoch = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
+        if (currentEpoch !== epoch) {
+          return yield* new PreviewAutomationControlInterruptedError({
+            operation: action,
+            tabId,
+            webContentsId: wc.id,
+          });
+        }
+      });
       const send: SendCommand = Effect.fn("PreviewManager.sendCommand")(
         function* (method, commandParams) {
-          const before = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (before !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
-              tabId,
-              webContentsId: wc.id,
-            });
-          }
+          yield* checkControl;
           const result = yield* attemptPromise(
             { operation: `${action}.${method}`, tabId, webContentsId: wc.id },
             () => control.debugger.sendCommand(method, commandParams),
           );
-          const after = (yield* Ref.get(controlEpochRef)).get(tabId) ?? 0;
-          if (after !== epoch) {
-            return yield* new PreviewAutomationControlInterruptedError({
-              operation: action,
-              tabId,
-              webContentsId: wc.id,
-            });
-          }
+          yield* checkControl;
           return result;
         },
       );
@@ -1469,7 +1469,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
         },
       );
-      return yield* use(send, sendCleanup);
+      return yield* use(send, sendCleanup, checkControl);
     });
     const finalize = Effect.fn("PreviewManager.finalizeControlAction")(function* (
       exit: Exit.Exit<A, PreviewManagerError>,
@@ -3921,6 +3921,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationPressInput,
     send: SendCommand,
     sendCleanup: SendCommand,
+    checkControl: Effect.Effect<void, PreviewManagerError>,
   ) {
     yield* prepareAutomationInput(send, false);
     const keySequence = makePreviewAutomationKeySequence(input, {
@@ -3930,17 +3931,75 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     // WebContents.focus() is a no-op for webview guests. Native input targets
     // this guest's widget directly, so Enter cannot submit the host composer.
     yield* Effect.gen(function* () {
-      yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
-      yield* expectAgentInput(tabId, keySequence.signal);
       if (keySequence.commands?.length) {
-        yield* evaluateWithDebugger(
-          tabId,
-          send,
-          previewAutomationEditingCommandExpression(input, keySequence),
-          true,
+        // Follow active iframe WindowProxy identities, which remain comparable
+        // across origins even when the host holds native focus.
+        let frame = yield* attempt(
+          { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+          () => wc.mainFrame,
         );
-        return;
+        while (true) {
+          yield* checkControl;
+          const childIndex = yield* attemptPromise(
+            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+            async () => {
+              const index: unknown = await frame.executeJavaScript(`(() => {
+                let element = document.activeElement;
+                while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+                if (element?.tagName !== "IFRAME") return -1;
+                for (let index = 0; index < window.length; index++) {
+                  if (window[index] === element.contentWindow) return index;
+                }
+                throw new Error("The focused preview iframe is unavailable.");
+              })()`);
+              if (typeof index !== "number" || !Number.isInteger(index)) {
+                throw new Error("The focused preview iframe index is invalid.");
+              }
+              return index;
+            },
+          );
+          yield* checkControl;
+          if (childIndex === -1) {
+            yield* attemptPromise(
+              { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+              () =>
+                frame.executeJavaScript(
+                  previewAutomationEditingCommandExpression(input, keySequence),
+                  true,
+                ),
+            );
+            yield* checkControl;
+            return;
+          }
+          const children = yield* attempt(
+            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+            () => frame.frames,
+          );
+          let activeChild: Electron.WebFrameMain | undefined;
+          for (const child of children) {
+            yield* checkControl;
+            const matches = yield* attemptPromise(
+              { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+              () => child.executeJavaScript(`window.parent[${childIndex}] === window`),
+            );
+            yield* checkControl;
+            if (matches) {
+              activeChild = child;
+              break;
+            }
+          }
+          frame = yield* attempt(
+            { operation: "automationPress.editFocusedFrame", tabId, webContentsId: wc.id },
+            () => {
+              if (!activeChild) throw new Error("The focused preview iframe is unavailable.");
+              return activeChild;
+            },
+          );
+        }
       }
+      yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
+      yield* checkControl;
+      yield* expectAgentInput(tabId, keySequence.signal);
       yield* attempt(
         { operation: "automationPress.sendInputEvent", tabId, webContentsId: wc.id },
         () => {
@@ -3952,6 +4011,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           }
         },
       );
+      yield* checkControl;
     }).pipe(
       Effect.ensuring(
         sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(Effect.ignore),
@@ -3964,8 +4024,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     input: PreviewAutomationPressInput,
   ) {
     const wc = yield* requireWebContents(tabId);
-    yield* withControlSession(tabId, wc, "press", (send, sendCleanup) =>
-      performAutomationPress(tabId, wc, input, send, sendCleanup),
+    yield* withControlSession(tabId, wc, "press", (send, sendCleanup, checkControl) =>
+      performAutomationPress(tabId, wc, input, send, sendCleanup, checkControl),
     );
   });
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -4000,17 +4000,23 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
       yield* checkControl;
       yield* expectAgentInput(tabId, keySequence.signal);
-      yield* attempt(
+      const dispatched = yield* attempt(
         { operation: "automationPress.sendInputEvent", tabId, webContentsId: wc.id },
         () => {
+          if (!BrowserWindow.fromWebContents(wc.hostWebContents ?? wc)?.isFocused()) return false;
           try {
             wc.sendInputEvent(keySequence.keyDown);
             if (keySequence.char) wc.sendInputEvent(keySequence.char);
           } finally {
             wc.sendInputEvent(keySequence.keyUp);
           }
+          return true;
         },
       );
+      if (!dispatched) {
+        yield* consumeExpectedAgentInput(tabId, keySequence.signal);
+        return yield* new PreviewAutomationWindowNotFocusedError({ tabId });
+      }
       yield* checkControl;
     }).pipe(
       Effect.ensuring(
@@ -4423,6 +4429,15 @@ export class PreviewAutomationDebuggerAttachedError extends Schema.TaggedError<P
   }
 }
 
+export class PreviewAutomationWindowNotFocusedError extends Schema.TaggedError<PreviewAutomationWindowNotFocusedError>()(
+  "PreviewAutomationWindowNotFocusedError",
+  { tabId: Schema.String },
+) {
+  override get message(): string {
+    return `Focus the window containing preview tab ${this.tabId} and retry the key press, or use preview_type for background text entry. No keys were sent.`;
+  }
+}
+
 export class PreviewAutomationEvaluationError extends Schema.TaggedError<PreviewAutomationEvaluationError>()(
   "PreviewAutomationEvaluationError",
   {
@@ -4572,6 +4587,7 @@ export const PreviewManagerError = Schema.Union([
   PreviewArtifactImageLoadError,
   PreviewAutomationDevToolsOpenError,
   PreviewAutomationDebuggerAttachedError,
+  PreviewAutomationWindowNotFocusedError,
   PreviewAutomationEvaluationError,
   PreviewAutomationTargetNotFoundError,
   PreviewAutomationTargetNotEditableError,

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -74,7 +74,10 @@ import {
 } from "./GuestProtocol.ts";
 import { isPreviewAnnotationPayload } from "./PickedElementPayload.ts";
 import { playwrightInjectedRuntimeInstallExpression } from "./PlaywrightInjectedRuntime.ts";
-import { makePreviewAutomationKeySequence } from "./PreviewKeyboard.ts";
+import {
+  makePreviewAutomationKeySequence,
+  previewAutomationEditingCommandExpression,
+} from "./PreviewKeyboard.ts";
 import { captureFavicon, safeHttpOrigin, selectFaviconCandidates } from "./FaviconCapture.ts";
 
 export type PreviewNavStatus =
@@ -3923,45 +3926,37 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const keySequence = makePreviewAutomationKeySequence(input, {
       isMac: hostPlatform === "darwin",
     });
-    const previouslyFocused = yield* attempt(
-      { operation: "automationPress.getFocusedWebContents", tabId, webContentsId: wc.id },
-      () => webContents.getFocusedWebContents(),
-    );
-    let keyDownAttempted = false;
-    const releaseInput = Effect.gen(function* () {
-      if (keyDownAttempted) {
-        yield* sendCleanup("Input.dispatchKeyEvent", keySequence.keyUp).pipe(Effect.ignore);
-      }
-      yield* sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(
-        Effect.ignore,
-      );
-      if (previouslyFocused && previouslyFocused.id !== wc.id && !previouslyFocused.isDestroyed()) {
-        yield* attempt(
-          {
-            operation: "automationPress.restoreFocusedWebContents",
-            tabId,
-            webContentsId: previouslyFocused.id,
-          },
-          () => previouslyFocused.focus(),
-        ).pipe(Effect.ignore);
-      }
-    });
-
-    // Focus the guest WebContents itself, not its containing BrowserWindow. This
-    // activates native keyboard behavior for hidden/background previews without
-    // changing which thread is mounted in the UI. Restore the previous renderer
-    // after dispatch so automation never leaves the app's input focus behind.
+    // CDP keyboard dispatch follows the embedder's focused renderer, and
+    // WebContents.focus() is a no-op for webview guests. Native input targets
+    // this guest's widget directly, so Enter cannot submit the host composer.
     yield* Effect.gen(function* () {
-      yield* attempt(
-        { operation: "automationPress.focusWebContents", tabId, webContentsId: wc.id },
-        () => wc.focus(),
-      );
-      yield* send("Page.bringToFront");
       yield* send("Emulation.setFocusEmulationEnabled", { enabled: true });
       yield* expectAgentInput(tabId, keySequence.signal);
-      keyDownAttempted = true;
-      yield* send("Input.dispatchKeyEvent", keySequence.keyDown);
-    }).pipe(Effect.ensuring(releaseInput));
+      if (keySequence.commands?.length) {
+        yield* evaluateWithDebugger(
+          tabId,
+          send,
+          previewAutomationEditingCommandExpression(input, keySequence),
+          true,
+        );
+        return;
+      }
+      yield* attempt(
+        { operation: "automationPress.sendInputEvent", tabId, webContentsId: wc.id },
+        () => {
+          try {
+            wc.sendInputEvent(keySequence.keyDown);
+            if (keySequence.char) wc.sendInputEvent(keySequence.char);
+          } finally {
+            wc.sendInputEvent(keySequence.keyUp);
+          }
+        },
+      );
+    }).pipe(
+      Effect.ensuring(
+        sendCleanup("Emulation.setFocusEmulationEnabled", { enabled: false }).pipe(Effect.ignore),
+      ),
+    );
   });
 
   const automationPress = Effect.fn("PreviewManager.automationPress")(function* (

--- a/apps/desktop/src/preview/PreviewKeyboard.test.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.test.ts
@@ -93,4 +93,30 @@ describe("preview keyboard packets", () => {
     expect(sequence.char).toBeUndefined();
     expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
   });
+
+  it("matches native uppercase key signals without inventing shortcut modifiers", () => {
+    const plain = makePreviewAutomationKeySequence({ key: "X" });
+    expect(plain.signal).toEqual({ kind: "key", key: "x", code: "KeyX" });
+    expect(plain.char?.keyCode).toBe("X");
+    const shortcut = makePreviewAutomationKeySequence({ key: "A", modifiers: ["Control"] });
+    expect(shortcut.signal).toEqual({ kind: "key", key: "a", code: "KeyA" });
+    expect(shortcut.keyDown.modifiers).toEqual(["control"]);
+    expect(shortcut.char).toBeUndefined();
+    expect(makePreviewAutomationKeySequence({ key: "X", modifiers: ["Shift"] }).signal).toEqual({
+      kind: "key",
+      key: "X",
+      code: "KeyX",
+    });
+  });
+
+  it("matches native signals for Unicode text and literal spaces", () => {
+    const unicode = makePreviewAutomationKeySequence({ key: "é" });
+    expect(unicode.signal).toEqual({ kind: "key", key: "", code: "" });
+    expect(unicode.char?.keyCode).toBe("é");
+    expect(makePreviewAutomationKeySequence({ key: " " }).signal).toEqual({
+      kind: "key",
+      key: " ",
+      code: "Space",
+    });
+  });
 });

--- a/apps/desktop/src/preview/PreviewKeyboard.test.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.test.ts
@@ -1,44 +1,116 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  makePreviewAutomationFrameKeySequence,
   makePreviewAutomationKeySequence,
+  makePreviewAutomationNativeKeySequence,
 } from "./PreviewKeyboard.ts";
 
 describe("preview keyboard packets", () => {
-  it("sends Enter directly to the guest with its character event", () => {
+  it("includes the Chromium virtual key code and Enter text", () => {
     expect(makePreviewAutomationKeySequence({ key: "Enter" })).toEqual({
       keyDown: {
         type: "keyDown",
-        keyCode: "Enter",
-        modifiers: [],
-        skipIfUnhandled: true,
-      },
-      char: {
-        type: "char",
-        keyCode: "\r",
-        modifiers: [],
-        skipIfUnhandled: true,
+        key: "Enter",
+        code: "Enter",
+        modifiers: 0,
+        windowsVirtualKeyCode: 13,
+        location: 0,
+        isKeypad: false,
+        text: "\r",
+        unmodifiedText: "\r",
       },
       keyUp: {
         type: "keyUp",
-        keyCode: "Enter",
-        modifiers: [],
-        skipIfUnhandled: true,
+        key: "Enter",
+        code: "Enter",
+        modifiers: 0,
+        windowsVirtualKeyCode: 13,
+        location: 0,
+        isKeypad: false,
       },
       signal: { kind: "key", key: "Enter", code: "Enter" },
     });
   });
 
-  it("sends printable text separately from keydown", () => {
+  it("dispatches printable keys as text key-down events", () => {
     const sequence = makePreviewAutomationKeySequence({ key: "z" });
-    expect(sequence.keyDown).toMatchObject({ type: "keyDown", keyCode: "z" });
-    expect(sequence.char).toMatchObject({ type: "char", keyCode: "z" });
-    expect(sequence.keyUp).toMatchObject({ type: "keyUp", keyCode: "z" });
+    expect(sequence.keyDown).toMatchObject({
+      type: "keyDown",
+      key: "z",
+      code: "KeyZ",
+      windowsVirtualKeyCode: 90,
+      text: "z",
+    });
+    expect(sequence.keyUp).not.toHaveProperty("text");
+  });
+
+  it("suppresses text and uses raw key-down for shortcuts", () => {
+    expect(
+      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }, { isMac: true }).keyDown,
+    ).toEqual({
+      type: "rawKeyDown",
+      key: "a",
+      code: "KeyA",
+      modifiers: 4,
+      windowsVirtualKeyCode: 65,
+      location: 0,
+      isKeypad: false,
+      commands: ["selectAll"],
+    });
+  });
+
+  it("maps common macOS editing shortcuts without changing other platforms", () => {
+    expect(
+      makePreviewAutomationKeySequence({ key: "z", modifiers: ["Shift", "Meta"] }, { isMac: true })
+        .keyDown.commands,
+    ).toEqual(["redo"]);
+    expect(
+      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).keyDown,
+    ).not.toHaveProperty("commands");
+  });
+
+  it("resolves shifted printable keys to their browser values", () => {
+    const sequence = makePreviewAutomationKeySequence({ key: "1", modifiers: ["Shift"] });
+    expect(sequence.keyDown).toMatchObject({
+      key: "!",
+      code: "Digit1",
+      modifiers: 8,
+      windowsVirtualKeyCode: 49,
+      text: "!",
+    });
+    expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
+  });
+
+  it("keeps shifted key values while suppressing text for modified chords", () => {
+    const sequence = makePreviewAutomationKeySequence({
+      key: "1",
+      modifiers: ["Control", "Shift"],
+    });
+    expect(sequence.keyDown).toEqual({
+      type: "rawKeyDown",
+      key: "!",
+      code: "Digit1",
+      modifiers: 10,
+      windowsVirtualKeyCode: 49,
+      location: 0,
+      isKeypad: false,
+    });
+    expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
+  });
+
+  it.each([
+    ["Enter", "\r"],
+    ["z", "z"],
+  ])("converts %s into native down, char, and up packets", (key, text) => {
+    const sequence = makePreviewAutomationNativeKeySequence({ key });
+    const shared = { keyCode: key, modifiers: [], skipIfUnhandled: true };
+    expect(sequence.keyDown).toEqual({ type: "keyDown", ...shared });
+    expect(sequence.char).toEqual({ type: "char", ...shared, keyCode: text });
+    expect(sequence.keyUp).toEqual({ type: "keyUp", ...shared });
   });
 
   it("suppresses text for shortcuts and retains macOS editing commands", () => {
-    const sequence = makePreviewAutomationKeySequence(
+    const sequence = makePreviewAutomationNativeKeySequence(
       { key: "a", modifiers: ["Meta"] },
       { isMac: true },
     );
@@ -52,60 +124,30 @@ describe("preview keyboard packets", () => {
     expect(sequence.commands).toEqual(["selectAll"]);
   });
 
-  it("maps common macOS editing shortcuts without changing other platforms", () => {
-    expect(
-      makePreviewAutomationKeySequence({ key: "z", modifiers: ["Shift", "Meta"] }, { isMac: true })
-        .commands,
-    ).toEqual(["redo"]);
-    expect(
-      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).commands,
-    ).toBeUndefined();
-  });
-
   it.each([
     ["ArrowLeft", "Left"],
     ["ArrowRight", "Right"],
     ["ArrowUp", "Up"],
     ["ArrowDown", "Down"],
   ])("maps %s to Electron's %s accelerator", (key, keyCode) => {
-    const sequence = makePreviewAutomationKeySequence({ key });
+    const sequence = makePreviewAutomationNativeKeySequence({ key });
     expect(sequence.keyDown.keyCode).toBe(keyCode);
     expect(sequence.keyUp.keyCode).toBe(keyCode);
     expect(sequence.signal.key).toBe(key);
     expect(sequence.char).toBeUndefined();
   });
 
-  it("resolves shifted printable keys to their browser values", () => {
-    const sequence = makePreviewAutomationKeySequence({ key: "1", modifiers: ["Shift"] });
-    expect(sequence.keyDown).toMatchObject({ keyCode: "!", modifiers: ["shift"] });
-    expect(sequence.char).toMatchObject({ keyCode: "!" });
-    expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
-  });
-
-  it("keeps shifted key values while suppressing text for modified chords", () => {
-    const sequence = makePreviewAutomationKeySequence({
-      key: "1",
-      modifiers: ["Control", "Shift"],
-    });
-    expect(sequence.keyDown).toEqual({
-      type: "keyDown",
-      keyCode: "!",
-      modifiers: ["control", "shift"],
-      skipIfUnhandled: true,
-    });
-    expect(sequence.char).toBeUndefined();
-    expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
-  });
-
   it("matches native uppercase key signals without inventing shortcut modifiers", () => {
-    const plain = makePreviewAutomationKeySequence({ key: "X" });
+    const plain = makePreviewAutomationNativeKeySequence({ key: "X" });
     expect(plain.signal).toEqual({ kind: "key", key: "x", code: "KeyX" });
     expect(plain.char?.keyCode).toBe("X");
-    const shortcut = makePreviewAutomationKeySequence({ key: "A", modifiers: ["Control"] });
+    const shortcut = makePreviewAutomationNativeKeySequence({ key: "A", modifiers: ["Control"] });
     expect(shortcut.signal).toEqual({ kind: "key", key: "a", code: "KeyA" });
     expect(shortcut.keyDown.modifiers).toEqual(["control"]);
     expect(shortcut.char).toBeUndefined();
-    expect(makePreviewAutomationKeySequence({ key: "X", modifiers: ["Shift"] }).signal).toEqual({
+    expect(
+      makePreviewAutomationNativeKeySequence({ key: "X", modifiers: ["Shift"] }).signal,
+    ).toEqual({
       kind: "key",
       key: "X",
       code: "KeyX",
@@ -113,10 +155,10 @@ describe("preview keyboard packets", () => {
   });
 
   it("matches native signals for Unicode text and literal spaces", () => {
-    const unicode = makePreviewAutomationKeySequence({ key: "é" });
+    const unicode = makePreviewAutomationNativeKeySequence({ key: "é" });
     expect(unicode.signal).toEqual({ kind: "key", key: "", code: "" });
     expect(unicode.char?.keyCode).toBe("é");
-    expect(makePreviewAutomationKeySequence({ key: " " }).signal).toEqual({
+    expect(makePreviewAutomationNativeKeySequence({ key: " " }).signal).toEqual({
       kind: "key",
       key: " ",
       code: "Space",
@@ -124,10 +166,10 @@ describe("preview keyboard packets", () => {
   });
 
   it("preserves text and editing commands for isolated child renderer targets", () => {
-    const text = makePreviewAutomationFrameKeySequence({ key: "é" });
+    const text = makePreviewAutomationKeySequence({ key: "é" });
     expect(text.keyDown).toMatchObject({ type: "keyDown", text: "é", key: "é" });
     expect(text.keyUp).toMatchObject({ type: "keyUp", key: "é" });
-    const shortcut = makePreviewAutomationFrameKeySequence(
+    const shortcut = makePreviewAutomationKeySequence(
       { key: "a", modifiers: ["Meta"] },
       { isMac: true },
     );

--- a/apps/desktop/src/preview/PreviewKeyboard.test.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { makePreviewAutomationKeySequence } from "./PreviewKeyboard.ts";
+import {
+  makePreviewAutomationFrameKeySequence,
+  makePreviewAutomationKeySequence,
+} from "./PreviewKeyboard.ts";
 
 describe("preview keyboard packets", () => {
   it("sends Enter directly to the guest with its character event", () => {
@@ -118,5 +121,22 @@ describe("preview keyboard packets", () => {
       key: " ",
       code: "Space",
     });
+  });
+
+  it("preserves text and editing commands for isolated child renderer targets", () => {
+    const text = makePreviewAutomationFrameKeySequence({ key: "é" });
+    expect(text.keyDown).toMatchObject({ type: "keyDown", text: "é", key: "é" });
+    expect(text.keyUp).toMatchObject({ type: "keyUp", key: "é" });
+    const shortcut = makePreviewAutomationFrameKeySequence(
+      { key: "a", modifiers: ["Meta"] },
+      { isMac: true },
+    );
+    expect(shortcut.keyDown).toMatchObject({
+      type: "rawKeyDown",
+      modifiers: 4,
+      commands: ["selectAll"],
+    });
+    expect(shortcut.keyDown).not.toHaveProperty("text");
+    expect(shortcut.keyDown).not.toHaveProperty("nativeVirtualKeyCode");
   });
 });

--- a/apps/desktop/src/preview/PreviewKeyboard.test.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.test.ts
@@ -3,78 +3,79 @@ import { describe, expect, it } from "vite-plus/test";
 import { makePreviewAutomationKeySequence } from "./PreviewKeyboard.ts";
 
 describe("preview keyboard packets", () => {
-  it("includes the Chromium virtual key code and Enter text", () => {
+  it("sends Enter directly to the guest with its character event", () => {
     expect(makePreviewAutomationKeySequence({ key: "Enter" })).toEqual({
       keyDown: {
         type: "keyDown",
-        key: "Enter",
-        code: "Enter",
-        modifiers: 0,
-        windowsVirtualKeyCode: 13,
-        location: 0,
-        isKeypad: false,
-        text: "\r",
-        unmodifiedText: "\r",
+        keyCode: "Enter",
+        modifiers: [],
+        skipIfUnhandled: true,
+      },
+      char: {
+        type: "char",
+        keyCode: "\r",
+        modifiers: [],
+        skipIfUnhandled: true,
       },
       keyUp: {
         type: "keyUp",
-        key: "Enter",
-        code: "Enter",
-        modifiers: 0,
-        windowsVirtualKeyCode: 13,
-        location: 0,
-        isKeypad: false,
+        keyCode: "Enter",
+        modifiers: [],
+        skipIfUnhandled: true,
       },
       signal: { kind: "key", key: "Enter", code: "Enter" },
     });
   });
 
-  it("dispatches printable keys as text key-down events", () => {
+  it("sends printable text separately from keydown", () => {
     const sequence = makePreviewAutomationKeySequence({ key: "z" });
-    expect(sequence.keyDown).toMatchObject({
-      type: "keyDown",
-      key: "z",
-      code: "KeyZ",
-      windowsVirtualKeyCode: 90,
-      text: "z",
-    });
-    expect(sequence.keyUp).not.toHaveProperty("text");
+    expect(sequence.keyDown).toMatchObject({ type: "keyDown", keyCode: "z" });
+    expect(sequence.char).toMatchObject({ type: "char", keyCode: "z" });
+    expect(sequence.keyUp).toMatchObject({ type: "keyUp", keyCode: "z" });
   });
 
-  it("suppresses text and uses raw key-down for shortcuts", () => {
-    expect(
-      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }, { isMac: true }).keyDown,
-    ).toEqual({
-      type: "rawKeyDown",
-      key: "a",
-      code: "KeyA",
-      modifiers: 4,
-      windowsVirtualKeyCode: 65,
-      location: 0,
-      isKeypad: false,
-      commands: ["selectAll"],
+  it("suppresses text for shortcuts and retains macOS editing commands", () => {
+    const sequence = makePreviewAutomationKeySequence(
+      { key: "a", modifiers: ["Meta"] },
+      { isMac: true },
+    );
+    expect(sequence.keyDown).toEqual({
+      type: "keyDown",
+      keyCode: "a",
+      modifiers: ["meta"],
+      skipIfUnhandled: true,
     });
+    expect(sequence.char).toBeUndefined();
+    expect(sequence.commands).toEqual(["selectAll"]);
   });
 
   it("maps common macOS editing shortcuts without changing other platforms", () => {
     expect(
       makePreviewAutomationKeySequence({ key: "z", modifiers: ["Shift", "Meta"] }, { isMac: true })
-        .keyDown.commands,
+        .commands,
     ).toEqual(["redo"]);
     expect(
-      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).keyDown,
-    ).not.toHaveProperty("commands");
+      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).commands,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["ArrowLeft", "Left"],
+    ["ArrowRight", "Right"],
+    ["ArrowUp", "Up"],
+    ["ArrowDown", "Down"],
+  ])("maps %s to Electron's %s accelerator", (key, keyCode) => {
+    const sequence = makePreviewAutomationKeySequence({ key });
+    expect(sequence.keyDown.keyCode).toBe(keyCode);
+    expect(sequence.keyUp.keyCode).toBe(keyCode);
+    expect(sequence.signal.key).toBe(key);
+    expect(sequence.char).toBeUndefined();
   });
 
   it("resolves shifted printable keys to their browser values", () => {
     const sequence = makePreviewAutomationKeySequence({ key: "1", modifiers: ["Shift"] });
-    expect(sequence.keyDown).toMatchObject({
-      key: "!",
-      code: "Digit1",
-      modifiers: 8,
-      windowsVirtualKeyCode: 49,
-      text: "!",
-    });
+    expect(sequence.keyDown).toMatchObject({ keyCode: "!", modifiers: ["shift"] });
+    expect(sequence.char).toMatchObject({ keyCode: "!" });
     expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
   });
 
@@ -84,14 +85,12 @@ describe("preview keyboard packets", () => {
       modifiers: ["Control", "Shift"],
     });
     expect(sequence.keyDown).toEqual({
-      type: "rawKeyDown",
-      key: "!",
-      code: "Digit1",
-      modifiers: 10,
-      windowsVirtualKeyCode: 49,
-      location: 0,
-      isKeypad: false,
+      type: "keyDown",
+      keyCode: "!",
+      modifiers: ["control", "shift"],
+      skipIfUnhandled: true,
     });
+    expect(sequence.char).toBeUndefined();
     expect(sequence.signal).toEqual({ kind: "key", key: "!", code: "Digit1" });
   });
 });

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -230,6 +230,7 @@ export function makePreviewAutomationFrameKeySequence(
 export function previewAutomationEditingCommandExpression(
   input: PreviewAutomationPressInput,
   sequence: PreviewAutomationKeySequence,
+  clipboardData: ReadonlyArray<{ readonly type: string; readonly data: string }> = [],
 ): string {
   const definition = resolveKeyDefinition(input);
   const event = {
@@ -246,7 +247,7 @@ export function previewAutomationEditingCommandExpression(
     cancelable: true,
     composed: true,
   };
-  return `(async () => {
+  return `(() => {
     let element = document.activeElement;
     while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
     if (!element) return;
@@ -254,15 +255,15 @@ export function previewAutomationEditingCommandExpression(
     try {
       if (!element.dispatchEvent(new KeyboardEvent("keydown", event))) return;
       for (const command of ${JSON.stringify(sequence.commands ?? [])}) {
-        // Chromium disables DOM execCommand("paste"). Read the permitted browser
-        // clipboard and let the page's paste handler consume its original formats.
+        // Main-process clipboard reads also work on insecure HTTP previews.
+        // Let the page's paste handler consume the original MIME formats.
         if (command === "paste") {
           const transfer = new DataTransfer();
-          for (const item of await navigator.clipboard.read()) {
-            for (const type of item.types) {
-              const blob = await item.getType(type);
-              if (type.startsWith("text/")) transfer.setData(type, await blob.text());
-              else transfer.items.add(new File([blob], "clipboard", { type }));
+          for (const { type, data } of ${JSON.stringify(clipboardData)}) {
+            if (type.startsWith("text/")) transfer.setData(type, data);
+            else {
+              const bytes = Uint8Array.from(atob(data), character => character.charCodeAt(0));
+              transfer.items.add(new File([bytes], "clipboard", { type }));
             }
           }
           if (!element.dispatchEvent(new ClipboardEvent("paste", {

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -246,7 +246,7 @@ export function previewAutomationEditingCommandExpression(
     cancelable: true,
     composed: true,
   };
-  return `(() => {
+  return `(async () => {
     let element = document.activeElement;
     while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
     if (!element) return;
@@ -254,6 +254,29 @@ export function previewAutomationEditingCommandExpression(
     try {
       if (!element.dispatchEvent(new KeyboardEvent("keydown", event))) return;
       for (const command of ${JSON.stringify(sequence.commands ?? [])}) {
+        // Chromium disables DOM execCommand("paste"). Read the permitted browser
+        // clipboard and let the page's paste handler consume its original formats.
+        if (command === "paste") {
+          const transfer = new DataTransfer();
+          for (const item of await navigator.clipboard.read()) {
+            for (const type of item.types) {
+              const blob = await item.getType(type);
+              if (type.startsWith("text/")) transfer.setData(type, await blob.text());
+              else transfer.items.add(new File([blob], "clipboard", { type }));
+            }
+          }
+          if (!element.dispatchEvent(new ClipboardEvent("paste", {
+            clipboardData: transfer, bubbles: true, cancelable: true, composed: true,
+          }))) continue;
+          const text = transfer.getData("text/plain");
+          if (!element.dispatchEvent(new InputEvent("beforeinput", {
+            inputType: "insertFromPaste", data: text, dataTransfer: transfer,
+            bubbles: true, cancelable: true, composed: true,
+          }))) continue;
+          const html = element.isContentEditable ? transfer.getData("text/html") : "";
+          document.execCommand(html ? "insertHTML" : "insertText", false, html || text);
+          continue;
+        }
         const inputType = command === "deleteToBeginningOfLine" ? "deleteSoftLineBackward"
           : command === "undo" ? "historyUndo"
           : command === "redo" ? "historyRedo" : null;

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -9,15 +9,23 @@ interface KeyDefinition {
   readonly shiftedKey?: string;
 }
 
-export interface PreviewAutomationKeyEvent extends Electron.KeyboardInputEvent {
-  readonly skipIfUnhandled: true;
+export interface PreviewAutomationKeyEvent {
+  readonly [key: string]: unknown;
+  readonly type: "keyDown" | "rawKeyDown" | "keyUp";
+  readonly key: string;
+  readonly code: string;
+  readonly modifiers: number;
+  readonly windowsVirtualKeyCode: number;
+  readonly location: number;
+  readonly isKeypad: boolean;
+  readonly text?: string;
+  readonly unmodifiedText?: string;
+  readonly commands?: ReadonlyArray<string>;
 }
 
 export interface PreviewAutomationKeySequence {
   readonly keyDown: PreviewAutomationKeyEvent;
-  readonly char?: PreviewAutomationKeyEvent;
   readonly keyUp: PreviewAutomationKeyEvent;
-  readonly commands?: ReadonlyArray<string>;
   readonly signal: {
     readonly kind: "key";
     readonly key: string;
@@ -108,6 +116,20 @@ const macEditingCommands = (
   return command ? [command] : [];
 };
 
+const modifierMask = (modifiers: PreviewAutomationPressInput["modifiers"]): number =>
+  (modifiers ?? []).reduce((value, modifier) => {
+    switch (modifier) {
+      case "Alt":
+        return value | 1;
+      case "Control":
+        return value | 2;
+      case "Meta":
+        return value | 4;
+      case "Shift":
+        return value | 8;
+    }
+  }, 0);
+
 function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition {
   const named = NAMED_KEYS[input.key === " " ? "Space" : input.key];
   if (named) return named;
@@ -146,90 +168,81 @@ function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition
 }
 
 /**
- * Send directly to the guest widget. CDP keyboard input resolves the embedder's
- * focused widget and can deliver a background preview's keys to the composer.
+ * Build Chromium CDP key packets using the same required fields and down-event
+ * choice as Playwright's pinned Chromium keyboard implementation.
  */
 export function makePreviewAutomationKeySequence(
   input: PreviewAutomationPressInput,
   options?: { readonly isMac?: boolean },
 ): PreviewAutomationKeySequence {
   const definition = resolveKeyDefinition(input);
-  const modifiers = (input.modifiers ?? []).map((modifier) => {
-    switch (modifier) {
-      case "Alt":
-        return "alt" as const;
-      case "Control":
-        return "control" as const;
-      case "Meta":
-        return "meta" as const;
-      case "Shift":
-        return "shift" as const;
-    }
-  });
+  const modifiers = modifierMask(input.modifiers);
   const suppressText = input.modifiers?.some((modifier) => modifier !== "Shift") ?? false;
   const text = suppressText ? "" : (definition.text ?? "");
-  const commands = options?.isMac ? macEditingCommands(definition.code, input.modifiers) : [];
-  const shared = {
-    keyCode: definition.key.startsWith("Arrow") ? definition.key.slice(5) : definition.key,
-    modifiers,
-    skipIfUnhandled: true as const,
-  };
-  // Electron's accelerator parser lowercases letters unless Shift is explicit.
-  // Unsupported character accelerators still insert text, but report an empty key.
-  const nativeKey =
-    definition.keyCode === 0 && definition.key.length === 1
-      ? ""
-      : /^[A-Z]$/.test(definition.key) && !modifiers.includes("shift")
-        ? definition.key.toLowerCase()
-        : definition.key;
-
-  return {
-    keyDown: {
-      type: "keyDown",
-      ...shared,
-    },
-    ...(text ? { char: { ...shared, type: "char" as const, keyCode: text } } : {}),
-    keyUp: { type: "keyUp", ...shared },
-    ...(commands.length > 0 ? { commands } : {}),
-    signal: { kind: "key", key: nativeKey, code: definition.code },
-  };
-}
-
-/** CDP is safe for child renderer targets, which cannot retarget keys to the desktop. */
-export function makePreviewAutomationFrameKeySequence(
-  input: PreviewAutomationPressInput,
-  options?: { readonly isMac?: boolean },
-) {
-  const definition = resolveKeyDefinition(input);
-  const modifiers = (input.modifiers ?? []).reduce(
-    (mask, modifier) => mask | { Alt: 1, Control: 2, Meta: 4, Shift: 8 }[modifier],
-    0,
-  );
-  const text = input.modifiers?.some((modifier) => modifier !== "Shift")
-    ? ""
-    : (definition.text ?? "");
+  const location = definition.location ?? 0;
   const commands = options?.isMac ? macEditingCommands(definition.code, input.modifiers) : [];
   const shared = {
     key: definition.key,
     code: definition.code,
     modifiers,
     windowsVirtualKeyCode: definition.keyCode,
+    location,
+    isKeypad: location === 3,
   };
+
   return {
     keyDown: {
       type: text ? "keyDown" : "rawKeyDown",
       ...shared,
       ...(text ? { text, unmodifiedText: text } : {}),
-      ...(commands.length ? { commands } : {}),
+      ...(commands.length > 0 ? { commands } : {}),
     },
     keyUp: { type: "keyUp", ...shared },
+    signal: { kind: "key", key: definition.key, code: definition.code },
+  };
+}
+
+/** Root CDP input can retarget the embedder; native packets address the guest widget. */
+export function makePreviewAutomationNativeKeySequence(
+  input: PreviewAutomationPressInput,
+  options?: { readonly isMac?: boolean },
+) {
+  const { keyDown, signal } = makePreviewAutomationKeySequence(input, options);
+  const modifiers = (
+    [
+      [1, "alt"],
+      [2, "control"],
+      [4, "meta"],
+      [8, "shift"],
+    ] as const
+  )
+    .filter(([mask]) => keyDown.modifiers & mask)
+    .map(([, modifier]) => modifier);
+  const shared = {
+    keyCode: keyDown.key.startsWith("Arrow") ? keyDown.key.slice(5) : keyDown.key,
+    modifiers,
+    skipIfUnhandled: true as const,
+  };
+  // Electron lowercases unshifted letters and reports no key for Unicode accelerators.
+  const key =
+    keyDown.windowsVirtualKeyCode === 0 && keyDown.key.length === 1
+      ? ""
+      : /^[A-Z]$/.test(keyDown.key) && !modifiers.includes("shift")
+        ? keyDown.key.toLowerCase()
+        : keyDown.key;
+  return {
+    keyDown: { type: "keyDown" as const, ...shared },
+    ...(keyDown.text ? { char: { type: "char" as const, ...shared, keyCode: keyDown.text } } : {}),
+    keyUp: { type: "keyUp" as const, ...shared },
+    ...(keyDown.commands ? { commands: keyDown.commands } : {}),
+    signal: { ...signal, key },
   };
 }
 
 /** Keep macOS editing shortcuts inside the target page without native focus. */
 export function previewAutomationEditingCommandExpression(
   input: PreviewAutomationPressInput,
-  sequence: PreviewAutomationKeySequence,
+  sequence: ReturnType<typeof makePreviewAutomationNativeKeySequence>,
   clipboardData: ReadonlyArray<{ readonly type: string; readonly data: string }> = [],
 ): string {
   const definition = resolveKeyDefinition(input);

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -256,11 +256,16 @@ export function previewAutomationEditingCommandExpression(
       if (!element.dispatchEvent(new KeyboardEvent("keydown", event))) return;
       for (const command of ${JSON.stringify(sequence.commands ?? [])}) {
         // Main-process clipboard reads also work on insecure HTTP previews.
-        // Let the page's paste handler consume the original MIME formats.
+        // Let the page's paste handler consume the clipboard MIME formats.
         if (command === "paste") {
           const transfer = new DataTransfer();
           for (const { type, data } of ${JSON.stringify(clipboardData)}) {
-            if (type.startsWith("text/")) transfer.setData(type, data);
+            if (type === "text/html") {
+              // Match native paste sanitization before page handlers or insertion.
+              const container = document.createElement("div");
+              container.setHTML(data);
+              transfer.setData(type, container.innerHTML);
+            } else if (type.startsWith("text/")) transfer.setData(type, data);
             else {
               const bytes = Uint8Array.from(atob(data), character => character.charCodeAt(0));
               transfer.items.add(new File([bytes], "clipboard", { type }));

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -195,6 +195,37 @@ export function makePreviewAutomationKeySequence(
   };
 }
 
+/** CDP is safe for child renderer targets, which cannot retarget keys to the desktop. */
+export function makePreviewAutomationFrameKeySequence(
+  input: PreviewAutomationPressInput,
+  options?: { readonly isMac?: boolean },
+) {
+  const definition = resolveKeyDefinition(input);
+  const modifiers = (input.modifiers ?? []).reduce(
+    (mask, modifier) => mask | { Alt: 1, Control: 2, Meta: 4, Shift: 8 }[modifier],
+    0,
+  );
+  const text = input.modifiers?.some((modifier) => modifier !== "Shift")
+    ? ""
+    : (definition.text ?? "");
+  const commands = options?.isMac ? macEditingCommands(definition.code, input.modifiers) : [];
+  const shared = {
+    key: definition.key,
+    code: definition.code,
+    modifiers,
+    windowsVirtualKeyCode: definition.keyCode,
+  };
+  return {
+    keyDown: {
+      type: text ? "keyDown" : "rawKeyDown",
+      ...shared,
+      ...(text ? { text, unmodifiedText: text } : {}),
+      ...(commands.length ? { commands } : {}),
+    },
+    keyUp: { type: "keyUp", ...shared },
+  };
+}
+
 /** Keep macOS editing shortcuts inside the target page without native focus. */
 export function previewAutomationEditingCommandExpression(
   input: PreviewAutomationPressInput,

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -242,7 +242,8 @@ export function previewAutomationEditingCommandExpression(
           const selectionElement = selection?.anchorNode?.nodeType === Node.ELEMENT_NODE
             ? selection.anchorNode : selection?.anchorNode?.parentElement;
           const editable = element.isContentEditable || selectionElement?.isContentEditable ||
-            ((element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) &&
+            (((element instanceof HTMLInputElement && element.selectionStart !== null) ||
+              element instanceof HTMLTextAreaElement) &&
               !element.readOnly && !element.disabled);
           if (!editable && (command === "moveToBeginningOfDocument" || command === "moveToEndOfDocument")) {
             let scrollable = element === document.body ? selectionElement ?? element : element;
@@ -263,6 +264,10 @@ export function previewAutomationEditingCommandExpression(
             direction,
             command.includes("Document") ? "documentboundary" : "lineboundary",
           );
+          if (element instanceof HTMLInputElement && element.selectionStart !== null) {
+            if (command.includes("Left") || command.includes("Beginning")) element.scrollLeft = 0;
+            else element.scrollLeft = element.scrollWidth;
+          }
           // Programmatic selection changes do not reveal the caret like native editing commands.
           if (editable && command.includes("Document")) {
             const beginning = command.includes("Beginning");

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -9,23 +9,15 @@ interface KeyDefinition {
   readonly shiftedKey?: string;
 }
 
-export interface PreviewAutomationKeyEvent {
-  readonly [key: string]: unknown;
-  readonly type: "keyDown" | "rawKeyDown" | "keyUp";
-  readonly key: string;
-  readonly code: string;
-  readonly modifiers: number;
-  readonly windowsVirtualKeyCode: number;
-  readonly location: number;
-  readonly isKeypad: boolean;
-  readonly text?: string;
-  readonly unmodifiedText?: string;
-  readonly commands?: ReadonlyArray<string>;
+export interface PreviewAutomationKeyEvent extends Electron.KeyboardInputEvent {
+  readonly skipIfUnhandled: true;
 }
 
 export interface PreviewAutomationKeySequence {
   readonly keyDown: PreviewAutomationKeyEvent;
+  readonly char?: PreviewAutomationKeyEvent;
   readonly keyUp: PreviewAutomationKeyEvent;
+  readonly commands?: ReadonlyArray<string>;
   readonly signal: {
     readonly kind: "key";
     readonly key: string;
@@ -116,20 +108,6 @@ const macEditingCommands = (
   return command ? [command] : [];
 };
 
-const modifierMask = (modifiers: PreviewAutomationPressInput["modifiers"]): number =>
-  (modifiers ?? []).reduce((value, modifier) => {
-    switch (modifier) {
-      case "Alt":
-        return value | 1;
-      case "Control":
-        return value | 2;
-      case "Meta":
-        return value | 4;
-      case "Shift":
-        return value | 8;
-    }
-  }, 0);
-
 function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition {
   const named = NAMED_KEYS[input.key];
   if (named) return named;
@@ -168,36 +146,105 @@ function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition
 }
 
 /**
- * Build Chromium CDP key packets using the same required fields and down-event
- * choice as Playwright's pinned Chromium keyboard implementation.
+ * Send directly to the guest widget. CDP keyboard input resolves the embedder's
+ * focused widget and can deliver a background preview's keys to the composer.
  */
 export function makePreviewAutomationKeySequence(
   input: PreviewAutomationPressInput,
   options?: { readonly isMac?: boolean },
 ): PreviewAutomationKeySequence {
   const definition = resolveKeyDefinition(input);
-  const modifiers = modifierMask(input.modifiers);
+  const modifiers = (input.modifiers ?? []).map((modifier) => {
+    switch (modifier) {
+      case "Alt":
+        return "alt" as const;
+      case "Control":
+        return "control" as const;
+      case "Meta":
+        return "meta" as const;
+      case "Shift":
+        return "shift" as const;
+    }
+  });
   const suppressText = input.modifiers?.some((modifier) => modifier !== "Shift") ?? false;
   const text = suppressText ? "" : (definition.text ?? "");
-  const location = definition.location ?? 0;
   const commands = options?.isMac ? macEditingCommands(definition.code, input.modifiers) : [];
   const shared = {
-    key: definition.key,
-    code: definition.code,
+    keyCode: definition.key.startsWith("Arrow") ? definition.key.slice(5) : definition.key,
     modifiers,
-    windowsVirtualKeyCode: definition.keyCode,
-    location,
-    isKeypad: location === 3,
+    skipIfUnhandled: true as const,
   };
 
   return {
     keyDown: {
-      type: text ? "keyDown" : "rawKeyDown",
+      type: "keyDown",
       ...shared,
-      ...(text ? { text, unmodifiedText: text } : {}),
-      ...(commands.length > 0 ? { commands } : {}),
     },
+    ...(text ? { char: { ...shared, type: "char" as const, keyCode: text } } : {}),
     keyUp: { type: "keyUp", ...shared },
+    ...(commands.length > 0 ? { commands } : {}),
     signal: { kind: "key", key: definition.key, code: definition.code },
   };
+}
+
+/** Keep macOS editing shortcuts inside the target page without native focus. */
+export function previewAutomationEditingCommandExpression(
+  input: PreviewAutomationPressInput,
+  sequence: PreviewAutomationKeySequence,
+): string {
+  const definition = resolveKeyDefinition(input);
+  const event = {
+    key: definition.key,
+    code: definition.code,
+    keyCode: definition.keyCode,
+    which: definition.keyCode,
+    location: definition.location ?? 0,
+    altKey: input.modifiers?.includes("Alt") ?? false,
+    ctrlKey: input.modifiers?.includes("Control") ?? false,
+    metaKey: input.modifiers?.includes("Meta") ?? false,
+    shiftKey: input.modifiers?.includes("Shift") ?? false,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  };
+  return `(() => {
+    let element = document.activeElement;
+    while (element?.shadowRoot?.activeElement) element = element.shadowRoot.activeElement;
+    if (!element) return;
+    const event = ${JSON.stringify(event)};
+    try {
+      if (!element.dispatchEvent(new KeyboardEvent("keydown", event))) return;
+      for (const command of ${JSON.stringify(sequence.commands ?? [])}) {
+        const inputType = command === "deleteToBeginningOfLine" ? "deleteSoftLineBackward"
+          : command === "undo" ? "historyUndo"
+          : command === "redo" ? "historyRedo" : null;
+        // execCommand emits input without beforeinput. Let controlled editors
+        // perform the edit before applying the browser's default operation.
+        if (inputType && !element.dispatchEvent(new InputEvent("beforeinput", {
+          inputType, bubbles: true, cancelable: true, composed: true,
+        }))) continue;
+        const selection = document.getSelection();
+        if (command === "deleteToBeginningOfLine") {
+          const collapsed = typeof element.selectionStart === "number"
+            ? element.selectionStart === element.selectionEnd
+            : selection?.isCollapsed;
+          if (collapsed) selection?.modify("extend", "backward", "lineboundary");
+          document.execCommand("delete");
+        } else if (command.startsWith("moveTo")) {
+          const direction = command.includes("Beginning") ? "backward"
+            : command.includes("Left") ? "left"
+            : command.includes("Right") ? "right" : "forward";
+          selection?.modify(
+            command.endsWith("AndModifySelection") ? "extend" : "move",
+            direction,
+            command.includes("Document") ? "documentboundary" : "lineboundary",
+          );
+        } else {
+          document.execCommand(command);
+        }
+      }
+    } finally {
+      element.dispatchEvent(new KeyboardEvent("keyup", event));
+    }
+  })()`;
 }

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -109,7 +109,7 @@ const macEditingCommands = (
 };
 
 function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition {
-  const named = NAMED_KEYS[input.key];
+  const named = NAMED_KEYS[input.key === " " ? "Space" : input.key];
   if (named) return named;
 
   const functionKey = /^F([1-9]|1[0-2])$/.exec(input.key);
@@ -174,6 +174,14 @@ export function makePreviewAutomationKeySequence(
     modifiers,
     skipIfUnhandled: true as const,
   };
+  // Electron's accelerator parser lowercases letters unless Shift is explicit.
+  // Unsupported character accelerators still insert text, but report an empty key.
+  const nativeKey =
+    definition.keyCode === 0 && definition.key.length === 1
+      ? ""
+      : /^[A-Z]$/.test(definition.key) && !modifiers.includes("shift")
+        ? definition.key.toLowerCase()
+        : definition.key;
 
   return {
     keyDown: {
@@ -183,7 +191,7 @@ export function makePreviewAutomationKeySequence(
     ...(text ? { char: { ...shared, type: "char" as const, keyCode: text } } : {}),
     keyUp: { type: "keyUp", ...shared },
     ...(commands.length > 0 ? { commands } : {}),
-    signal: { kind: "key", key: definition.key, code: definition.code },
+    signal: { kind: "key", key: nativeKey, code: definition.code },
   };
 }
 
@@ -231,6 +239,22 @@ export function previewAutomationEditingCommandExpression(
           if (collapsed) selection?.modify("extend", "backward", "lineboundary");
           document.execCommand("delete");
         } else if (command.startsWith("moveTo")) {
+          const selectionElement = selection?.anchorNode?.nodeType === Node.ELEMENT_NODE
+            ? selection.anchorNode : selection?.anchorNode?.parentElement;
+          const editable = element.isContentEditable || selectionElement?.isContentEditable ||
+            ((element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) &&
+              !element.readOnly && !element.disabled);
+          if (!editable && (command === "moveToBeginningOfDocument" || command === "moveToEndOfDocument")) {
+            let scrollable = element === document.body ? selectionElement ?? element : element;
+            while (scrollable && !(scrollable.scrollHeight > scrollable.clientHeight &&
+              /^(auto|scroll|overlay)$/.test(getComputedStyle(scrollable).overflowY))) {
+              scrollable = scrollable.parentElement ?? scrollable.getRootNode().host;
+            }
+            scrollable ??= document.scrollingElement;
+            if (scrollable) scrollable.scrollTop = command === "moveToBeginningOfDocument"
+              ? 0 : scrollable.scrollHeight;
+            continue;
+          }
           const direction = command.includes("Beginning") ? "backward"
             : command.includes("Left") ? "left"
             : command.includes("Right") ? "right" : "forward";
@@ -239,6 +263,17 @@ export function previewAutomationEditingCommandExpression(
             direction,
             command.includes("Document") ? "documentboundary" : "lineboundary",
           );
+          // Programmatic selection changes do not reveal the caret like native editing commands.
+          if (editable && command.includes("Document")) {
+            const beginning = command.includes("Beginning");
+            if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+              element.scrollTop = beginning ? 0 : element.scrollHeight;
+            } else {
+              const caretElement = selection?.focusNode?.nodeType === Node.ELEMENT_NODE
+                ? selection.focusNode : selection?.focusNode?.parentElement;
+              caretElement?.scrollIntoView({ block: beginning ? "start" : "end", inline: "nearest" });
+            }
+          }
         } else {
           document.execCommand(command);
         }


### PR DESCRIPTION
background preview enter could reach the focused desktop composer and send an unfinished draft while an agent was working. production logs put the unintended submission 423 ms after preview_press started; an isolated electron reproduction confirmed the host received the key.

resolve the focused preview frame once, derive native packets from the existing keyboard builder, and suppress forwarding to the desktop. retain bounded focus emulation, frame-specific routing, and editing shortcuts so background previews keep working.

verified: 105 focused tests, desktop typecheck, targeted lint, and the real composer with a running codex provider in electron 44.1.0 on linux. background enter preserves the draft, typing continues, and intentional enter still sends. additional runtime checks cover unfocused typing, unhandled shortcuts, cross-origin iframe input, copy/paste/cut, undo/redo, scrolling, plain-http paste, keyup interception, enter navigation, immediate select-all/backspace, backward selections, and rich-html paste sanitization. the mac command branch was exercised on linux; native macos remains unverified.

before: background enter sends the unfinished draft.

https://github.com/user-attachments/assets/8b4c07cf-9f9d-408a-9bd7-cc88a29f961e

after: background enter leaves the draft intact, and typing continues.

https://github.com/user-attachments/assets/736c3026-9744-4446-8b7e-49eb8a8c2888

after: unfocused preview typing and clipboard shortcuts preserve the host draft while the provider works.

https://github.com/user-attachments/assets/12a43ca2-7899-420b-b02d-9c5c01c5587b

model: `gpt-6-astra`. harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved preview keyboard automation with native key input and support for nested frames.
  - Enhanced handling of keyboard shortcuts, modifier keys, arrow keys, Unicode characters, spaces, and shifted input.
  - Improved copy, cut, and paste behavior while preserving selections and target elements.
  - Added more reliable focus handling, keyup confirmation, and input delivery during automation.
- **Bug Fixes**
  - Improved caret visibility, text editing, and scrolling behavior for preview interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

