### PR TITLE
fix(web): remove pr description reactions

### DIFF
--- a/apps/web/src/components/pullRequest/PullRequestReactions.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReactions.tsx
@@ -51,7 +51,6 @@ export function PullRequestReactionBar({
   reference,
   onRefresh,
   className,
-  compact = false,
 }: {
   readonly reactions: ReadonlyArray<PullRequestReaction>;
   readonly canReact: boolean;
@@ -61,7 +60,6 @@ export function PullRequestReactionBar({
   readonly reference: PullRequestRef;
   readonly onRefresh: () => void;
   readonly className?: string | undefined;
-  readonly compact?: boolean;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pending, setPending] = useState<{
@@ -112,7 +110,6 @@ export function PullRequestReactionBar({
                 disabled={!canReact}
                 className={cn(
                   PILL_CLASS,
-                  compact && "h-5 px-1.5",
                   reaction.viewerHasReacted
                     ? "border-primary/60 bg-primary/10 text-foreground"
                     : "border-border/70 bg-muted/40 text-muted-foreground",
@@ -139,7 +136,6 @@ export function PullRequestReactionBar({
                 className={cn(
                   PILL_CLASS,
                   "border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
-                  compact && "h-5 px-1",
                   shown.length === 0 &&
                     !pickerOpen &&
                     "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100",
@@ -147,7 +143,7 @@ export function PullRequestReactionBar({
               />
             }
           >
-            <SmilePlusIcon aria-hidden className={compact ? "size-3" : "size-3.5"} />
+            <SmilePlusIcon aria-hidden className="size-3.5" />
           </PopoverTrigger>
           <PopoverPopup align="start" className="w-auto" side="top" viewportClassName="py-2">
             <div className="flex items-center gap-0.5">

--- a/apps/web/src/components/pullRequest/PullRequestReactions.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestReactions.tsx
@@ -51,6 +51,7 @@ export function PullRequestReactionBar({
   reference,
   onRefresh,
   className,
+  compact = false,
 }: {
   readonly reactions: ReadonlyArray<PullRequestReaction>;
   readonly canReact: boolean;
@@ -60,6 +61,7 @@ export function PullRequestReactionBar({
   readonly reference: PullRequestRef;
   readonly onRefresh: () => void;
   readonly className?: string | undefined;
+  readonly compact?: boolean;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pending, setPending] = useState<{
@@ -110,6 +112,7 @@ export function PullRequestReactionBar({
                 disabled={!canReact}
                 className={cn(
                   PILL_CLASS,
+                  compact && "h-5 px-1.5",
                   reaction.viewerHasReacted
                     ? "border-primary/60 bg-primary/10 text-foreground"
                     : "border-border/70 bg-muted/40 text-muted-foreground",
@@ -136,6 +139,7 @@ export function PullRequestReactionBar({
                 className={cn(
                   PILL_CLASS,
                   "border-border/70 px-1.5 text-muted-foreground hover:border-primary/60 hover:text-foreground",
+                  compact && "h-5 px-1",
                   shown.length === 0 &&
                     !pickerOpen &&
                     "opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100",
@@ -143,7 +147,7 @@ export function PullRequestReactionBar({
               />
             }
           >
-            <SmilePlusIcon aria-hidden className="size-3.5" />
+            <SmilePlusIcon aria-hidden className={compact ? "size-3" : "size-3.5"} />
           </PopoverTrigger>
           <PopoverPopup align="start" className="w-auto" side="top" viewportClassName="py-2">
             <div className="flex items-center gap-0.5">

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -757,14 +757,6 @@ export function PullRequestSummaryTab({
               ) : null}
             </div>
           )}
-          <PullRequestReactionBar
-            compact
-            reactions={detail.reactions ?? []}
-            canReact={detail.capabilities.reactions === true}
-            environmentId={environmentId}
-            reference={reference}
-            onRefresh={onRefresh}
-          />
         </div>
       </section>
 

--- a/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
+++ b/apps/web/src/components/pullRequest/PullRequestSummaryTab.tsx
@@ -758,7 +758,7 @@ export function PullRequestSummaryTab({
             </div>
           )}
           <PullRequestReactionBar
-            className="mt-2"
+            compact
             reactions={detail.reactions ?? []}
             canReact={detail.capabilities.reactions === true}
             environmentId={environmentId}


### PR DESCRIPTION
Remove reactions from PR descriptions so they no longer reserve a row below the body. Reactions on conversation comments and review comments remain available.

Verified against a real GitHub-backed PR: the description has no reaction control or reserved row, and a conversation comment's picker still opens with all eight reactions. Web typecheck and scoped lint passed (one existing array-index-key warning). Shared web/desktop panel; native mobile is unchanged.

![before: reactions still reserve a description row](https://uploads-production-47e4.up.railway.app/files/8ee8c09c-634c-4a6d-a1ea-ec19cce73c5b/pr-remove-reactions-before.png)

![after: description reaction row removed](https://uploads-production-47e4.up.railway.app/files/ad04af1e-0196-4b5b-883c-ee7cdbb2b048/pr-remove-reactions-after.png)

model: `gpt-6-astra`. harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the reaction bar displayed beneath pull request descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->