### PR TITLE
feat(mcp): add t3_thread_start for handing work to a new thread

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -15,6 +15,7 @@ import { HttpBody, HttpClient, HttpRouter, HttpServerResponse } from "effect/uns
 
 import { OrchestrationEngineService } from "../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadBootstrap } from "../orchestration/Services/ThreadBootstrap.ts";
 import * as ServerConfig from "../config.ts";
 import * as McpHttpServer from "./McpHttpServer.ts";
 import * as McpInvocationContext from "./McpInvocationContext.ts";
@@ -59,6 +60,19 @@ const PullRequestsTestLayer = McpHttpServer.PullRequestsToolkitRegistrationLive.
         getThreadShellById: () => Effect.succeed(Option.none()),
       }),
       Layer.mock(OrchestrationEngineService)({}),
+      NodeServices.layer,
+    ),
+  ),
+);
+
+const ThreadsTestLayer = McpHttpServer.ThreadsToolkitRegistrationLive.pipe(
+  Layer.provideMerge(McpServer.McpServer.layer),
+  Layer.provide(
+    Layer.mergeAll(
+      Layer.mock(ProjectionSnapshotQuery)({
+        getThreadShellById: () => Effect.succeed(Option.none()),
+      }),
+      Layer.mock(ThreadBootstrap)({}),
       NodeServices.layer,
     ),
   ),
@@ -398,6 +412,27 @@ it.effect(
         { type: "text", text: "MCP credential does not grant the pull-requests capability." },
       ]);
     }).pipe(Effect.provide(PullRequestsTestLayer)),
