### PR TITLE
fix(web): keep comment actions visible when pr comments are folded

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -363,7 +363,7 @@ function CommentComposer({
   };
 
   return (
-    <div className="mt-3 space-y-2">
+    <div className="space-y-2">
       <Textarea
         // Locked while posting: the body is cleared on success, which would otherwise throw
         // away a new draft typed while the request was still in flight.
@@ -719,7 +719,7 @@ export function PullRequestSummaryTab({
         </div>
       </section>
 
-      <section aria-label="Description" className="px-4 pt-2 pb-4">
+      <section aria-label="Description" className="px-4 pt-2 pb-1">
         <div className="group">
           {bodyScope === detail.url ? (
             <PullRequestMarkdownEditor
@@ -991,7 +991,9 @@ export function PullRequestSummaryTab({
             )}
           </>
         )}
-        {/* Posting is a core capability and remains usable even if the activity read failed. */}
+      </Section>
+      <div className="px-4 pb-4">
+        {/* Posting stays available when the conversation is folded or its activity read failed. */}
         {detail.capabilities.comment && detail.viewerPermissions.comment ? (
           <CommentComposer
             reference={reference}
@@ -1009,7 +1011,7 @@ export function PullRequestSummaryTab({
             onCommented={onRefresh}
           />
         ) : null}
-      </Section>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Folding the PR conversation hid the comment composer and its close/reopen actions. Keep the existing composer outside the fold so actions and drafts remain available, and reduce the description's bottom padding by 12px.

Verified in the real GitHub-backed web client: drafts survive folding/unfolding, Comment and Close with comment remain enabled, and a comment posted successfully while folded. Close/reopen mutations were not exercised. Web typecheck and scoped lint passed (one existing array-index-key warning); all GitHub checks passed. This shared web panel also serves desktop; native mobile is unchanged.

Before:

![folded comments previously hid the composer](https://uploads-production-47e4.up.railway.app/files/78c20ba0-812e-4b38-a26c-2f4242670973/browser-screenshot-100-92-30-110-mtxqz46t-d8a20c2f.png)

After:

![folded comments keep the composer and tighter description spacing](https://uploads-production-47e4.up.railway.app/files/a8713c43-77ad-4751-8da2-34bcb92d3f4b/browser-screenshot-100-92-30-110-mtxqzmxm-affa9c77.png)

![folding comments and posting through the retained composer](https://uploads-production-47e4.up.railway.app/files/93a65531-01b5-4f6a-95c9-aa8b87a467db/pr-fold-interaction.gif)

model: `gpt-6-astra`. harness: codex.
