### PR TITLE
feat: rewind conversations while keeping file changes

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1683,10 +1683,17 @@ describe("CheckpointReactor", () => {
     }),
   );
 
-  it.each(["thread.checkpoint.revert", "thread.conversation.revert"] as const)(
-    "%s rewinds history with the requested filesystem behavior",
-    async (commandType) => {
-      const harness = await createHarness();
+  it.each([
+    { commandType: "thread.checkpoint.revert", initializeGit: true },
+    { commandType: "thread.conversation.revert", initializeGit: true },
+    { commandType: "thread.conversation.revert", initializeGit: false },
+  ] as const)(
+    "$commandType rewinds history with the requested filesystem behavior (git: $initializeGit)",
+    async ({ commandType, initializeGit }) => {
+      const harness = await createHarness({
+        initializeGit,
+        seedFilesystemCheckpoints: initializeGit,
+      });
       const createdAt = "2026-01-01T00:00:00.000Z";
 
       await Effect.runPromise(
@@ -1714,8 +1721,10 @@ describe("CheckpointReactor", () => {
           threadId: ThreadId.make("thread-1"),
           turnId: asTurnId("turn-1"),
           completedAt: createdAt,
-          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
-          status: "ready",
+          checkpointRef: initializeGit
+            ? checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1)
+            : CheckpointRef.make("provider-diff:thread-1:turn-1"),
+          status: initializeGit ? "ready" : "missing",
           files: [],
           checkpointTurnCount: 1,
           createdAt,
@@ -1728,8 +1737,10 @@ describe("CheckpointReactor", () => {
           threadId: ThreadId.make("thread-1"),
           turnId: asTurnId("turn-2"),
           completedAt: createdAt,
-          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
-          status: "ready",
+          checkpointRef: initializeGit
+            ? checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)
+            : CheckpointRef.make("provider-diff:thread-1:turn-2"),
+          status: initializeGit ? "ready" : "missing",
           files: [],
           checkpointTurnCount: 2,
           createdAt,
@@ -1737,13 +1748,17 @@ describe("CheckpointReactor", () => {
       );
 
       NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "staged edit\n");
-      NodeChildProcess.execFileSync("git", ["add", "README.md"], { cwd: harness.cwd });
+      if (initializeGit) {
+        NodeChildProcess.execFileSync("git", ["add", "README.md"], { cwd: harness.cwd });
+      }
       NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "unstaged edit\n");
       NodeFS.writeFileSync(NodePath.join(harness.cwd, "scratch.txt"), "untracked edit\n");
-      const indexBefore = NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
-        cwd: harness.cwd,
-        encoding: "utf8",
-      });
+      const indexBefore = initializeGit
+        ? NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
+            cwd: harness.cwd,
+            encoding: "utf8",
+          })
+        : undefined;
 
       await Effect.runPromise(
         harness.engine.dispatch({
@@ -1776,16 +1791,22 @@ describe("CheckpointReactor", () => {
         expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "scratch.txt"), "utf8")).toBe(
           "untracked edit\n",
         );
-        expect(
-          NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
-            cwd: harness.cwd,
-            encoding: "utf8",
-          }),
-        ).toBe(indexBefore);
+        if (initializeGit) {
+          expect(
+            NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
+              cwd: harness.cwd,
+              encoding: "utf8",
+            }),
+          ).toBe(indexBefore);
+        }
       }
-      expect(
-        gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
-      ).toBe(false);
+      if (initializeGit) {
+        expect(
+          gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
+        ).toBe(false);
+      } else {
+        expect(NodeFS.existsSync(NodePath.join(harness.cwd, ".git"))).toBe(false);
+      }
     },
   );
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1683,86 +1683,111 @@ describe("CheckpointReactor", () => {
     }),
   );
 
-  it("executes provider revert and emits thread.reverted for checkpoint revert requests", async () => {
-    const harness = await createHarness();
-    const createdAt = "2026-01-01T00:00:00.000Z";
+  it.each(["thread.checkpoint.revert", "thread.conversation.revert"] as const)(
+    "%s rewinds history with the requested filesystem behavior",
+    async (commandType) => {
+      const harness = await createHarness();
+      const createdAt = "2026-01-01T00:00:00.000Z";
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.make("cmd-session-set"),
-        threadId: ThreadId.make("thread-1"),
-        session: {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.make("cmd-session-set"),
           threadId: ThreadId.make("thread-1"),
+          session: {
+            threadId: ThreadId.make("thread-1"),
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        }),
+      );
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make("cmd-diff-1"),
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-1"),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
           status: "ready",
-          providerName: "codex",
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: createdAt,
-        },
-        createdAt,
-      }),
-    );
+          files: [],
+          checkpointTurnCount: 1,
+          createdAt,
+        }),
+      );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.make("cmd-diff-2"),
+          threadId: ThreadId.make("thread-1"),
+          turnId: asTurnId("turn-2"),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
+          status: "ready",
+          files: [],
+          checkpointTurnCount: 2,
+          createdAt,
+        }),
+      );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-diff-1"),
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "staged edit\n");
+      NodeChildProcess.execFileSync("git", ["add", "README.md"], { cwd: harness.cwd });
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "README.md"), "unstaged edit\n");
+      NodeFS.writeFileSync(NodePath.join(harness.cwd, "scratch.txt"), "untracked edit\n");
+      const indexBefore = NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
+        cwd: harness.cwd,
+        encoding: "utf8",
+      });
+
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: commandType,
+          commandId: CommandId.make("cmd-revert-request"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 1,
+          createdAt,
+        }),
+      );
+
+      await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
+      const thread = await waitForThread(
+        harness.readModel,
+        (entry) => entry.checkpoints.length === 1,
+      );
+
+      expect(thread.latestTurn?.turnId).toBe("turn-1");
+      expect(thread.checkpoints).toHaveLength(1);
+      expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
+      expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
         threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-1"),