+);
+
+it.effect("registers the threads toolkit and surfaces a missing capability as a tool error", () =>
+  Effect.gen(function* () {
+    const server = yield* McpServer.McpServer;
+    const startTool = server.tools.find(({ tool }) => tool.name === "t3_thread_start");
+    expect(startTool?.tool.annotations?.destructiveHint).toBe(false);
+    expect(startTool?.tool.annotations?.openWorldHint).toBe(false);
+    expect(startTool?.tool.description).toContain("NEW top-level T3 Code thread");
+
+    const denied = yield* server
+      .callTool({ name: "t3_thread_start", arguments: { prompt: "Continue the migration." } })
+      .pipe(
+        Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+        Effect.provideService(McpSchema.McpServerClient, client),
+      );
+    expect(denied.isError).toBe(true);
+    expect(denied.content).toEqual([
+      { type: "text", text: "MCP credential does not grant the threads capability." },
+    ]);
+  }).pipe(Effect.provide(ThreadsTestLayer)),
 );
 
 it.effect("keeps the snapshot text under the agent's output ceiling", () =>

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -31,6 +31,8 @@ import {
 } from "./toolkits/preview/tools.ts";
 import { PullRequestsToolkitHandlersLive } from "./toolkits/pullRequests/handlers.ts";
 import { PullRequestsToolkit } from "./toolkits/pullRequests/tools.ts";
+import { ThreadsToolkitHandlersLive } from "./toolkits/threads/handlers.ts";
+import { ThreadsToolkit } from "./toolkits/threads/tools.ts";
 import {
   DeviceScreenshotToolkitHandlersLive,
   DeviceStandardToolkitHandlersLive,
@@ -608,6 +610,10 @@ export const PullRequestsToolkitRegistrationLive = McpServer.toolkit(PullRequest
   Layer.provide(PullRequestsToolkitHandlersLive),
 );
 
+export const ThreadsToolkitRegistrationLive = McpServer.toolkit(ThreadsToolkit).pipe(
+  Layer.provide(ThreadsToolkitHandlersLive),
+);
+
 const DeviceStandardToolkitRegistrationLive = McpServer.toolkit(DeviceStandardToolkit).pipe(
   Layer.provide(DeviceStandardToolkitHandlersLive),
 );
@@ -631,5 +637,6 @@ const McpTransportLive = McpServer.layerHttp({
 export const layer = Layer.mergeAll(
   PreviewToolkitRegistrationLive,
   PullRequestsToolkitRegistrationLive,
+  ThreadsToolkitRegistrationLive,
   DeviceToolkitRegistrationLive,
 ).pipe(Layer.provideMerge(McpTransportLive));

--- a/apps/server/src/mcp/McpInvocationContext.test.ts
+++ b/apps/server/src/mcp/McpInvocationContext.test.ts
@@ -57,6 +57,13 @@ it.effect("reports other missing capabilities with the neutral error", () => {
     expect(error).toBeInstanceOf(McpCapabilityUnavailableError);
     expect(error).toMatchObject({ capability: "pull-requests", threadId: invocation.threadId });
 
+    const threadsError = yield* McpInvocationContext.requireMcpCapability("threads").pipe(
+      Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+      Effect.flip,
+    );
+    expect(threadsError).toBeInstanceOf(McpCapabilityUnavailableError);
+    expect(threadsError).toMatchObject({ capability: "threads", threadId: invocation.threadId });
+
     const scope = yield* McpInvocationContext.requireMcpCapability("preview").pipe(
       Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
     );

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -8,7 +8,7 @@ import {
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
-export type McpCapability = "preview" | "device" | "pull-requests";
+export type McpCapability = "preview" | "device" | "pull-requests" | "threads";
 
 export interface McpInvocationScope {
   readonly environmentId: EnvironmentId;

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -55,33 +55,35 @@ it.effect("stores only a token hash, resolves the bearer token, and revokes by t
   }),
 );
 
-it.effect("always grants pull-requests and gates browser and device access independently", () =>
-  Effect.gen(function* () {
-    const registry = yield* makeRegistry(() => 1_000);
-    const withPreview = yield* registry.issue({
-      threadId: ThreadId.make("thread-preview"),
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      capabilities: new Set(["preview"]),
-    });
-    const withoutPreview = yield* registry.issue({
-      threadId: ThreadId.make("thread-no-preview"),
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      capabilities: new Set(),
-    });
-    const withDevice = yield* registry.issue({
-      threadId: ThreadId.make("thread-device"),
-      providerInstanceId: ProviderInstanceId.make("codex"),
-      capabilities: new Set(["device"]),
-    });
-    const capabilitiesOf = (issued: typeof withPreview) =>
-      registry
-        .resolve(issued.config.authorizationHeader.replace(/^Bearer\s+/, ""))
-        .pipe(Effect.map((scope) => [...(scope?.capabilities ?? [])].sort()));
+it.effect(
+  "always grants pull-requests and threads and gates browser and device access independently",
+  () =>
+    Effect.gen(function* () {
+      const registry = yield* makeRegistry(() => 1_000);
+      const withPreview = yield* registry.issue({
+        threadId: ThreadId.make("thread-preview"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["preview"]),
+      });
+      const withoutPreview = yield* registry.issue({
+        threadId: ThreadId.make("thread-no-preview"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(),
+      });
+      const withDevice = yield* registry.issue({
+        threadId: ThreadId.make("thread-device"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        capabilities: new Set(["device"]),
+      });
+      const capabilitiesOf = (issued: typeof withPreview) =>
+        registry
+          .resolve(issued.config.authorizationHeader.replace(/^Bearer\s+/, ""))
+          .pipe(Effect.map((scope) => [...(scope?.capabilities ?? [])].sort()));
 
-    expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests"]);
-    expect(yield* capabilitiesOf(withoutPreview)).toEqual(["pull-requests"]);
-    expect(yield* capabilitiesOf(withDevice)).toEqual(["device", "pull-requests"]);
-  }),
+      expect(yield* capabilitiesOf(withPreview)).toEqual(["preview", "pull-requests", "threads"]);
+      expect(yield* capabilitiesOf(withoutPreview)).toEqual(["pull-requests", "threads"]);
+      expect(yield* capabilitiesOf(withDevice)).toEqual(["device", "pull-requests", "threads"]);
+    }),
 );
 
 it.effect("builds MCP endpoints from the bound server host", () =>

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -131,6 +131,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         providerInstanceId: ProviderInstanceId.make(request.providerInstanceId),
         capabilities: new Set<McpInvocationContext.McpCapability>([
           "pull-requests",
+          "threads",
           ...request.capabilities,
         ]),
         issuedAt,

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -96,6 +96,7 @@ interface HarnessOptions {
   readonly project?: OrchestrationProjectShell | null;
   readonly existing?: ReadonlyMap<string, OrchestrationThreadShell>;
   readonly failDispatch?: boolean;
+  readonly appearsAfterFailedDispatch?: OrchestrationThreadShell;
 }
 
 const makeHarness = Effect.fn("makeThreadsToolkitHarness")(function* (
@@ -104,7 +105,7 @@ const makeHarness = Effect.fn("makeThreadsToolkitHarness")(function* (
   const commands = yield* Ref.make<ReadonlyArray<TurnStart>>([]);
   const thread = options.thread === undefined ? makeThread() : options.thread;
   const project = options.project === undefined ? makeProject() : options.project;
-  const existing = options.existing ?? new Map();
+  const existing = new Map(options.existing ?? []);
   const dependencies = Layer.mergeAll(
     Layer.mock(ProjectionSnapshotQuery)({
       getThreadShellById: (threadId) =>
@@ -116,12 +117,20 @@ const makeHarness = Effect.fn("makeThreadsToolkitHarness")(function* (
       getProjectShellById: () => Effect.succeed(Option.fromNullishOr(project)),
     }),
     Layer.mock(ThreadBootstrap)({
-      dispatchTurnStart: (command) =>
-        options.failDispatch
+      dispatchTurnStart: (command) => {
+        const raced = options.appearsAfterFailedDispatch;
+        if (raced) {
+          existing.set(raced.id, raced);
+          return Effect.fail(
+            new OrchestrationDispatchCommandError({ message: "Thread already exists." }),
+          );
+        }
+        return options.failDispatch
           ? Effect.fail(new OrchestrationDispatchCommandError({ message: "worktree exists" }))
           : Ref.update(commands, (recorded) => [...recorded, command]).pipe(
               Effect.as({ sequence: 1 }),
-            ),
+            );
+      },
     }),
     Layer.succeed(Crypto.Crypto, testCrypto),
   );
@@ -313,6 +322,23 @@ describe("threads toolkit handlers", () => {
         alreadyStarted: true,
       });
       expect(yield* harness.dispatched).toEqual([]);
+    }),
+  );
+
+  it.effect("returns the thread a concurrent call created under the same clientRequestId", () =>
+    Effect.gen(function* () {
+      const probe = yield* makeHarness();
+      const created = yield* probe.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      const raced = makeThread({ id: ThreadId.make(created.threadId), title: "Raced" });
+      const harness = yield* makeHarness({ appearsAfterFailedDispatch: raced });
+      const result = yield* harness.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      expect(result.threadId).toBe(created.threadId);
+      expect(result.title).toBe("Raced");
+      expect(result.alreadyStarted).toBe(true);
+
+      const noKey = yield* makeHarness({ appearsAfterFailedDispatch: raced });
+      const error = yield* noKey.call({ prompt: PROMPT }).pipe(Effect.flip);
+      expect(error._tag).toBe("ThreadStartFailedError");
     }),
   );
 

--- a/apps/server/src/mcp/toolkits/threads/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.test.ts
@@ -1,0 +1,358 @@
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationCommand,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Stream from "effect/Stream";
+import type { Tool } from "effect/unstable/ai";
+
+import { OrchestrationDispatchCommandError } from "@t3tools/contracts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadBootstrap } from "../../../orchestration/Services/ThreadBootstrap.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { defaultThreadTitle, ThreadsToolkitHandlersLive } from "./handlers.ts";
+import { ThreadsToolkit } from "./tools.ts";
+
+const PROJECT_ID = ProjectId.make("project-1");
+const THREAD_ID = ThreadId.make("thread-1");
+const CODEX = ProviderInstanceId.make("codex");
+const CLAUDE = ProviderInstanceId.make("claude");
+
+const testCrypto = Crypto.make({
+  randomBytes: (size) => new Uint8Array(size).fill(0xab),
+  digest: (_algorithm, data) => {
+    const out = new Uint8Array(32);
+    for (let index = 0; index < data.length; index += 1) {
+      out[index % 32] = (out[index % 32]! + data[index]!) & 0xff;
+    }
+    return Effect.succeed(out);
+  },
+});
+
+const invocation = (
+  capabilities: ReadonlyArray<McpInvocationContext.McpCapability>,
+): McpInvocationContext.McpInvocationScope => ({
+  environmentId: EnvironmentId.make("environment-1"),
+  threadId: THREAD_ID,
+  providerSessionId: "provider-session-1",
+  providerInstanceId: CODEX,
+  capabilities: new Set(capabilities),
+  issuedAt: 1,
+});
+
+function makeProject(): OrchestrationProjectShell {
+  return {
+    id: PROJECT_ID,
+    title: "Project",
+    workspaceRoot: "/workspace/project",
+    defaultModelSelection: null,
+    scripts: [],
+    repositoryIdentity: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  };
+}
+
+function makeThread(overrides: Partial<OrchestrationThreadShell> = {}): OrchestrationThreadShell {
+  return {
+    id: THREAD_ID,
+    projectId: PROJECT_ID,
+    title: "API review",
+    modelSelection: { instanceId: CODEX, model: "gpt-5" },
+    runtimeMode: "auto-accept-edits",
+    interactionMode: "default",
+    branch: "feature/api",
+    worktreePath: "/workspace/project/.worktrees/api",
+    pullRequests: [],
+    latestTurn: null,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-20T00:00:00.000Z",
+    archivedAt: null,
+    settledOverride: null,
+    settledAt: null,
+    session: null,
+    latestUserMessageAt: "2026-08-20T00:00:00.000Z",
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  };
+}
+
+type TurnStart = Extract<OrchestrationCommand, { type: "thread.turn.start" }>;
+
+interface HarnessOptions {
+  readonly thread?: OrchestrationThreadShell | null;
+  readonly project?: OrchestrationProjectShell | null;
+  readonly existing?: ReadonlyMap<string, OrchestrationThreadShell>;
+  readonly failDispatch?: boolean;
+}
+
+const makeHarness = Effect.fn("makeThreadsToolkitHarness")(function* (
+  options: HarnessOptions = {},
+) {
+  const commands = yield* Ref.make<ReadonlyArray<TurnStart>>([]);
+  const thread = options.thread === undefined ? makeThread() : options.thread;
+  const project = options.project === undefined ? makeProject() : options.project;
+  const existing = options.existing ?? new Map();
+  const dependencies = Layer.mergeAll(
+    Layer.mock(ProjectionSnapshotQuery)({
+      getThreadShellById: (threadId) =>
+        Effect.succeed(
+          threadId === THREAD_ID
+            ? Option.fromNullishOr(thread)
+            : Option.fromNullishOr(existing.get(threadId)),
+        ),
+      getProjectShellById: () => Effect.succeed(Option.fromNullishOr(project)),
+    }),
+    Layer.mock(ThreadBootstrap)({
+      dispatchTurnStart: (command) =>
+        options.failDispatch
+          ? Effect.fail(new OrchestrationDispatchCommandError({ message: "worktree exists" }))
+          : Ref.update(commands, (recorded) => [...recorded, command]).pipe(
+              Effect.as({ sequence: 1 }),
+            ),
+    }),
+    Layer.succeed(Crypto.Crypto, testCrypto),
+  );
+  const toolkit = yield* ThreadsToolkit.pipe(
+    Effect.provide(ThreadsToolkitHandlersLive.pipe(Layer.provide(dependencies))),
+  );
+  const call = (
+    params: Parameters<typeof toolkit.handle<"t3_thread_start">>[1],
+    capabilities: ReadonlyArray<McpInvocationContext.McpCapability> = ["threads"],
+  ) =>
+    toolkit.handle("t3_thread_start", params).pipe(
+      Stream.unwrap,
+      Stream.runCollect,
+      Effect.map(
+        (chunk) =>
+          chunk.at(-1)!.result as Tool.Success<(typeof ThreadsToolkit.tools)["t3_thread_start"]>,
+      ),
+      Effect.provideService(McpInvocationContext.McpInvocationContext, invocation(capabilities)),
+      Effect.provide(dependencies),
+    );
+  const dispatched = Ref.get(commands);
+  return { call, dispatched };
+});
+
+const PROMPT = "Finish the pagination fix\n\nThe cursor is in src/api/list.ts.";
+
+describe("threads toolkit handlers", () => {
+  it.effect("refuses a credential without the threads capability", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const error = yield* harness.call({ prompt: PROMPT }, ["preview"]).pipe(Effect.flip);
+      expect(error).toMatchObject({
+        _tag: "McpCapabilityUnavailableError",
+        capability: "threads",
+        threadId: THREAD_ID,
+      });
+      expect(yield* harness.dispatched).toEqual([]);
+    }),
+  );
+
+  it.effect("creates and starts a sibling thread that inherits the caller's settings", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const result = yield* harness.call({ prompt: PROMPT });
+      const [command] = yield* harness.dispatched;
+
+      expect(result).toEqual({
+        threadId: "abababab-abab-4bab-abab-abababababab",
+        title: "Finish the pagination fix",
+        modelSelection: { instanceId: CODEX, model: "gpt-5" },
+        runtimeMode: "auto-accept-edits",
+        interactionMode: "default",
+        branch: "feature/api",
+        worktreePath: "/workspace/project/.worktrees/api",
+        alreadyStarted: false,
+      });
+      expect(command?.message.text).toBe(
+        `> Handed off from T3 thread "API review" (thread-1).\n\n${PROMPT}`,
+      );
+      expect(command?.titleSeed).toBe("Finish the pagination fix");
+      expect(command?.bootstrap).toEqual({
+        createThread: {
+          projectId: PROJECT_ID,
+          title: "Finish the pagination fix",
+          modelSelection: { instanceId: CODEX, model: "gpt-5" },
+          runtimeMode: "auto-accept-edits",
+          interactionMode: "default",
+          branch: "feature/api",
+          worktreePath: "/workspace/project/.worktrees/api",
+          createdAt: command?.createdAt,
+        },
+      });
+      expect(command?.threadId).toBe("abababab-abab-4bab-abab-abababababab");
+      expect(command?.commandId).toMatch(/^server:mcp-thread-start:thread-1:/);
+    }),
+  );
+
+  it.effect("uses an explicit title and skips the title seed", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const result = yield* harness.call({ prompt: PROMPT, title: "Pagination" });
+      const [command] = yield* harness.dispatched;
+      expect(result.title).toBe("Pagination");
+      expect(command?.bootstrap?.createThread?.title).toBe("Pagination");
+      expect(command?.titleSeed).toBeUndefined();
+    }),
+  );
+
+  it.effect("applies model and interaction overrides but keeps the caller's permission mode", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const result = yield* harness.call({
+        prompt: PROMPT,
+        modelSelection: { instanceId: CLAUDE, model: "claude-opus-5" },
+        interactionMode: "plan",
+      });
+      const [command] = yield* harness.dispatched;
+      expect(result.modelSelection).toEqual({ instanceId: CLAUDE, model: "claude-opus-5" });
+      expect(result.interactionMode).toBe("plan");
+      expect(result.runtimeMode).toBe("auto-accept-edits");
+      expect(command?.modelSelection).toEqual({ instanceId: CLAUDE, model: "claude-opus-5" });
+      expect(command?.interactionMode).toBe("plan");
+      expect(command?.runtimeMode).toBe("auto-accept-edits");
+      expect(command?.bootstrap?.createThread?.modelSelection).toEqual({
+        instanceId: CLAUDE,
+        model: "claude-opus-5",
+      });
+    }),
+  );
+
+  it.effect("prepares a fresh worktree from the caller's branch when asked", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* harness.call({ prompt: PROMPT, worktree: {} });
+      const [command] = yield* harness.dispatched;
+      expect(command?.bootstrap).toEqual({
+        createThread: expect.objectContaining({ branch: null, worktreePath: null }),
+        prepareWorktree: {
+          projectCwd: "/workspace/project",
+          baseBranch: "feature/api",
+          branch: "t3code/abababab",
+        },
+        runSetupScript: true,
+      });
+    }),
+  );
+
+  it.effect("passes explicit worktree options through", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      yield* harness.call({
+        prompt: PROMPT,
+        worktree: { baseBranch: "main", branch: "feat/pagination", startFromOrigin: true },
+      });
+      const [command] = yield* harness.dispatched;
+      expect(command?.bootstrap?.prepareWorktree).toEqual({
+        projectCwd: "/workspace/project",
+        baseBranch: "main",
+        branch: "feat/pagination",
+        startFromOrigin: true,
+      });
+    }),
+  );
+
+  it.effect("requires a base branch for a worktree when the caller has none", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ thread: makeThread({ branch: null }) });
+      const error = yield* harness.call({ prompt: PROMPT, worktree: {} }).pipe(Effect.flip);
+      expect(error._tag).toBe("ThreadStartWorktreeBaseRequiredError");
+      expect(yield* harness.dispatched).toEqual([]);
+    }),
+  );
+
+  it.effect("derives the thread and command ids from clientRequestId", () =>
+    Effect.gen(function* () {
+      const first = yield* makeHarness();
+      const second = yield* makeHarness();
+      const a = yield* first.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      const b = yield* second.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      expect(a.threadId).toBe(b.threadId);
+      expect(a.threadId).not.toBe("abababab-abab-4bab-abab-abababababab");
+      const [commandA] = yield* first.dispatched;
+      const [commandB] = yield* second.dispatched;
+      expect(commandA?.commandId).toBe("server:mcp-thread-start:thread-1:req-1");
+      expect(commandB?.commandId).toBe("server:mcp-thread-start:thread-1:req-1");
+    }),
+  );
+
+  it.effect("returns the existing thread for a repeated clientRequestId", () =>
+    Effect.gen(function* () {
+      const probe = yield* makeHarness();
+      const created = yield* probe.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      const existingThread = makeThread({
+        id: ThreadId.make(created.threadId),
+        title: "Finish the pagination fix",
+      });
+      const harness = yield* makeHarness({
+        existing: new Map([[created.threadId, existingThread]]),
+      });
+      const result = yield* harness.call({ prompt: PROMPT, clientRequestId: "req-1" });
+      expect(result).toEqual({
+        threadId: created.threadId,
+        title: "Finish the pagination fix",
+        modelSelection: { instanceId: CODEX, model: "gpt-5" },
+        runtimeMode: "auto-accept-edits",
+        interactionMode: "default",
+        branch: "feature/api",
+        worktreePath: "/workspace/project/.worktrees/api",
+        alreadyStarted: true,
+      });
+      expect(yield* harness.dispatched).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects an archived caller and a missing project", () =>
+    Effect.gen(function* () {
+      const archived = yield* makeHarness({
+        thread: makeThread({ archivedAt: "2026-08-21T00:00:00.000Z" }),
+      });
+      const archivedError = yield* archived.call({ prompt: PROMPT }).pipe(Effect.flip);
+      expect(archivedError).toMatchObject({
+        _tag: "ThreadStartCallerArchivedError",
+        threadId: THREAD_ID,
+      });
+
+      const orphan = yield* makeHarness({ project: null });
+      const orphanError = yield* orphan.call({ prompt: PROMPT }).pipe(Effect.flip);
+      expect(orphanError).toMatchObject({
+        _tag: "ThreadStartProjectNotFoundError",
+        projectId: PROJECT_ID,
+      });
+    }),
+  );
+
+  it.effect("surfaces a bootstrap failure as ThreadStartFailedError", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness({ failDispatch: true });
+      const error = yield* harness.call({ prompt: PROMPT }).pipe(Effect.flip);
+      expect(error._tag).toBe("ThreadStartFailedError");
+    }),
+  );
+});
+
+describe("defaultThreadTitle", () => {
+  it("takes the first non-empty line", () => {
+    expect(defaultThreadTitle("\n\n  Ship it  \nmore")).toBe("Ship it");
+  });
+
+  it("truncates long lines with an ellipsis", () => {
+    const long = "x".repeat(100);
+    expect(defaultThreadTitle(long)).toBe(`${"x".repeat(79)}…`);
+    expect(defaultThreadTitle(long)).toHaveLength(80);
+  });
+});

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -1,0 +1,208 @@
+import {
+  CommandId,
+  MessageId,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+  ThreadId,
+  type ThreadTurnStartBootstrap,
+} from "@t3tools/contracts";
+import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import * as Cause from "effect/Cause";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ThreadBootstrap from "../../../orchestration/Services/ThreadBootstrap.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import {
+  ThreadStartCallerArchivedError,
+  ThreadStartCallerNotFoundError,
+  ThreadStartFailedError,
+  type ThreadStartInput,
+  ThreadStartProjectNotFoundError,
+  type ThreadStartResult,
+  ThreadStartWorktreeBaseRequiredError,
+  ThreadsToolkit,
+} from "./tools.ts";
+
+const TITLE_MAX_CHARS = 80;
+
+export function defaultThreadTitle(prompt: string): string {
+  const firstLine =
+    prompt
+      .split("\n")
+      .find((line) => line.trim().length > 0)
+      ?.trim() ?? prompt;
+  return firstLine.length <= TITLE_MAX_CHARS
+    ? firstLine
+    : `${firstLine.slice(0, TITLE_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+export function handoffMessageText(
+  caller: Pick<OrchestrationThreadShell, "id" | "title">,
+  prompt: string,
+): string {
+  return `> Handed off from T3 thread "${caller.title}" (${caller.id}).\n\n${prompt}`;
+}
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const uuidFromHex = (hex: string): string =>
+  `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+
+const make = Effect.gen(function* () {
+  const snapshots = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
+  const bootstrap = yield* ThreadBootstrap.ThreadBootstrap;
+  const crypto = yield* Crypto.Crypto;
+
+  const randomUUID = crypto.randomUUIDv4.pipe(Effect.orDie);
+  const randomHex = (byteLength: number) =>
+    crypto.randomBytes(byteLength).pipe(Effect.map(bytesToHex), Effect.orDie);
+  const deterministicUUID = (seed: string) =>
+    crypto
+      .digest("SHA-256", new TextEncoder().encode(seed))
+      .pipe(Effect.map(bytesToHex), Effect.map(uuidFromHex), Effect.orDie);
+
+  const readThread = (threadId: ThreadId) =>
+    snapshots
+      .getThreadShellById(threadId)
+      .pipe(Effect.mapError((cause) => new ThreadStartFailedError({ cause })));
+
+  const resultOf = (
+    thread: Pick<
+      OrchestrationThreadShell,
+      | "id"
+      | "title"
+      | "modelSelection"
+      | "runtimeMode"
+      | "interactionMode"
+      | "branch"
+      | "worktreePath"
+    >,
+    alreadyStarted: boolean,
+  ): ThreadStartResult => ({
+    threadId: thread.id,
+    title: thread.title,
+    modelSelection: thread.modelSelection,
+    runtimeMode: thread.runtimeMode,
+    interactionMode: thread.interactionMode,
+    branch: thread.branch,
+    worktreePath: thread.worktreePath,
+    alreadyStarted,
+  });
+
+  const worktreeBootstrap = Effect.fn("ThreadsToolkit.worktreeBootstrap")(function* (
+    input: NonNullable<ThreadStartInput["worktree"]>,
+    caller: OrchestrationThreadShell,
+    project: OrchestrationProjectShell,
+  ) {
+    const baseBranch = input.baseBranch ?? caller.branch;
+    if (baseBranch === null) {
+      return yield* new ThreadStartWorktreeBaseRequiredError({});
+    }
+    const hex = yield* randomHex(4);
+    const branch = input.branch ?? buildTemporaryWorktreeBranchName(() => hex);
+    return {
+      projectCwd: project.workspaceRoot,
+      baseBranch,
+      branch,
+      ...(input.startFromOrigin === true ? { startFromOrigin: true } : {}),
+    } satisfies NonNullable<ThreadTurnStartBootstrap["prepareWorktree"]>;
+  });
+
+  const start = Effect.fn("ThreadsToolkit.t3_thread_start")(function* (input: ThreadStartInput) {
+    const scope = yield* McpInvocationContext.requireMcpCapability("threads");
+    const caller = yield* readThread(scope.threadId);
+    if (Option.isNone(caller)) {
+      return yield* new ThreadStartCallerNotFoundError({ threadId: scope.threadId });
+    }
+    if (caller.value.archivedAt !== null) {
+      return yield* new ThreadStartCallerArchivedError({ threadId: scope.threadId });
+    }
+    const project = yield* snapshots
+      .getProjectShellById(caller.value.projectId)
+      .pipe(Effect.mapError((cause) => new ThreadStartFailedError({ cause })));
+    if (Option.isNone(project)) {
+      return yield* new ThreadStartProjectNotFoundError({ projectId: caller.value.projectId });
+    }
+
+    const requestKey = input.clientRequestId;
+    const threadId = ThreadId.make(
+      requestKey === undefined
+        ? yield* randomUUID
+        : yield* deterministicUUID(`${scope.threadId}\n${requestKey}`),
+    );
+    if (requestKey !== undefined) {
+      const existing = yield* readThread(threadId);
+      if (Option.isSome(existing)) {
+        return resultOf(existing.value, true);
+      }
+    }
+    const commandId = CommandId.make(
+      `server:mcp-thread-start:${scope.threadId}:${requestKey ?? (yield* randomUUID)}`,
+    );
+    const messageId = MessageId.make(yield* randomUUID);
+
+    const modelSelection = input.modelSelection ?? caller.value.modelSelection;
+    const interactionMode = input.interactionMode ?? caller.value.interactionMode;
+    const runtimeMode = caller.value.runtimeMode;
+    const titleSeed = defaultThreadTitle(input.prompt);
+    const title = input.title ?? titleSeed;
+    const createdAt = DateTime.formatIso(yield* DateTime.now);
+
+    const prepareWorktree = input.worktree
+      ? yield* worktreeBootstrap(input.worktree, caller.value, project.value)
+      : undefined;
+    const createThread = {
+      projectId: caller.value.projectId,
+      title,
+      modelSelection,
+      runtimeMode,
+      interactionMode,
+      branch: prepareWorktree ? null : caller.value.branch,
+      worktreePath: prepareWorktree ? null : caller.value.worktreePath,
+      createdAt,
+    };
+
+    yield* bootstrap
+      .dispatchTurnStart({
+        type: "thread.turn.start",
+        commandId,
+        threadId,
+        message: {
+          messageId,
+          role: "user",
+          text: handoffMessageText(caller.value, input.prompt),
+          attachments: [],
+        },
+        modelSelection,
+        ...(input.title === undefined ? { titleSeed } : {}),
+        runtimeMode,
+        interactionMode,
+        bootstrap: {
+          createThread,
+          ...(prepareWorktree ? { prepareWorktree, runSetupScript: true } : {}),
+        },
+        createdAt,
+      })
+      .pipe(
+        Effect.catchCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.failCause(cause as Cause.Cause<never>)
+            : Effect.fail(new ThreadStartFailedError({ cause })),
+        ),
+      );
+
+    const started = yield* readThread(threadId);
+    return Option.isSome(started)
+      ? resultOf(started.value, false)
+      : resultOf({ id: threadId, ...createThread }, false);
+  });
+
+  return ThreadsToolkit.of({ t3_thread_start: start });
+});
+
+export const ThreadsToolkitHandlersLive = ThreadsToolkit.toLayer(make);

--- a/apps/server/src/mcp/toolkits/threads/handlers.ts
+++ b/apps/server/src/mcp/toolkits/threads/handlers.ts
@@ -167,7 +167,7 @@ const make = Effect.gen(function* () {
       createdAt,
     };
 
-    yield* bootstrap
+    const alreadyStarted = yield* bootstrap
       .dispatchTurnStart({
         type: "thread.turn.start",
         commandId,
@@ -194,11 +194,21 @@ const make = Effect.gen(function* () {
             ? Effect.failCause(cause as Cause.Cause<never>)
             : Effect.fail(new ThreadStartFailedError({ cause })),
         ),
+        Effect.as(false),
+        requestKey === undefined
+          ? (effect) => effect
+          : Effect.catchTag("ThreadStartFailedError", (error) =>
+              readThread(threadId).pipe(
+                Effect.flatMap((thread) =>
+                  Option.isSome(thread) ? Effect.succeed(true) : Effect.fail(error),
+                ),
+              ),
+            ),
       );
 
     const started = yield* readThread(threadId);
     return Option.isSome(started)
-      ? resultOf(started.value, false)
+      ? resultOf(started.value, alreadyStarted)
       : resultOf({ id: threadId, ...createThread }, false);
   });
 

--- a/apps/server/src/mcp/toolkits/threads/tools.ts
+++ b/apps/server/src/mcp/toolkits/threads/tools.ts
@@ -1,0 +1,161 @@
+import {
+  McpCapabilityUnavailableError,
+  ModelSelection,
+  ProviderInteractionMode,
+  RuntimeMode,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import * as Tool from "effect/unstable/ai/Tool";
+import * as Toolkit from "effect/unstable/ai/Toolkit";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import * as ProjectionSnapshotQuery from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ThreadBootstrap from "../../../orchestration/Services/ThreadBootstrap.ts";
+
+const dependencies = [
+  McpInvocationContext.McpInvocationContext,
+  ProjectionSnapshotQuery.ProjectionSnapshotQuery,
+  ThreadBootstrap.ThreadBootstrap,
+];
+
+export const ThreadStartWorktreeInput = Schema.Struct({
+  baseBranch: Schema.optional(
+    TrimmedNonEmptyString.annotate({
+      description: "Branch to start the worktree from. Defaults to this thread's branch.",
+    }),
+  ),
+  branch: Schema.optional(
+    TrimmedNonEmptyString.annotate({
+      description: "Name for the new worktree branch. Defaults to a generated t3code/<hex> name.",
+    }),
+  ),
+  startFromOrigin: Schema.optional(
+    Schema.Boolean.annotate({
+      description: "Fetch origin and start from the remote baseBranch when it exists.",
+    }),
+  ),
+});
+export type ThreadStartWorktreeInput = typeof ThreadStartWorktreeInput.Type;
+
+export const ThreadStartInput = Schema.Struct({
+  prompt: TrimmedNonEmptyString.check(Schema.isMaxLength(16_000)).annotate({
+    description:
+      "First user message of the new thread. Write it for a person and an agent who have none of this thread's context: goal, decisions already made, file paths, and what is left.",
+  }),
+  title: Schema.optional(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(200)).annotate({
+      description: "Sidebar title for the new thread. Defaults to the first line of the prompt.",
+    }),
+  ),
+  interactionMode: Schema.optional(
+    ProviderInteractionMode.annotate({
+      description: "default or plan. Defaults to this thread's interaction mode.",
+    }),
+  ),
+  modelSelection: Schema.optional(
+    ModelSelection.annotate({
+      description:
+        "Provider instance and model for the new thread, as { instanceId, model, options? }. Defaults to this thread's selection; the result echoes the resolved selection so you can copy its shape.",
+    }),
+  ),
+  worktree: Schema.optional(
+    ThreadStartWorktreeInput.annotate({
+      description:
+        "Give the new thread its own git worktree instead of sharing this checkout. Pass {} for the defaults. The project's setup script runs in the new worktree.",
+    }),
+  ),
+  clientRequestId: Schema.optional(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(128)).annotate({
+      description:
+        "Your own id for this request. Repeating a call with the same id returns the thread created the first time instead of creating a second one.",
+    }),
+  ),
+});
+export type ThreadStartInput = typeof ThreadStartInput.Type;
+
+export const ThreadStartResult = Schema.Struct({
+  threadId: ThreadId,
+  title: Schema.String,
+  modelSelection: ModelSelection,
+  runtimeMode: RuntimeMode,
+  interactionMode: ProviderInteractionMode,
+  branch: Schema.NullOr(Schema.String),
+  worktreePath: Schema.NullOr(Schema.String),
+  alreadyStarted: Schema.Boolean.annotate({
+    description: "True when clientRequestId matched a thread this tool created before.",
+  }),
+});
+export type ThreadStartResult = typeof ThreadStartResult.Type;
+
+export class ThreadStartCallerNotFoundError extends Schema.TaggedError<ThreadStartCallerNotFoundError>()(
+  "ThreadStartCallerNotFoundError",
+  { threadId: Schema.String },
+) {
+  override get message(): string {
+    return `Thread ${this.threadId} was not found.`;
+  }
+}
+
+export class ThreadStartCallerArchivedError extends Schema.TaggedError<ThreadStartCallerArchivedError>()(
+  "ThreadStartCallerArchivedError",
+  { threadId: Schema.String },
+) {
+  override get message(): string {
+    return `Thread ${this.threadId} is archived and cannot start new threads.`;
+  }
+}
+
+export class ThreadStartProjectNotFoundError extends Schema.TaggedError<ThreadStartProjectNotFoundError>()(
+  "ThreadStartProjectNotFoundError",
+  { projectId: Schema.String },
+) {
+  override get message(): string {
+    return `Project ${this.projectId} was not found.`;
+  }
+}
+
+export class ThreadStartWorktreeBaseRequiredError extends Schema.TaggedError<ThreadStartWorktreeBaseRequiredError>()(
+  "ThreadStartWorktreeBaseRequiredError",
+  {},
+) {
+  override get message(): string {
+    return "This thread has no branch. Pass worktree.baseBranch.";
+  }
+}
+
+export class ThreadStartFailedError extends Schema.TaggedError<ThreadStartFailedError>()(
+  "ThreadStartFailedError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not start the new thread.";
+  }
+}
+
+export const ThreadStartToolError = Schema.Union([
+  McpCapabilityUnavailableError,
+  ThreadStartCallerNotFoundError,
+  ThreadStartCallerArchivedError,
+  ThreadStartProjectNotFoundError,
+  ThreadStartWorktreeBaseRequiredError,
+  ThreadStartFailedError,
+]);
+export type ThreadStartToolError = typeof ThreadStartToolError.Type;
+
+const ThreadStartTool = Tool.make("t3_thread_start", {
+  description:
+    "Hand work off to a NEW top-level T3 Code thread that the user drives from the sidebar. Creates the thread in this thread's project and immediately starts its first turn with your prompt. The new thread inherits this thread's checkout, provider, model, permission mode, and interaction mode unless overridden; pass worktree to give it a fresh git worktree instead of sharing this checkout. This is not a subagent: it does not report back, and you do not wait for it. Use it when the user asks to continue, split off, or delegate work into a separate session.",
+  parameters: ThreadStartInput,
+  success: ThreadStartResult,
+  failure: ThreadStartToolError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Start a T3 thread")
+  .annotate(Tool.Readonly, false)
+  .annotate(Tool.Destructive, false)
+  .annotate(Tool.Idempotent, false)
+  .annotate(Tool.OpenWorld, false);
+
+export const ThreadsToolkit = Toolkit.make(ThreadStartTool);

--- a/apps/server/src/orchestration/Layers/ThreadBootstrap.ts
+++ b/apps/server/src/orchestration/Layers/ThreadBootstrap.ts
@@ -1,0 +1,387 @@
+import {
+  CommandId,
+  EventId,
+  type OrchestrationClientOrigin,
+  type OrchestrationCommand,
+  OrchestrationDispatchCommandError,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import * as GitWorkflowService from "../../git/GitWorkflowService.ts";
+import * as ProjectSetupScriptRunner from "../../project/ProjectSetupScriptRunner.ts";
+import * as VcsStatusBroadcaster from "../../vcs/VcsStatusBroadcaster.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import {
+  ThreadBootstrap,
+  type ThreadBootstrapShape,
+  type ThreadTurnStartCommand,
+} from "../Services/ThreadBootstrap.ts";
+import { ThreadDeletionReactor } from "../Services/ThreadDeletionReactor.ts";
+
+const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+function unexpectedCompatibilityError(error: never): never {
+  throw new Error(`Unhandled compatibility error: ${String(error)}`);
+}
+
+/** Preserve the setup runner's broader pre-refactor message normalization. */
+function legacySetupFailureDescription(cause: unknown): string {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
+  ) {
+    return cause.message;
+  }
+  return String(cause);
+}
+
+function projectSetupScriptCompatibilityDetail(
+  error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError,
+): string {
+  switch (error._tag) {
+    case "ProjectSetupScriptOperationError":
+      return legacySetupFailureDescription(error.cause);
+    case "ProjectSetupScriptProjectNotFoundError":
+      return "Project was not found for setup script execution.";
+    default:
+      return unexpectedCompatibilityError(error);
+  }
+}
+
+const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const threadDeletionReactor = yield* ThreadDeletionReactor;
+  const gitWorkflow = yield* GitWorkflowService.GitWorkflowService;
+  const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+  const vcsStatusBroadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+
+  const toDispatchCommandError = (cause: unknown, fallbackMessage: string) =>
+    isOrchestrationDispatchCommandError(cause)
+      ? cause
+      : new OrchestrationDispatchCommandError({
+          message: cause instanceof Error ? cause.message : fallbackMessage,
+          cause,
+        });
+  const randomUUID = crypto.randomUUIDv4.pipe(
+    Effect.mapError((cause) =>
+      toDispatchCommandError(cause, "Failed to generate orchestration command identifier."),
+    ),
+  );
+  const serverEventId = randomUUID.pipe(Effect.map(EventId.make));
+  const serverCommandId = (tag: string) =>
+    randomUUID.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
+
+  const toBootstrapDispatchCommandCauseError = (cause: Cause.Cause<unknown>) => {
+    const error = Cause.squash(cause);
+    return isOrchestrationDispatchCommandError(error)
+      ? error
+      : new OrchestrationDispatchCommandError({
+          message:
+            error instanceof Error ? error.message : "Failed to bootstrap thread turn start.",
+          cause,
+        });
+  };
+
+  const refreshGitStatus = (cwd: string) =>
+    vcsStatusBroadcaster
+      .refreshStatus(cwd)
+      .pipe(Effect.ignoreCause({ log: true }), Effect.forkDetach, Effect.asVoid);
+
+  const dispatchTurnStart: ThreadBootstrapShape["dispatchTurnStart"] = (
+    command: ThreadTurnStartCommand,
+    options?: { readonly origin?: OrchestrationClientOrigin },
+  ) =>
+    Effect.gen(function* () {
+      const origin = options?.origin;
+      const dispatch: OrchestrationEngineService["Service"]["dispatch"] = (
+        subcommand: OrchestrationCommand,
+      ) => orchestrationEngine.dispatch(subcommand, origin ? { origin } : undefined);
+
+      const appendSetupScriptActivity = (input: {
+        readonly threadId: ThreadId;
+        readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
+        readonly summary: string;
+        readonly createdAt: string;
+        readonly payload: Record<string, unknown>;
+        readonly tone: "info" | "error";
+      }) =>
+        Effect.all({
+          commandId: serverCommandId("setup-script-activity"),
+          activityId: serverEventId,
+        }).pipe(
+          Effect.flatMap(({ commandId, activityId }) =>
+            dispatch({
+              type: "thread.activity.append",
+              commandId,
+              threadId: input.threadId,
+              activity: {
+                id: activityId,
+                tone: input.tone,
+                kind: input.kind,
+                summary: input.summary,
+                payload: input.payload,
+                turnId: null,
+                createdAt: input.createdAt,
+              },
+              createdAt: input.createdAt,
+            }),
+          ),
+        );
+
+      const bootstrap = command.bootstrap;
+      const { bootstrap: _bootstrap, ...finalTurnStartCommand } = command;
+      let createdThread = false;
+      let targetProjectId = bootstrap?.createThread?.projectId;
+      let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
+      let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
+
+      const cleanupCreatedThread = () =>
+        createdThread
+          ? serverCommandId("bootstrap-thread-delete").pipe(
+              Effect.flatMap((commandId) =>
+                dispatch({
+                  type: "thread.delete",
+                  commandId,
+                  threadId: command.threadId,
+                }),
+              ),
+              Effect.as(true),
+            )
+          : Effect.succeed(false);
+
+      const recordSetupScriptLaunchFailure = (input: {
+        readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
+        readonly requestedAt: string;
+        readonly worktreePath: string;
+      }) => {
+        const detail = projectSetupScriptCompatibilityDetail(input.error);
+        return appendSetupScriptActivity({
+          threadId: command.threadId,
+          kind: "setup-script.failed",
+          summary: "Setup script failed to start",
+          createdAt: input.requestedAt,
+          payload: {
+            detail,
+            worktreePath: input.worktreePath,
+          },
+          tone: "error",
+        }).pipe(
+          Effect.ignoreCause({ log: false }),
+          Effect.flatMap(() =>
+            Effect.logWarning("bootstrap turn start failed to launch setup script", {
+              threadId: command.threadId,
+              worktreePath: input.worktreePath,
+              detail,
+            }),
+          ),
+        );
+      };
+
+      const recordSetupScriptStarted = (input: {
+        readonly requestedAt: string;
+        readonly worktreePath: string;
+        readonly scriptId: string;
+        readonly scriptName: string;
+        readonly terminalId: string;
+      }) =>
+        Effect.gen(function* () {
+          const startedAt = yield* nowIso;
+          const payload = {
+            scriptId: input.scriptId,
+            scriptName: input.scriptName,
+            terminalId: input.terminalId,
+            worktreePath: input.worktreePath,
+          };
+          yield* Effect.all([
+            appendSetupScriptActivity({
+              threadId: command.threadId,
+              kind: "setup-script.requested",
+              summary: "Starting setup script",
+              createdAt: input.requestedAt,
+              payload,
+              tone: "info",
+            }),
+            appendSetupScriptActivity({
+              threadId: command.threadId,
+              kind: "setup-script.started",
+              summary: "Setup script started",
+              createdAt: startedAt,
+              payload,
+              tone: "info",
+            }),
+          ]).pipe(
+            Effect.asVoid,
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "bootstrap turn start launched setup script but failed to record setup activity",
+                {
+                  threadId: command.threadId,
+                  worktreePath: input.worktreePath,
+                  scriptId: input.scriptId,
+                  terminalId: input.terminalId,
+                  detail: error.message,
+                },
+              ),
+            ),
+          );
+        });
+
+      const runSetupProgram = () =>
+        Effect.gen(function* () {
+          if (!bootstrap?.runSetupScript || !targetWorktreePath) {
+            return;
+          }
+          const worktreePath = targetWorktreePath;
+          const requestedAt = yield* nowIso;
+          yield* projectSetupScriptRunner
+            .runForThread({
+              threadId: command.threadId,
+              ...(targetProjectId ? { projectId: targetProjectId } : {}),
+              ...(targetProjectCwd ? { projectCwd: targetProjectCwd } : {}),
+              worktreePath,
+            })
+            .pipe(
+              Effect.matchEffect({
+                onFailure: (error) =>
+                  recordSetupScriptLaunchFailure({
+                    error,
+                    requestedAt,
+                    worktreePath,
+                  }),
+                onSuccess: (setupResult) => {
+                  if (setupResult.status !== "started") {
+                    return Effect.void;
+                  }
+                  return recordSetupScriptStarted({
+                    requestedAt,
+                    worktreePath,
+                    scriptId: setupResult.scriptId,
+                    scriptName: setupResult.scriptName,
+                    terminalId: setupResult.terminalId,
+                  });
+                },
+              }),
+            );
+        });
+
+      const bootstrapProgram = Effect.gen(function* () {
+        if (bootstrap?.createThread) {
+          const created = yield* dispatch({
+            type: "thread.create",
+            commandId: yield* serverCommandId("bootstrap-thread-create"),
+            threadId: command.threadId,
+            projectId: bootstrap.createThread.projectId,
+            title: bootstrap.createThread.title,
+            modelSelection: bootstrap.createThread.modelSelection,
+            runtimeMode: bootstrap.createThread.runtimeMode,
+            interactionMode: bootstrap.createThread.interactionMode,
+            branch: bootstrap.createThread.branch,
+            worktreePath: bootstrap.createThread.worktreePath,
+            createdAt: bootstrap.createThread.createdAt,
+          });
+          // The successful create is a fence in the engine command queue:
+          // every delete for the prior incarnation committed before it.
+          // Drain through that event before setup or turn start can own
+          // terminals and provider sessions under the reused thread id.
+          yield* threadDeletionReactor.drainThrough(created.sequence);
+          createdThread = true;
+        }
+
+        if (bootstrap?.prepareWorktree) {
+          let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
+          // "Start from origin" is a stored default; repos without the
+          // requested remote branch fall back to the local base branch.
+          const startFromOrigin =
+            bootstrap.prepareWorktree.startFromOrigin === true &&
+            (yield* gitWorkflow.remoteExists({
+              cwd: bootstrap.prepareWorktree.projectCwd,
+              remoteName: "origin",
+            }));
+          if (startFromOrigin) {
+            yield* gitWorkflow.fetchRemote({
+              cwd: bootstrap.prepareWorktree.projectCwd,
+              remoteName: "origin",
+            });
+            const remoteBaseExists = yield* gitWorkflow.remoteBranchExists({
+              cwd: bootstrap.prepareWorktree.projectCwd,
+              refName: bootstrap.prepareWorktree.baseBranch,
+              remoteName: "origin",
+            });
+            if (remoteBaseExists) {
+              const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
+                cwd: bootstrap.prepareWorktree.projectCwd,
+                refName: bootstrap.prepareWorktree.baseBranch,
+                fallbackRemoteName: "origin",
+              });
+              worktreeBaseRef = resolvedRemoteBase.commitSha;
+            }
+          }
+          const worktree = yield* gitWorkflow.createWorktree({
+            cwd: bootstrap.prepareWorktree.projectCwd,
+            refName: worktreeBaseRef,
+            newRefName: bootstrap.prepareWorktree.branch,
+            baseRefName: bootstrap.prepareWorktree.baseBranch,
+            path: null,
+          });
+          targetWorktreePath = worktree.worktree.path;
+          yield* dispatch({
+            type: "thread.meta.update",
+            commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
+            threadId: command.threadId,
+            branch: worktree.worktree.refName,
+            worktreePath: targetWorktreePath,
+          });
+          yield* refreshGitStatus(targetWorktreePath);
+        }
+
+        yield* runSetupProgram();
+
+        return yield* dispatch(finalTurnStartCommand);
+      });
+
+      return yield* bootstrapProgram.pipe(
+        Effect.catchCause((cause) => {
+          const dispatchError = toBootstrapDispatchCommandCauseError(cause);
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.fail(dispatchError);
+          }
+          return Effect.uninterruptible(cleanupCreatedThread()).pipe(
+            Effect.matchCauseEffect({
+              onFailure: (cleanupCause) =>
+                Effect.logWarning("bootstrap thread cleanup failed", {
+                  threadId: command.threadId,
+                  detail: Cause.pretty(cleanupCause),
+                }).pipe(Effect.flatMap(() => Effect.fail(dispatchError))),
+              onSuccess: (threadDeleted) =>
+                Effect.fail(
+                  threadDeleted
+                    ? new OrchestrationDispatchCommandError({
+                        message: dispatchError.message,
+                        ...(dispatchError.cause !== undefined
+                          ? { cause: dispatchError.cause }
+                          : {}),
+                        bootstrapThreadDisposition: "deleted",
+                      })
+                    : dispatchError,
+                ),
+            }),
+          );
+        }),
+      );
+    });
+
+  return ThreadBootstrap.of({ dispatchTurnStart });
+});
+
+export const ThreadBootstrapLive = Layer.effect(ThreadBootstrap, make);