-        completedAt: createdAt,
-        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 1),
-        status: "ready",
-        files: [],
-        checkpointTurnCount: 1,
-        createdAt,
-      }),
-    );
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.turn.diff.complete",
-        commandId: CommandId.make("cmd-diff-2"),
-        threadId: ThreadId.make("thread-1"),
-        turnId: asTurnId("turn-2"),
-        completedAt: createdAt,
-        checkpointRef: checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2),
-        status: "ready",
-        files: [],
-        checkpointTurnCount: 2,
-        createdAt,
-      }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.checkpoint.revert",
-        commandId: CommandId.make("cmd-revert-request"),
-        threadId: ThreadId.make("thread-1"),
-        turnCount: 1,
-        createdAt,
-      }),
-    );
-
-    await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
-    const thread = await waitForThread(
-      harness.readModel,
-      (entry) => entry.checkpoints.length === 1,
-    );
-
-    expect(thread.latestTurn?.turnId).toBe("turn-1");
-    expect(thread.checkpoints).toHaveLength(1);
-    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
-    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
-    expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
-      threadId: ThreadId.make("thread-1"),
-      numTurns: 1,
-    });
-    expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
-    expect(
-      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
-    ).toBe(false);
-  });
+        numTurns: 1,
+      });
+      expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "README.md"), "utf8")).toBe(
+        commandType === "thread.conversation.revert" ? "unstaged edit\n" : "v2\n",
+      );
+      if (commandType === "thread.conversation.revert") {
+        expect(NodeFS.readFileSync(NodePath.join(harness.cwd, "scratch.txt"), "utf8")).toBe(
+          "untracked edit\n",
+        );
+        expect(
+          NodeChildProcess.execFileSync("git", ["ls-files", "--stage"], {
+            cwd: harness.cwd,
+            encoding: "utf8",
+          }),
+        ).toBe(indexBefore);
+      }
+      expect(
+        gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.make("thread-1"), 2)),
+      ).toBe(false);
+    },
+  );
 
   it("executes provider revert and emits thread.reverted for claude sessions", async () => {
     const harness = await createHarness({ providerName: ProviderDriverKind.make("claudeAgent") });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -704,16 +704,11 @@ const make = Effect.gen(function* () {
       thread,
       projects: yield* resolveThreadProjects(thread.projectId),
       preferSessionRuntime: true,
-    });
-    if (!checkpointCwd) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: "Checkpoint workspace is unavailable or is not a git repository.",
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
+    }).pipe(
+      Effect.catch((error) =>
+        event.payload.restoreFiles === false ? Effect.succeed(undefined) : Effect.fail(error),
+      ),
+    );
 
     const currentTurnCount = thread.checkpoints.reduce(
       (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
@@ -730,26 +725,36 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const targetCheckpointRef =
-      event.payload.turnCount === 0
-        ? checkpointRefForThreadTurn(event.payload.threadId, 0)
-        : thread.checkpoints.find(
-            (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
-          )?.checkpointRef;
-
-    if (!targetCheckpointRef) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-
     yield* providerService.assertConversationRollbackSupported(event.payload.threadId);
 
     if (event.payload.restoreFiles !== false) {
+      if (!checkpointCwd) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: "Checkpoint workspace is unavailable or is not a git repository.",
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const targetCheckpointRef =
+        event.payload.turnCount === 0
+          ? checkpointRefForThreadTurn(event.payload.threadId, 0)
+          : thread.checkpoints.find(
+              (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+            )?.checkpointRef;
+
+      if (!targetCheckpointRef) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
       const restored = yield* checkpointStore.restoreCheckpoint({
         cwd: checkpointCwd,
         checkpointRef: targetCheckpointRef,
@@ -785,7 +790,7 @@ const make = Effect.gen(function* () {
       }
     }
 
-    if (staleCheckpointRefs.length > 0) {
+    if (checkpointCwd && staleCheckpointRefs.length > 0) {
       yield* checkpointStore.deleteCheckpointRefs({
         cwd: checkpointCwd,
         checkpointRefs: staleCheckpointRefs,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -749,24 +749,26 @@ const make = Effect.gen(function* () {
 
     yield* providerService.assertConversationRollbackSupported(event.payload.threadId);
 
-    const restored = yield* checkpointStore.restoreCheckpoint({
-      cwd: checkpointCwd,
-      checkpointRef: targetCheckpointRef,
-      fallbackToHead: event.payload.turnCount === 0,
-    });
-    if (!restored) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
+    if (event.payload.restoreFiles !== false) {
+      const restored = yield* checkpointStore.restoreCheckpoint({
+        cwd: checkpointCwd,
+        checkpointRef: targetCheckpointRef,
+        fallbackToHead: event.payload.turnCount === 0,
+      });
+      if (!restored) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
 
-    // Refresh the workspace entry index so the @-mention file picker
-    // reflects the reverted filesystem state.
-    yield* workspaceEntries.refresh(checkpointCwd);
+      // Refresh the workspace entry index so the @-mention file picker
+      // reflects the reverted filesystem state.
+      yield* workspaceEntries.refresh(checkpointCwd);
+    }
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1640,6 +1640,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.conversation.revert":
     case "thread.checkpoint.revert": {
       yield* requireThread({
         readModel,
@@ -1657,6 +1658,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           turnCount: command.turnCount,
+          ...(command.type === "thread.conversation.revert" ? { restoreFiles: false } : {}),
           createdAt: command.createdAt,
         },
       };

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -369,7 +369,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             typeof input.sessionID === "string" &&
             typeof input.messageID === "string"
           ) {
-            runtimeMock.state.messages.push({
+            const messages =
+              runtimeMock.state.forkMessagesBySession.get(input.sessionID) ??
+              runtimeMock.state.messages;
+            messages.push({
               info: { id: input.messageID, role: "user" },
               parts: [],
             });
@@ -397,7 +400,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             runtimeMock.state.messageFailures -= 1;
             throw new Error("message lookup failed", { cause: { status: 500 } });
           }
-          const message = runtimeMock.state.messages.find((entry) => entry.info.id === messageID);
+          const messages =
+            runtimeMock.state.forkMessagesBySession.get(sessionID) ?? runtimeMock.state.messages;
+          const message = messages.find((entry) => entry.info.id === messageID);
           if (!message) {
             throw new Error(`Message not found: ${messageID}`, {
               cause: { status: 404, body: { name: "NotFoundError" } },
@@ -6391,11 +6396,17 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       ];
 
-      const originalCursor = (yield* adapter.listSessions())[0]?.resumeCursor;
+      const originalCursor = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === threadId,
+      )?.resumeCursor;
       runtimeMock.state.forkPreservesBoundary = false;
       const boundaryError = yield* adapter.rollbackThread(threadId, 1).pipe(Effect.flip);
       NodeAssert.match(boundaryError.message, /did not preserve the requested rewind boundary/);
-      NodeAssert.deepEqual((yield* adapter.listSessions())[0]?.resumeCursor, originalCursor);
+      NodeAssert.deepEqual(
+        (yield* adapter.listSessions()).find((session) => session.threadId === threadId)
+          ?.resumeCursor,
+        originalCursor,
+      );
       runtimeMock.state.forkPreservesBoundary = true;
 
       for (const numTurns of [0, 1, 2, 3]) {
@@ -6458,6 +6469,29 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         (runtimeMock.state.promptCalls.at(-1) as { sessionID: string }).sessionID,
         "http://127.0.0.1:9999/session_fork_fork",
       );
+      const continuation = runtimeMock.state.promptCalls.at(-1) as {
+        sessionID: string;
+        messageID: string;
+      };
+      runtimeMock.state.forkMessagesBySession.get(continuation.sessionID)!.push({
+        info: { id: "continuation-answer", role: "assistant" },
+        parts: [{ id: "continuation-part", type: "text", text: "continued answer" }],
+      });
+      const continuationCursor = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === threadId,
+      )?.resumeCursor;
+      yield* adapter.stopSession(threadId);
+      yield* adapter.startSession({
+        threadId,
+        runtimeMode: "full-access",
+        resumeCursor: continuationCursor,
+      });
+      NodeAssert.deepEqual(
+        (yield* adapter.readThread(threadId)).turns.map((turn) => turn.id),
+        ["continuation-answer"],
+      );
+      NodeAssert.deepEqual((yield* adapter.rollbackThread(threadId, 1)).turns, []);
+      NodeAssert.equal(runtimeMock.state.forkCalls.at(-1)?.messageID, continuation.messageID);
       yield* adapter.stopSession(threadId);
       yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
       runtimeMock.state.messages = runtimeMock.state.messages.filter(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -97,6 +97,8 @@ const runtimeMock = {
     promptEchoEvents: [] as Array<unknown>,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
+    forkMessagesBySession: new Map<string, MessageEntry[]>(),
+    forkPreservesBoundary: true,
     subscribedEvents: [] as Array<unknown | Promise<unknown>>,
     eventSubscribeObserved: null as (() => void) | null,
     eventStreamError: null as ((cause: unknown) => void) | null,
@@ -128,7 +130,7 @@ const runtimeMock = {
     permissionListImplementation: null as (() => Promise<Array<PermissionRequest>>) | null,
     questionListImplementation: null as (() => Promise<Array<QuestionRequest>>) | null,
     sessionUpdateCalls: [] as Array<{ sessionID: string; permission: unknown }>,
-    forkCalls: [] as Array<{ sessionID: string; directory?: string }>,
+    forkCalls: [] as Array<{ sessionID: string; directory?: string; messageID?: string }>,
   },
   reset() {
     this.state.startCalls.length = 0;
@@ -157,6 +159,8 @@ const runtimeMock = {
     this.state.promptEchoEvents.length = 0;
     this.state.closeError = null;
     this.state.messages = [];
+    this.state.forkMessagesBySession.clear();
+    this.state.forkPreservesBoundary = true;
     this.state.subscribedEvents = [];
     this.state.eventSubscribeObserved = null;
     this.state.eventStreamError = null;
@@ -264,7 +268,8 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           return {
             data: {
               id: sessionID,
-              ...(runtimeMock.state.revertMessageID
+              ...(runtimeMock.state.revertMessageID &&
+              !runtimeMock.state.forkMessagesBySession.has(sessionID)
                 ? { revert: { messageID: runtimeMock.state.revertMessageID } }
                 : {}),
               ...(directory ? { directory } : {}),
@@ -276,10 +281,37 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.sessionUpdateCalls.push({ sessionID, permission });
           return { data: { id: sessionID } };
         },
-        fork: async ({ sessionID, directory }: { sessionID: string; directory?: string }) => {
+        fork: async ({
+          sessionID,
+          directory,
+          messageID,
+        }: {
+          sessionID: string;
+          directory?: string;
+          messageID?: string;
+        }) => {
           // Fork clones history into a new session bound to the directory.
           const forkedId = `${sessionID}_fork`;
-          runtimeMock.state.forkCalls.push({ sessionID, ...(directory ? { directory } : {}) });
+          runtimeMock.state.forkCalls.push({
+            sessionID,
+            ...(directory ? { directory } : {}),
+            ...(messageID ? { messageID } : {}),
+          });
+          if (messageID) {
+            const messages =
+              runtimeMock.state.forkMessagesBySession.get(sessionID) ?? runtimeMock.state.messages;
+            const boundary = messages.findIndex((entry) => entry.info.id === messageID);
+            NodeAssert.notEqual(boundary, -1);
+            runtimeMock.state.forkMessagesBySession.set(
+              forkedId,
+              messages
+                .slice(0, runtimeMock.state.forkPreservesBoundary ? boundary : messages.length)
+                .map((entry) => ({
+                  ...entry,
+                  info: { ...entry.info, id: `${entry.info.id}_fork` },
+                })),
+            );
+          }
           if (directory) {
             runtimeMock.state.sessionDirectoryById.set(forkedId, directory);
           }
@@ -355,7 +387,10 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
           runtimeMock.state.summarizeCalls.push(input);
           return { data: true };
         },
-        messages: async () => ({ data: runtimeMock.state.messages }),
+        messages: async ({ sessionID }: { sessionID: string }) => ({
+          data:
+            runtimeMock.state.forkMessagesBySession.get(sessionID) ?? runtimeMock.state.messages,
+        }),
         message: async ({ sessionID, messageID }: { sessionID: string; messageID: string }) => {
           runtimeMock.state.messageCalls.push({ sessionID, messageID });
           if (runtimeMock.state.messageFailures > 0) {
@@ -6333,7 +6368,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }).pipe(Effect.provide(adapterLayer));
   });
 
-  it.effect("reverts the first removed assistant message and returns only retained turns", () =>
+  it.effect("forks before the removed user prompt and resumes only retained history", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-rollback-all");
@@ -6356,49 +6391,87 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         },
       ];
 
+      const originalCursor = (yield* adapter.listSessions())[0]?.resumeCursor;
+      runtimeMock.state.forkPreservesBoundary = false;
+      const boundaryError = yield* adapter.rollbackThread(threadId, 1).pipe(Effect.flip);
+      NodeAssert.match(boundaryError.message, /did not preserve the requested rewind boundary/);
+      NodeAssert.deepEqual((yield* adapter.listSessions())[0]?.resumeCursor, originalCursor);
+      runtimeMock.state.forkPreservesBoundary = true;
+
       for (const numTurns of [0, 1, 2, 3]) {
-        runtimeMock.state.revertMessageID = undefined;
-        runtimeMock.state.revertCalls.length = 0;
+        yield* adapter.stopSession(threadId);
+        yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
+        runtimeMock.state.forkCalls.length = 0;
         const snapshot = yield* adapter.rollbackThread(threadId, numTurns);
         NodeAssert.deepEqual(
-          runtimeMock.state.revertCalls,
+          runtimeMock.state.forkCalls.map(({ sessionID, messageID }) => ({ sessionID, messageID })),
           numTurns === 0
             ? []
             : [
                 {
                   sessionID: "http://127.0.0.1:9999/session",
-                  messageID: numTurns === 1 ? "assistant-2" : "assistant-1",
+                  messageID: numTurns === 1 ? "user-2" : "user-1",
                 },
               ],
         );
         NodeAssert.deepEqual(
           snapshot.turns.map((turn) => turn.id),
-          ["assistant-1", "assistant-2"].slice(0, Math.max(0, 2 - numTurns)),
+          numTurns === 0
+            ? ["assistant-1", "assistant-2"]
+            : ["assistant-1_fork"].slice(0, Math.max(0, 2 - numTurns)),
         );
+        NodeAssert.deepEqual(runtimeMock.state.revertCalls, []);
       }
-      runtimeMock.state.revertMessageID = undefined;
+      yield* adapter.stopSession(threadId);
+      yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
       for (const remaining of [1, 0]) {
         const snapshot = yield* adapter.rollbackThread(threadId, 1);
         NodeAssert.equal(snapshot.turns.length, remaining);
         NodeAssert.deepEqual((yield* adapter.readThread(threadId)).turns, snapshot.turns);
+        const cursor = (yield* adapter.listSessions()).find(
+          (session) => session.threadId === threadId,
+        )?.resumeCursor;
+        NodeAssert.deepEqual(cursor, {
+          schemaVersion: 1,
+          sessionId:
+            remaining === 1
+              ? "http://127.0.0.1:9999/session_fork"
+              : "http://127.0.0.1:9999/session_fork_fork",
+        });
+        yield* adapter.stopSession(threadId);
+        yield* adapter.startSession({ threadId, runtimeMode: "full-access", resumeCursor: cursor });
+        NodeAssert.deepEqual((yield* adapter.readThread(threadId)).turns, snapshot.turns);
       }
       NodeAssert.deepEqual(
-        runtimeMock.state.revertCalls.slice(-2).map((call) => call.messageID),
-        ["assistant-2", "assistant-1"],
+        runtimeMock.state.forkCalls.slice(-2).map((call) => call.messageID),
+        ["user-2", "user-1_fork"],
       );
-      runtimeMock.state.revertMessageID = undefined;
+      yield* adapter.sendTurn({
+        threadId,
+        input: "continue the retained conversation",
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("opencode"),
+          "anthropic/claude-sonnet-4-5",
+        ),
+      });
+      NodeAssert.equal(
+        (runtimeMock.state.promptCalls.at(-1) as { sessionID: string }).sessionID,
+        "http://127.0.0.1:9999/session_fork_fork",
+      );
+      yield* adapter.stopSession(threadId);
+      yield* adapter.startSession({ threadId, runtimeMode: "full-access" });
       runtimeMock.state.messages = runtimeMock.state.messages.filter(
         (entry) => entry.info.id !== "user-2",
       );
       const sharedUserSnapshot = yield* adapter.rollbackThread(threadId, 1);
-      NodeAssert.equal(runtimeMock.state.revertMessageID, "user-1");
+      NodeAssert.equal(runtimeMock.state.forkCalls.at(-1)?.messageID, "user-1");
       NodeAssert.deepEqual(sharedUserSnapshot.turns, []);
       NodeAssert.deepEqual((yield* adapter.readThread(threadId)).turns, []);
 
       runtimeMock.state.messages = [];
-      runtimeMock.state.revertCalls.length = 0;
+      runtimeMock.state.forkCalls.length = 0;
       const emptySnapshot = yield* adapter.rollbackThread(threadId, 1);
-      NodeAssert.deepEqual(runtimeMock.state.revertCalls, []);
+      NodeAssert.deepEqual(runtimeMock.state.forkCalls, []);
       NodeAssert.deepEqual(emptySnapshot.turns, []);
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -338,7 +338,7 @@ interface OpenCodeSessionContext {
   readonly client: OpencodeClient;
   readonly server: OpenCodeServerConnection;
   readonly directory: string;
-  readonly openCodeSessionId: string;
+  openCodeSessionId: string;
   readonly relatedSessionIds: Set<string>;
   readonly resolvedRequestIds: Set<string>;
   readonly autoRepliedRequestIds: Set<string>;
@@ -3812,14 +3812,89 @@ export function makeOpenCodeAdapter(
         const targetIndex = Math.max(0, snapshot.turns.length - numTurns);
         const target = snapshot.turns[targetIndex];
         if (target) {
-          yield* runOpenCodeSdk("session.revert", () =>
-            context.client.session.revert({
+          const messages = yield* runOpenCodeSdk("session.messages", () =>
+            context.client.session.messages({ sessionID: context.openCodeSessionId }),
+          ).pipe(Effect.mapError(toRequestError));
+          const entries = messages.data ?? [];
+          const targetMessageIndex = entries.findIndex((entry) => entry.info.id === target.id);
+          if (targetMessageIndex < 0) {
+            return yield* toRequestError(
+              new OpenCodeRuntimeError({
+                operation: "session.fork",
+                detail: "The OpenCode rewind boundary is no longer available.",
+              }),
+            );
+          }
+          const firstRemovedMessage =
+            entries
+              .slice(0, targetMessageIndex + 1)
+              .findLast((entry) => entry.info.role === "user") ?? entries[targetMessageIndex]!;
+          // Native revert also rewrites workspace files. Fork only the retained
+          // conversation so T3 alone decides whether filesystem changes survive.
+          const fork = yield* runOpenCodeSdk("session.fork", () =>
+            context.client.session.fork({
               sessionID: context.openCodeSessionId,
-              messageID: target.id,
+              messageID: firstRemovedMessage.info.id,
+              directory: context.directory,
             }),
           ).pipe(Effect.mapError(toRequestError));
-          // Native revert can move the boundary to the preceding user message.
-          return yield* readThread(threadId);
+          if (!fork.data) {
+            return yield* toRequestError(
+              new OpenCodeRuntimeError({
+                operation: "session.fork",
+                detail: "OpenCode session.fork returned no session payload.",
+              }),
+            );
+          }
+          const forkedSessionId = fork.data.id;
+          const forkMessages = yield* runOpenCodeSdk("session.messages", () =>
+            context.client.session.messages({ sessionID: forkedSessionId }),
+          ).pipe(Effect.mapError(toRequestError));
+          if (forkMessages.data?.length !== entries.indexOf(firstRemovedMessage)) {
+            return yield* toRequestError(
+              new OpenCodeRuntimeError({
+                operation: "session.fork",
+                detail: "OpenCode did not preserve the requested rewind boundary.",
+              }),
+            );
+          }
+          yield* runOpenCodeSdk("session.update", () =>
+            context.client.session.update({
+              sessionID: forkedSessionId,
+              permission: buildOpenCodePermissionRules(context.session.runtimeMode),
+            }),
+          ).pipe(Effect.mapError(toRequestError));
+          yield* clearPendingOpenCodeRequests(context, { type: "session.fork" });
+          context.openCodeSessionId = forkedSessionId;
+          context.relatedSessionIds.clear();
+          context.relatedSessionIds.add(forkedSessionId);
+          context.messageRoleById.clear();
+          context.textPartsByMessageId.clear();
+          context.turnTokenUsage = undefined;
+          context.activeTurnId = undefined;
+          context.interruptedTurnId = undefined;
+          context.reconcileIdleStatus = false;
+          context.awaitingBusyAfterInterruption = false;
+          context.pendingIdleReconciliation = undefined;
+          context.session = {
+            ...context.session,
+            resumeCursor: { schemaVersion: OPENCODE_RESUME_VERSION, sessionId: forkedSessionId },
+            updatedAt: yield* nowIso,
+          };
+          yield* emit({
+            ...(yield* buildEventBase({ threadId })),
+            type: "thread.started",
+            payload: { providerThreadId: forkedSessionId },
+          });
+          return {
+            threadId,
+            turns: forkMessages.data
+              .filter((entry) => entry.info.role === "assistant")
+              .map((entry) => ({
+                id: TurnId.make(entry.info.id),
+                items: [entry.info, ...entry.parts],
+              })),
+          };
         }
 
         return snapshot;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6533,8 +6533,14 @@ export default function ChatView(props: ChatViewProps) {
     return () => window.removeEventListener("paste", handler, true);
   }, [activeThreadId, composerRef]);
 
+  const [pendingRevert, setPendingRevert] = useState<{
+    turnCount: number;
+    messageId: MessageId;
+    routeThreadKey: string;
+  } | null>(null);
+
   const onRevertToTurnCount = useCallback(
-    async (turnCount: number, messageId: MessageId) => {
+    async (turnCount: number, messageId: MessageId, restoreFiles?: boolean) => {
       const localApi = readLocalApi();
       if (!localApi || !activeThread || isRevertingCheckpoint) return;
       const message = activeThread.messages.find((message) => message.id === messageId);
@@ -6558,15 +6564,8 @@ export default function ChatView(props: ChatViewProps) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
-      const confirmed = await localApi.dialogs.confirm(
-        [
-          "Edit from here?",
-          "Rewind files and chat to before this message.",
-          "Your prompt and attachments return to the composer.",
-        ].join("\n"),
-        { variant: "destructive" },
-      );
-      if (!confirmed) {
+      if (restoreFiles === undefined) {
+        setPendingRevert({ turnCount, messageId, routeThreadKey });
         return;
       }
 
@@ -6599,7 +6598,7 @@ export default function ChatView(props: ChatViewProps) {
         await waitForRevertedMessage(routeThreadRef, messageId, turnCount, async () => {
           const result = await revertThreadCheckpoint({
             environmentId,
-            input: { threadId: activeThread.id, turnCount },
+            input: { threadId: activeThread.id, turnCount, restoreFiles },
           });
           if (result._tag === "Failure") throw squashAtomCommandFailure(result);
         });
@@ -9144,6 +9143,44 @@ export default function ChatView(props: ChatViewProps) {
         </RightPanelSheet>
       ) : null}
 
+      <AlertDialog
+        open={pendingRevert !== null && pendingRevert.routeThreadKey === routeThreadKey}
+        onOpenChange={(open) => {
+          if (!open) setPendingRevert(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Edit from here?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Rewind chat to before this message. Your prompt and attachments return to the
+              composer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!pendingRevert || pendingRevert.routeThreadKey !== routeThreadKey) return;
+                setPendingRevert(null);
+                void onRevertToTurnCount(pendingRevert.turnCount, pendingRevert.messageId, true);
+              }}
+            >
+              Revert files too
+            </Button>
+            <Button
+              onClick={() => {
+                if (!pendingRevert || pendingRevert.routeThreadKey !== routeThreadKey) return;
+                setPendingRevert(null);
+                void onRevertToTurnCount(pendingRevert.turnCount, pendingRevert.messageId, false);
+              }}
+            >
+              Revert and keep changes
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
       <LinkPullRequestDialogHost />
       {expandedImage && (
         <ExpandedImageDialog

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6539,6 +6539,10 @@ export default function ChatView(props: ChatViewProps) {
     routeThreadKey: string;
   } | null>(null);
 
+  if (pendingRevert && pendingRevert.routeThreadKey !== routeThreadKey) {
+    setPendingRevert(null);
+  }
+
   const onRevertToTurnCount = useCallback(
     async (turnCount: number, messageId: MessageId, restoreFiles?: boolean) => {
       const localApi = readLocalApi();

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -72,9 +72,10 @@ into a normal draft.
 ## Edit an earlier prompt
 
 On web and desktop, choose **Edit from here** beneath a sent message to rewind
-the conversation and workspace files to before that message. The selected prompt
-and its attachments return to the composer for editing and resending. Any unsent
-draft stays above the restored prompt.
+the conversation to before that message. Choose **Revert and keep changes** to
+leave workspace files as they are, or **Revert files too** to restore them as well.
+The selected prompt and its attachments return to the composer for editing and
+resending. Any unsent draft stays above the restored prompt.
 
 This removes the selected message and later conversation from the active thread
 and provider history. It does not undo external actions or separate provider

--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -24,6 +24,7 @@ import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 import {
   archiveThread,
   createProject,
+  revertThreadCheckpoint,
   reorderActiveThread,
   settleThread,
   stopThreadSession,
@@ -97,6 +98,27 @@ describe("environment commands", () => {
           workspaceRoot: "/workspace/project",
           createdAt: "2026-06-06T00:00:00.000Z",
         },
+      ]);
+    }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),
+  );
+
+  it.effect("uses a distinct command when keeping workspace changes", () =>
+    Effect.gen(function* () {
+      const dispatched: ClientOrchestrationCommand[] = [];
+      const supervisor = yield* makeSupervisor(dispatched);
+      for (const restoreFiles of [undefined, true, false]) {
+        yield* revertThreadCheckpoint({
+          commandId: CommandId.make("rewind-command"),
+          threadId: ThreadId.make("thread-1"),
+          turnCount: 0,
+          restoreFiles,
+          createdAt: "2026-06-06T00:01:00.000Z",
+        }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
+      }
+      expect(dispatched.map((command) => command.type)).toEqual([
+        "thread.checkpoint.revert",
+        "thread.checkpoint.revert",
+        "thread.conversation.revert",
       ]);
     }).pipe(Effect.provide(TEST_CRYPTO_LAYER)),
   );

--- a/packages/client-runtime/src/operations/commands.test.ts
+++ b/packages/client-runtime/src/operations/commands.test.ts
@@ -111,7 +111,7 @@ describe("environment commands", () => {
           commandId: CommandId.make("rewind-command"),
           threadId: ThreadId.make("thread-1"),
           turnCount: 0,
-          restoreFiles,
+          ...(restoreFiles !== undefined ? { restoreFiles } : {}),
           createdAt: "2026-06-06T00:01:00.000Z",
         }).pipe(Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor));
       }

--- a/packages/client-runtime/src/operations/commands.ts
+++ b/packages/client-runtime/src/operations/commands.ts
@@ -53,7 +53,9 @@ export type InterruptThreadTurnInput = CommandInput<"thread.turn.interrupt">;
 export type RespondToThreadApprovalInput = CommandInput<"thread.approval.respond">;
 export type RespondToThreadUserInputInput = CommandInput<"thread.user-input.respond">;
 export type DismissThreadUserInputInput = CommandInput<"thread.user-input.dismiss">;
-export type RevertThreadCheckpointInput = CommandInput<"thread.checkpoint.revert">;
+export type RevertThreadCheckpointInput = CommandInput<"thread.checkpoint.revert"> & {
+  readonly restoreFiles?: boolean;
+};
 export type StopThreadSessionInput = CommandInput<"thread.session.stop">;
 
 type DispatchTag = typeof ORCHESTRATION_WS_METHODS.dispatchCommand;
@@ -355,9 +357,10 @@ export const dismissThreadUserInput: (input: DismissThreadUserInputInput) => Com
 export const revertThreadCheckpoint: (input: RevertThreadCheckpointInput) => CommandEffect =
   Effect.fn("EnvironmentCommands.revertThreadCheckpoint")(function* (input) {
     const metadata = yield* timestampedCommandMetadata(input);
+    const { restoreFiles, ...command } = input;
     return yield* dispatch({
-      ...input,
-      type: "thread.checkpoint.revert",
+      ...command,
+      type: restoreFiles === false ? "thread.conversation.revert" : "thread.checkpoint.revert",
       commandId: metadata.commandId,
       createdAt: metadata.createdAt,
     });

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1287,6 +1287,13 @@ const ThreadCheckpointRevertCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+// A separate command makes older servers reject history-only rewinds rather than
+// ignoring an unfamiliar option and restoring files.
+const ThreadConversationRevertCommand = Schema.Struct({
+  ...ThreadCheckpointRevertCommand.fields,
+  type: Schema.Literal("thread.conversation.revert"),
+});
+
 const ThreadSessionStopCommand = Schema.Struct({
   type: Schema.Literal("thread.session.stop"),
   commandId: CommandId,
@@ -1327,6 +1334,7 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadUserInputDismissCommand,
   ThreadCheckpointRevertCommand,
+  ThreadConversationRevertCommand,
   ThreadSessionStopCommand,
 ]);
 export type DispatchableClientOrchestrationCommand =
@@ -1359,6 +1367,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadUserInputDismissCommand,
   ThreadCheckpointRevertCommand,
+  ThreadConversationRevertCommand,
   ThreadSessionStopCommand,
 ]);
 export type ClientOrchestrationCommand = typeof ClientOrchestrationCommand.Type;
@@ -1762,6 +1771,7 @@ const ThreadUserInputResponseRequestedPayload = Schema.Struct({
 export const ThreadCheckpointRevertRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   turnCount: NonNegativeInt,
+  restoreFiles: Schema.optional(Schema.Boolean),
   createdAt: IsoDateTime,
 });
 


### PR DESCRIPTION
Rewinding a prompt now offers **Revert and keep changes**, which removes later chat history and restores the prompt for editing while leaving workspace files and staging intact. **Revert files too** preserves the existing filesystem restore action. A distinct command lets older servers reject the new action safely; OpenCode forks retained history so its native revert cannot undo files behind this choice.

Verified real Codex, Claude, and OpenCode file edits, keep-files rewind, prompt editing/resend, unchanged staged/unstaged/untracked contents, and full-file restore. Claude and OpenCode continuation confirm discarded prompts are absent from provider history. Nongit keep-files rewind passes through the real OpenCode client path. All 151 focused existing tests pass; server/web/client-runtime typechecks and scoped lint/formatting pass.

Cursor and Grok do not support provider history rollback; the existing unavailable controls remain unchanged. Antigravity is not installed. The dialog is shared by web and desktop; the mobile action retains its existing file-restore behavior.

![before: rewind always restores files](https://uploads-production-47e4.up.railway.app/files/115a9559-4f9f-4e10-b86e-be872cc4a924/rewind-copy-after.png)

![after: choose whether to keep file changes](https://uploads-production-47e4.up.railway.app/files/7c684222-36ef-41bd-ab89-afdad5ba3979/keep-files-dialog-after.png)

![opencode: keep files, edit the restored prompt, and resend](https://uploads-production-47e4.up.railway.app/files/a32b54e4-e7ca-48d6-8571-b9bd99389e28/keep-files-opencode.gif)

![claude: keep files, restore the prompt, edit and resend](https://uploads-production-47e4.up.railway.app/files/38e715f1-c463-4a16-83de-229ea0dcf274/keep-files-claude.gif)

Implemented with GPT-6 in Codex.