--- a/apps/server/src/orchestration/Services/ThreadBootstrap.ts
+++ b/apps/server/src/orchestration/Services/ThreadBootstrap.ts
@@ -2,8 +2,7 @@
  * ThreadBootstrap - Create-and-start sequence for a thread's first turn.
  *
  * Runs the `thread.turn.start` bootstrap: create the thread, prepare a
- * worktree, run the setup script, then dispatch the turn. Shared by the
- * WebSocket transport and the MCP server.
+ * worktree, run the setup script, then dispatch the turn.
  *
  * @module ThreadBootstrap
  */

--- a/apps/server/src/orchestration/Services/ThreadBootstrap.ts
+++ b/apps/server/src/orchestration/Services/ThreadBootstrap.ts
@@ -1,0 +1,29 @@
+/**
+ * ThreadBootstrap - Create-and-start sequence for a thread's first turn.
+ *
+ * Runs the `thread.turn.start` bootstrap: create the thread, prepare a
+ * worktree, run the setup script, then dispatch the turn. Shared by the
+ * WebSocket transport and the MCP server.
+ *
+ * @module ThreadBootstrap
+ */
+import type {
+  OrchestrationClientOrigin,
+  OrchestrationCommand,
+  OrchestrationDispatchCommandError,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+
+export type ThreadTurnStartCommand = Extract<OrchestrationCommand, { type: "thread.turn.start" }>;
+
+export interface ThreadBootstrapShape {
+  readonly dispatchTurnStart: (
+    command: ThreadTurnStartCommand,
+    options?: { readonly origin?: OrchestrationClientOrigin },
+  ) => Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError>;
+}
+
+export class ThreadBootstrap extends Context.Service<ThreadBootstrap, ThreadBootstrapShape>()(
+  "t3/orchestration/Services/ThreadBootstrap",
+) {}

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -5018,7 +5018,7 @@ describe("agent browser access", () => {
     });
 
   // The capability on the credential is the observable that matters: a session
-  // always gets a credential (the pull request toolkit is never withheld), and
+  // always gets a credential (the pull request and thread toolkits are never withheld), and
   // `preview` on it is what actually grants or denies the browser tools.
   it.effect("issues a credential without preview when agent browser access is off", () =>
     Effect.gen(function* () {
@@ -5026,7 +5026,7 @@ describe("agent browser access", () => {
 
       const issued = yield* startSessionWith(false, threadId);
 
-      assert.deepEqual(issued, [{ threadId, capabilities: ["pull-requests"] }]);
+      assert.deepEqual(issued, [{ threadId, capabilities: ["pull-requests", "threads"] }]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5037,7 +5037,7 @@ describe("agent browser access", () => {
       const issued = yield* startSessionWith(true, threadId);
 
       assert.deepEqual(issued, [
-        { threadId, capabilities: ["device", "preview", "pull-requests"] },
+        { threadId, capabilities: ["device", "preview", "pull-requests", "threads"] },
       ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
@@ -5048,7 +5048,9 @@ describe("agent browser access", () => {
 
       const issued = yield* startSessionWith({ browser: false, device: true }, threadId);
 
-      assert.deepEqual(issued, [{ threadId, capabilities: ["device", "pull-requests"] }]);
+      assert.deepEqual(issued, [
+        { threadId, capabilities: ["device", "pull-requests", "threads"] },
+      ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5056,7 +5058,7 @@ describe("agent browser access", () => {
     Effect.gen(function* () {
       const threadId = asThreadId("thread-project-browser-off");
       const issued = yield* startSessionWith({ browser: true, device: false }, threadId, false);
-      assert.deepEqual(issued, [{ threadId, capabilities: ["pull-requests"] }]);
+      assert.deepEqual(issued, [{ threadId, capabilities: ["pull-requests", "threads"] }]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5064,7 +5066,9 @@ describe("agent browser access", () => {
     Effect.gen(function* () {
       const threadId = asThreadId("thread-project-browser-off-device-on");
       const issued = yield* startSessionWith(true, threadId, false);
-      assert.deepEqual(issued, [{ threadId, capabilities: ["device", "pull-requests"] }]);
+      assert.deepEqual(issued, [
+        { threadId, capabilities: ["device", "pull-requests", "threads"] },
+      ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5072,7 +5076,9 @@ describe("agent browser access", () => {
     Effect.gen(function* () {
       const threadId = asThreadId("thread-project-browser-on");
       const issued = yield* startSessionWith({ browser: false, device: false }, threadId, true);
-      assert.deepEqual(issued, [{ threadId, capabilities: ["preview", "pull-requests"] }]);
+      assert.deepEqual(issued, [
+        { threadId, capabilities: ["preview", "pull-requests", "threads"] },
+      ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5082,7 +5088,9 @@ describe("agent browser access", () => {
       const issued = yield* startSessionWith({ browser: false, device: false }, threadId, {
         device: true,
       });
-      assert.deepEqual(issued, [{ threadId, capabilities: ["device", "pull-requests"] }]);
+      assert.deepEqual(issued, [
+        { threadId, capabilities: ["device", "pull-requests", "threads"] },
+      ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 
@@ -5097,7 +5105,9 @@ describe("agent browser access", () => {
         { device: false },
         { withoutOrchestration: true },
       );
-      assert.deepEqual(issued, [{ threadId, capabilities: ["preview", "pull-requests"] }]);
+      assert.deepEqual(issued, [
+        { threadId, capabilities: ["preview", "pull-requests", "threads"] },
+      ]);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -906,7 +906,7 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
   const agentAccessCapabilities = Effect.fn("ProviderService.agentAccessCapabilities")(function* (
     threadId: ThreadId,
   ) {
-    const capabilities = new Set<McpInvocationContext.McpCapability>(["pull-requests"]);
+    const capabilities = new Set<McpInvocationContext.McpCapability>(["pull-requests", "threads"]);
     const access = yield* agentAccessSettings(threadId);
     if (access.browser) capabilities.add("preview");
     if (access.device) capabilities.add("device");

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -118,6 +118,7 @@ import {
   OrchestrationThreadSettleBlockedError,
 } from "./orchestration/Errors.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadBootstrapLive } from "./orchestration/Layers/ThreadBootstrap.ts";
 import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionReactor.ts";
 import * as PullRequestSyncReactor from "./orchestration/PullRequestSyncReactor.ts";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
@@ -747,6 +748,7 @@ const buildAppUnderTest = (options?: {
         routerConfig: HTTP_ROUTER_CONFIG,
       },
     ).pipe(
+      Layer.provide(ThreadBootstrapLive),
       Layer.provide(
         Layer.mergeAll(
           Layer.mock(Keybindings.Keybindings)({
@@ -899,8 +901,7 @@ const buildAppUnderTest = (options?: {
             }),
         }),
       ),
-      Layer.provide(gitManagerLayer),
-      Layer.provide(gitVcsDriverLayer),
+      Layer.provide(Layer.mergeAll(gitManagerLayer, gitVcsDriverLayer)),
       Layer.provide(gitWorkflowLayer),
       Layer.provide(reviewLayer),
       Layer.provide(vcsProvisioningLayer),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -71,6 +71,7 @@ import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor.ts";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
+import { ThreadBootstrapLive } from "./orchestration/Layers/ThreadBootstrap.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import * as ThreadSettlementReactor from "./orchestration/ThreadSettlementReactor.ts";
 import * as PullRequestSyncReactor from "./orchestration/PullRequestSyncReactor.ts";
@@ -278,6 +279,7 @@ const PlatformServicesLive = Layer.unwrap(
 );
 
 const ReactorLayerLive = Layer.empty.pipe(
+  Layer.provideMerge(ThreadBootstrapLive),
   Layer.provideMerge(OrchestrationReactorLive),
   Layer.provideMerge(ProviderRuntimeIngestionLive),
   Layer.provideMerge(ProviderCommandReactorLive),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -2,7 +2,6 @@ import {
   sameUsageLimitCommandCoverage,
   withUsageLimitsCommands,
 } from "@t3tools/shared/usageLimits";
-import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
@@ -27,7 +26,6 @@ import {
   ClientWebDeployment,
   CommandId,
   type DiscoveredLocalServerList,
-  EventId,
   type EditorId,
   type FileManagerRevealKind,
   type OrchestrationClientOrigin,
@@ -95,6 +93,7 @@ import {
 } from "./orchestration/Normalizer.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadBootstrap } from "./orchestration/Services/ThreadBootstrap.ts";
 import { ThreadDeletionReactor } from "./orchestration/Services/ThreadDeletionReactor.ts";
 import {
   observeRpcEffect as instrumentRpcEffect,
@@ -128,7 +127,6 @@ import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import { linkCreatedPullRequest } from "./git/linkCreatedPullRequest.ts";
 import * as ReviewService from "./review/ReviewService.ts";
-import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import * as AgentSessionScanner from "./project/AgentSessionScanner.ts";
 import { importRecentAgentThreads } from "./project/AgentSessionImporter.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
@@ -187,19 +185,6 @@ export const resolveFileManagerRevealKindForConfig = <E, R>(
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
-}
-
-/** Preserve the setup runner's broader pre-refactor message normalization. */
-function legacySetupFailureDescription(cause: unknown): string {
-  if (
-    typeof cause === "object" &&
-    cause !== null &&
-    "message" in cause &&
-    typeof cause.message === "string"
-  ) {
-    return cause.message;
-  }
-  return String(cause);
 }
 
 function projectEntriesFailureContext(error: WorkspaceEntries.WorkspaceEntriesError): {
@@ -301,19 +286,6 @@ function projectFileFailureContext(
       return { failure: "path_not_file", resolvedPath: error.resolvedPath };
     case "WorkspaceBinaryFileError":
       return { failure: "binary_file", resolvedPath: error.resolvedPath };
-    default:
-      return unexpectedCompatibilityError(error);
-  }
-}
-
-function projectSetupScriptCompatibilityDetail(
-  error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError,
-): string {
-  switch (error._tag) {
-    case "ProjectSetupScriptOperationError":
-      return legacySetupFailureDescription(error.cause);
-    case "ProjectSetupScriptProjectNotFoundError":
-      return "Project was not found for setup script execution.";
     default:
       return unexpectedCompatibilityError(error);
   }
@@ -497,6 +469,7 @@ const makeWsRpcLayer = (
             );
       const orchestrationEngine = yield* OrchestrationEngine.OrchestrationEngineService;
       const threadDeletionReactor = yield* ThreadDeletionReactor;
+      const threadBootstrap = yield* ThreadBootstrap;
       const analytics = yield* AnalyticsService.AnalyticsService;
       // Every command dispatched on this connection carries the connecting
       // client's origin, including server-generated bootstrap sub-commands:
@@ -589,7 +562,6 @@ const makeWsRpcLayer = (
         }
         return true;
       });
-      const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
       const agentSessionScanner = yield* AgentSessionScanner.AgentSessionScanner;
       const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
       const backgroundPolicy = yield* BackgroundPolicy.BackgroundPolicy;
@@ -697,7 +669,6 @@ const makeWsRpcLayer = (
           toDispatchCommandError(cause, "Failed to generate orchestration command identifier."),
         ),
       );
-      const serverEventId = randomUUID.pipe(Effect.map(EventId.make));
       const serverCommandId = (tag: string) =>
         randomUUID.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
 
@@ -713,48 +684,6 @@ const makeWsRpcLayer = (
               }),
           ),
         );
-
-      const appendSetupScriptActivity = (input: {
-        readonly threadId: ThreadId;
-        readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
-        readonly summary: string;
-        readonly createdAt: string;
-        readonly payload: Record<string, unknown>;
-        readonly tone: "info" | "error";
-      }) =>
-        Effect.all({
-          commandId: serverCommandId("setup-script-activity"),
-          activityId: serverEventId,
-        }).pipe(
-          Effect.flatMap(({ commandId, activityId }) =>
-            dispatchFromClient({
-              type: "thread.activity.append",
-              commandId,
-              threadId: input.threadId,
-              activity: {
-                id: activityId,
-                tone: input.tone,
-                kind: input.kind,
-                summary: input.summary,
-                payload: input.payload,
-                turnId: null,
-                createdAt: input.createdAt,
-              },
-              createdAt: input.createdAt,
-            }),
-          ),
-        );
-
-      const toBootstrapDispatchCommandCauseError = (cause: Cause.Cause<unknown>) => {
-        const error = Cause.squash(cause);
-        return isOrchestrationDispatchCommandError(error)
-          ? error
-          : new OrchestrationDispatchCommandError({
-              message:
-                error instanceof Error ? error.message : "Failed to bootstrap thread turn start.",
-              cause,
-            });
-      };
 
       // Shell updates refetch the aggregate. Message and tool bodies are not needed.
       const toShellEvent = ({
@@ -973,258 +902,15 @@ const makeWsRpcLayer = (
           return output;
         });
 
-      const dispatchBootstrapTurnStart = (
-        command: Extract<OrchestrationCommand, { type: "thread.turn.start" }>,
-      ): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> =>
-        Effect.gen(function* () {
-          const bootstrap = command.bootstrap;
-          const { bootstrap: _bootstrap, ...finalTurnStartCommand } = command;
-          let createdThread = false;
-          let targetProjectId = bootstrap?.createThread?.projectId;
-          let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
-          let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
-
-          const cleanupCreatedThread = () =>
-            createdThread
-              ? serverCommandId("bootstrap-thread-delete").pipe(
-                  Effect.flatMap((commandId) =>
-                    dispatchFromClient({
-                      type: "thread.delete",
-                      commandId,
-                      threadId: command.threadId,
-                    }),
-                  ),
-                  Effect.as(true),
-                )
-              : Effect.succeed(false);
-
-          const recordSetupScriptLaunchFailure = (input: {
-            readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
-            readonly requestedAt: string;
-            readonly worktreePath: string;
-          }) => {
-            const detail = projectSetupScriptCompatibilityDetail(input.error);
-            return appendSetupScriptActivity({
-              threadId: command.threadId,
-              kind: "setup-script.failed",
-              summary: "Setup script failed to start",
-              createdAt: input.requestedAt,
-              payload: {
-                detail,
-                worktreePath: input.worktreePath,
-              },
-              tone: "error",
-            }).pipe(
-              Effect.ignoreCause({ log: false }),
-              Effect.flatMap(() =>
-                Effect.logWarning("bootstrap turn start failed to launch setup script", {
-                  threadId: command.threadId,
-                  worktreePath: input.worktreePath,
-                  detail,
-                }),
-              ),
-            );
-          };
-
-          const recordSetupScriptStarted = (input: {
-            readonly requestedAt: string;
-            readonly worktreePath: string;
-            readonly scriptId: string;
-            readonly scriptName: string;
-            readonly terminalId: string;
-          }) =>
-            Effect.gen(function* () {
-              const startedAt = yield* nowIso;
-              const payload = {
-                scriptId: input.scriptId,
-                scriptName: input.scriptName,
-                terminalId: input.terminalId,
-                worktreePath: input.worktreePath,
-              };
-              yield* Effect.all([
-                appendSetupScriptActivity({
-                  threadId: command.threadId,
-                  kind: "setup-script.requested",
-                  summary: "Starting setup script",
-                  createdAt: input.requestedAt,
-                  payload,
-                  tone: "info",
-                }),
-                appendSetupScriptActivity({
-                  threadId: command.threadId,
-                  kind: "setup-script.started",
-                  summary: "Setup script started",
-                  createdAt: startedAt,
-                  payload,
-                  tone: "info",
-                }),
-              ]).pipe(
-                Effect.asVoid,
-                Effect.catch((error) =>
-                  Effect.logWarning(
-                    "bootstrap turn start launched setup script but failed to record setup activity",
-                    {
-                      threadId: command.threadId,
-                      worktreePath: input.worktreePath,
-                      scriptId: input.scriptId,
-                      terminalId: input.terminalId,
-                      detail: error.message,
-                    },
-                  ),
-                ),
-              );
-            });
-
-          const runSetupProgram = () =>
-            Effect.gen(function* () {
-              if (!bootstrap?.runSetupScript || !targetWorktreePath) {
-                return;
-              }
-              const worktreePath = targetWorktreePath;
-              const requestedAt = yield* nowIso;
-              yield* projectSetupScriptRunner
-                .runForThread({
-                  threadId: command.threadId,
-                  ...(targetProjectId ? { projectId: targetProjectId } : {}),
-                  ...(targetProjectCwd ? { projectCwd: targetProjectCwd } : {}),
-                  worktreePath,
-                })
-                .pipe(
-                  Effect.matchEffect({
-                    onFailure: (error) =>
-                      recordSetupScriptLaunchFailure({
-                        error,
-                        requestedAt,
-                        worktreePath,
-                      }),
-                    onSuccess: (setupResult) => {
-                      if (setupResult.status !== "started") {
-                        return Effect.void;
-                      }
-                      return recordSetupScriptStarted({
-                        requestedAt,
-                        worktreePath,
-                        scriptId: setupResult.scriptId,
-                        scriptName: setupResult.scriptName,
-                        terminalId: setupResult.terminalId,
-                      });
-                    },
-                  }),
-                );
-            });
-
-          const bootstrapProgram = Effect.gen(function* () {
-            if (bootstrap?.createThread) {
-              const created = yield* dispatchFromClient({
-                type: "thread.create",
-                commandId: yield* serverCommandId("bootstrap-thread-create"),
-                threadId: command.threadId,
-                projectId: bootstrap.createThread.projectId,
-                title: bootstrap.createThread.title,
-                modelSelection: bootstrap.createThread.modelSelection,
-                runtimeMode: bootstrap.createThread.runtimeMode,
-                interactionMode: bootstrap.createThread.interactionMode,
-                branch: bootstrap.createThread.branch,
-                worktreePath: bootstrap.createThread.worktreePath,
-                createdAt: bootstrap.createThread.createdAt,
-              });
-              // The successful create is a fence in the engine command queue:
-              // every delete for the prior incarnation committed before it.
-              // Drain through that event before setup or turn start can own
-              // terminals and provider sessions under the reused thread id.
-              yield* threadDeletionReactor.drainThrough(created.sequence);
-              createdThread = true;
-            }
-
-            if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              // "Start from origin" is a stored default; repos without the
-              // requested remote branch fall back to the local base branch.
-              const startFromOrigin =
-                bootstrap.prepareWorktree.startFromOrigin === true &&
-                (yield* gitWorkflow.remoteExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                }));
-              if (startFromOrigin) {
-                yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                });
-                const remoteBaseExists = yield* gitWorkflow.remoteBranchExists({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  remoteName: "origin",
-                });
-                if (remoteBaseExists) {
-                  const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                    cwd: bootstrap.prepareWorktree.projectCwd,
-                    refName: bootstrap.prepareWorktree.baseBranch,
-                    fallbackRemoteName: "origin",
-                  });
-                  worktreeBaseRef = resolvedRemoteBase.commitSha;
-                }
-              }
-              const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
-                refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
-                path: null,
-              });
-              targetWorktreePath = worktree.worktree.path;
-              yield* dispatchFromClient({
-                type: "thread.meta.update",
-                commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
-                threadId: command.threadId,
-                branch: worktree.worktree.refName,
-                worktreePath: targetWorktreePath,
-              });
-              yield* refreshGitStatus(targetWorktreePath);
-            }
-
-            yield* runSetupProgram();
-
-            return yield* dispatchFromClient(finalTurnStartCommand);
-          });
-
-          return yield* bootstrapProgram.pipe(
-            Effect.catchCause((cause) => {
-              const dispatchError = toBootstrapDispatchCommandCauseError(cause);
-              if (Cause.hasInterruptsOnly(cause)) {
-                return Effect.fail(dispatchError);
-              }
-              return Effect.uninterruptible(cleanupCreatedThread()).pipe(
-                Effect.matchCauseEffect({
-                  onFailure: (cleanupCause) =>
-                    Effect.logWarning("bootstrap thread cleanup failed", {
-                      threadId: command.threadId,
-                      detail: Cause.pretty(cleanupCause),
-                    }).pipe(Effect.flatMap(() => Effect.fail(dispatchError))),
-                  onSuccess: (threadDeleted) =>
-                    Effect.fail(
-                      threadDeleted
-                        ? new OrchestrationDispatchCommandError({
-                            message: dispatchError.message,
-                            ...(dispatchError.cause !== undefined
-                              ? { cause: dispatchError.cause }
-                              : {}),
-                            bootstrapThreadDisposition: "deleted",
-                          })
-                        : dispatchError,
-                    ),
-                }),
-              );
-            }),
-          );
-        });
-
       const dispatchNormalizedCommand = (
         normalizedCommand: OrchestrationCommand,
       ): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> => {
         const dispatchEffect =
           normalizedCommand.type === "thread.turn.start" && normalizedCommand.bootstrap
-            ? dispatchBootstrapTurnStart(normalizedCommand)
+            ? threadBootstrap.dispatchTurnStart(
+                normalizedCommand,
+                hasClientOrigin ? { origin: clientOrigin } : undefined,
+              )
             : dispatchFromClient(normalizedCommand).pipe(
                 Effect.tap(({ sequence }) =>
                   // Returning from thread.create is the handoff point at which


### PR DESCRIPTION
## What Changed

Adds one tool to the built-in `t3-code` MCP server: `t3_thread_start`. An agent calls it to hand work to a new top-level thread that the user then drives from the sidebar. The tool creates the thread in the caller's project and starts its first turn with the agent's prompt, through the same `thread.turn.start` bootstrap the web client already uses for every new thread.

Defaults come from the calling thread: project, checkout, provider and model, permission mode, and interaction mode. The agent may override `modelSelection` and `interactionMode`, or pass `worktree` to give the new thread a fresh git worktree (setup script runs, same as the web flow). Permission mode is never an input, so a handoff cannot widen access. The first message carries a server-authored line naming the source thread. `clientRequestId` makes a retried call return the thread created the first time instead of a second one.

Two commits:

1. `refactor(server)`: moves the bootstrap program (create thread, prepare worktree, run setup script, dispatch turn, clean up on failure) out of the per-connection closure in `ws.ts` into a `ThreadBootstrap` service. No behavior change; the WebSocket path calls the service with the same client origin.
2. `feat(mcp)`: the toolkit, a `threads` capability granted alongside `pull-requests`, registration, and tests.

Not included: parent/child lineage in the sidebar, waiting on the child, messaging between threads, or cross-project creation. Those are tracked in #8433 and belong to the orchestrator work in #2829. This is the smallest slice that lets an agent continue work in a fresh thread today.

## Why

An agent that finishes a task, or runs out of context mid-task, has no way to continue in a new T3 thread. The user opens one by hand and retypes the context. Prior attempts at this (#7487, #8452, #8492) added new lifecycle state, client cards, or a CLI plugin. This one reuses an existing command and adds no schema, migration, or UI.

## Verification

- `vp test run` on `apps/server/src/mcp/toolkits/threads/handlers.test.ts`, `McpHttpServer.test.ts`, `McpSessionRegistry.test.ts`, `McpInvocationContext.test.ts` (37 passed), the ProviderService capability tests (8 passed), and the `server.test.ts` bootstrap, worktree, and setup-script cases (14 passed) plus `OrchestrationEngine.test.ts`, `bin.test.ts`, `cli/app.test.ts` (61 passed).
- `tsc --noEmit` for `apps/server` clean.
- Live: an isolated `vp run dev` environment, a Claude Sonnet 5 thread instructed to call `t3_thread_start`. The tool returned the new thread; the new thread appeared in the sidebar with the attribution line as its first user message and completed its own first turn.

Model/harness: Claude Fable 5.1 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP support for starting new T3 Code threads.
  - Thread creation supports prompts, titles, model and interaction settings, client request IDs, and optional worktree configuration.
  - Worktree setup supports custom branches and origin-based starting points.
  - Repeated requests can safely reuse an already-started thread.
  - Threads capability is available by default alongside pull-request tools.

- **Bug Fixes**
  - Added clear errors for unavailable capabilities, archived or missing callers, missing projects, and invalid worktree setup.
  - Improved handling of thread setup failures and concurrent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->