### PR TITLE
feat(github): route pull request operations across matching accounts

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,7 +75,7 @@
     "effect": "catalog:",
     "expo": "~57.0.18",
     "expo-asset": "~57.0.15",
-    "expo-audio": "~57.0.4",
+    "expo-audio": "57.0.4",
     "expo-auth-session": "~57.0.10",
     "expo-blur": "~57.0.2",
     "expo-build-properties": "~57.0.15",

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -13,6 +13,8 @@ import {
   ConnectionTransientError,
   CredentialStore,
   ProfileStore,
+  GitHubRoutingPermissions,
+  makeGitHubRoutingPermissions,
 } from "@t3tools/client-runtime/connection";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -33,6 +35,11 @@ function targetPersistenceError(
 export const connectionStorageLayer = Layer.effectContext(
   Effect.gen(function* () {
     const catalog = yield* CatalogStore.make();
+    const githubRoutingPermissions = yield* makeGitHubRoutingPermissions({
+      read: catalog.read.pipe(Effect.map((document) => document.githubRoutingPermissions ?? [])),
+      write: (githubRoutingPermissions) =>
+        catalog.update((document) => ({ ...document, githubRoutingPermissions })),
+    });
 
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
@@ -122,6 +129,7 @@ export const connectionStorageLayer = Layer.effectContext(
         })),
     });
     return Context.make(ConnectionTargetStore, targetStore).pipe(
+      Context.add(GitHubRoutingPermissions, githubRoutingPermissions),
       Context.add(ConnectionRegistrationStore, registrationStore),
       Context.add(ProfileStore.ConnectionProfileStore, profileStore),
       Context.add(CredentialStore.ConnectionCredentialStore, credentialStore),

--- a/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
@@ -11,6 +11,7 @@ import { AppText as Text } from "../../components/AppText";
 import { cn } from "../../lib/cn";
 import { useRemoteConnections } from "../../state/use-remote-environment-registry";
 import { ConnectionEnvironmentRow } from "./ConnectionEnvironmentRow";
+import { GitHubRoutingSettings } from "./GitHubRoutingSettings";
 
 export function ConnectionsRouteScreen() {
   const {
@@ -95,6 +96,7 @@ export function ConnectionsRouteScreen() {
             </Text>
           </View>
         )}
+        <GitHubRoutingSettings />
       </ScrollView>
     </View>
   );

--- a/apps/mobile/src/features/connection/GitHubRoutingSettings.tsx
+++ b/apps/mobile/src/features/connection/GitHubRoutingSettings.tsx
@@ -1,0 +1,126 @@
+import { useAtomValue } from "@effect/atom-react";
+import {
+  connectionCatalogDisplayUrl,
+  gitHubRoutingConnectionKey,
+  gitHubRoutingPermissionFor,
+  type GitHubRoutingPermission,
+} from "@t3tools/client-runtime/connection";
+import { useState } from "react";
+import { Alert, Pressable, View } from "react-native";
+
+import { AppText as Text } from "../../components/AppText";
+import { SymbolView } from "../../components/AppSymbol";
+import { environmentCatalog } from "../../connection/catalog";
+import { useAtomCommand } from "../../state/use-atom-command";
+import { SettingsSection } from "../settings/components/SettingsSection";
+
+const options: ReadonlyArray<{
+  value: GitHubRoutingPermission;
+  label: string;
+  description: string;
+}> = [
+  { value: "off", label: "Off", description: "Keep GitHub requests on this environment." },
+  {
+    value: "read",
+    label: "Read PRs",
+    description: "Share PR data with other enabled environments.",
+  },
+  {
+    value: "read-write",
+    label: "Read and act",
+    description: "Actions may use broader GitHub permissions than the original environment.",
+  },
+];
+
+export function GitHubRoutingSettings() {
+  const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
+  const permissions = useAtomValue(environmentCatalog.githubRoutingPermissionsValueAtom);
+  const update = useAtomCommand(environmentCatalog.setGitHubRoutingPermission);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  if (catalog.entries.size === 0) return null;
+
+  return (
+    <View className="mt-5 gap-3">
+      <SettingsSection title="GitHub routing">
+        {[...catalog.entries.values()].map((entry, index) => {
+          const environmentId = entry.target.environmentId;
+          const selected = gitHubRoutingPermissionFor(entry, permissions);
+          const disabled = !catalog.isReady || saving || gitHubRoutingConnectionKey(entry) === null;
+          return (
+            <View
+              key={environmentId}
+              className={index === 0 ? undefined : "border-t border-border-subtle"}
+            >
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`${entry.target.label} GitHub routing`}
+                accessibilityState={{ expanded: expanded === environmentId }}
+                className="flex-row items-center gap-3 p-4"
+                onPress={() => setExpanded(expanded === environmentId ? null : environmentId)}
+              >
+                <View className="min-w-0 flex-1 gap-0.5">
+                  <Text className="text-base font-t3-bold text-foreground">
+                    {entry.target.label}
+                  </Text>
+                  <Text className="text-xs text-foreground-muted" numberOfLines={1}>
+                    {connectionCatalogDisplayUrl(entry) ?? "T3 Connect"}
+                  </Text>
+                </View>
+                <Text className="text-sm text-foreground-muted">
+                  {options.find((option) => option.value === selected)?.label}
+                </Text>
+                <SymbolView
+                  name={expanded === environmentId ? "chevron.up" : "chevron.down"}
+                  size={12}
+                  tintColorClassName="accent-icon-muted"
+                />
+              </Pressable>
+              {expanded === environmentId
+                ? options.map((option) => (
+                    <Pressable
+                      key={option.value}
+                      accessibilityRole="radio"
+                      accessibilityState={{ checked: selected === option.value, disabled }}
+                      disabled={disabled}
+                      className="flex-row items-center gap-4 border-t border-border-subtle p-4 disabled:opacity-50"
+                      onPress={() => {
+                        setSaving(true);
+                        void update({ environmentId, permission: option.value }).then((result) => {
+                          setSaving(false);
+                          if (result._tag === "Failure")
+                            Alert.alert(
+                              "Could not save GitHub routing permission",
+                              "Try again before leaving this screen.",
+                            );
+                        });
+                      }}
+                    >
+                      <View className="min-w-0 flex-1 gap-1">
+                        <Text className="text-base text-foreground">{option.label}</Text>
+                        <Text className="text-sm leading-normal text-foreground-muted">
+                          {option.description}
+                        </Text>
+                      </View>
+                      {selected === option.value ? (
+                        <SymbolView
+                          name="checkmark"
+                          size={18}
+                          tintColorClassName="accent-icon"
+                          weight="semibold"
+                        />
+                      ) : null}
+                    </Pressable>
+                  ))
+                : null}
+            </View>
+          );
+        })}
+      </SettingsSection>
+      <Text className="px-2 text-sm text-foreground-muted">
+        Choose environments you trust to share PR data and use each other's GitHub access. Enable
+        both environments. This applies only to this client.
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
@@ -10,6 +10,7 @@ import { AppText as Text } from "../../components/AppText";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { CloudEnvironmentRows } from "../connection/CloudEnvironmentRows";
 import { ConnectionEnvironmentRow } from "../connection/ConnectionEnvironmentRow";
+import { GitHubRoutingSettings } from "../connection/GitHubRoutingSettings";
 import { splitEnvironmentSections } from "../connection/environmentSections";
 import { cn } from "../../lib/cn";
 import { useUniwindTheme } from "../../lib/useUniwindTheme";
@@ -171,6 +172,7 @@ export function SettingsEnvironmentsRouteScreen() {
               }
             : {})}
         />
+        <GitHubRoutingSettings />
       </ScrollView>
     </View>
   );

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -68,6 +68,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsList]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsSummary]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsRouting]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsStack]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsLinkedThreads]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,

--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -69,6 +69,7 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.pullRequestsListStats]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsSummary]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsRouting]: AuthOrchestrationReadScope,
+  [WS_METHODS.pullRequestsRoutingIdentity]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsStack]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsLinkedThreads]: AuthOrchestrationReadScope,
   [WS_METHODS.pullRequestsDetail]: AuthOrchestrationReadScope,

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -2458,9 +2458,76 @@ layer("GitHubPullRequestCli.layer", (it) => {
       mockedExecute.mockReturnValueOnce(Effect.succeed(output("  ")));
       const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
 
-      const error = yield* Effect.flip(cli.getViewerLogin({ cwd: "/w" }));
+      const error = yield* Effect.flip(cli.getViewerLogin({ cwd: "/w", host: "github.com" }));
 
       assert.strictEqual(error._tag, "GitHubViewerLoginUnavailableError");
+    }),
+  );
+
+  it.effect("looks up the authenticated account on the requested enterprise host", () =>
+    Effect.gen(function* () {
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output("enterprise-test-credential")))
+        .mockReturnValueOnce(Effect.succeed(output('{"id":456,"login":"enterprise-user"}')));
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const login = yield* cli.getViewerLogin({ cwd: "/w", host: "github.acme.com" });
+
+      expect(login).toBe("enterprise-user");
+      expect(callAt(0).args).toEqual(["auth", "token", "--hostname", "github.acme.com"]);
+      expect(callAt(1).args).toEqual(["api", "user", "--hostname", "github.acme.com"]);
+    }),
+  );
+
+  it.effect("reuses verified credentials offline and refuses an unverified replacement", () =>
+    Effect.gen(function* () {
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const input = { cwd: "/w", host: "github.identity-cache.test" };
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output("test-credential-a")))
+        .mockReturnValueOnce(Effect.succeed(output('{"id":123,"login":"maria-rcks"}')));
+      expect(yield* cli.getRoutingIdentity(input)).toEqual({
+        accountId: "123",
+        viewer: "maria-rcks",
+      });
+      expect(callAt(1).env).toMatchObject({
+        GH_ENTERPRISE_TOKEN: "test-credential-a",
+        GH_DEBUG: "",
+      });
+
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("test-credential-a")));
+      expect(yield* cli.getRoutingIdentity(input)).toEqual({
+        accountId: "123",
+        viewer: "maria-rcks",
+      });
+      expect(mockedExecute).toHaveBeenCalledTimes(3);
+
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output("test-credential-b")))
+        .mockReturnValueOnce(
+          Effect.fail(
+            new GitHubCli.GitHubCliCommandError({
+              command: "gh",
+              cwd: "/w",
+              cause: new Error("upstream failed with test-credential-b"),
+            }),
+          ),
+        );
+      const failure = yield* cli.getRoutingIdentity(input).pipe(Effect.flip);
+      expect(failure._tag).toBe("GitHubViewerLoginUnavailableError");
+      expect(String(failure)).not.toContain("test-credential-b");
+      expect(callAt(4).env).toMatchObject({
+        GH_ENTERPRISE_TOKEN: "test-credential-b",
+        GH_DEBUG: "",
+      });
+
+      mockedExecute
+        .mockReturnValueOnce(Effect.succeed(output("test-credential-b")))
+        .mockReturnValueOnce(Effect.succeed(output('{"id":456,"login":"maria-rcks"}')));
+      expect(yield* cli.getRoutingIdentity(input)).toEqual({
+        accountId: "456",
+        viewer: "maria-rcks",
+      });
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, assert, expect, it, vi } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as TestClock from "effect/testing/TestClock";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
+import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubGraphQlBudget from "../sourceControl/githubGraphQlBudget.ts";
 import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
 import { BASE_COMPARISON_GRAPHQL_QUERY } from "./gitHubPullRequestJson.ts";
@@ -192,7 +195,118 @@ afterEach(() => {
   mockedGetPullRequest.mockReset();
 });
 
+it.effect(
+  "keeps a verified credential through an auth switch and separates token fingerprints",
+  () =>
+    Effect.gen(function* () {
+      let activeToken = "broad-credential";
+      const commands: VcsProcess.VcsProcessInput[] = [];
+      const github = yield* GitHubCli.make.pipe(
+        Effect.provideService(VcsProcess.VcsProcess, {
+          run: (input) =>
+            Effect.sync(() => {
+              commands.push(input);
+              if (input.args[0] === "auth") return output(activeToken);
+              if (input.args[0] === "api") return output('{"id":123,"login":"same-account"}');
+              return output("");
+            }),
+        }),
+      );
+      const cli = yield* GitHubPullRequestCli.make.pipe(
+        Effect.provideService(GitHubCli.GitHubCli, github),
+        Effect.provide(GitHubGraphQlBudget.layer),
+      );
+      const input = { cwd: "/repo", host: "github.com" };
+      const first = yield* cli.withVerifiedCredential(input, (identity) =>
+        Effect.gen(function* () {
+          activeToken = "restricted-credential";
+          expect(yield* cli.getViewerLogin(input)).toBe("same-account");
+          yield* cli.commentOnPullRequest({
+            ...input,
+            repository: "owner/repo",
+            number: 1,
+            body: "comment",
+          });
+          return identity;
+        }),
+      );
+      const second = yield* cli.withVerifiedCredential(input, Effect.succeed);
+      expect(first.accountId).toBe(second.accountId);
+      expect(first.credentialFingerprint).not.toBe(second.credentialFingerprint);
+      expect(encodeJson([first, second])).not.toContain("broad-credential");
+      expect(encodeJson([first, second])).not.toContain("restricted-credential");
+      expect(commands.find((command) => command.args[0] === "pr")?.env).toMatchObject({
+        GH_TOKEN: "broad-credential",
+        GITHUB_TOKEN: "broad-credential",
+        GH_DEBUG: "",
+      });
+      expect(
+        commands
+          .filter((command) => command.args[0] === "api")
+          .map((command) => command.env?.GH_TOKEN),
+      ).toEqual(["broad-credential", "restricted-credential"]);
+      expect(yield* cli.getRoutingIdentity(input)).toEqual({
+        accountId: "123",
+        viewer: "same-account",
+      });
+    }),
+);
+
 layer("GitHubPullRequestCli.layer", (it) => {
+  it.effect("coalesces concurrent identity verification for the same host and credential", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((input) =>
+        input.args[0] === "auth"
+          ? Effect.succeed(output("shared-credential"))
+          : Effect.yieldNow.pipe(Effect.as(output('{"id":123,"login":"viewer"}'))),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const results = yield* Effect.all(
+        Array.from({ length: 4 }, () =>
+          cli.getRoutingIdentity({ cwd: "/w", host: "github.identity-flight.test" }),
+        ),
+        { concurrency: 4 },
+      );
+      expect(results).toEqual(
+        Array.from({ length: 4 }, () => ({ accountId: "123", viewer: "viewer" })),
+      );
+      expect(mockedExecute.mock.calls.filter(([input]) => input.args[0] === "api")).toHaveLength(1);
+    }),
+  );
+
+  it.effect(
+    "lets another identity reader continue when the first verification is interrupted",
+    () =>
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>();
+        const secondStarted = yield* Deferred.make<void>();
+        let tokens = 0;
+        let verifications = 0;
+        mockedExecute.mockImplementation((input) =>
+          Effect.gen(function* () {
+            if (input.args[0] === "auth") {
+              if (++tokens === 2) yield* Deferred.succeed(secondStarted, undefined);
+              return output("cancel-credential");
+            }
+            if (++verifications === 1) {
+              yield* Deferred.succeed(firstStarted, undefined);
+              return yield* Effect.never;
+            }
+            return output('{"id":123,"login":"viewer"}');
+          }),
+        );
+        const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+        const input = { cwd: "/w", host: "github.identity-cancel.test" };
+        const first = yield* cli.getRoutingIdentity(input).pipe(Effect.forkChild);
+        yield* Deferred.await(firstStarted);
+        const second = yield* cli.getRoutingIdentity(input).pipe(Effect.forkChild);
+        yield* Deferred.await(secondStarted);
+        yield* Fiber.interrupt(first);
+        expect(yield* Fiber.join(second)).toEqual({ accountId: "123", viewer: "viewer" });
+        expect(verifications).toBe(2);
+      }),
+  );
+
   it.effect("reads linked pull request status with the overview fields in one request", () =>
     Effect.gen(function* () {
       mockedExecute.mockReturnValueOnce(

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -1,11 +1,15 @@
 import { runGitHubStackAction, type GitHubStackActionError } from "./githubStackActions.ts";
 import * as Context from "effect/Context";
+import * as Clock from "effect/Clock";
+import * as NodeCrypto from "node:crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import {
   resolvePullRequestAuthorFilter,
+  PositiveInt,
+  TrimmedNonEmptyString,
   type PullRequestAction,
   type PullRequestStackHead,
   type PullRequestActor,
@@ -413,8 +417,16 @@ export interface GitHubPullRequestDiffSlice {
 export class GitHubPullRequestCli extends Context.Service<
   GitHubPullRequestCli,
   {
+    readonly getRoutingIdentity: (input: {
+      readonly cwd: string;
+      readonly host: string;
+    }) => Effect.Effect<
+      { readonly accountId: string; readonly viewer: string },
+      GitHubPullRequestCliError
+    >;
     readonly getViewerLogin: (input: {
       readonly cwd: string;
+      readonly host: string;
     }) => Effect.Effect<string, GitHubPullRequestCliError>;
 
     readonly listPullRequests: (input: {
@@ -991,6 +1003,63 @@ function actionArgs(
 export const make = Effect.gen(function* () {
   const github = yield* GitHubCli.GitHubCli;
   const graphQlBudget = yield* GitHubGraphQlBudget.GitHubGraphQlBudget;
+  const routingIdentities = new Map<
+    string,
+    {
+      at: number;
+      value: { accountId: string; viewer: string };
+    }
+  >();
+  const decodeRoutingIdentity = Schema.decodeUnknownEffect(
+    Schema.fromJsonString(
+      Schema.Struct({
+        id: PositiveInt,
+        login: TrimmedNonEmptyString,
+      }),
+    ),
+  );
+  const getRoutingIdentity = Effect.fn("GitHubPullRequestCli.getRoutingIdentity")(
+    function* (input: { readonly cwd: string; readonly host: string }) {
+      const unavailable = () =>
+        new GitHubViewerLoginUnavailableError({ command: "gh", cwd: input.cwd });
+      const host = input.host.toLowerCase();
+      // Only the digest is retained. Never attach credential lookup output to an error.
+      const token = (yield* github
+        .execute({
+          cwd: input.cwd,
+          args: ["auth", "token", "--hostname", host],
+          env: { GH_DEBUG: "" },
+        })
+        .pipe(Effect.mapError(unavailable))).stdout.trim();
+      if (!token) return yield* unavailable();
+      const key = `${host}:${NodeCrypto.createHash("sha256").update(token).digest("hex")}`;
+      const now = yield* Clock.currentTimeMillis;
+      const cached = routingIdentities.get(key);
+      if (cached !== undefined && now - cached.at < 10 * 60_000) return cached.value;
+      // Pin this read to the captured credential so an auth switch cannot poison its cache entry.
+      const response = yield* github
+        .execute({
+          cwd: input.cwd,
+          args: ["api", "user", "--hostname", host],
+          env: {
+            GH_TOKEN: token,
+            GITHUB_TOKEN: token,
+            GH_ENTERPRISE_TOKEN: token,
+            GITHUB_ENTERPRISE_TOKEN: token,
+            GH_DEBUG: "",
+          },
+        })
+        .pipe(Effect.mapError(unavailable));
+      const identity = yield* decodeRoutingIdentity(response.stdout).pipe(
+        Effect.mapError(unavailable),
+      );
+      const value = { accountId: String(identity.id), viewer: identity.login };
+      if (routingIdentities.size >= 128)
+        routingIdentities.delete(routingIdentities.keys().next().value!);
+      routingIdentities.set(key, { at: now, value });
+      return value;
+    },
+  );
 
   /**
    * The pull request's own node id, which is what a mutation against the pull request itself is
@@ -1468,15 +1537,9 @@ export const make = Effect.gen(function* () {
         );
 
   return GitHubPullRequestCli.of({
+    getRoutingIdentity,
     getViewerLogin: (input) =>
-      github.execute({ cwd: input.cwd, args: ["api", "user", "--jq", ".login"] }).pipe(
-        Effect.flatMap((result) => {
-          const login = result.stdout.trim();
-          return login.length > 0
-            ? Effect.succeed(login)
-            : Effect.fail(new GitHubViewerLoginUnavailableError({ command: "gh", cwd: input.cwd }));
-        }),
-      ),
+      getRoutingIdentity(input).pipe(Effect.map((identity) => identity.viewer)),
 
     listPullRequests: (input) => {
       const fallbackMaxRows = Math.max(input.limit + 1, PULL_REQUEST_FALLBACK_MAX_ROWS);

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -4,8 +4,10 @@ import * as Clock from "effect/Clock";
 import * as NodeCrypto from "node:crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
 import {
   resolvePullRequestAuthorFilter,
   PositiveInt,
@@ -417,6 +419,14 @@ export interface GitHubPullRequestDiffSlice {
 export class GitHubPullRequestCli extends Context.Service<
   GitHubPullRequestCli,
   {
+    readonly withVerifiedCredential: <A, E, R>(
+      input: { readonly cwd: string; readonly host: string },
+      use: (identity: {
+        readonly accountId: string;
+        readonly viewer: string;
+        readonly credentialFingerprint: string;
+      }) => Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | GitHubPullRequestCliError, R>;
     readonly getRoutingIdentity: (input: {
       readonly cwd: string;
       readonly host: string;
@@ -1010,6 +1020,7 @@ export const make = Effect.gen(function* () {
       value: { accountId: string; viewer: string };
     }
   >();
+  const identityLocks = new Map<string, { gate: Semaphore.Semaphore; users: number }>();
   const decodeRoutingIdentity = Schema.decodeUnknownEffect(
     Schema.fromJsonString(
       Schema.Struct({
@@ -1018,48 +1029,95 @@ export const make = Effect.gen(function* () {
       }),
     ),
   );
-  const getRoutingIdentity = Effect.fn("GitHubPullRequestCli.getRoutingIdentity")(
+  const captureVerifiedCredential = Effect.fn("GitHubPullRequestCli.captureVerifiedCredential")(
     function* (input: { readonly cwd: string; readonly host: string }) {
       const unavailable = () =>
         new GitHubViewerLoginUnavailableError({ command: "gh", cwd: input.cwd });
       const host = input.host.toLowerCase();
+      const pinned = yield* GitHubCli.PinnedGitHubCredential;
+      if (pinned !== null && pinned.host !== host) return yield* unavailable();
       // Only the digest is retained. Never attach credential lookup output to an error.
-      const token = (yield* github
-        .execute({
-          cwd: input.cwd,
-          args: ["auth", "token", "--hostname", host],
-          env: { GH_DEBUG: "" },
-        })
-        .pipe(Effect.mapError(unavailable))).stdout.trim();
+      const token =
+        pinned !== null
+          ? Redacted.value(pinned.token)
+          : (yield* github
+              .execute({
+                cwd: input.cwd,
+                args: ["auth", "token", "--hostname", host],
+                env: { GH_DEBUG: "" },
+              })
+              .pipe(Effect.mapError(unavailable))).stdout.trim();
       if (!token) return yield* unavailable();
       const key = `${host}:${NodeCrypto.createHash("sha256").update(token).digest("hex")}`;
-      const now = yield* Clock.currentTimeMillis;
-      const cached = routingIdentities.get(key);
-      if (cached !== undefined && now - cached.at < 10 * 60_000) return cached.value;
-      // Pin this read to the captured credential so an auth switch cannot poison its cache entry.
-      const response = yield* github
-        .execute({
-          cwd: input.cwd,
-          args: ["api", "user", "--hostname", host],
-          env: {
-            GH_TOKEN: token,
-            GITHUB_TOKEN: token,
-            GH_ENTERPRISE_TOKEN: token,
-            GITHUB_ENTERPRISE_TOKEN: token,
-            GH_DEBUG: "",
-          },
-        })
-        .pipe(Effect.mapError(unavailable));
-      const identity = yield* decodeRoutingIdentity(response.stdout).pipe(
-        Effect.mapError(unavailable),
+      const credential = { host, token: Redacted.make(token), credentialFingerprint: key };
+      // A cold page may ask several times. Wait per credential and check again after the
+      // first verification; cancellation releases the next waiter without losing its request.
+      return yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          const lock = identityLocks.get(key) ?? { gate: Semaphore.makeUnsafe(1), users: 0 };
+          lock.users++;
+          identityLocks.set(key, lock);
+          return lock;
+        }),
+        (lock) =>
+          lock.gate.withPermit(
+            Effect.gen(function* () {
+              const now = yield* Clock.currentTimeMillis;
+              const cached = routingIdentities.get(key);
+              if (cached !== undefined && now - cached.at < 10 * 60_000)
+                return { ...credential, ...cached.value };
+              // Pin this read so an auth switch cannot poison its cache entry.
+              const response = yield* github
+                .execute({
+                  cwd: input.cwd,
+                  args: ["api", "user", "--hostname", host],
+                  env: {
+                    GH_HOST: host,
+                    GH_TOKEN: token,
+                    GITHUB_TOKEN: token,
+                    GH_ENTERPRISE_TOKEN: token,
+                    GITHUB_ENTERPRISE_TOKEN: token,
+                    GH_DEBUG: "",
+                  },
+                })
+                .pipe(Effect.mapError(unavailable));
+              const identity = yield* decodeRoutingIdentity(response.stdout).pipe(
+                Effect.mapError(unavailable),
+              );
+              const value = { accountId: String(identity.id), viewer: identity.login };
+              if (routingIdentities.size >= 128)
+                routingIdentities.delete(routingIdentities.keys().next().value!);
+              routingIdentities.set(key, { at: now, value });
+              return { ...credential, ...value };
+            }),
+          ),
+        (lock) =>
+          Effect.sync(() => {
+            lock.users--;
+            if (lock.users === 0) identityLocks.delete(key);
+          }),
       );
-      const value = { accountId: String(identity.id), viewer: identity.login };
-      if (routingIdentities.size >= 128)
-        routingIdentities.delete(routingIdentities.keys().next().value!);
-      routingIdentities.set(key, { at: now, value });
-      return value;
     },
   );
+  const withVerifiedCredential: GitHubPullRequestCli["Service"]["withVerifiedCredential"] = (
+    input,
+    use,
+  ) =>
+    captureVerifiedCredential(input).pipe(
+      Effect.flatMap(({ host, token, accountId, viewer, credentialFingerprint }) =>
+        use({ accountId, viewer, credentialFingerprint }).pipe(
+          Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+            host,
+            token,
+            credentialFingerprint,
+          }),
+        ),
+      ),
+    );
+  const getRoutingIdentity: GitHubPullRequestCli["Service"]["getRoutingIdentity"] = (input) =>
+    captureVerifiedCredential(input).pipe(
+      Effect.map(({ accountId, viewer }) => ({ accountId, viewer })),
+    );
 
   /**
    * The pull request's own node id, which is what a mutation against the pull request itself is
@@ -1537,6 +1595,7 @@ export const make = Effect.gen(function* () {
         );
 
   return GitHubPullRequestCli.of({
+    withVerifiedCredential,
     getRoutingIdentity,
     getViewerLogin: (input) =>
       getRoutingIdentity(input).pipe(Effect.map((identity) => identity.viewer)),

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -513,6 +513,36 @@ it.effect("propagates workflow discovery rate limits", () =>
 );
 
 describe("getViewerPermissions", () => {
+  it.effect("checks fresh access without reading branch details for unrelated operations", () => {
+    let accessReads = 0;
+    return Effect.gen(function* () {
+      const provider = yield* make;
+      const permissions = yield* provider.getViewerPermissions({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        number: 7,
+        includeUpdateBranch: false,
+      });
+
+      expect(accessReads).toBe(1);
+      expect(permissions.actions).toContain("merge");
+      expect(permissions.actions).not.toContain("update-branch");
+    }).pipe(
+      Effect.provide(
+        Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+          getPullRequestDetail: () => Effect.die("Unexpected detail read"),
+          getPullRequestBaseComparison: () => Effect.die("Unexpected comparison read"),
+          getViewerAccess: () =>
+            Effect.sync(() => {
+              accessReads++;
+              return { canWrite: true, canTriage: true, canUpdate: true, didAuthor: false };
+            }),
+        }),
+      ),
+    );
+  });
+
   const layerWithComparison = (
     comparison: Effect.Effect<{
       readonly behindBy: number | null;

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.test.ts
@@ -1,12 +1,51 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import type { PullRequestReaction } from "@t3tools/contracts";
 
 import * as GitHubCli from "../sourceControl/GitHubCli.ts";
 import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
 import { gitHubViewerPermissions, loginAvatarUrl, make } from "./GitHubPullRequestProvider.ts";
 import type { GitHubReviewThreadComments } from "./gitHubPullRequestJson.ts";
+
+it.effect("maps credential verification failures without relabeling operation failures", () =>
+  Effect.gen(function* () {
+    let verificationFails = true;
+    let operations = 0;
+    const provider = yield* make.pipe(
+      Effect.provide(
+        Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
+          withVerifiedCredential: (_input, use) =>
+            verificationFails
+              ? Effect.fail(
+                  new GitHubPullRequestCli.GitHubViewerLoginUnavailableError({
+                    command: "gh",
+                    cwd: "/w",
+                  }),
+                )
+              : use({ accountId: "123", viewer: "viewer", credentialFingerprint: "fingerprint" }),
+        }),
+      ),
+    );
+    const verify = provider.withVerifiedCredential;
+    if (verify === undefined)
+      return yield* Effect.die("credential verification was not implemented");
+    const input = { cwd: "/w", host: "github.com" };
+    const operation = () =>
+      Effect.sync(() => {
+        operations++;
+      }).pipe(Effect.andThen(Effect.fail("operation-failed")));
+    expect(yield* verify(input, operation).pipe(Effect.flip)).toMatchObject({
+      _tag: "PullRequestProviderError",
+      operation: "routeIdentity",
+    });
+    expect(operations).toBe(0);
+    verificationFails = false;
+    expect(yield* verify(input, operation).pipe(Effect.flip)).toBe("operation-failed");
+    expect(operations).toBe(1);
+  }),
+);
 
 it.effect("uses one narrow read for a linked pull request summary", () =>
   Effect.gen(function* () {
@@ -215,6 +254,23 @@ describe("gitHubViewerPermissions", () => {
         description: "GitHub could not determine whether workflows are awaiting approval.",
         url: null,
       });
+      for (const fingerprint of ["broad", "restricted", "broad"]) {
+        const scoped = yield* provider
+          .getChangeRequest({
+            cwd: "/w",
+            repository: "acme/web",
+            host: "github.com",
+            number: 7,
+          })
+          .pipe(
+            Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+              host: "github.com",
+              token: Redacted.make("credential"),
+              credentialFingerprint: fingerprint,
+            }),
+          );
+        expect(scoped.mergeCapabilities.squash).toBe(fingerprint !== "restricted");
+      }
     }).pipe(
       Effect.provide(
         Layer.mock(GitHubPullRequestCli.GitHubPullRequestCli)({
@@ -250,10 +306,16 @@ describe("gitHubViewerPermissions", () => {
               commits: [],
             }),
           getRepositoryAccess: () =>
-            Effect.succeed({
-              canWrite: false,
-              mergeCapabilities: { merge: true, squash: true, rebase: true },
-            }),
+            GitHubCli.PinnedGitHubCredential.pipe(
+              Effect.map((credential) => ({
+                canWrite: false,
+                mergeCapabilities: {
+                  merge: true,
+                  squash: credential?.credentialFingerprint !== "restricted",
+                  rebase: true,
+                },
+              })),
+            ),
           getViewerAccess: () =>
             Effect.succeed({
               canWrite: false,

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -212,9 +212,13 @@ export const make = Effect.gen(function* () {
   const provider: PullRequestProviderApi = {
     kind: "github",
     capabilities: CAPABILITIES,
+    getRoutingIdentity: (input) =>
+      cli.getRoutingIdentity(input).pipe(Effect.mapError(fail("routeIdentity"))),
 
     getViewer: (input) =>
-      cli.getViewerLogin({ cwd: input.cwd }).pipe(Effect.mapError(fail("getViewer"))),
+      cli
+        .getViewerLogin({ cwd: input.cwd, host: input.host ?? "github.com" })
+        .pipe(Effect.mapError(fail("getViewer"))),
 
     listChangeRequests: (input) =>
       cli
@@ -494,20 +498,22 @@ export const make = Effect.gen(function* () {
           // comparison only resolves through the head ref the detail carries. A failure here
           // withholds that one action rather than the whole answer, the way the detail path
           // leaves the banner unknown.
-          cli.getPullRequestDetail(input).pipe(
-            Effect.flatMap((pullRequest) =>
-              pullRequest.state !== "open" || pullRequest.headRepositoryOwner === null
-                ? Effect.succeed(false)
-                : cli
-                    .getPullRequestBaseComparison({
-                      ...input,
-                      headRef: `${pullRequest.headRepositoryOwner}:${pullRequest.headBranch}`,
-                      allowReserve: true,
-                    })
-                    .pipe(Effect.map((comparison) => comparison.viewerCanUpdate === true)),
-            ),
-            Effect.orElseSucceed(() => false),
-          ),
+          input.includeUpdateBranch === false
+            ? Effect.succeed(false)
+            : cli.getPullRequestDetail(input).pipe(
+                Effect.flatMap((pullRequest) =>
+                  pullRequest.state !== "open" || pullRequest.headRepositoryOwner === null
+                    ? Effect.succeed(false)
+                    : cli
+                        .getPullRequestBaseComparison({
+                          ...input,
+                          headRef: `${pullRequest.headRepositoryOwner}:${pullRequest.headBranch}`,
+                          allowReserve: true,
+                        })
+                        .pipe(Effect.map((comparison) => comparison.viewerCanUpdate === true)),
+                ),
+                Effect.orElseSucceed(() => false),
+              ),
         ],
         { concurrency: 2 },
       ).pipe(

--- a/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestProvider.ts
@@ -11,6 +11,7 @@ import type {
 } from "@t3tools/contracts";
 
 import * as GitHubPullRequestCli from "./GitHubPullRequestCli.ts";
+import { PinnedGitHubCredential } from "../sourceControl/GitHubCli.ts";
 import {
   PullRequestProviderError,
   type PullRequestProviderFailure,
@@ -198,7 +199,20 @@ export const make = Effect.gen(function* () {
     readonly cwd: string;
     readonly repository: string;
     readonly host: string;
-  }) => Cache.get(repositoryAccessCache, JSON.stringify([input.cwd, input.repository, input.host]));
+  }) =>
+    PinnedGitHubCredential.pipe(
+      Effect.flatMap((credential) =>
+        Cache.get(
+          repositoryAccessCache,
+          JSON.stringify([
+            input.cwd,
+            input.repository,
+            input.host,
+            credential?.credentialFingerprint ?? null,
+          ]),
+        ),
+      ),
+    );
 
   const fail = (operation: string) => (error: GitHubPullRequestCli.GitHubPullRequestCliError) =>
     new PullRequestProviderError({
@@ -214,6 +228,10 @@ export const make = Effect.gen(function* () {
     capabilities: CAPABILITIES,
     getRoutingIdentity: (input) =>
       cli.getRoutingIdentity(input).pipe(Effect.mapError(fail("routeIdentity"))),
+    withVerifiedCredential: (input, use) =>
+      cli
+        .withVerifiedCredential(input, (identity) => use(identity).pipe(Effect.result))
+        .pipe(Effect.mapError(fail("routeIdentity")), Effect.flatMap(Effect.fromResult)),
 
     getViewer: (input) =>
       cli

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -276,12 +276,20 @@ export interface ProviderRepositoryRef {
  * failing at call time.
  */
 export interface PullRequestProviderApi {
+  readonly getRoutingIdentity?: (input: {
+    readonly cwd: string;
+    readonly host: string;
+  }) => Effect.Effect<
+    { readonly accountId: string; readonly viewer: string },
+    PullRequestProviderError
+  >;
   readonly kind: SourceControlProviderKind;
   readonly capabilities: PullRequestCapabilities;
 
   /** The signed-in account, which is what involvement filtering compares against. */
   readonly getViewer: (input: {
     readonly cwd: string;
+    readonly host?: string;
   }) => Effect.Effect<string, PullRequestProviderError>;
 
   readonly listChangeRequests: (
@@ -397,7 +405,11 @@ export interface PullRequestProviderApi {
    * is no request at all.
    */
   readonly getViewerPermissions: (
-    input: ProviderRepositoryRef & { readonly number: number },
+    input: ProviderRepositoryRef & {
+      readonly number: number;
+      /** Skip branch comparison when checking permission for an unrelated operation. */
+      readonly includeUpdateBranch?: boolean;
+    },
   ) => Effect.Effect<PullRequestViewerPermissions, PullRequestProviderError>;
 
   /**

--- a/apps/server/src/pullRequest/PullRequestProvider.ts
+++ b/apps/server/src/pullRequest/PullRequestProvider.ts
@@ -276,6 +276,14 @@ export interface ProviderRepositoryRef {
  * failing at call time.
  */
 export interface PullRequestProviderApi {
+  readonly withVerifiedCredential?: <A, E, R>(
+    input: { readonly cwd: string; readonly host: string },
+    use: (identity: {
+      readonly accountId: string;
+      readonly viewer: string;
+      readonly credentialFingerprint: string;
+    }) => Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | PullRequestProviderError, R>;
   readonly getRoutingIdentity?: (input: {
     readonly cwd: string;
     readonly host: string;

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -975,6 +975,49 @@ it.effect("tries another workspace on the same host for the viewer", () =>
   }),
 );
 
+it.effect("routing verifies the current account on the requested host without caching it", () =>
+  Effect.gen(function* () {
+    let viewer = "first-account";
+    const service = yield* makeService({
+      projects: [
+        project({
+          id: "p1",
+          title: "web",
+          workspaceRoot: "/a",
+          repository: "acme/web",
+          host: "github.example.test",
+        }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          getRoutingIdentity: (input) => {
+            assert.deepStrictEqual(input, { cwd: "/a", host: "github.example.test" });
+            return Effect.succeed({
+              viewer,
+              accountId: viewer === "first-account" ? "123" : "456",
+            });
+          },
+        }),
+      ],
+    });
+    const ref = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+    assert.deepStrictEqual(yield* service.routing(ref), {
+      host: "github.example.test",
+      provider: "github",
+      viewer: "first-account",
+      accountId: "123",
+    });
+    viewer = "second-account";
+    assert.strictEqual((yield* service.routing(ref)).viewer, "second-account");
+    viewer = " ";
+    const failure = yield* service.routing(ref).pipe(Effect.flip);
+    assert.strictEqual(failure._tag, "PullRequestOperationError");
+    if (failure._tag === "PullRequestOperationError") {
+      assert.strictEqual(failure.operation, "routeIdentity");
+    }
+  }),
+);
+
 it.effect("refuses an action the host never claimed it could run", () =>
   Effect.gen(function* () {
     let ran = false;
@@ -3596,9 +3639,7 @@ it.effect("shares linked summaries and reuses them for display without asking th
 
     yield* TestClock.adjust("61 seconds");
     failing = true;
-    const strict = yield* Effect.flip(
-      service.summary(reference, { recoverTransientFailure: false }),
-    );
+    const strict = yield* Effect.flip(service.summary({ ...reference, allowStale: false }));
     assert.strictEqual(strict._tag, "PullRequestOperationError");
 
     const stale = yield* service.summary(reference);
@@ -3867,6 +3908,8 @@ it.effect("keeps recent detail on a transient refresh failure but not after inva
     yield* service.detail(reference);
     yield* TestClock.adjust("16 seconds");
     failing = true;
+    const strict = yield* Effect.flip(service.detail({ ...reference, allowStale: false }));
+    assert.strictEqual(strict._tag, "PullRequestOperationError");
     const stale = yield* service.detail(reference);
     assert.strictEqual(stale.body, "last good body");
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3825,6 +3825,13 @@ it.effect("does not let a stale detail reopen overwrite a fresher linked summary
     assert.strictEqual(display.title, "merged title");
     assert.strictEqual(display.state, "merged");
     assert.strictEqual(detailCalls, 2);
+
+    summaryTitle = "updated after merge";
+    yield* TestClock.adjust("61 seconds");
+    assert.strictEqual((yield* service.summary(reference)).title, "merged title");
+    const refreshed = yield* service.summary({ ...reference, allowStale: false });
+    assert.strictEqual(refreshed.title, "updated after merge");
+    assert.strictEqual(refreshed.state, "merged");
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -3653,6 +3653,41 @@ it.effect("shares linked summaries and reuses them for display without asking th
   }),
 );
 
+it.effect("keeps routed summaries and details separate when the GitHub account changes", () =>
+  Effect.gen(function* () {
+    for (const operation of ["summary", "detail"] as const) {
+      let failing = false;
+      let calls = 0;
+      const read = () =>
+        Effect.suspend(() => {
+          calls += 1;
+          return failing
+            ? Effect.fail(requestFailed)
+            : Effect.succeed(hostedChangeRequest("account A content"));
+        });
+      const service = yield* makeService({
+        projects: [
+          project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" }),
+        ],
+        providers: [
+          fakeProvider("github", { getChangeRequestSummary: read, getChangeRequest: read }),
+        ],
+      });
+      const reference = { projectId: "p1" as ProjectId, repository: "acme/web", number: 1 };
+      yield* service[operation]({ ...reference, expectedAccountId: "101" });
+      failing = true;
+
+      for (const allowStale of [false, true]) {
+        const error = yield* Effect.flip(
+          service[operation]({ ...reference, expectedAccountId: "202", allowStale }),
+        );
+        assert.strictEqual(error._tag, "PullRequestOperationError");
+      }
+      assert.strictEqual(calls, 3);
+    }
+  }),
+);
+
 it.effect("answers a known pull request immediately while the host refreshes", () =>
   Effect.gen(function* () {
     const gate = yield* Deferred.make<void>();

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -1006,6 +1006,8 @@ it.effect("routing verifies the current account on the requested host without ca
       provider: "github",
       viewer: "first-account",
       accountId: "123",
+      projectTitle: "web",
+      workspaceRoot: "/a",
     });
     viewer = "second-account";
     assert.strictEqual((yield* service.routing(ref)).viewer, "second-account");

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -16,6 +16,7 @@ import type {
   PullRequestReviewerCapabilities,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
+import { PullRequestOperationError } from "@t3tools/contracts";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as SourceControlProviderRegistry from "../sourceControl/SourceControlProviderRegistry.ts";
@@ -3687,6 +3688,112 @@ it.effect("keeps routed summaries and details separate when the GitHub account c
       }
       assert.strictEqual(calls, 3);
     }
+  }),
+);
+
+it.effect("isolates routed caches for two credentials belonging to the same account", () =>
+  Effect.gen(function* () {
+    for (const operation of ["summary", "detail"] as const) {
+      let credential = "broad";
+      let calls = 0;
+      const read = () =>
+        Effect.suspend(() => {
+          calls += 1;
+          return credential === "broad"
+            ? Effect.succeed(hostedChangeRequest("private content"))
+            : Effect.fail(requestFailed);
+        });
+      const service = yield* makeService({
+        projects: [
+          project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" }),
+        ],
+        providers: [
+          fakeProvider("github", {
+            withVerifiedCredential: (_, use) =>
+              Effect.suspend(() =>
+                use({
+                  accountId: "101",
+                  viewer: "octocat",
+                  credentialFingerprint: credential,
+                }),
+              ),
+            getChangeRequest: read,
+            getChangeRequestSummary: read,
+          }),
+        ],
+      });
+      const reference = {
+        projectId: "p1" as ProjectId,
+        repository: "acme/web",
+        number: 1,
+        host: "github.com",
+        expectedAccountId: "101",
+      };
+      yield* service.withRoutingCredential(reference, service[operation](reference));
+      credential = "restricted";
+      for (const allowStale of [false, true]) {
+        const error = yield* Effect.flip(
+          service.withRoutingCredential(
+            reference,
+            service[operation]({ ...reference, allowStale }),
+          ),
+        );
+        assert.strictEqual(error._tag, "PullRequestOperationError");
+      }
+      assert.strictEqual(calls, 3);
+    }
+  }),
+);
+
+it.effect("rejects mismatched routing credentials before use and preserves action errors", () =>
+  Effect.gen(function* () {
+    let operations = 0;
+    const service = yield* makeService({
+      projects: [project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" })],
+      providers: [
+        fakeProvider("github", {
+          getRoutingIdentity: () => Effect.succeed({ accountId: "101", viewer: "octocat" }),
+          withVerifiedCredential: (_, use) =>
+            use({
+              accountId: "101",
+              viewer: "octocat",
+              credentialFingerprint: "credential-a",
+            }),
+        }),
+      ],
+    });
+    const reference = {
+      projectId: "p1" as ProjectId,
+      repository: "acme/web",
+      number: 1,
+      host: "github.com",
+      expectedAccountId: "202",
+    };
+    const actionError = new PullRequestOperationError({
+      operation: "runAction",
+      detail: "ambiguous",
+    });
+    const operation = Effect.sync(() => {
+      operations += 1;
+    }).pipe(Effect.andThen(Effect.fail(actionError)));
+    const rejected = yield* Effect.flip(service.withRoutingCredential(reference, operation));
+    assert.strictEqual(rejected._tag, "PullRequestOperationError");
+    if (rejected._tag === "PullRequestOperationError")
+      assert.strictEqual(rejected.operation, "routeIdentity");
+    assert.strictEqual(operations, 0);
+    assert.strictEqual(
+      yield* Effect.flip(
+        service.withRoutingCredential({ ...reference, expectedAccountId: "101" }, operation),
+      ),
+      actionError,
+    );
+    assert.strictEqual(operations, 1);
+    assert.deepStrictEqual(yield* service.routingIdentity({ host: "github.com" }), {
+      accountId: "101",
+      viewer: "octocat",
+      host: "github.com",
+      provider: "github",
+    });
   }),
 );
 

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2315,18 +2315,21 @@ export const make = Effect.gen(function* () {
       ref.host?.toLowerCase() ?? null,
       ref.repository.toLowerCase(),
       ref.number,
+      ref.expectedAccountId ?? null,
     ]);
   const refOfCacheKey = (key: string): PullRequestRef => {
-    const [, projectId, host, repository, number] = JSON.parse(key) as [
+    const [, projectId, host, repository, number, expectedAccountId] = JSON.parse(key) as [
       number,
       string,
       string | null,
       string,
       number,
+      string | null,
     ];
     return {
       projectId,
       ...(host === null ? {} : { host }),
+      ...(expectedAccountId === null ? {} : { expectedAccountId }),
       repository,
       number,
     } as PullRequestRef;
@@ -2387,6 +2390,7 @@ export const make = Effect.gen(function* () {
       project.project.id,
       project.project.workspaceRoot,
       String(input.number),
+      input.expectedAccountId ?? "",
     ]
       .map(encodeURIComponent)
       .join(":");

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -1311,7 +1311,13 @@ export const make = Effect.gen(function* () {
         detail: "The signed-in account could not be verified.",
       });
     }
-    return { host: project.host, provider: project.api.kind, ...identity };
+    return {
+      host: project.host,
+      provider: project.api.kind,
+      ...identity,
+      projectTitle: project.project.title,
+      workspaceRoot: project.project.workspaceRoot,
+    };
   });
 
   const summaryUncached: PullRequestService["Service"]["summary"] = (input) =>

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -45,6 +45,7 @@ import {
   type PullRequestProviderSummary,
   type PullRequestReactionInput,
   type PullRequestRef,
+  type PullRequestRoutingResult,
   type PullRequestReviewVerdict,
   type PullRequestReviewerCandidateList,
   type PullRequestReviewerRequestInput,
@@ -146,6 +147,9 @@ export class PullRequestService extends Context.Service<
     readonly listStats: (
       input: PullRequestListStatsInput,
     ) => Effect.Effect<PullRequestListStatsResult, PullRequestError>;
+    readonly routing: (
+      input: PullRequestRef,
+    ) => Effect.Effect<PullRequestRoutingResult, PullRequestError>;
     readonly summary: (
       input: PullRequestRef,
       options?: { readonly recoverTransientFailure?: boolean },
@@ -472,6 +476,7 @@ function withRateLimitBackoff(
     kind: api.kind,
     capabilities: api.capabilities,
     getViewer: wrap("getViewer", api.getViewer),
+    ...(api.getRoutingIdentity === undefined ? {} : { getRoutingIdentity: api.getRoutingIdentity }),
     listChangeRequests: wrap("listChangeRequests", api.listChangeRequests),
     ...(api.listChangeRequestsAcross === undefined
       ? {}
@@ -747,13 +752,19 @@ export const make = Effect.gen(function* () {
    * handed to a provider on the client's word. Read freshly for that reason, rather than taken
    * from whatever the detail said when the page loaded.
    */
-  const viewerPermissionsOf = (project: SupportedProject, ref: PullRequestRef, operation: string) =>
+  const viewerPermissionsOf = (
+    project: SupportedProject,
+    ref: PullRequestRef,
+    operation: string,
+    includeUpdateBranch = false,
+  ) =>
     project.api
       .getViewerPermissions({
         cwd: project.project.workspaceRoot,
         repository: project.repository,
         host: project.host,
         number: ref.number,
+        includeUpdateBranch,
       })
       .pipe(Effect.mapError(toPullRequestError(operation)));
 
@@ -813,7 +824,7 @@ export const make = Effect.gen(function* () {
         return Effect.die(new Error(`Missing pull request provider: ${kind}`));
       }
       const api = withRateLimitBackoff(registered, host, rateLimits);
-      return Effect.firstSuccessOf(roots.map((cwd) => api.getViewer({ cwd }))).pipe(
+      return Effect.firstSuccessOf(roots.map((cwd) => api.getViewer({ cwd, host }))).pipe(
         Effect.map((viewer) => ({
           host,
           kind,
@@ -1282,6 +1293,27 @@ export const make = Effect.gen(function* () {
   const viewerOf = (project: SupportedProject): Effect.Effect<string | null> =>
     resolveViewers([project], new Map()).pipe(Effect.map(([resolved]) => resolved?.viewer ?? null));
 
+  const routing = Effect.fn("PullRequestService.routing")(function* (input: PullRequestRef) {
+    const project = yield* requireProject(input);
+    const api = project.api.kind === "github" ? registry.get("github") : null;
+    if (api?.getRoutingIdentity === undefined) {
+      return yield* new PullRequestUnavailableError({ reason: "provider-unsupported" });
+    }
+    const identity = yield* api
+      .getRoutingIdentity({
+        cwd: project.project.workspaceRoot,
+        host: project.host,
+      })
+      .pipe(Effect.mapError(toPullRequestError("routeIdentity")));
+    if (!identity.viewer.trim() || !identity.accountId.trim()) {
+      return yield* new PullRequestOperationError({
+        operation: "routeIdentity",
+        detail: "The signed-in account could not be verified.",
+      });
+    }
+    return { host: project.host, provider: project.api.kind, ...identity };
+  });
+
   const summaryUncached: PullRequestService["Service"]["summary"] = (input) =>
     requireProject(input).pipe(
       Effect.flatMap((project) => {
@@ -1591,7 +1623,12 @@ export const make = Effect.gen(function* () {
         // What the host can do and what this account may ask of it are two questions, and both
         // have to say yes. The second is asked last, because it costs a request and the checks
         // above do not.
-        return viewerPermissionsOf(project, input, "runAction").pipe(
+        return viewerPermissionsOf(
+          project,
+          input,
+          "runAction",
+          input.action === "update-branch",
+        ).pipe(
           Effect.flatMap((viewer): Effect.Effect<string, PullRequestError> => {
             const stackRebase = input.stackNumber !== undefined && input.action === "update-branch";
             if (
@@ -2380,7 +2417,8 @@ export const make = Effect.gen(function* () {
     const cached = persistedRead(input, "summary", summaryCodec, summaryUncached(input));
     const held = lastGoodSummary.peek(key);
     return held !== undefined &&
-      (options?.recoverTransientFailure !== false || held.state === "merged")
+      ((input.allowStale !== false && options?.recoverTransientFailure !== false) ||
+        held.state === "merged")
       ? Effect.succeed(held)
       : cached.pipe(
           Effect.tap((value) =>
@@ -2537,18 +2575,17 @@ export const make = Effect.gen(function* () {
     // `serveHeld` returns immediately. Skip the write when that read is older
     // than a later strict summary — display reuse would otherwise keep the
     // regression and never ask the host again.
-    return lastGoodDetail.serveHeld(
-      key,
-      Cache.get(detailCache, key).pipe(
-        Effect.tap((value) => {
-          const summary = summaryFromDetail(value, lastGoodSummary.peek(key));
-          return shouldReplaceHeldSummary(key, summary)
-            ? lastGoodSummary.record(key, summary)
-            : Effect.void;
-        }),
-      ),
-      "revalidate",
+    const read = Cache.get(detailCache, key).pipe(
+      Effect.tap((value) => {
+        const summary = summaryFromDetail(value, lastGoodSummary.peek(key));
+        return shouldReplaceHeldSummary(key, summary)
+          ? lastGoodSummary.record(key, summary)
+          : Effect.void;
+      }),
     );
+    return input.allowStale === false
+      ? read.pipe(Effect.tap((value) => lastGoodDetail.record(key, value)))
+      : lastGoodDetail.serveHeld(key, read, "revalidate");
   };
 
   const activityCache = yield* Cache.makeWith(
@@ -2730,6 +2767,7 @@ export const make = Effect.gen(function* () {
   });
 
   return PullRequestService.of({
+    routing,
     list,
     listStats,
     summary,

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -2417,8 +2417,8 @@ export const make = Effect.gen(function* () {
     const cached = persistedRead(input, "summary", summaryCodec, summaryUncached(input));
     const held = lastGoodSummary.peek(key);
     return held !== undefined &&
-      ((input.allowStale !== false && options?.recoverTransientFailure !== false) ||
-        held.state === "merged")
+      input.allowStale !== false &&
+      (options?.recoverTransientFailure !== false || held.state === "merged")
       ? Effect.succeed(held)
       : cached.pipe(
           Effect.tap((value) =>

--- a/apps/server/src/pullRequest/PullRequestService.ts
+++ b/apps/server/src/pullRequest/PullRequestService.ts
@@ -46,6 +46,8 @@ import {
   type PullRequestReactionInput,
   type PullRequestRef,
   type PullRequestRoutingResult,
+  type PullRequestRoutingIdentityInput,
+  type PullRequestRoutingIdentityResult,
   type PullRequestReviewVerdict,
   type PullRequestReviewerCandidateList,
   type PullRequestReviewerRequestInput,
@@ -138,6 +140,14 @@ const VIEWER_CACHE_CAPACITY = 32;
 
 export type PullRequestError = PullRequestUnavailableError | PullRequestOperationError;
 
+const routingCredential = Context.Reference<{
+  readonly credentialFingerprint: string;
+  readonly viewer: string;
+} | null>("t3/PullRequestService/routingCredential", { defaultValue: () => null });
+// Internal only: the client cannot choose its cache's credential namespace.
+const credentialNamespace = Symbol("pullRequestCredentialNamespace");
+type CredentialRef = PullRequestRef & { readonly [credentialNamespace]?: string };
+
 export class PullRequestService extends Context.Service<
   PullRequestService,
   {
@@ -150,6 +160,13 @@ export class PullRequestService extends Context.Service<
     readonly routing: (
       input: PullRequestRef,
     ) => Effect.Effect<PullRequestRoutingResult, PullRequestError>;
+    readonly routingIdentity: (
+      input: PullRequestRoutingIdentityInput,
+    ) => Effect.Effect<PullRequestRoutingIdentityResult, PullRequestError>;
+    readonly withRoutingCredential: <A, E, R>(
+      input: PullRequestRef,
+      operation: Effect.Effect<A, E, R>,
+    ) => Effect.Effect<A, E | PullRequestError, R>;
     readonly summary: (
       input: PullRequestRef,
       options?: { readonly recoverTransientFailure?: boolean },
@@ -477,6 +494,9 @@ function withRateLimitBackoff(
     capabilities: api.capabilities,
     getViewer: wrap("getViewer", api.getViewer),
     ...(api.getRoutingIdentity === undefined ? {} : { getRoutingIdentity: api.getRoutingIdentity }),
+    ...(api.withVerifiedCredential === undefined
+      ? {}
+      : { withVerifiedCredential: api.withVerifiedCredential }),
     listChangeRequests: wrap("listChangeRequests", api.listChangeRequests),
     ...(api.listChangeRequestsAcross === undefined
       ? {}
@@ -1291,7 +1311,65 @@ export const make = Effect.gen(function* () {
    * and a host that cannot say leaves it null rather than failing the read it decorates.
    */
   const viewerOf = (project: SupportedProject): Effect.Effect<string | null> =>
-    resolveViewers([project], new Map()).pipe(Effect.map(([resolved]) => resolved?.viewer ?? null));
+    routingCredential.pipe(
+      Effect.flatMap((credential) =>
+        credential !== null
+          ? Effect.succeed(credential.viewer)
+          : resolveViewers([project], new Map()).pipe(
+              Effect.map(([resolved]) => resolved?.viewer ?? null),
+            ),
+      ),
+    );
+
+  const routingIdentity: PullRequestService["Service"]["routingIdentity"] = Effect.fn(
+    "PullRequestService.routingIdentity",
+  )(function* (input) {
+    const host = input.host.toLowerCase();
+    const { supported } = yield* listWorkspaceProjects({ host });
+    const project = supported.find((candidate) => candidate.api.kind === "github");
+    const api = registry.get("github");
+    if (project === undefined || api?.getRoutingIdentity === undefined) {
+      return yield* new PullRequestUnavailableError({ reason: "provider-unsupported" });
+    }
+    const identity = yield* api
+      .getRoutingIdentity({
+        cwd: project.project.workspaceRoot,
+        host,
+      })
+      .pipe(Effect.mapError(toPullRequestError("routeIdentity")));
+    return { ...identity, host, provider: "github" as const };
+  });
+
+  const withRoutingCredential: PullRequestService["Service"]["withRoutingCredential"] = (
+    input,
+    operation,
+  ) =>
+    Effect.gen(function* () {
+      if (input.expectedAccountId === undefined) return yield* operation;
+      const rejected = () =>
+        new PullRequestOperationError({
+          operation: "routeIdentity",
+          detail: "The GitHub account could not be verified before starting the operation.",
+        });
+      const project = yield* requireProject(input).pipe(Effect.mapError(rejected));
+      const api = project.api.kind === "github" ? registry.get("github") : null;
+      if (
+        api?.withVerifiedCredential === undefined ||
+        input.host?.toLowerCase() !== project.host.toLowerCase()
+      ) {
+        return yield* rejected();
+      }
+      const result = yield* api
+        .withVerifiedCredential(
+          { cwd: project.project.workspaceRoot, host: project.host },
+          (identity) =>
+            identity.accountId === input.expectedAccountId
+              ? operation.pipe(Effect.provideService(routingCredential, identity), Effect.result)
+              : Effect.fail(rejected()),
+        )
+        .pipe(Effect.catchTag("PullRequestProviderError", () => Effect.fail(rejected())));
+      return yield* Effect.fromResult(result);
+    });
 
   const routing = Effect.fn("PullRequestService.routing")(function* (input: PullRequestRef) {
     const project = yield* requireProject(input);
@@ -2207,6 +2285,12 @@ export const make = Effect.gen(function* () {
 
   const context = yield* Effect.context<never>();
   const runFork = Effect.runForkWith(context);
+  const revalidate = <A, E>(read: Effect.Effect<A, E>) =>
+    Effect.context<never>().pipe(
+      Effect.flatMap((caller) =>
+        Effect.sync(() => runFork(Effect.ignore(read).pipe(Effect.provideContext(caller)))),
+      ),
+    );
 
   /**
    * The diff is not live-polled and is expensive enough to keep its stale-while-revalidate path.
@@ -2232,7 +2316,7 @@ export const make = Effect.gen(function* () {
         // Run as its own fiber rather than a child: the caller is answered and gone before the
         // refresh lands. The read still coalesces on the cache key, so ten stale reads in one
         // window cost one host request — and a failed refresh costs nothing but the retry.
-        return Effect.sync(() => runFork(Effect.ignore(recorded))).pipe(Effect.as(snapshot.value));
+        return revalidate(recorded).pipe(Effect.as(snapshot.value));
       });
     };
   })();
@@ -2290,9 +2374,7 @@ export const make = Effect.gen(function* () {
       const snapshot = held.get(key);
       if (snapshot === undefined) return read(key, effect);
       if (mode === "reuse") return Effect.succeed(snapshot.value);
-      return Effect.sync(() => runFork(Effect.ignore(read(key, effect)))).pipe(
-        Effect.as(snapshot.value),
-      );
+      return revalidate(read(key, effect)).pipe(Effect.as(snapshot.value));
     };
     return { peek: (key: string) => held.get(key)?.value, read, record, serveHeld };
   };
@@ -2314,7 +2396,7 @@ export const make = Effect.gen(function* () {
     Math.max(turnRefreshEpoch, refEpochs.get(refScope(ref)) ?? 0);
   // Keys carry the reference back out of the cache loader, so the slot layout is shared with
   // `refOfCacheKey` rather than read positionally at every loader.
-  const refCacheKey = (ref: PullRequestRef) =>
+  const refCacheKey = (ref: CredentialRef) =>
     JSON.stringify([
       refEpoch(ref),
       ref.projectId,
@@ -2322,20 +2404,17 @@ export const make = Effect.gen(function* () {
       ref.repository.toLowerCase(),
       ref.number,
       ref.expectedAccountId ?? null,
+      ref[credentialNamespace] ?? null,
     ]);
   const refOfCacheKey = (key: string): PullRequestRef => {
-    const [, projectId, host, repository, number, expectedAccountId] = JSON.parse(key) as [
-      number,
-      string,
-      string | null,
-      string,
-      number,
-      string | null,
-    ];
+    const [, projectId, host, repository, number, expectedAccountId, fingerprint] = JSON.parse(
+      key,
+    ) as [number, string, string | null, string, number, string | null, string | null];
     return {
       projectId,
       ...(host === null ? {} : { host }),
       ...(expectedAccountId === null ? {} : { expectedAccountId }),
+      ...(fingerprint === null ? {} : { [credentialNamespace]: fingerprint }),
       repository,
       number,
     } as PullRequestRef;
@@ -2382,7 +2461,7 @@ export const make = Effect.gen(function* () {
   };
 
   const persistedRead = Effect.fn("PullRequestService.persistedRead")(function* <A>(
-    input: PullRequestRef,
+    input: CredentialRef,
     operation: string,
     codec: Schema.Codec<A, string>,
     read: Effect.Effect<A, PullRequestError>,
@@ -2397,6 +2476,7 @@ export const make = Effect.gen(function* () {
       project.project.workspaceRoot,
       String(input.number),
       input.expectedAccountId ?? "",
+      input[credentialNamespace] ?? "",
     ]
       .map(encodeURIComponent)
       .join(":");
@@ -2776,12 +2856,33 @@ export const make = Effect.gen(function* () {
     }
   });
 
+  const credentialCached =
+    <I extends PullRequestRef, Args extends ReadonlyArray<unknown>, A, E>(
+      read: (input: I, ...args: Args) => Effect.Effect<A, E>,
+    ) =>
+    (input: I, ...args: Args) =>
+      routingCredential.pipe(
+        Effect.flatMap((credential) =>
+          read(
+            credential === null
+              ? input
+              : {
+                  ...input,
+                  [credentialNamespace]: credential.credentialFingerprint,
+                },
+            ...args,
+          ),
+        ),
+      );
+
   return PullRequestService.of({
     routing,
+    routingIdentity,
+    withRoutingCredential,
     list,
     listStats,
-    summary,
-    stack,
+    summary: credentialCached(summary),
+    stack: credentialCached(stack),
     subscribeMerges: PubSub.subscribe(mergedPullRequests).pipe(
       Effect.map((subscription) => Stream.fromSubscription(subscription)),
     ),
@@ -2789,8 +2890,8 @@ export const make = Effect.gen(function* () {
       Stream.filter((revision) => revision > 0),
     ),
     refreshAfterTurn,
-    detail,
-    activity,
+    detail: credentialCached(detail),
+    activity: credentialCached(activity),
     threadComments,
     diff,
     diffFileContents,

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -1,12 +1,17 @@
 import { assert, it, afterEach, describe, expect, vi } from "@effect/vitest";
+import * as Cache from "effect/Cache";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubCli from "./GitHubCli.ts";
+
+const encodeGitHubCliError = Schema.encodeEffect(Schema.fromJsonString(GitHubCli.GitHubCliError));
 
 const processOutput = (stdout: string): VcsProcess.VcsProcessOutput => ({
   exitCode: ChildProcessSpawner.ExitCode(0),
@@ -31,6 +36,111 @@ afterEach(() => {
 });
 
 describe("GitHubCli.layer", () => {
+  it.effect("pins concurrent cached commands to their own verified credentials", () =>
+    Effect.gen(function* () {
+      mockRun.mockImplementation((input) =>
+        Effect.succeed(processOutput(input.env?.GH_TOKEN ?? "ambient")),
+      );
+      const gh = yield* GitHubCli.GitHubCli;
+      // Constructed outside either request, like the PR service's read caches.
+      const cache = yield* Cache.make({
+        lookup: (host: string) =>
+          gh.execute({
+            cwd: "/repo",
+            args: ["api", "user", "--hostname", host],
+            env: { GH_DEBUG: "api", GH_TOKEN: "changed-after-verification" },
+          }),
+        capacity: 2,
+        timeToLive: "1 minute",
+      });
+      const results = yield* Effect.all(
+        ["github.com", "github.example.test"].map((host, index) =>
+          Cache.get(cache, host).pipe(
+            Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+              host,
+              token: Redacted.make(`credential-${index}`),
+              credentialFingerprint: `fingerprint-${index}`,
+            }),
+          ),
+        ),
+        { concurrency: 2 },
+      );
+      expect(results.map((result) => result.stdout)).toEqual(["credential-0", "credential-1"]);
+      for (const [input] of mockRun.mock.calls) {
+        expect(input.env).toMatchObject({
+          GH_HOST: input.args[3],
+          GH_DEBUG: "",
+          GH_TOKEN: input.env?.GITHUB_TOKEN,
+          GH_ENTERPRISE_TOKEN: input.env?.GH_TOKEN,
+          GITHUB_ENTERPRISE_TOKEN: input.env?.GH_TOKEN,
+        });
+      }
+      expect((yield* gh.execute({ cwd: "/repo", args: ["api", "user"] })).stdout).toBe("ambient");
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("refuses other or implicit hosts before exposing a scoped credential to gh", () =>
+    Effect.gen(function* () {
+      const gh = yield* GitHubCli.GitHubCli;
+      for (const args of [
+        ["api", "user", "--hostname", "other.example.test"],
+        ["api", "user", "--hostname=other.example.test"],
+        ["pr", "view", "1", "--repo", "other.example.test/owner/repo"],
+        ["repo", "view", "other.example.test/owner/repo", "--json", "name"],
+        ["api", "https://other.example.test/user", "--hostname", "github.com"],
+        ["api", "user"],
+      ]) {
+        const failure = yield* gh.execute({ cwd: "/repo", args }).pipe(
+          Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+            host: "github.com",
+            token: Redacted.make("secret-credential"),
+            credentialFingerprint: "fingerprint",
+          }),
+          Effect.flip,
+        );
+        expect(failure._tag).toBe("GitHubCliCommandError");
+        expect(yield* encodeGitHubCliError(failure)).not.toContain("secret-credential");
+      }
+      expect(mockRun).not.toHaveBeenCalled();
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("pins repository-targeted writes on enterprise hosts", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValue(Effect.succeed(processOutput("")));
+      const gh = yield* GitHubCli.GitHubCli;
+      yield* gh
+        .execute({
+          cwd: "/repo",
+          args: ["pr", "merge", "1", "--repo", "github.example.test/owner/repo"],
+        })
+        .pipe(
+          Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+            host: "github.example.test",
+            token: Redacted.make("enterprise-credential"),
+            credentialFingerprint: "fingerprint",
+          }),
+        );
+      yield* gh
+        .execute({
+          cwd: "/repo",
+          args: ["repo", "view", "github.example.test/owner/repo", "--json", "name"],
+        })
+        .pipe(
+          Effect.provideService(GitHubCli.PinnedGitHubCredential, {
+            host: "github.example.test",
+            token: Redacted.make("enterprise-credential"),
+            credentialFingerprint: "fingerprint",
+          }),
+        );
+      expect(mockRun.mock.calls[0]?.[0].env).toMatchObject({
+        GH_HOST: "github.example.test",
+        GH_ENTERPRISE_TOKEN: "enterprise-credential",
+        GH_DEBUG: "",
+      });
+    }).pipe(Effect.provide(layer)),
+  );
+
   it("does not classify a missing cwd as an unavailable gh executable", () => {
     const context = { command: "gh", cwd: "/repo" } as const;
     const missingCwd = new VcsProcessSpawnError({

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -237,6 +237,7 @@ export class GitHubCli extends Context.Service<
       readonly timeoutMs?: number;
       /** Piped to the child's stdin, for payloads that must never appear in argv. */
       readonly stdin?: string;
+      readonly env?: NodeJS.ProcessEnv;
       readonly maxOutputBytes?: number;
     }) => Effect.Effect<VcsProcess.VcsProcessOutput, GitHubCliError>;
 
@@ -351,6 +352,7 @@ export const make = Effect.gen(function* () {
         cwd: input.cwd,
         timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+        ...(input.env !== undefined ? { env: input.env } : {}),
         ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
       })
       .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as Redacted from "effect/Redacted";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 
@@ -21,6 +22,40 @@ import {
 } from "./gitHubPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Server-local credential scope; never put its value in RPC payloads or cache keys. */
+export const PinnedGitHubCredential = Context.Reference<{
+  readonly host: string;
+  readonly token: Redacted.Redacted<string>;
+  readonly credentialFingerprint: string;
+} | null>("t3/sourceControl/PinnedGitHubCredential", { defaultValue: () => null });
+
+function targetsVerifiedHost(args: ReadonlyArray<string>, host: string): boolean {
+  const hosts: Array<string | null> = [];
+  const repositoryHost = (repository: string | undefined) => {
+    if (repository === undefined) return null;
+    if (/^https?:\/\//i.test(repository)) {
+      try {
+        return new URL(repository).host.toLowerCase();
+      } catch {
+        return null;
+      }
+    }
+    const parts = repository.split("/");
+    return parts.length === 3 ? parts[0]!.toLowerCase() : null;
+  };
+  if (args[0] === "repo" && args[1] === "view") hosts.push(repositoryHost(args[2]));
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!;
+    if (arg === "--hostname") hosts.push(args[++index]?.toLowerCase() ?? null);
+    else if (arg.startsWith("--hostname=")) hosts.push(arg.slice(11).toLowerCase());
+    else if (arg === "--repo" || arg === "-R") hosts.push(repositoryHost(args[++index]));
+    else if (arg.startsWith("--repo=")) hosts.push(repositoryHost(arg.slice(7)));
+    else if (arg.startsWith("-R")) hosts.push(repositoryHost(arg.slice(2)));
+    else if (/^https?:\/\//i.test(arg)) hosts.push(repositoryHost(arg));
+  }
+  return hosts.length > 0 && hosts.every((target) => target === host);
+}
 
 const gitHubCliFailureFields = {
   command: Schema.Literal("gh"),
@@ -343,19 +378,43 @@ function deriveRepositoryCloneUrlsFromCreateOutput(
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
 
-  const execute: GitHubCli["Service"]["execute"] = (input) =>
-    process
-      .run({
-        operation: "GitHubCli.execute",
-        command: "gh",
-        args: input.args,
-        cwd: input.cwd,
-        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
-        ...(input.env !== undefined ? { env: input.env } : {}),
-        ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
-      })
-      .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+  const execute: GitHubCli["Service"]["execute"] = Effect.fn("GitHubCli.execute")(
+    function* (input) {
+      const credential = yield* PinnedGitHubCredential;
+      if (credential !== null && !targetsVerifiedHost(input.args, credential.host)) {
+        return yield* new GitHubCliCommandError({
+          command: "gh",
+          cwd: input.cwd,
+          cause: new Error("The GitHub command does not target the verified credential's host."),
+        });
+      }
+      const token = credential === null ? undefined : Redacted.value(credential.token);
+      const env =
+        credential === null
+          ? input.env
+          : {
+              ...input.env,
+              GH_HOST: credential.host,
+              GH_TOKEN: token,
+              GITHUB_TOKEN: token,
+              GH_ENTERPRISE_TOKEN: token,
+              GITHUB_ENTERPRISE_TOKEN: token,
+              GH_DEBUG: "",
+            };
+      return yield* process
+        .run({
+          operation: "GitHubCli.execute",
+          command: "gh",
+          args: input.args,
+          cwd: input.cwd,
+          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          ...(input.stdin !== undefined ? { stdin: input.stdin } : {}),
+          ...(env !== undefined ? { env } : {}),
+          ...(input.maxOutputBytes !== undefined ? { maxOutputBytes: input.maxOutputBytes } : {}),
+        })
+        .pipe(Effect.mapError((error) => fromVcsError({ command: "gh", cwd: input.cwd }, error)));
+    },
+  );
 
   return GitHubCli.of({
     execute,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -71,6 +71,7 @@ import {
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
   type PullRequestRef,
+  PullRequestOperationError,
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
@@ -623,6 +624,41 @@ const makeWsRpcLayer = (
       const sourceControlRepositories =
         yield* SourceControlRepositoryService.SourceControlRepositoryService;
       const pullRequests = yield* PullRequestService.PullRequestService;
+      const guardPullRequestViewer = Effect.fn("ws.guardPullRequestViewer")(function* (
+        input: PullRequestRef,
+      ) {
+        const expectedAccountId = input.expectedAccountId;
+        if (expectedAccountId === undefined) return;
+        yield* pullRequests.routing(input).pipe(
+          Effect.flatMap((route) =>
+            route.provider === "github" &&
+            route.accountId === expectedAccountId &&
+            input.host !== undefined &&
+            route.host.toLowerCase() === input.host.toLowerCase()
+              ? Effect.void
+              : Effect.fail(
+                  new PullRequestOperationError({
+                    operation: "routeIdentity",
+                    detail: "The GitHub account does not match the requested account.",
+                  }),
+                ),
+          ),
+          Effect.catchCause((cause) =>
+            Effect.fail(
+              new PullRequestOperationError({
+                operation: "routeIdentity",
+                detail: "The GitHub account could not be verified before starting the operation.",
+                cause,
+              }),
+            ),
+          ),
+        );
+      });
+
+      const withPullRequestViewer = <A, E, R>(
+        input: PullRequestRef,
+        operation: Effect.Effect<A, E, R>,
+      ) => guardPullRequestViewer(input).pipe(Effect.andThen(operation));
       const pullRequestSync = yield* PullRequestSyncReactor.PullRequestSyncReactor;
       const bootstrapCredentials = yield* PairingGrantStore.PairingGrantStore;
       const sessions = yield* SessionStore.SessionStore;
@@ -2149,14 +2185,26 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsListStats, pullRequests.listStats(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsRouting]: (input) =>
+          observeRpcEffect(WS_METHODS.pullRequestsRouting, pullRequests.routing(input), {
+            "rpc.aggregate": "pull-requests",
+          }),
         [WS_METHODS.pullRequestsSummary]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsSummary, pullRequests.summary(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsSummary,
+            withPullRequestViewer(input, pullRequests.summary(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsStack]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsStack, pullRequests.stack(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsStack,
+            withPullRequestViewer(input, pullRequests.stack(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsLinkedThreads]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsLinkedThreads,
@@ -2172,17 +2220,25 @@ const makeWsRpcLayer = (
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsDetail]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsDetail, pullRequests.detail(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsDetail,
+            withPullRequestViewer(input, pullRequests.detail(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsActivity]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsActivity, pullRequests.activity(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsActivity,
+            withPullRequestViewer(input, pullRequests.activity(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsThreadComments]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsThreadComments,
-            pullRequests.threadComments(input),
+            withPullRequestViewer(input, pullRequests.threadComments(input)),
             {
               "rpc.aggregate": "pull-requests",
             },
@@ -2190,61 +2246,75 @@ const makeWsRpcLayer = (
         [WS_METHODS.pullRequestsDiffFileContents]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsDiffFileContents,
-            pullRequests.diffFileContents(input),
+            withPullRequestViewer(input, pullRequests.diffFileContents(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsRunAction]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsRunAction,
-            pullRequests
-              .runAction(input)
-              .pipe(
-                Effect.tap(() =>
-                  resolvePullRequestSyncKey(input).pipe(
-                    Effect.flatMap((key) =>
-                      key === null ? Effect.void : pullRequestSync.requestSync(key),
-                    ),
+            withPullRequestViewer(input, pullRequests.runAction(input)).pipe(
+              Effect.tap(() =>
+                resolvePullRequestSyncKey(input).pipe(
+                  Effect.flatMap((key) =>
+                    key === null ? Effect.void : pullRequestSync.requestSync(key),
                   ),
                 ),
               ),
+            ),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsUpdate]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsUpdate, pullRequests.update(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsUpdate,
+            withPullRequestViewer(input, pullRequests.update(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsComment]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsComment, pullRequests.comment(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsComment,
+            withPullRequestViewer(input, pullRequests.comment(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsUpdateComment]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsUpdateComment,
-            pullRequests.updateComment(input),
+            withPullRequestViewer(input, pullRequests.updateComment(input)),
             {
               "rpc.aggregate": "pull-requests",
             },
           ),
         [WS_METHODS.pullRequestsSubmitReview]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsSubmitReview, pullRequests.submitReview(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsSubmitReview,
+            withPullRequestViewer(input, pullRequests.submitReview(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsReplyToThread]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsReplyToThread,
-            pullRequests.replyToThread(input),
+            withPullRequestViewer(input, pullRequests.replyToThread(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsSetThreadResolution]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsSetThreadResolution,
-            pullRequests.setThreadResolution(input),
+            withPullRequestViewer(input, pullRequests.setThreadResolution(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsSetReaction]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsSetReaction, pullRequests.setReaction(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsSetReaction,
+            withPullRequestViewer(input, pullRequests.setReaction(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsInvalidate]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsInvalidate,
@@ -2272,25 +2342,29 @@ const makeWsRpcLayer = (
         [WS_METHODS.pullRequestsReviewerCandidates]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsReviewerCandidates,
-            pullRequests.reviewerCandidates(input),
+            withPullRequestViewer(input, pullRequests.reviewerCandidates(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsRequestReviewers]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsRequestReviewers,
-            pullRequests.requestReviewers(input),
+            withPullRequestViewer(input, pullRequests.requestReviewers(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsLabelCandidates]: (input) =>
           observeRpcEffect(
             WS_METHODS.pullRequestsLabelCandidates,
-            pullRequests.labelCandidates(input),
+            withPullRequestViewer(input, pullRequests.labelCandidates(input)),
             { "rpc.aggregate": "pull-requests" },
           ),
         [WS_METHODS.pullRequestsSetLabels]: (input) =>
-          observeRpcEffect(WS_METHODS.pullRequestsSetLabels, pullRequests.setLabels(input), {
-            "rpc.aggregate": "pull-requests",
-          }),
+          observeRpcEffect(
+            WS_METHODS.pullRequestsSetLabels,
+            withPullRequestViewer(input, pullRequests.setLabels(input)),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.sourceControlLookupRepository]: (input) =>
           observeRpcEffect(
             WS_METHODS.sourceControlLookupRepository,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -71,7 +71,6 @@ import {
   type TerminalEvent,
   type TerminalMetadataStreamEvent,
   type PullRequestRef,
-  PullRequestOperationError,
   WS_METHODS,
   WsRpcGroup,
 } from "@t3tools/contracts";
@@ -624,41 +623,7 @@ const makeWsRpcLayer = (
       const sourceControlRepositories =
         yield* SourceControlRepositoryService.SourceControlRepositoryService;
       const pullRequests = yield* PullRequestService.PullRequestService;
-      const guardPullRequestViewer = Effect.fn("ws.guardPullRequestViewer")(function* (
-        input: PullRequestRef,
-      ) {
-        const expectedAccountId = input.expectedAccountId;
-        if (expectedAccountId === undefined) return;
-        yield* pullRequests.routing(input).pipe(
-          Effect.flatMap((route) =>
-            route.provider === "github" &&
-            route.accountId === expectedAccountId &&
-            input.host !== undefined &&
-            route.host.toLowerCase() === input.host.toLowerCase()
-              ? Effect.void
-              : Effect.fail(
-                  new PullRequestOperationError({
-                    operation: "routeIdentity",
-                    detail: "The GitHub account does not match the requested account.",
-                  }),
-                ),
-          ),
-          Effect.catchCause((cause) =>
-            Effect.fail(
-              new PullRequestOperationError({
-                operation: "routeIdentity",
-                detail: "The GitHub account could not be verified before starting the operation.",
-                cause,
-              }),
-            ),
-          ),
-        );
-      });
-
-      const withPullRequestViewer = <A, E, R>(
-        input: PullRequestRef,
-        operation: Effect.Effect<A, E, R>,
-      ) => guardPullRequestViewer(input).pipe(Effect.andThen(operation));
+      const withPullRequestViewer = pullRequests.withRoutingCredential;
       const pullRequestSync = yield* PullRequestSyncReactor.PullRequestSyncReactor;
       const bootstrapCredentials = yield* PairingGrantStore.PairingGrantStore;
       const sessions = yield* SessionStore.SessionStore;
@@ -2185,6 +2150,14 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.pullRequestsListStats, pullRequests.listStats(input), {
             "rpc.aggregate": "pull-requests",
           }),
+        [WS_METHODS.pullRequestsRoutingIdentity]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.pullRequestsRoutingIdentity,
+            pullRequests.routingIdentity(input),
+            {
+              "rpc.aggregate": "pull-requests",
+            },
+          ),
         [WS_METHODS.pullRequestsRouting]: (input) =>
           observeRpcEffect(WS_METHODS.pullRequestsRouting, pullRequests.routing(input), {
             "rpc.aggregate": "pull-requests",

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -61,6 +61,7 @@ import {
 import { searchableSetting } from "./settingsSearch";
 import { EnvironmentIconPicker } from "./EnvironmentIconPicker";
 import { LoadBalancingSettings } from "./LoadBalancingSettings";
+import { GitHubRoutingSettings } from "./GitHubRoutingSettings";
 import { Input } from "../ui/input";
 import { CommandShortcut } from "../ui/command";
 import {
@@ -3599,6 +3600,7 @@ export function ConnectionsSettings() {
           savedEnvironments={savedEnvironments}
         />
       </SettingsSection>
+      <GitHubRoutingSettings environments={environments} />
       <LoadBalancingSettings environments={environments} />
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/GitHubRoutingSettings.tsx
+++ b/apps/web/src/components/settings/GitHubRoutingSettings.tsx
@@ -1,0 +1,86 @@
+import { useAtomValue } from "@effect/atom-react";
+import {
+  gitHubRoutingConnectionKey,
+  gitHubRoutingPermissionFor,
+  type GitHubRoutingPermission,
+} from "@t3tools/client-runtime/connection";
+import { useState } from "react";
+
+import { environmentCatalog } from "~/connection/catalog";
+import type { EnvironmentPresentation } from "~/state/environments";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { toastManager } from "../ui/toast";
+import { SettingsRow, SettingsSection } from "./settingsLayout";
+import { searchableSetting } from "./settingsSearch";
+
+const options: ReadonlyArray<{ value: GitHubRoutingPermission; label: string }> = [
+  { value: "off", label: "Off" },
+  { value: "read", label: "Read PRs" },
+  { value: "read-write", label: "Read and act" },
+];
+
+export function GitHubRoutingSettings({
+  environments,
+}: {
+  readonly environments: ReadonlyArray<EnvironmentPresentation>;
+}) {
+  const permissions = useAtomValue(environmentCatalog.githubRoutingPermissionsValueAtom);
+  const catalog = useAtomValue(environmentCatalog.catalogValueAtom);
+  const update = useAtomCommand(environmentCatalog.setGitHubRoutingPermission);
+  const [saving, setSaving] = useState(false);
+
+  return (
+    <SettingsSection {...searchableSetting("github-routing")}>
+      <SettingsRow
+        title="Share GitHub access"
+        description="Choose environments you trust to share PR data and use each other's GitHub access. Enable both environments. Read and act may use broader permissions than the original environment. This applies only to this client."
+      />
+      {environments.map((environment) => (
+        <SettingsRow
+          key={environment.environmentId}
+          title={environment.label}
+          description={environment.displayUrl ?? "T3 Connect"}
+          control={
+            <Select
+              items={options}
+              value={gitHubRoutingPermissionFor(environment.entry, permissions)}
+              disabled={
+                !catalog.isReady || saving || gitHubRoutingConnectionKey(environment.entry) === null
+              }
+              onValueChange={(permission) => {
+                if (permission === null) return;
+                setSaving(true);
+                void update({ environmentId: environment.environmentId, permission }).then(
+                  (result) => {
+                    setSaving(false);
+                    if (result._tag === "Failure")
+                      toastManager.add({
+                        type: "error",
+                        title: "Could not save GitHub routing permission",
+                      });
+                  },
+                );
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-full sm:w-40"
+                aria-label={`${environment.label} GitHub routing`}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                {options.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          }
+        />
+      ))}
+    </SettingsSection>
+  );
+}

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -672,6 +672,12 @@ export const SETTINGS_SEARCH_ITEMS = [
     ],
   },
   {
+    id: "github-routing",
+    title: "GitHub routing",
+    to: "/settings/connections",
+    searchTerms: ["pull request trusted environments shared credentials permissions read actions"],
+  },
+  {
     id: "archive",
     title: "Archived threads",
     to: "/settings/archived",

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -1,11 +1,22 @@
-import { ConnectionTransientError } from "@t3tools/client-runtime/connection";
+import {
+  ConnectionTransientError,
+  PrimaryConnectionTarget,
+} from "@t3tools/client-runtime/connection";
+import { EnvironmentId } from "@t3tools/contracts";
 import { ConnectionCatalogDocument } from "@t3tools/client-runtime/platform";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Deferred from "effect/Deferred";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 import { afterEach, vi } from "vite-plus/test";
 
-import { makeCatalogBackend, makeCatalogStore } from "./storage";
+import {
+  makeBrowserGitHubRoutingPermissions,
+  makeCatalogBackend,
+  makeCatalogStore,
+} from "./storage";
 
 const emptyCatalog = {
   schemaVersion: 1,
@@ -15,6 +26,7 @@ const emptyCatalog = {
   remoteDpopTokens: [],
 } as const;
 const decodeCatalog = Schema.decodeUnknownSync(Schema.fromJsonString(ConnectionCatalogDocument));
+const encodeCatalog = Schema.encodeSync(Schema.fromJsonString(ConnectionCatalogDocument));
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -73,5 +85,91 @@ describe("makeCatalogBackend", () => {
       expect(error.message).toContain("Desktop secure storage is unavailable");
       expect(setConnectionCatalog).toHaveBeenCalledWith("{}");
     }),
+  );
+});
+
+describe("browser GitHub routing permissions", () => {
+  it.effect("revokes across runtimes before storage events and resists stale catalog writes", () =>
+    Effect.gen(function* () {
+      const values = new Map<string, string>();
+      const localStorage: Storage = {
+        get length() {
+          return values.size;
+        },
+        key: (index) => [...values.keys()][index] ?? null,
+        getItem: (key) => values.get(key) ?? null,
+        setItem: (key, value) => {
+          values.set(key, value);
+        },
+        removeItem: (key) => {
+          values.delete(key);
+        },
+        clear: () => {
+          values.clear();
+        },
+      };
+      const firstBrowser = Object.assign(new EventTarget(), { localStorage });
+      const secondBrowser = Object.assign(new EventTarget(), { localStorage });
+      const first = makeBrowserGitHubRoutingPermissions(firstBrowser);
+      const second = makeBrowserGitHubRoutingPermissions(secondBrowser);
+      const entry = {
+        target: new PrimaryConnectionTarget({
+          environmentId: EnvironmentId.make("first"),
+          label: "First",
+          httpBaseUrl: "http://localhost:3000",
+          wsBaseUrl: "ws://localhost:3000",
+        }),
+        profile: Option.none(),
+      };
+      const other = {
+        ...entry,
+        target: new PrimaryConnectionTarget({
+          ...entry.target,
+          environmentId: EnvironmentId.make("second"),
+        }),
+      };
+      expect(yield* first.get(entry)).toBe("off");
+      yield* first.set(entry, "read-write");
+      expect(yield* second.get(entry)).toBe("read-write");
+      const oldPermissions = Option.getOrThrow(yield* Stream.runHead(first.changes));
+      const staleCatalog = yield* makeCatalogStore({
+        read: Effect.succeed(
+          encodeCatalog({ ...emptyCatalog, githubRoutingPermissions: oldPermissions }),
+        ),
+        write: () => Effect.void,
+      });
+      yield* staleCatalog.read;
+      const listening = yield* Deferred.make<void>();
+      const revoked = yield* Deferred.make<void>();
+      yield* second.changes.pipe(
+        Stream.runForEach((permissions) =>
+          Deferred.succeed(permissions.length > 0 ? listening : revoked, undefined),
+        ),
+        Effect.forkChild,
+      );
+      yield* Deferred.await(listening);
+
+      yield* first.set(entry, "off");
+      expect(yield* second.get(entry)).toBe("off");
+      secondBrowser.dispatchEvent(Object.assign(new Event("storage"), { key: null }));
+      yield* Deferred.await(revoked);
+      yield* second.set(other, "read");
+      yield* staleCatalog.update((document) => ({ ...document, accountId: "updated" }));
+      expect(yield* second.get(entry)).toBe("off");
+      expect(yield* first.get(other)).toBe("read");
+      expect(yield* makeBrowserGitHubRoutingPermissions(firstBrowser).get(entry)).toBe("off");
+
+      yield* first.set(entry, "read-write");
+      yield* second.forget(entry.target.environmentId);
+      expect(yield* first.get(entry)).toBe("off");
+      expect(yield* first.get(other)).toBe("read");
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+        throw new Error("Storage unavailable");
+      });
+      expect(yield* first.set(entry, "read-write").pipe(Effect.flip)).toBeInstanceOf(
+        ConnectionTransientError,
+      );
+      expect(yield* second.get(entry)).toBe("off");
+    }).pipe(Effect.scoped),
   );
 });

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -15,8 +15,13 @@ import {
 import { TokenStore } from "@t3tools/client-runtime/authorization";
 import {
   ConnectionTransientError,
+  ConnectionBlockedError,
   CredentialStore,
   ProfileStore,
+  GitHubRoutingPermissions,
+  StoredGitHubRoutingPermission,
+  gitHubRoutingConnectionKey,
+  gitHubRoutingPermissionFor,
 } from "@t3tools/client-runtime/connection";
 import {
   EnvironmentId,
@@ -31,8 +36,10 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
 import { projectFaviconCache } from "../assets/projectFaviconCache";
 
 const DATABASE_NAME = "t3code:connection-runtime";
@@ -365,12 +372,114 @@ export const makeCatalogStore = Effect.fn("web.connectionStorage.makeCatalogStor
   return { read, update } satisfies CatalogStore;
 });
 
+const GITHUB_ROUTING_KEY_PREFIX = "t3code:github-routing:";
+const GITHUB_ROUTING_CHANGED = "t3code:github-routing-changed";
+const isStoredGitHubRoutingPermission = Schema.is(StoredGitHubRoutingPermission);
+const encodeStoredGitHubRoutingPermission = Schema.encodeSync(
+  Schema.fromJsonString(StoredGitHubRoutingPermission),
+);
+
+/** Each grant has its own key so stale tabs and unrelated catalog saves cannot restore trust. */
+export function makeBrowserGitHubRoutingPermissions(
+  browser: Pick<Window, "localStorage"> & EventTarget = window,
+) {
+  const read = (key: string): StoredGitHubRoutingPermission | null => {
+    try {
+      const raw = browser.localStorage.getItem(key);
+      const value: unknown = raw === null ? null : JSON.parse(raw);
+      return isStoredGitHubRoutingPermission(value) &&
+        key === `${GITHUB_ROUTING_KEY_PREFIX}${value.environmentId}`
+        ? value
+        : null;
+    } catch {
+      return null;
+    }
+  };
+  const readAll = (): ReadonlyArray<StoredGitHubRoutingPermission> => {
+    try {
+      const values: StoredGitHubRoutingPermission[] = [];
+      const storage = browser.localStorage;
+      for (let index = 0; index < storage.length; index++) {
+        const key = storage.key(index);
+        if (key?.startsWith(GITHUB_ROUTING_KEY_PREFIX)) {
+          const value = read(key);
+          if (value !== null) values.push(value);
+        }
+      }
+      return values;
+    } catch {
+      return [];
+    }
+  };
+  const write = (environmentId: EnvironmentId, value: StoredGitHubRoutingPermission | null) =>
+    Effect.try({
+      try: () => {
+        const key = `${GITHUB_ROUTING_KEY_PREFIX}${environmentId}`;
+        if (value === null) browser.localStorage.removeItem(key);
+        else browser.localStorage.setItem(key, encodeStoredGitHubRoutingPermission(value));
+        browser.dispatchEvent(new Event(GITHUB_ROUTING_CHANGED));
+      },
+      catch: (cause) => catalogError("save GitHub routing permissions in", cause),
+    });
+  return GitHubRoutingPermissions.of({
+    get: (entry) =>
+      Effect.sync(() => {
+        const value = read(`${GITHUB_ROUTING_KEY_PREFIX}${entry.target.environmentId}`);
+        return gitHubRoutingPermissionFor(entry, value === null ? [] : [value]);
+      }),
+    changes: Stream.callback<ReadonlyArray<StoredGitHubRoutingPermission>>((queue) =>
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          const listener = (event: Event) => {
+            if (event.type === "storage") {
+              const key = (event as StorageEvent).key;
+              if (key !== null && !key?.startsWith(GITHUB_ROUTING_KEY_PREFIX)) return;
+            }
+            Queue.offerUnsafe(queue, readAll());
+          };
+          browser.addEventListener("storage", listener);
+          browser.addEventListener(GITHUB_ROUTING_CHANGED, listener);
+          Queue.offerUnsafe(queue, readAll());
+          return listener;
+        }),
+        (listener) =>
+          Effect.sync(() => {
+            browser.removeEventListener("storage", listener);
+            browser.removeEventListener(GITHUB_ROUTING_CHANGED, listener);
+          }),
+      ).pipe(Effect.asVoid),
+    ),
+    set: (entry, permission) => {
+      const connectionKey = gitHubRoutingConnectionKey(entry);
+      if (connectionKey === null)
+        return Effect.fail(
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: "This environment does not have a saved connection endpoint.",
+          }),
+        );
+      return write(
+        entry.target.environmentId,
+        permission === "off"
+          ? null
+          : {
+              environmentId: entry.target.environmentId,
+              connectionKey,
+              permission,
+            },
+      );
+    },
+    forget: (environmentId) => write(environmentId, null),
+  });
+}
+
 export const connectionStorageLayer = Layer.effectContext(
   Effect.gen(function* () {
     const database = yield* Effect.acquireRelease(openDatabase(), (database) =>
       Effect.sync(() => database.close()),
     );
     const catalog = yield* makeCatalogStore(makeCatalogBackend(database));
+    const githubRoutingPermissions = makeBrowserGitHubRoutingPermissions();
 
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
@@ -659,6 +768,7 @@ export const connectionStorageLayer = Layer.effectContext(
     });
 
     return Context.make(ConnectionTargetStore, targetStore).pipe(
+      Context.add(GitHubRoutingPermissions, githubRoutingPermissions),
       Context.add(ConnectionRegistrationStore, registrationStore),
       Context.add(ProfileStore.ConnectionProfileStore, profileStore),
       Context.add(CredentialStore.ConnectionCredentialStore, credentialStore),

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -79,6 +79,15 @@ GitLab calls these merge requests.
 GitHub, GitLab, and Azure DevOps support auto-merge while checks are outstanding. GitHub also
 supports approving waiting fork workflows and opening a revert pull request for a merged change.
 
+GitHub review details, linked PR status, and review actions can use another connected environment
+signed in to the same GitHub account. Each environment needs a project on that GitHub host.
+A connected local environment is preferred for actions and can answer slow or failed reads.
+Browsers and mobile clients need a paired environment to use its GitHub CLI credentials.
+Credentials stay on their machines. Previously verified credentials remain usable for routing
+for ten minutes during a GitHub outage; new credentials must be verified first. An action with
+an uncertain result is never automatically retried elsewhere. Listings, diffs, and checkout or
+PR creation from Git actions continue to use the project's environment.
+
 For Azure DevOps, use the host website to view diffs or change comments. Bitbucket does not support
 reopening a declined pull request.
 

--- a/docs/user/source-control.md
+++ b/docs/user/source-control.md
@@ -79,8 +79,15 @@ GitLab calls these merge requests.
 GitHub, GitLab, and Azure DevOps support auto-merge while checks are outstanding. GitHub also
 supports approving waiting fork workflows and opening a revert pull request for a merged change.
 
-GitHub review details, linked PR status, and review actions can use another connected environment
-signed in to the same GitHub account. Each environment needs a project on that GitHub host.
+GitHub routing is off by default. In Settings → Connections (Environments on mobile), choose
+**Read PRs** or **Read and act** for each environment you trust to share GitHub access.
+Enable both the original environment and the environment answering its requests on this client.
+**Read and act** can use broader GitHub permissions than the original environment's credential;
+only enable it for environments you control and trust. Changing a saved endpoint or removing an
+environment clears its permission.
+
+GitHub review details, linked PR status, and permitted review actions can then use another
+connected environment signed in to the same GitHub account. Each needs a project on that host.
 A connected local environment is preferred for actions and can answer slow or failed reads.
 Browsers and mobile clients need a paired environment to use its GitHub CLI credentials.
 Credentials stay on their machines. Previously verified credentials remain usable for routing

--- a/packages/client-runtime/src/connection/githubRoutingPermissions.ts
+++ b/packages/client-runtime/src/connection/githubRoutingPermissions.ts
@@ -1,0 +1,147 @@
+import { EnvironmentId } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+
+import type { ConnectionCatalogEntry } from "./catalog.ts";
+import { ConnectionBlockedError, type ConnectionAttemptError } from "./model.ts";
+
+export const GitHubRoutingPermission = Schema.Literals(["off", "read", "read-write"]);
+export type GitHubRoutingPermission = typeof GitHubRoutingPermission.Type;
+export const StoredGitHubRoutingPermission = Schema.Struct({
+  environmentId: EnvironmentId,
+  connectionKey: Schema.String,
+  permission: GitHubRoutingPermission,
+});
+export type StoredGitHubRoutingPermission = typeof StoredGitHubRoutingPermission.Type;
+
+/** Trust belongs to the saved endpoint, never to an environment id advertised by a server alone. */
+export function gitHubRoutingConnectionKey(entry: ConnectionCatalogEntry): string | null {
+  const target = entry.target;
+  if (target._tag === "RelayConnectionTarget")
+    return JSON.stringify([target._tag, target.environmentId]);
+  const profile = Option.getOrNull(entry.profile);
+  if (target._tag === "SshConnectionTarget") {
+    if (profile?._tag !== "SshConnectionProfile") return null;
+    const { alias, hostname, username, port } = profile.target;
+    return JSON.stringify([target._tag, target.environmentId, alias, hostname, username, port]);
+  }
+  const baseUrls =
+    target._tag === "PrimaryConnectionTarget"
+      ? [target.httpBaseUrl, target.wsBaseUrl]
+      : profile?._tag === "BearerConnectionProfile"
+        ? [profile.httpBaseUrl, profile.wsBaseUrl]
+        : null;
+  if (baseUrls === null) return null;
+  try {
+    const urls = baseUrls.map((baseUrl) => new URL(baseUrl));
+    if (
+      !["http:", "https:"].includes(urls[0]!.protocol) ||
+      !["ws:", "wss:"].includes(urls[1]!.protocol) ||
+      urls.some((url) => url.username || url.password)
+    )
+      return null;
+    return JSON.stringify([
+      target._tag,
+      target.environmentId,
+      ...urls.map((url) => url.href.replace(/\/+$/, "")),
+    ]);
+  } catch {
+    return null;
+  }
+}
+
+export function gitHubRoutingPermissionFor(
+  entry: ConnectionCatalogEntry,
+  permissions: ReadonlyArray<StoredGitHubRoutingPermission>,
+): GitHubRoutingPermission {
+  const key = gitHubRoutingConnectionKey(entry);
+  return key === null
+    ? "off"
+    : (permissions.find((permission) => permission.connectionKey === key)?.permission ?? "off");
+}
+
+export class GitHubRoutingPermissions extends Context.Reference<{
+  readonly get: (entry: ConnectionCatalogEntry) => Effect.Effect<GitHubRoutingPermission>;
+  readonly changes: Stream.Stream<ReadonlyArray<StoredGitHubRoutingPermission>>;
+  readonly set: (
+    entry: ConnectionCatalogEntry,
+    permission: GitHubRoutingPermission,
+  ) => Effect.Effect<void, ConnectionAttemptError>;
+  readonly forget: (environmentId: EnvironmentId) => Effect.Effect<void, ConnectionAttemptError>;
+}>("@t3tools/client-runtime/connection/GitHubRoutingPermissions", {
+  defaultValue: () => ({
+    get: () => Effect.succeed("off"),
+    changes: Stream.succeed([]),
+    set: () =>
+      Effect.fail(
+        new ConnectionBlockedError({
+          reason: "unsupported",
+          detail: "GitHub routing preferences are unavailable on this client.",
+        }),
+      ),
+    forget: () => Effect.void,
+  }),
+}) {}
+
+export const makeGitHubRoutingPermissions = Effect.fn("makeGitHubRoutingPermissions")(
+  function* (storage: {
+    readonly read: Effect.Effect<
+      ReadonlyArray<StoredGitHubRoutingPermission>,
+      ConnectionAttemptError
+    >;
+    readonly write: (
+      permissions: ReadonlyArray<StoredGitHubRoutingPermission>,
+    ) => Effect.Effect<void, ConnectionAttemptError>;
+  }) {
+    const state = yield* SubscriptionRef.make(yield* storage.read);
+    const lock = yield* Semaphore.make(1);
+    const update = (
+      transform: (
+        current: ReadonlyArray<StoredGitHubRoutingPermission>,
+      ) => ReadonlyArray<StoredGitHubRoutingPermission>,
+    ) =>
+      lock.withPermits(1)(
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const next = transform(current);
+          if (next === current) return;
+          yield* storage.write(next);
+          yield* SubscriptionRef.set(state, next);
+        }),
+      );
+    return GitHubRoutingPermissions.of({
+      get: (entry) =>
+        SubscriptionRef.get(state).pipe(
+          Effect.map((permissions) => gitHubRoutingPermissionFor(entry, permissions)),
+        ),
+      changes: SubscriptionRef.changes(state),
+      set: (entry, permission) => {
+        const connectionKey = gitHubRoutingConnectionKey(entry);
+        if (connectionKey === null)
+          return Effect.fail(
+            new ConnectionBlockedError({
+              reason: "configuration",
+              detail: "This environment does not have a saved connection endpoint.",
+            }),
+          );
+        return update((current) => [
+          ...current.filter((value) => value.environmentId !== entry.target.environmentId),
+          ...(permission === "off"
+            ? []
+            : [{ environmentId: entry.target.environmentId, connectionKey, permission }]),
+        ]);
+      },
+      forget: (environmentId) =>
+        update((current) =>
+          current.some((permission) => permission.environmentId === environmentId)
+            ? current.filter((permission) => permission.environmentId !== environmentId)
+            : current,
+        ),
+    });
+  },
+);

--- a/packages/client-runtime/src/connection/index.ts
+++ b/packages/client-runtime/src/connection/index.ts
@@ -3,6 +3,7 @@ export * as Connectivity from "./connectivity.ts";
 export * as CredentialStore from "./credentialStore.ts";
 export { type ConnectionDriverProgress, type EnvironmentConnectionLease } from "./driver.ts";
 export * from "./errors.ts";
+export * from "./githubRoutingPermissions.ts";
 export * as Connection from "./layer.ts";
 export * from "./model.ts";
 export {

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -47,6 +47,10 @@ import {
 import * as Persistence from "../platform/persistence.ts";
 import * as ConnectionProfileStore from "./profileStore.ts";
 import * as EnvironmentRegistry from "./registry.ts";
+import {
+  GitHubRoutingPermissions,
+  makeGitHubRoutingPermissions,
+} from "./githubRoutingPermissions.ts";
 import * as RpcSession from "../rpc/session.ts";
 import * as EnvironmentSupervisor from "./supervisor.ts";
 import * as ConnectionWakeups from "./wakeups.ts";
@@ -848,10 +852,17 @@ describe("EnvironmentRegistry", () => {
         label: "Shadowed relay environment",
       });
       const harness = yield* makeHarness([shadowedTarget]);
+      const permissions = yield* makeGitHubRoutingPermissions({
+        read: Effect.succeed([]),
+        write: () => Effect.void,
+      });
+      const shadowedEntry = { target: shadowedTarget, profile: Option.none() };
+      yield* permissions.set(shadowedEntry, "read-write");
 
       yield* Effect.gen(function* () {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
         yield* registry.registerPlatform(new PrimaryConnectionRegistration({ target: TARGET }));
+        expect(yield* permissions.get(shadowedEntry)).toBe("off");
 
         expect(
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
@@ -864,7 +875,11 @@ describe("EnvironmentRegistry", () => {
           (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
         ).toEqual(TARGET);
         expect((yield* Ref.get(harness.storedTargets)).has(TARGET.environmentId)).toBe(false);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+      }).pipe(
+        Effect.provide(harness.layer),
+        Effect.provideService(GitHubRoutingPermissions, permissions),
+        Effect.scoped,
+      );
     }),
   );
 
@@ -951,6 +966,20 @@ describe("EnvironmentRegistry", () => {
   it.effect("retains a healthy runtime when the platform repeats an identical registration", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness([]);
+      let failWrites = false;
+      const permissions = yield* makeGitHubRoutingPermissions({
+        read: Effect.succeed([]),
+        write: () =>
+          failWrites
+            ? Effect.fail(
+                new ConnectionTransientError({
+                  reason: "remote-unavailable",
+                  detail: "Storage unavailable",
+                }),
+              )
+            : Effect.void,
+      });
+      const entry = { target: TARGET, profile: Option.none() };
 
       yield* Effect.gen(function* () {
         const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
@@ -961,11 +990,43 @@ describe("EnvironmentRegistry", () => {
           TARGET.environmentId,
           (state) => state.phase === "connected",
         );
+        yield* permissions.set(entry, "read-write");
 
         yield* registry.registerPlatform(registration);
 
         expect(yield* Ref.get(harness.sessions)).toHaveLength(1);
-      }).pipe(Effect.provide(harness.layer), Effect.scoped);
+        expect(yield* permissions.get(entry)).toBe("read-write");
+
+        const changedTarget = new PrimaryConnectionTarget({
+          ...TARGET,
+          httpBaseUrl: "https://changed.example.test",
+        });
+        failWrites = true;
+        yield* registry.registerPlatform(
+          new PrimaryConnectionRegistration({ target: changedTarget }),
+        );
+        expect(
+          (yield* SubscriptionRef.get(registry.entries)).get(TARGET.environmentId)?.target,
+        ).toEqual(TARGET);
+        yield* registry.reconcilePlatform([]);
+        expect((yield* SubscriptionRef.get(registry.entries)).has(TARGET.environmentId)).toBe(true);
+
+        failWrites = false;
+        yield* registry.registerPlatform(
+          new PrimaryConnectionRegistration({ target: changedTarget }),
+        );
+        expect(yield* permissions.get(entry)).toBe("off");
+        yield* registry.registerPlatform(registration);
+        expect(yield* permissions.get(entry)).toBe("off");
+        yield* permissions.set(entry, "read-write");
+        yield* registry.reconcilePlatform([]);
+        yield* registry.registerPlatform(registration);
+        expect(yield* permissions.get(entry)).toBe("off");
+      }).pipe(
+        Effect.provide(harness.layer),
+        Effect.provideService(GitHubRoutingPermissions, permissions),
+        Effect.scoped,
+      );
     }),
   );
 

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -34,6 +34,10 @@ import * as Persistence from "../platform/persistence.ts";
 import * as EnvironmentSupervisor from "./supervisor.ts";
 import * as ConnectionDriver from "./driver.ts";
 import * as ConnectionWakeups from "./wakeups.ts";
+import {
+  GitHubRoutingPermissions,
+  gitHubRoutingConnectionKey,
+} from "./githubRoutingPermissions.ts";
 
 const isSshConnectionProfile = Schema.is(SshConnectionProfile);
 
@@ -134,6 +138,7 @@ export const make = Effect.gen(function* () {
   const ownedDataCleanup = yield* Persistence.EnvironmentOwnedDataCleanup;
   const profiles = yield* ConnectionProfileStore.ConnectionProfileStore;
   const credentials = yield* ConnectionCredentialStore.ConnectionCredentialStore;
+  const githubRoutingPermissions = yield* GitHubRoutingPermissions;
   const connectivity = yield* Connectivity.Connectivity;
   const driver = yield* ConnectionDriver.ConnectionDriver;
   const wakeups = yield* ConnectionWakeups.ConnectionWakeups;
@@ -399,6 +404,21 @@ export const make = Effect.gen(function* () {
         if ((yield* Ref.get(platformEnvironmentIds)).has(environmentId)) {
           return;
         }
+        const previous = (yield* SubscriptionRef.get(entries)).get(environmentId);
+        if (
+          previous !== undefined &&
+          gitHubRoutingConnectionKey(previous) !== gitHubRoutingConnectionKey(entry)
+        ) {
+          yield* githubRoutingPermissions.forget(environmentId).pipe(
+            Effect.mapError(
+              (error) =>
+                new Persistence.ConnectionPersistenceError({
+                  operation: "register-connection",
+                  message: error.message,
+                }),
+            ),
+          );
+        }
         yield* registrations.register(registration);
         yield* Ref.update(persistedTargetsByEnvironment, (current) => {
           const next = new Map(current);
@@ -417,6 +437,29 @@ export const make = Effect.gen(function* () {
       yield* withLeaseLock(
         target.environmentId,
         Effect.gen(function* () {
+          const previous = (yield* SubscriptionRef.get(entries)).get(target.environmentId);
+          const persistedTarget = (yield* Ref.get(persistedTargetsByEnvironment)).get(
+            target.environmentId,
+          );
+          if (
+            persistedTarget !== undefined ||
+            (previous !== undefined &&
+              gitHubRoutingConnectionKey(previous) !== gitHubRoutingConnectionKey(entry))
+          ) {
+            const revoked = yield* githubRoutingPermissions.forget(target.environmentId).pipe(
+              Effect.tapError((error) =>
+                Effect.logWarning(
+                  "Could not clear GitHub routing permission for a platform environment.",
+                  {
+                    environmentId: target.environmentId,
+                    error,
+                  },
+                ),
+              ),
+              Effect.exit,
+            );
+            if (Exit.isFailure(revoked)) return;
+          }
           yield* Ref.update(platformEnvironmentIds, (current) => {
             const next = new Set(current);
             next.add(target.environmentId);
@@ -438,9 +481,6 @@ export const make = Effect.gen(function* () {
             );
           }
 
-          const persistedTarget = (yield* Ref.get(persistedTargetsByEnvironment)).get(
-            target.environmentId,
-          );
           if (persistedTarget !== undefined) {
             yield* registrations.remove(persistedTarget).pipe(
               Effect.tap(() =>
@@ -478,6 +518,19 @@ export const make = Effect.gen(function* () {
         environmentId,
         Effect.gen(function* () {
           const entry = (yield* SubscriptionRef.get(entries)).get(environmentId);
+          const revoked = yield* githubRoutingPermissions.forget(environmentId).pipe(
+            Effect.tapError((error) =>
+              Effect.logWarning(
+                "Could not clear GitHub routing permission after platform removal.",
+                {
+                  environmentId,
+                  error,
+                },
+              ),
+            ),
+            Effect.exit,
+          );
+          if (Exit.isFailure(revoked)) return;
           yield* Ref.update(platformEnvironmentIds, (current) => {
             const next = new Set(current);
             next.delete(environmentId);
@@ -558,6 +611,7 @@ export const make = Effect.gen(function* () {
             ? yield* profiles.get(target.connectionId)
             : Option.none();
 
+        yield* githubRoutingPermissions.forget(environmentId);
         yield* registrations.remove(target);
         yield* Ref.update(persistedTargetsByEnvironment, (current) => {
           const next = new Map(current);

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -28,6 +28,11 @@ import {
   type ConnectionTarget,
 } from "./model.ts";
 import * as ConnectionProfileStore from "./profileStore.ts";
+import {
+  GitHubRoutingPermissions,
+  gitHubRoutingConnectionKey,
+  makeGitHubRoutingPermissions,
+} from "./githubRoutingPermissions.ts";
 
 const ENVIRONMENT_ID = EnvironmentId.make("environment-1");
 const ENDPOINT = {
@@ -64,6 +69,7 @@ function collectingTracer(spans: Array<string>): Tracer.Tracer {
 
 const makeDependencies = Effect.fn("TestConnectionResolver.makeDependencies")((options?: {
   readonly profiles?: ReadonlyArray<ConnectionProfile>;
+  readonly profileStore?: ConnectionProfileStore.ConnectionProfileStore["Service"];
   readonly credentials?: ReadonlyArray<readonly [string, ConnectionCredential]>;
   readonly authorizeBearer?: RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization["Service"]["authorizeBearer"];
   readonly authorizeDpop?: RemoteEnvironmentAuthorization.RemoteEnvironmentAuthorization["Service"]["authorizeDpop"];
@@ -134,7 +140,10 @@ const makeDependencies = Effect.fn("TestConnectionResolver.makeDependencies")((o
   });
 
   const dependencies = Layer.mergeAll(
-    Layer.succeed(ConnectionProfileStore.ConnectionProfileStore, profileStore),
+    Layer.succeed(
+      ConnectionProfileStore.ConnectionProfileStore,
+      options?.profileStore ?? profileStore,
+    ),
     Layer.succeed(ConnectionCredentialStore.ConnectionCredentialStore, credentialStore),
     Layer.succeed(
       ClientCapabilities.PrimaryEnvironmentAuth,
@@ -375,6 +384,102 @@ describe("ConnectionResolver", () => {
       expect(yield* Ref.get(connectionMethods)).toEqual(["ssh"]);
     }),
   );
+
+  for (const scenario of ["unchanged", "changed", "revocation-failed"] as const) {
+    it.effect(`handles ${scenario} SSH routing consent before saving or authorizing`, () =>
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const target = new SshConnectionTarget({
+          environmentId: ENVIRONMENT_ID,
+          label: "SSH",
+          connectionId: "ssh-1",
+        });
+        const profile = new SshConnectionProfile({
+          connectionId: target.connectionId,
+          environmentId: ENVIRONMENT_ID,
+          label: "SSH",
+          target: SSH_TARGET,
+        });
+        const entry = catalogEntry(target, Option.some(profile));
+        const preparedTarget =
+          scenario === "unchanged"
+            ? SSH_TARGET
+            : { ...SSH_TARGET, hostname: "replacement.example.test" };
+        const failure = new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not persist routing consent.",
+        });
+        const permissions = yield* makeGitHubRoutingPermissions({
+          read: Effect.succeed([
+            {
+              environmentId: ENVIRONMENT_ID,
+              connectionKey: gitHubRoutingConnectionKey(entry)!,
+              permission: "read-write",
+            },
+          ]),
+          write: () =>
+            Effect.sync(() => {
+              calls.push("revoke");
+            }).pipe(
+              Effect.andThen(scenario === "revocation-failed" ? Effect.fail(failure) : Effect.void),
+            ),
+        });
+        let savedProfile: ConnectionProfile = profile;
+        const brokerLayer = yield* makeDependencies({
+          profileStore: {
+            get: () => Effect.sync(() => Option.some(savedProfile)),
+            put: (value) =>
+              Effect.sync(() => {
+                calls.push("profile");
+                savedProfile = value;
+              }),
+            remove: () => Effect.die("unused"),
+          },
+          prepareSsh: () =>
+            Effect.succeed({
+              bootstrap: {
+                target: preparedTarget,
+                httpBaseUrl: "http://127.0.0.1:4010",
+                wsBaseUrl: "ws://127.0.0.1:4010",
+                pairingToken: null,
+              },
+              bearerToken: "ssh-bearer",
+            }),
+          authorizeBearer: (input) =>
+            Effect.sync(() => {
+              calls.push("authorize");
+              return {
+                environmentId: input.expectedEnvironmentId,
+                label: "SSH",
+                httpBaseUrl: input.httpBaseUrl,
+                socketUrl: "ws://127.0.0.1:4010/ws?wsTicket=ssh",
+                httpAuthorization: { _tag: "Bearer" as const, token: input.bearerToken },
+              };
+            }),
+        });
+        const broker = yield* ConnectionResolver.ConnectionResolver.pipe(
+          Effect.provide(brokerLayer),
+        );
+        const prepare = broker
+          .prepare(entry)
+          .pipe(Effect.provideService(GitHubRoutingPermissions, permissions));
+        if (scenario === "revocation-failed") {
+          expect(yield* Effect.flip(prepare)).toBe(failure);
+          expect(savedProfile).toBe(profile);
+          expect(calls).toEqual(["revoke"]);
+        } else {
+          expect((yield* prepare).socketUrl).toContain("wsTicket=ssh");
+          expect(savedProfile).toMatchObject({ target: preparedTarget });
+          expect(calls).toEqual(
+            scenario === "unchanged"
+              ? ["profile", "authorize"]
+              : ["revoke", "profile", "authorize"],
+          );
+        }
+        expect(yield* permissions.get(entry)).toBe(scenario === "changed" ? "off" : "read-write");
+      }),
+    );
+  }
 
   it.effect("preserves relay authorization failure classification and trace details", () =>
     Effect.gen(function* () {

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -17,6 +17,10 @@ import {
 } from "./catalog.ts";
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import { credentialMissingError, environmentMismatchError, profileMissingError } from "./errors.ts";
+import {
+  GitHubRoutingPermissions,
+  gitHubRoutingConnectionKey,
+} from "./githubRoutingPermissions.ts";
 import type {
   BearerConnectionTarget,
   ConnectionTarget,
@@ -192,14 +196,20 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
       expectedEnvironmentId: target.environmentId,
       target: profile.target,
     });
-    yield* profiles.put(
-      new SshConnectionProfile({
-        connectionId: profile.connectionId,
-        environmentId: profile.environmentId,
-        label: profile.label,
-        target: prepared.bootstrap.target,
-      }),
-    );
+    const preparedProfile = new SshConnectionProfile({
+      connectionId: profile.connectionId,
+      environmentId: profile.environmentId,
+      label: profile.label,
+      target: prepared.bootstrap.target,
+    });
+    if (
+      gitHubRoutingConnectionKey(entry) !==
+      gitHubRoutingConnectionKey({ ...entry, profile: Option.some(preparedProfile) })
+    ) {
+      const permissions = yield* GitHubRoutingPermissions;
+      yield* permissions.forget(target.environmentId);
+    }
+    yield* profiles.put(preparedProfile);
     const authorized = yield* remote.authorizeBearer({
       expectedEnvironmentId: target.environmentId,
       httpBaseUrl: prepared.bootstrap.httpBaseUrl,

--- a/packages/client-runtime/src/platform/storageDocument.test.ts
+++ b/packages/client-runtime/src/platform/storageDocument.test.ts
@@ -1,6 +1,8 @@
 import { EnvironmentId } from "@t3tools/contracts";
 import { describe, expect, it } from "@effect/vitest";
 import * as Schema from "effect/Schema";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 
 import * as TokenStore from "../authorization/tokenStore.ts";
 import {
@@ -13,9 +15,15 @@ import {
 } from "../connection/catalog.ts";
 import {
   BearerConnectionTarget,
+  ConnectionTransientError,
+  PrimaryConnectionTarget,
   RelayConnectionTarget,
   SshConnectionTarget,
 } from "../connection/model.ts";
+import {
+  GitHubRoutingPermissions,
+  makeGitHubRoutingPermissions,
+} from "../connection/githubRoutingPermissions.ts";
 import {
   ConnectionCatalogDocument,
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
@@ -23,6 +31,8 @@ import {
   registerConnectionInCatalog,
   removeConnectionFromCatalog,
 } from "./storageDocument.ts";
+
+const decodeConnectionCatalogDocument = Schema.decodeUnknownEffect(ConnectionCatalogDocument);
 
 const ENVIRONMENT_ID = EnvironmentId.make("environment-1");
 
@@ -59,6 +69,124 @@ const REMOTE_TOKEN = new TokenStore.RemoteDpopAccessToken({
 });
 
 describe("ConnectionCatalogDocument", () => {
+  it.effect("persists explicit GitHub trust and forgets it when a connection is removed", () =>
+    Effect.gen(function* () {
+      let document = EMPTY_CONNECTION_CATALOG_DOCUMENT;
+      const entry = { target: BEARER_TARGET, profile: Option.some(BEARER_PROFILE) };
+      const storage = {
+        read: Effect.sync(() => document.githubRoutingPermissions ?? []),
+        write: (githubRoutingPermissions: NonNullable<typeof document.githubRoutingPermissions>) =>
+          Effect.gen(function* () {
+            document = yield* decodeConnectionCatalogDocument({
+              ...document,
+              githubRoutingPermissions,
+            }).pipe(Effect.orDie);
+          }),
+      };
+      const permissions = yield* makeGitHubRoutingPermissions(storage);
+      expect(yield* permissions.get(entry)).toBe("off");
+      yield* permissions.set(entry, "read");
+      const restarted = yield* makeGitHubRoutingPermissions(storage);
+      expect(yield* restarted.get(entry)).toBe("read");
+
+      const changedEndpoint = {
+        ...entry,
+        profile: Option.some(
+          new BearerConnectionProfile({
+            ...BEARER_PROFILE,
+            httpBaseUrl: "https://different.example.test",
+          }),
+        ),
+      };
+      expect(yield* restarted.get(changedEndpoint)).toBe("off");
+      expect(
+        yield* restarted.get({
+          ...entry,
+          profile: Option.some(
+            new BearerConnectionProfile({
+              ...BEARER_PROFILE,
+              wsBaseUrl: "wss://different.example.test",
+            }),
+          ),
+        }),
+      ).toBe("off");
+      expect(yield* restarted.get({ target: RELAY_TARGET, profile: Option.none() })).toBe("off");
+      yield* restarted.set(entry, "read-write");
+      expect(yield* restarted.get(entry)).toBe("read-write");
+      yield* restarted.forget(ENVIRONMENT_ID);
+      expect(yield* restarted.get(entry)).toBe("off");
+      const afterRemoval = yield* makeGitHubRoutingPermissions(storage);
+      expect(yield* afterRemoval.get(entry)).toBe("off");
+
+      yield* permissions.set(entry, "read");
+      document = removeConnectionFromCatalog(document, BEARER_TARGET);
+      const afterCatalogRemoval = yield* makeGitHubRoutingPermissions(storage);
+      expect(yield* afterCatalogRemoval.get(entry)).toBe("off");
+    }),
+  );
+
+  it.effect("requires explicit trust for primary, relay, and SSH connections independently", () =>
+    Effect.gen(function* () {
+      const permissions = yield* makeGitHubRoutingPermissions({
+        read: Effect.succeed([]),
+        write: () => Effect.void,
+      });
+      const entries = [
+        {
+          target: new PrimaryConnectionTarget({
+            environmentId: ENVIRONMENT_ID,
+            label: "Local",
+            httpBaseUrl: "http://localhost:3000",
+            wsBaseUrl: "ws://localhost:3000",
+          }),
+          profile: Option.none(),
+        },
+        { target: RELAY_TARGET, profile: Option.none() },
+        {
+          target: new SshConnectionTarget({
+            environmentId: ENVIRONMENT_ID,
+            label: "SSH",
+            connectionId: "ssh-1",
+          }),
+          profile: Option.some(
+            new SshConnectionProfile({
+              environmentId: ENVIRONMENT_ID,
+              label: "SSH",
+              connectionId: "ssh-1",
+              target: { alias: "work", hostname: "work.example.test", username: "maria", port: 22 },
+            }),
+          ),
+        },
+      ];
+      for (const entry of entries) {
+        expect(yield* permissions.get(entry)).toBe("off");
+        yield* permissions.set(entry, "read");
+        expect(yield* permissions.get(entry)).toBe("read");
+        yield* permissions.set(entry, "off");
+        expect(yield* permissions.get(entry)).toBe("off");
+      }
+    }),
+  );
+
+  it.effect("does not enable GitHub routing when permission persistence fails", () =>
+    Effect.gen(function* () {
+      const entry = { target: BEARER_TARGET, profile: Option.some(BEARER_PROFILE) };
+      expect(yield* (yield* GitHubRoutingPermissions).get(entry)).toBe("off");
+      const permissions = yield* makeGitHubRoutingPermissions({
+        read: Effect.succeed([]),
+        write: () =>
+          Effect.fail(
+            new ConnectionTransientError({
+              reason: "remote-unavailable",
+              detail: "storage unavailable",
+            }),
+          ),
+      });
+      yield* permissions.set(entry, "read-write").pipe(Effect.flip);
+      expect(yield* permissions.get(entry)).toBe("off");
+    }),
+  );
+
   it.each([
     { name: "legacy", accountId: undefined },
     { name: "account-bound", accountId: "account-1" },

--- a/packages/client-runtime/src/platform/storageDocument.ts
+++ b/packages/client-runtime/src/platform/storageDocument.ts
@@ -7,6 +7,7 @@ import {
 } from "../connection/catalog.ts";
 import { type ConnectionTarget, PersistedConnectionTarget } from "../connection/model.ts";
 import * as TokenStore from "../authorization/tokenStore.ts";
+import { StoredGitHubRoutingPermission } from "../connection/githubRoutingPermissions.ts";
 
 export const StoredConnectionCredential = Schema.Struct({
   connectionId: Schema.String,
@@ -20,6 +21,7 @@ export const ConnectionCatalogDocument = Schema.Struct({
   profiles: Schema.Array(ConnectionProfile),
   credentials: Schema.Array(StoredConnectionCredential),
   remoteDpopTokens: Schema.Array(TokenStore.RemoteDpopAccessToken),
+  githubRoutingPermissions: Schema.optionalKey(Schema.Array(StoredGitHubRoutingPermission)),
 });
 export type ConnectionCatalogDocument = typeof ConnectionCatalogDocument.Type;
 
@@ -137,7 +139,15 @@ export function removeConnectionFromCatalog(
   document: ConnectionCatalogDocument,
   target: ConnectionTarget,
 ): ConnectionCatalogDocument {
-  return removeConnectionMetadata(document, target, true);
+  const next = removeConnectionMetadata(document, target, true);
+  return document.githubRoutingPermissions === undefined
+    ? next
+    : {
+        ...next,
+        githubRoutingPermissions: document.githubRoutingPermissions.filter(
+          (permission) => permission.environmentId !== target.environmentId,
+        ),
+      };
 }
 
 export function putRemoteDpopTokenInCatalog(

--- a/packages/client-runtime/src/state/connections.ts
+++ b/packages/client-runtime/src/state/connections.ts
@@ -10,6 +10,11 @@ import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
 import { AVAILABLE_CONNECTION_STATE } from "../connection/model.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import {
+  GitHubRoutingPermissions,
+  type GitHubRoutingPermission,
+  type StoredGitHubRoutingPermission,
+} from "../connection/githubRoutingPermissions.ts";
+import {
   createAtomCommandScheduler,
   createRuntimeCommand,
   followStreamInEnvironment,
@@ -49,6 +54,32 @@ export function createEnvironmentCatalogAtoms<R, E>(
   const catalogValueAtom = Atom.make((get) =>
     Option.getOrElse(AsyncResult.value(get(catalogAtom)), () => EMPTY_ENVIRONMENT_CATALOG_STATE),
   ).pipe(Atom.withLabel("environment-catalog-value"));
+
+  const githubRoutingPermissionsAtom = runtime.atom(
+    Stream.unwrap(GitHubRoutingPermissions.pipe(Effect.map((permissions) => permissions.changes))),
+    { initialValue: [] as ReadonlyArray<StoredGitHubRoutingPermission> },
+  );
+  const githubRoutingPermissionsValueAtom = Atom.make((get) =>
+    Option.getOrElse(AsyncResult.value(get(githubRoutingPermissionsAtom)), () => []),
+  ).pipe(Atom.withLabel("environment-github-routing-permissions"));
+  const setGitHubRoutingPermission = createRuntimeCommand(runtime, {
+    label: "environment-catalog:github-routing-permission",
+    scheduler: commandScheduler,
+    concurrency: serial,
+    execute: Effect.fn(function* (input: {
+      readonly environmentId: EnvironmentIdType;
+      readonly permission: GitHubRoutingPermission;
+    }) {
+      const registry = yield* EnvironmentRegistry.EnvironmentRegistry;
+      const entry = (yield* SubscriptionRef.get(registry.entries)).get(input.environmentId);
+      if (entry === undefined)
+        return yield* new EnvironmentRegistry.EnvironmentNotRegisteredError({
+          environmentId: input.environmentId,
+        });
+      const permissions = yield* GitHubRoutingPermissions;
+      yield* permissions.set(entry, input.permission);
+    }),
+  });
 
   const networkStatusAtom = runtime.atom(
     Stream.unwrap(
@@ -119,6 +150,8 @@ export function createEnvironmentCatalogAtoms<R, E>(
   return {
     catalogAtom,
     catalogValueAtom,
+    githubRoutingPermissionsValueAtom,
+    setGitHubRoutingPermission,
     networkStatusAtom,
     networkStatusValueAtom,
     stateAtom,

--- a/packages/client-runtime/src/state/pullRequestRouting.ts
+++ b/packages/client-runtime/src/state/pullRequestRouting.ts
@@ -177,6 +177,9 @@ export function createPullRequestRouter() {
                     [...refs.map((reference) => ({ reference })), {}],
                     (invalidation) =>
                       request(WS_METHODS.pullRequestsInvalidate, invalidation).pipe(
+                        // GitHub already accepted the write. A stalled reader on another
+                        // environment must not keep its confirmation pending indefinitely.
+                        Effect.timeoutOption("1 second"),
                         Effect.orElseSucceed(() => undefined),
                       ),
                     { concurrency: 3, discard: true },
@@ -282,7 +285,13 @@ export function createPullRequestRouter() {
           }),
           Effect.map((result) =>
             typeof result === "object" && result !== null && "projectId" in result
-              ? { ...result, projectId: ref.projectId }
+              ? {
+                  ...result,
+                  projectId: ref.projectId,
+                  ...(tag === WS_METHODS.pullRequestsDetail
+                    ? { projectTitle: identity.projectTitle, workspaceRoot: identity.workspaceRoot }
+                    : {}),
+                }
               : result,
           ),
         );

--- a/packages/client-runtime/src/state/pullRequestRouting.ts
+++ b/packages/client-runtime/src/state/pullRequestRouting.ts
@@ -1,0 +1,302 @@
+import {
+  WS_METHODS,
+  PullRequestRef,
+  PullRequestInvalidateInput,
+  type EnvironmentId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+
+import { EnvironmentRegistry, EnvironmentNotRegisteredError } from "../connection/registry.ts";
+import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
+import {
+  request,
+  EnvironmentRpcUnavailableError,
+  type EnvironmentRpcInput,
+  type EnvironmentUnaryRpcTag,
+} from "../rpc/client.ts";
+
+const reads = new Set<string>([
+  WS_METHODS.pullRequestsSummary,
+  WS_METHODS.pullRequestsStack,
+  WS_METHODS.pullRequestsDetail,
+  WS_METHODS.pullRequestsActivity,
+  WS_METHODS.pullRequestsThreadComments,
+  WS_METHODS.pullRequestsDiffFileContents,
+  WS_METHODS.pullRequestsReviewerCandidates,
+  WS_METHODS.pullRequestsLabelCandidates,
+]);
+const writes = new Set<string>([
+  WS_METHODS.pullRequestsRunAction,
+  WS_METHODS.pullRequestsUpdate,
+  WS_METHODS.pullRequestsComment,
+  WS_METHODS.pullRequestsUpdateComment,
+  WS_METHODS.pullRequestsSubmitReview,
+  WS_METHODS.pullRequestsReplyToThread,
+  WS_METHODS.pullRequestsSetReaction,
+  WS_METHODS.pullRequestsSetThreadResolution,
+  WS_METHODS.pullRequestsRequestReviewers,
+  WS_METHODS.pullRequestsSetLabels,
+]);
+const isRef = Schema.is(PullRequestRef);
+const isInvalidation = Schema.is(PullRequestInvalidateInput);
+interface RoutedRead {
+  origin: EnvironmentId;
+  reference: PullRequestRef;
+  targets: Set<EnvironmentId>;
+}
+const routedReads = new WeakMap<EnvironmentRegistry["Service"], Map<string, RoutedRead>>();
+const isUnregistered = Schema.is(EnvironmentNotRegisteredError);
+const encodeKey = Schema.encodeSync(
+  Schema.fromJsonString(Schema.Array(Schema.NullOr(Schema.String))),
+);
+
+function isLocal(entry: ConnectionCatalogEntry): boolean {
+  const url =
+    entry.target._tag === "PrimaryConnectionTarget"
+      ? entry.target.httpBaseUrl
+      : Option.isSome(entry.profile) && entry.profile.value._tag === "BearerConnectionProfile"
+        ? entry.profile.value.httpBaseUrl
+        : undefined;
+  if (url === undefined) return false;
+  try {
+    return ["localhost", "127.0.0.1", "[::1]"].includes(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/** A guard rejection is returned before the operation starts. Other write failures are ambiguous. */
+function rejectedBeforeDispatch(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    (error._tag === "EnvironmentRpcUnavailableError" ||
+      error._tag === "EnvironmentNotRegisteredError" ||
+      (error._tag === "PullRequestOperationError" &&
+        "operation" in error &&
+        error.operation === "routeIdentity"))
+  );
+}
+
+/** Credentials stay on their environments. Only a verified host and account cross the wire. */
+export function createPullRequestRouter() {
+  const routedRequest = Effect.fn("PullRequestRouting.request")(function* <
+    T extends EnvironmentUnaryRpcTag,
+  >(tag: T, input: EnvironmentRpcInput<T>) {
+    if (tag === WS_METHODS.pullRequestsInvalidate && isInvalidation(input)) {
+      const result = yield* request(tag, input);
+      const origin = yield* EnvironmentSupervisor;
+      const registry = yield* EnvironmentRegistry;
+      const used = routedReads.get(registry);
+      const targets = new Map<EnvironmentId, PullRequestRef>();
+      for (const entry of used?.values() ?? []) {
+        if (entry.origin !== origin.target.environmentId) continue;
+        const ref = input.reference;
+        if (
+          ref !== undefined &&
+          (entry.reference.projectId !== ref.projectId ||
+            entry.reference.repository.toLowerCase() !== ref.repository.toLowerCase() ||
+            entry.reference.number !== ref.number ||
+            (ref.host !== undefined &&
+              entry.reference.host?.toLowerCase() !== ref.host.toLowerCase()))
+        )
+          continue;
+        for (const target of entry.targets) targets.set(target, entry.reference);
+        if (input.reference !== undefined)
+          targets.set(origin.target.environmentId, entry.reference);
+      }
+      yield* Effect.forEach(
+        targets,
+        ([target, reference]) =>
+          registry
+            .run(
+              target,
+              request(
+                WS_METHODS.pullRequestsInvalidate,
+                input.reference === undefined ? {} : { reference },
+              ),
+            )
+            .pipe(Effect.orElseSucceed(() => undefined)),
+        { concurrency: 4, discard: true },
+      );
+      return result;
+    }
+    if ((!reads.has(tag) && !writes.has(tag)) || !isRef(input)) {
+      return yield* request(tag, input);
+    }
+    const ref = input;
+    const origin = yield* EnvironmentSupervisor;
+    const registry = yield* EnvironmentRegistry;
+    const entries = yield* SubscriptionRef.get(registry.entries);
+    const used = routedReads.get(registry) ?? new Map<string, RoutedRead>();
+    routedReads.set(registry, used);
+    const refKey = encodeKey([
+      origin.target.environmentId,
+      ref.projectId,
+      ref.host?.toLowerCase() ?? null,
+      ref.repository.toLowerCase(),
+      String(ref.number),
+    ]);
+    const finish = (operation: ReturnType<typeof request<T>>) =>
+      operation.pipe(
+        Effect.tap(() => {
+          if (!writes.has(tag) || used.size === 0) return Effect.void;
+          const targets = new Map<EnvironmentId, PullRequestRef[]>([
+            [origin.target.environmentId, [ref]],
+          ]);
+          for (const entry of used.values()) {
+            if (
+              entry.origin !== origin.target.environmentId ||
+              entry.reference.projectId !== ref.projectId ||
+              entry.reference.repository.toLowerCase() !== ref.repository.toLowerCase() ||
+              entry.reference.number !== ref.number ||
+              (ref.host !== undefined &&
+                entry.reference.host?.toLowerCase() !== ref.host.toLowerCase())
+            )
+              continue;
+            for (const target of [...entry.targets, origin.target.environmentId]) {
+              const refs = targets.get(target) ?? [];
+              if (!refs.some((existing) => existing.host === entry.reference.host))
+                refs.push(entry.reference);
+              targets.set(target, refs);
+            }
+          }
+          return Effect.forEach(
+            targets,
+            ([target, refs]) =>
+              registry
+                .run(
+                  target,
+                  Effect.forEach(
+                    [...refs.map((reference) => ({ reference })), {}],
+                    (invalidation) =>
+                      request(WS_METHODS.pullRequestsInvalidate, invalidation).pipe(
+                        Effect.orElseSucceed(() => undefined),
+                      ),
+                    { concurrency: 3, discard: true },
+                  ),
+                )
+                .pipe(Effect.orElseSucceed(() => undefined)),
+            { concurrency: 4, discard: true },
+          );
+        }),
+      );
+    const alternatives = [];
+    for (const [id, entry] of entries) {
+      if (id === origin.target.environmentId) continue;
+      const connected = yield* registry
+        .run(id, EnvironmentSupervisor.pipe(Effect.flatMap((s) => SubscriptionRef.get(s.session))))
+        .pipe(Effect.orElseSucceed(() => Option.none()));
+      if (Option.isSome(connected)) alternatives.push({ id, local: isLocal(entry) });
+    }
+    if (alternatives.length === 0) return yield* finish(request(tag, input));
+
+    const identity = yield* request(WS_METHODS.pullRequestsRouting, ref).pipe(
+      Effect.orElseSucceed(() => null),
+    );
+    // Old servers and unknown accounts retain the existing path.
+    if (identity === null || identity.provider !== "github")
+      return yield* finish(request(tag, input));
+
+    const routedInput = {
+      ...input,
+      host: identity.host,
+      expectedAccountId: identity.accountId,
+    };
+    const local = alternatives.filter((entry) => entry.local);
+    const remote = alternatives.filter((entry) => !entry.local);
+    const sourceEntry = entries.get(origin.target.environmentId);
+    const sourceLocal = sourceEntry !== undefined && isLocal(sourceEntry);
+    const candidates = [
+      ...(sourceLocal ? [origin.target.environmentId] : []),
+      ...local.map((entry) => entry.id),
+      ...(sourceLocal ? [] : [origin.target.environmentId]),
+      ...remote.map((entry) => entry.id),
+    ];
+    const run = (id: EnvironmentId): ReturnType<typeof request<T>> =>
+      registry.run(id, request(tag, routedInput)).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            const entry = used.get(refKey) ?? {
+              origin: origin.target.environmentId,
+              reference: { ...ref, host: identity.host },
+              targets: new Set<EnvironmentId>(),
+            };
+            entry.targets.add(id);
+            if (used.size >= 256 && !used.has(refKey)) {
+              const oldest = used.keys().next().value;
+              if (oldest !== undefined) used.delete(oldest);
+            }
+            used.set(refKey, entry);
+          }),
+        ),
+        Effect.mapError((error) =>
+          isUnregistered(error)
+            ? new EnvironmentRpcUnavailableError({
+                environmentId: id,
+                message: "The environment was removed.",
+              })
+            : error,
+        ),
+      );
+    const visit = (index: number): ReturnType<typeof request<T>> => {
+      const id = candidates[index];
+      if (id === undefined) return request(tag, routedInput);
+      return Effect.gen(function* () {
+        if (id !== origin.target.environmentId) {
+          // An older server would discard expectedAccountId. Verify it implements the guard first.
+          const alternate = yield* registry
+            .run(id, request(WS_METHODS.pullRequestsRouting, routedInput))
+            .pipe(Effect.orElseSucceed(() => null));
+          if (
+            alternate === null ||
+            alternate.provider !== "github" ||
+            alternate.host.toLowerCase() !== identity.host.toLowerCase() ||
+            alternate.accountId !== identity.accountId
+          ) {
+            return yield* visit(index + 1);
+          }
+        }
+        return yield* run(id).pipe(
+          Effect.catch((error) => {
+            if (
+              (reads.has(tag) || rejectedBeforeDispatch(error)) &&
+              index + 1 < candidates.length
+            ) {
+              return visit(index + 1);
+            }
+            return Effect.fail(error);
+          }),
+          Effect.map((result) =>
+            typeof result === "object" && result !== null && "projectId" in result
+              ? { ...result, projectId: ref.projectId }
+              : result,
+          ),
+        );
+      });
+    };
+    return yield* finish(visit(0));
+  });
+
+  return Effect.fn("PullRequestRouting.readOrWrite")(function* <T extends EnvironmentUnaryRpcTag>(
+    tag: T,
+    input: EnvironmentRpcInput<T>,
+  ) {
+    if (!reads.has(tag) || !isRef(input)) return yield* routedRequest(tag, input);
+    const registry = yield* EnvironmentRegistry;
+    const entries = yield* SubscriptionRef.get(registry.entries);
+    if (entries.size < 2) return yield* request(tag, input);
+    const strictInput = { ...input, allowStale: false };
+    // Cached source reads usually finish before another environment can verify its account.
+    // Hedge slow reads only; never race mutations or retry an ambiguous write.
+    return yield* Effect.race(
+      request(tag, strictInput),
+      routedRequest(tag, strictInput).pipe(Effect.delay("75 millis")),
+    ).pipe(Effect.catch(() => request(tag, input)));
+  });
+}

--- a/packages/client-runtime/src/state/pullRequestRouting.ts
+++ b/packages/client-runtime/src/state/pullRequestRouting.ts
@@ -5,6 +5,7 @@ import {
   type EnvironmentId,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Cause from "effect/Cause";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as SubscriptionRef from "effect/SubscriptionRef";
@@ -197,7 +198,9 @@ export function createPullRequestRouter() {
     if (alternatives.length === 0) return yield* finish(request(tag, input));
 
     const identity = yield* request(WS_METHODS.pullRequestsRouting, ref).pipe(
-      Effect.orElseSucceed(() => null),
+      Effect.catchCause((cause) =>
+        Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed(null),
+      ),
     );
     // Old servers and unknown accounts retain the existing path.
     if (identity === null || identity.provider !== "github")
@@ -252,7 +255,11 @@ export function createPullRequestRouter() {
           // An older server would discard expectedAccountId. Verify it implements the guard first.
           const alternate = yield* registry
             .run(id, request(WS_METHODS.pullRequestsRouting, routedInput))
-            .pipe(Effect.orElseSucceed(() => null));
+            .pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed(null),
+              ),
+            );
           if (
             alternate === null ||
             alternate.provider !== "github" ||

--- a/packages/client-runtime/src/state/pullRequestRouting.ts
+++ b/packages/client-runtime/src/state/pullRequestRouting.ts
@@ -216,10 +216,11 @@ export function createPullRequestRouter() {
     const sourceEntry = entries.get(origin.target.environmentId);
     const sourceLocal = sourceEntry !== undefined && isLocal(sourceEntry);
     const candidates = [
-      ...(sourceLocal ? [origin.target.environmentId] : []),
+      ...(sourceLocal && writes.has(tag) ? [origin.target.environmentId] : []),
       ...local.map((entry) => entry.id),
-      ...(sourceLocal ? [] : [origin.target.environmentId]),
+      ...(!sourceLocal && writes.has(tag) ? [origin.target.environmentId] : []),
       ...remote.map((entry) => entry.id),
+      ...(reads.has(tag) ? [origin.target.environmentId] : []),
     ];
     const run = (id: EnvironmentId): ReturnType<typeof request<T>> =>
       registry.run(id, request(tag, routedInput)).pipe(

--- a/packages/client-runtime/src/state/pullRequestRouting.ts
+++ b/packages/client-runtime/src/state/pullRequestRouting.ts
@@ -12,7 +12,12 @@ import * as SubscriptionRef from "effect/SubscriptionRef";
 
 import { EnvironmentRegistry, EnvironmentNotRegisteredError } from "../connection/registry.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import {
+  GitHubRoutingPermissions,
+  gitHubRoutingConnectionKey,
+} from "../connection/githubRoutingPermissions.ts";
 import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
+import { ConnectionProfileStore } from "../connection/profileStore.ts";
 import {
   request,
   EnvironmentRpcUnavailableError,
@@ -84,11 +89,42 @@ function rejectedBeforeDispatch(error: unknown): boolean {
   );
 }
 
+const routingAllowed = Effect.fn("PullRequestRouting.allowed")(function* (
+  registry: EnvironmentRegistry["Service"],
+  originId: EnvironmentId,
+  destinationId: EnvironmentId,
+  write: boolean,
+) {
+  const entries = yield* SubscriptionRef.get(registry.entries);
+  const origin = entries.get(originId);
+  const destination = entries.get(destinationId);
+  if (origin === undefined || destination === undefined) return false;
+  const permissions = yield* GitHubRoutingPermissions;
+  const source = yield* permissions.get(origin);
+  const target = yield* permissions.get(destination);
+  const allowed = write
+    ? source === "read-write" && target === "read-write"
+    : source !== "off" && target !== "off";
+  if (!allowed) return false;
+  for (const entry of [origin, destination]) {
+    if (entry.target._tag !== "SshConnectionTarget") continue;
+    const profiles = yield* Effect.serviceOption(ConnectionProfileStore);
+    if (Option.isNone(profiles)) return false;
+    const profile = yield* profiles.value
+      .get(entry.target.connectionId)
+      .pipe(Effect.orElseSucceed(() => Option.none()));
+    const key = gitHubRoutingConnectionKey(entry);
+    if (key === null || key !== gitHubRoutingConnectionKey({ ...entry, profile })) return false;
+  }
+  return true;
+});
+
 /** Credentials stay on their environments. Only a verified host and account cross the wire. */
 export function createPullRequestRouter() {
   const routedRequest = Effect.fn("PullRequestRouting.request")(function* <
     T extends EnvironmentUnaryRpcTag,
-  >(tag: T, input: EnvironmentRpcInput<T>) {
+  >(tag: T, input: EnvironmentRpcInput<T>, sourceRead?: ReturnType<typeof request<T>>) {
+    const source = sourceRead ?? request(tag, input);
     if (tag === WS_METHODS.pullRequestsInvalidate && isInvalidation(input)) {
       const result = yield* request(tag, input);
       const origin = yield* EnvironmentSupervisor;
@@ -114,15 +150,27 @@ export function createPullRequestRouter() {
       yield* Effect.forEach(
         targets,
         ([target, reference]) =>
-          registry
-            .run(
-              target,
-              request(
-                WS_METHODS.pullRequestsInvalidate,
-                input.reference === undefined ? {} : { reference },
-              ),
-            )
-            .pipe(Effect.orElseSucceed(() => undefined)),
+          (target === origin.target.environmentId
+            ? Effect.succeed(true)
+            : routingAllowed(registry, origin.target.environmentId, target, false)
+          ).pipe(
+            Effect.flatMap((allowed) =>
+              allowed
+                ? registry
+                    .run(
+                      target,
+                      request(
+                        WS_METHODS.pullRequestsInvalidate,
+                        input.reference === undefined ? {} : { reference },
+                      ),
+                    )
+                    .pipe(
+                      Effect.timeoutOption("1 second"),
+                      Effect.orElseSucceed(() => undefined),
+                    )
+                : Effect.void,
+            ),
+          ),
         { concurrency: 4, discard: true },
       );
       return result;
@@ -134,6 +182,7 @@ export function createPullRequestRouter() {
     const origin = yield* EnvironmentSupervisor;
     const registry = yield* EnvironmentRegistry;
     const entries = yield* SubscriptionRef.get(registry.entries);
+    const sourceEntry = entries.get(origin.target.environmentId);
     const used = routedReads.get(registry) ?? new Map<string, RoutedRead>();
     routedReads.set(registry, used);
     const refKey = encodeKey([
@@ -170,22 +219,31 @@ export function createPullRequestRouter() {
           return Effect.forEach(
             targets,
             ([target, refs]) =>
-              registry
-                .run(
-                  target,
-                  Effect.forEach(
-                    [...refs.map((reference) => ({ reference })), {}],
-                    (invalidation) =>
-                      request(WS_METHODS.pullRequestsInvalidate, invalidation).pipe(
-                        // GitHub already accepted the write. A stalled reader on another
-                        // environment must not keep its confirmation pending indefinitely.
-                        Effect.timeoutOption("1 second"),
-                        Effect.orElseSucceed(() => undefined),
-                      ),
-                    { concurrency: 3, discard: true },
-                  ),
-                )
-                .pipe(Effect.orElseSucceed(() => undefined)),
+              (target === origin.target.environmentId
+                ? Effect.succeed(true)
+                : routingAllowed(registry, origin.target.environmentId, target, false)
+              ).pipe(
+                Effect.flatMap((allowed) =>
+                  allowed
+                    ? registry
+                        .run(
+                          target,
+                          Effect.forEach(
+                            [...refs.map((reference) => ({ reference })), {}],
+                            (invalidation) =>
+                              request(WS_METHODS.pullRequestsInvalidate, invalidation).pipe(
+                                // GitHub already accepted the write. A stalled reader on another
+                                // environment must not keep its confirmation pending indefinitely.
+                                Effect.timeoutOption("1 second"),
+                                Effect.orElseSucceed(() => undefined),
+                              ),
+                            { concurrency: 3, discard: true },
+                          ),
+                        )
+                        .pipe(Effect.orElseSucceed(() => undefined))
+                    : Effect.void,
+                ),
+              ),
             { concurrency: 4, discard: true },
           );
         }),
@@ -193,30 +251,32 @@ export function createPullRequestRouter() {
     const alternatives = [];
     for (const [id, entry] of entries) {
       if (id === origin.target.environmentId) continue;
+      if (!(yield* routingAllowed(registry, origin.target.environmentId, id, writes.has(tag))))
+        continue;
       const connected = yield* registry
         .run(id, EnvironmentSupervisor.pipe(Effect.flatMap((s) => SubscriptionRef.get(s.session))))
         .pipe(Effect.orElseSucceed(() => Option.none()));
       if (Option.isSome(connected)) alternatives.push({ id, local: isLocal(entry) });
     }
-    if (alternatives.length === 0) return yield* finish(request(tag, input));
+    if (alternatives.length === 0) return yield* finish(source);
 
     const identity = yield* request(WS_METHODS.pullRequestsRouting, ref).pipe(
+      Effect.timeout("2 seconds"),
       Effect.catchCause((cause) =>
         Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed(null),
       ),
     );
     // Old servers and unknown accounts retain the existing path.
-    if (identity === null || identity.provider !== "github")
-      return yield* finish(request(tag, input));
+    if (identity === null || identity.provider !== "github") return yield* finish(source);
 
     const routedInput = {
       ...input,
       host: identity.host,
       expectedAccountId: identity.accountId,
     };
+    const guardedSource = sourceRead ?? (yield* Effect.cached(request(tag, routedInput)));
     const local = alternatives.filter((entry) => entry.local);
     const remote = alternatives.filter((entry) => !entry.local);
-    const sourceEntry = entries.get(origin.target.environmentId);
     const sourceLocal = sourceEntry !== undefined && isLocal(sourceEntry);
     const candidates = [
       ...(sourceLocal && writes.has(tag) ? [origin.target.environmentId] : []),
@@ -226,7 +286,10 @@ export function createPullRequestRouter() {
       ...(reads.has(tag) ? [origin.target.environmentId] : []),
     ];
     const run = (id: EnvironmentId): ReturnType<typeof request<T>> =>
-      registry.run(id, request(tag, routedInput)).pipe(
+      (id === origin.target.environmentId
+        ? guardedSource
+        : registry.run(id, request(tag, routedInput))
+      ).pipe(
         Effect.tap(() =>
           Effect.sync(() => {
             const entry = used.get(refKey) ?? {
@@ -253,13 +316,16 @@ export function createPullRequestRouter() {
       );
     const visit = (index: number): ReturnType<typeof request<T>> => {
       const id = candidates[index];
-      if (id === undefined) return request(tag, routedInput);
+      if (id === undefined) return guardedSource;
       return Effect.gen(function* () {
         if (id !== origin.target.environmentId) {
+          if (!(yield* routingAllowed(registry, origin.target.environmentId, id, writes.has(tag))))
+            return yield* visit(index + 1);
           // An older server would discard expectedAccountId. Verify it implements the guard first.
           const alternate = yield* registry
-            .run(id, request(WS_METHODS.pullRequestsRouting, routedInput))
+            .run(id, request(WS_METHODS.pullRequestsRoutingIdentity, { host: identity.host }))
             .pipe(
+              Effect.timeout("2 seconds"),
               Effect.catchCause((cause) =>
                 Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed(null),
               ),
@@ -272,6 +338,8 @@ export function createPullRequestRouter() {
           ) {
             return yield* visit(index + 1);
           }
+          if (!(yield* routingAllowed(registry, origin.target.environmentId, id, writes.has(tag))))
+            return yield* visit(index + 1);
         }
         return yield* run(id).pipe(
           Effect.catch((error) => {
@@ -308,12 +376,32 @@ export function createPullRequestRouter() {
     const registry = yield* EnvironmentRegistry;
     const entries = yield* SubscriptionRef.get(registry.entries);
     if (entries.size < 2) return yield* request(tag, input);
+    const origin = yield* EnvironmentSupervisor;
+    let allowed = false;
+    for (const id of entries.keys()) {
+      if (
+        id !== origin.target.environmentId &&
+        (yield* routingAllowed(registry, origin.target.environmentId, id, false))
+      ) {
+        allowed = true;
+        break;
+      }
+    }
+    if (!allowed) return yield* request(tag, input);
     const strictInput = { ...input, allowStale: false };
+    const source = yield* Effect.cached(request(tag, strictInput));
     // Cached source reads usually finish before another environment can verify its account.
     // Hedge slow reads only; never race mutations or retry an ambiguous write.
     return yield* Effect.race(
-      request(tag, strictInput),
-      routedRequest(tag, strictInput).pipe(Effect.delay("75 millis")),
-    ).pipe(Effect.catch(() => request(tag, input)));
+      source,
+      routedRequest(tag, strictInput, source).pipe(Effect.delay("75 millis")),
+    ).pipe(
+      Effect.catch((error) =>
+        input.allowStale !== false &&
+        (tag === WS_METHODS.pullRequestsSummary || tag === WS_METHODS.pullRequestsDetail)
+          ? request(tag, input)
+          : Effect.fail(error),
+      ),
+    );
   });
 }

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -44,6 +44,8 @@ for (const scenario of [
   "returns a fast source read without checking alternate identities",
   "keeps single-environment requests free of identity lookups",
   "keeps a local origin ahead of another local environment",
+  "keeps mutations on an old origin server without retrying them",
+  "skips an old alternate server before dispatching a mutation",
 ] as const) {
   it.effect(scenario, () =>
     Effect.scoped(
@@ -56,6 +58,10 @@ for (const scenario of [
           scenario === "returns a fast source read without checking alternate identities";
         const single = scenario === "keeps single-environment requests free of identity lookups";
         const localOrigin = scenario === "keeps a local origin ahead of another local environment";
+        const oldOrigin =
+          scenario === "keeps mutations on an old origin server without retrying them";
+        const oldAlternate =
+          scenario === "skips an old alternate server before dispatching a mutation";
         const failure = new PullRequestOperationError({
           operation: "runAction",
           detail: "connection lost after dispatch",
@@ -64,8 +70,13 @@ for (const scenario of [
           const name = local ? "local" : "origin";
           return {
             [WS_METHODS.pullRequestsRouting]: () =>
-              Effect.sync(() => {
+              Effect.gen(function* () {
                 calls.push(`${name}:identity`);
+                if ((!local && oldOrigin) || (local && oldAlternate)) {
+                  return yield* Effect.die(
+                    `Unknown request tag: ${WS_METHODS.pullRequestsRouting}`,
+                  );
+                }
                 return {
                   host: "github.com",
                   provider: "github",
@@ -125,7 +136,7 @@ for (const scenario of [
               "origin:mutation",
             ]);
           } else if (reading) expect(calls).toEqual(["origin:read"]);
-          else if (mismatch || localOrigin)
+          else if (mismatch || localOrigin || oldOrigin || oldAlternate)
             expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["origin:mutation"]);
           else {
             expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["local:mutation"]);

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -46,8 +46,11 @@ for (const scenario of [
   "keeps a local origin ahead of another local environment",
   "keeps mutations on an old origin server without retrying them",
   "skips an old alternate server before dispatching a mutation",
+  "returns a successful mutation when source invalidation stalls",
 ] as const) {
-  it.effect(scenario, () =>
+  (scenario === "returns a successful mutation when source invalidation stalls"
+    ? it.live
+    : it.effect)(scenario, () =>
     Effect.scoped(
       Effect.gen(function* () {
         const calls: string[] = [];
@@ -98,8 +101,14 @@ for (const scenario of [
                 return null;
               }),
             [WS_METHODS.pullRequestsInvalidate]: () =>
-              Effect.sync(() => {
+              Effect.gen(function* () {
                 calls.push(`${name}:invalidate`);
+                if (
+                  !local &&
+                  scenario === "returns a successful mutation when source invalidation stalls"
+                ) {
+                  return yield* Effect.never;
+                }
               }),
           } as unknown as WsRpcProtocolClient;
         };
@@ -315,6 +324,52 @@ for (const source of ["pending", "pending-local", "failed", "offline"] as const)
       ),
   );
 }
+
+it.live("keeps source workspace metadata when an alternate answers a detail read", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const clientFor = (local: boolean) =>
+        ({
+          [WS_METHODS.pullRequestsRouting]: () =>
+            Effect.succeed({
+              host: "github.com",
+              provider: "github",
+              viewer: "maria-rcks",
+              accountId: "123",
+              projectTitle: local ? "local project" : "source project",
+              workspaceRoot: local ? "/Users/local/repo" : "/srv/source/repo",
+            }),
+          [WS_METHODS.pullRequestsDetail]: () =>
+            local
+              ? Effect.succeed({
+                  projectId: "local-project",
+                  projectTitle: "local project",
+                  workspaceRoot: "/Users/local/repo",
+                  title: "github title",
+                })
+              : Effect.never,
+        }) as unknown as WsRpcProtocolClient;
+      const { environmentRegistry, supervisor } = yield* makeTestRuntime(
+        clientFor(false),
+        clientFor(true),
+      );
+      const result = yield* createPullRequestRouter()(WS_METHODS.pullRequestsDetail, {
+        projectId: ProjectId.make("project-1"),
+        repository: "acme/web",
+        number: 7,
+      }).pipe(
+        Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+      );
+      expect(result).toEqual({
+        projectId: "project-1",
+        projectTitle: "source project",
+        workspaceRoot: "/srv/source/repo",
+        title: "github title",
+      });
+    }),
+  ),
+);
 
 it.live(
   "refreshes identity before writes and invalidates prior readers across router instances",

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -1,4 +1,10 @@
-import { EnvironmentId, ProjectId, WS_METHODS, type PullRequestStack } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  ProjectId,
+  PullRequestOperationError,
+  WS_METHODS,
+  type PullRequestStack,
+} from "@t3tools/contracts";
 import { expect, it } from "@effect/vitest";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -17,6 +23,7 @@ import {
   type SupervisorConnectionState,
 } from "../connection/model.ts";
 import * as EnvironmentRegistry from "../connection/registry.ts";
+import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 import type { RpcSession } from "../rpc/session.ts";
@@ -26,8 +33,110 @@ import {
 } from "./pullRequests.ts";
 import { PullRequestDiffLoader } from "./pullRequestDiffHttp.ts";
 import { executeAtomQuery } from "./runtime.ts";
+import { createPullRequestRouter } from "./pullRequestRouting.ts";
 
 class MutationRefused extends Data.TaggedError("MutationRefused") {}
+
+for (const scenario of [
+  "prefers the local environment with the same github account",
+  "falls back before mutation when the local account differs",
+  "never retries an ambiguous mutation failure",
+  "returns a fast source read without checking alternate identities",
+  "keeps single-environment requests free of identity lookups",
+  "keeps a local origin ahead of another local environment",
+] as const) {
+  it.effect(scenario, () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const inputs: unknown[] = [];
+        const mismatch = scenario === "falls back before mutation when the local account differs";
+        const ambiguous = scenario === "never retries an ambiguous mutation failure";
+        const reading =
+          scenario === "returns a fast source read without checking alternate identities";
+        const single = scenario === "keeps single-environment requests free of identity lookups";
+        const localOrigin = scenario === "keeps a local origin ahead of another local environment";
+        const failure = new PullRequestOperationError({
+          operation: "runAction",
+          detail: "connection lost after dispatch",
+        });
+        const clientFor = (local: boolean) => {
+          const name = local ? "local" : "origin";
+          return {
+            [WS_METHODS.pullRequestsRouting]: () =>
+              Effect.sync(() => {
+                calls.push(`${name}:identity`);
+                return {
+                  host: "github.com",
+                  provider: "github",
+                  viewer: "maria-rcks",
+                  accountId: local && mismatch ? "456" : "123",
+                };
+              }),
+            [WS_METHODS.pullRequestsRunAction]: (input: unknown) =>
+              Effect.gen(function* () {
+                calls.push(`${name}:mutation`);
+                inputs.push(input);
+                if (local && ambiguous) return yield* failure;
+              }),
+            [WS_METHODS.pullRequestsSummary]: (input: { allowStale?: boolean }) =>
+              Effect.gen(function* () {
+                calls.push(`${name}:read`);
+                expect(input.allowStale).toBe(false);
+                if (local) return yield* failure;
+                return null;
+              }),
+            [WS_METHODS.pullRequestsInvalidate]: () =>
+              Effect.sync(() => {
+                calls.push(`${name}:invalidate`);
+              }),
+          } as unknown as WsRpcProtocolClient;
+        };
+        const { environmentRegistry, supervisor } = yield* makeTestRuntime(
+          clientFor(false),
+          single ? undefined : clientFor(true),
+          localOrigin,
+        );
+        const input = {
+          projectId: ProjectId.make("project-1"),
+          host: "github.com",
+          repository: "acme/web",
+          number: 7,
+          action: "merge" as const,
+        };
+        const route = createPullRequestRouter();
+        const result = yield* (
+          reading
+            ? route(WS_METHODS.pullRequestsSummary, input)
+            : route(WS_METHODS.pullRequestsRunAction, input)
+        ).pipe(
+          Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+          Effect.result,
+        );
+
+        if (ambiguous) {
+          expect(result).toMatchObject({ _tag: "Failure", failure });
+          expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["local:mutation"]);
+        } else {
+          expect(result._tag).toBe("Success");
+          if (single) {
+            expect(calls.filter((call) => !call.endsWith(":invalidate"))).toEqual([
+              "origin:mutation",
+            ]);
+          } else if (reading) expect(calls).toEqual(["origin:read"]);
+          else if (mismatch || localOrigin)
+            expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["origin:mutation"]);
+          else {
+            expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["local:mutation"]);
+            expect(calls).toContain("origin:invalidate");
+            expect(inputs).toEqual([{ ...input, expectedAccountId: "123" }]);
+          }
+        }
+      }),
+    ),
+  );
+}
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -38,7 +147,11 @@ const TARGET = new PrimaryConnectionTarget({
 
 function session(client: WsRpcProtocolClient): RpcSession {
   return {
-    client,
+    client: {
+      ...client,
+      [WS_METHODS.pullRequestsInvalidate]:
+        client[WS_METHODS.pullRequestsInvalidate] ?? (() => Effect.void),
+    },
     initialConfig: Effect.never,
     subscribeServerConfig: (input) => client.subscribeServerConfig(input),
     ready: Effect.void,
@@ -47,7 +160,18 @@ function session(client: WsRpcProtocolClient): RpcSession {
   };
 }
 
-const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (client: WsRpcProtocolClient) {
+const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (
+  client: WsRpcProtocolClient,
+  localClient?: WsRpcProtocolClient,
+  localOrigin = false,
+) {
+  const originTarget = localOrigin
+    ? new PrimaryConnectionTarget({
+        ...TARGET,
+        httpBaseUrl: "http://localhost:3774",
+        wsBaseUrl: "ws://localhost:3774",
+      })
+    : TARGET;
   const connectionState: SupervisorConnectionState = {
     ...AVAILABLE_CONNECTION_STATE,
     desired: true,
@@ -57,7 +181,7 @@ const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (client: WsRpcPro
     generation: 1,
   };
   const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
-    target: TARGET,
+    target: originTarget,
     state: yield* SubscriptionRef.make(connectionState),
     session: yield* SubscriptionRef.make(Option.some(session(client))),
     prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
@@ -65,9 +189,34 @@ const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (client: WsRpcPro
     disconnect: Effect.void,
     retryNow: Effect.void,
   } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+  const localTarget = new PrimaryConnectionTarget({
+    environmentId: EnvironmentId.make("local-environment"),
+    label: "Local environment",
+    httpBaseUrl: "http://localhost:3773",
+    wsBaseUrl: "ws://localhost:3773",
+  });
+  const localSupervisor = {
+    ...supervisor,
+    target: localTarget,
+    session: yield* SubscriptionRef.make(Option.some(session(localClient ?? client))),
+  };
   const environmentRegistry = EnvironmentRegistry.EnvironmentRegistry.of({
-    run: (_environmentId, effect) =>
-      Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+    entries: yield* SubscriptionRef.make<ReadonlyMap<EnvironmentId, ConnectionCatalogEntry>>(
+      new Map([
+        [originTarget.environmentId, { target: originTarget, profile: Option.none() }],
+        ...(localClient === undefined
+          ? []
+          : [
+              [localTarget.environmentId, { target: localTarget, profile: Option.none() }] as const,
+            ]),
+      ]),
+    ),
+    run: (environmentId, effect) =>
+      Effect.provideService(
+        effect,
+        EnvironmentSupervisor.EnvironmentSupervisor,
+        environmentId === localTarget.environmentId ? localSupervisor : supervisor,
+      ),
     runStream: (_environmentId, stream) =>
       Stream.provideService(stream, EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
     followStream: (_environmentId, stream) =>
@@ -86,8 +235,154 @@ const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (client: WsRpcPro
   const registry = yield* Effect.acquireRelease(Effect.sync(AtomRegistry.make), (registry) =>
     Effect.sync(() => registry.dispose()),
   );
-  return { runtime, atoms, registry };
+  return { runtime, atoms, registry, environmentRegistry, supervisor };
 });
+
+for (const source of ["pending", "failed", "offline"] as const) {
+  it.live(
+    source === "offline"
+      ? "returns held source data only after both fresh paths fail"
+      : `hedges a ${source} source read to local and interrupts the losing read`,
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          let interrupted = false;
+          const calls: string[] = [];
+          const clientFor = (local: boolean) =>
+            ({
+              [WS_METHODS.pullRequestsRouting]: () =>
+                Effect.succeed({
+                  host: "github.com",
+                  provider: "github",
+                  viewer: "maria-rcks",
+                  accountId: "123",
+                }),
+              [WS_METHODS.pullRequestsSummary]: (input: { allowStale?: boolean }) =>
+                Effect.gen(function* () {
+                  calls.push(local ? "local" : input.allowStale === false ? "origin" : "held");
+                  if (source === "offline" && !local && input.allowStale === undefined) {
+                    return { state: "open" };
+                  }
+                  expect(input.allowStale).toBe(false);
+                  if (local && source !== "offline") return null;
+                  if (source !== "pending")
+                    return yield* new PullRequestOperationError({
+                      operation: "summary",
+                      detail: "github unreachable",
+                    });
+                  return yield* Effect.never.pipe(
+                    Effect.onInterrupt(() =>
+                      Effect.sync(() => {
+                        interrupted = true;
+                      }),
+                    ),
+                  );
+                }),
+            }) as unknown as WsRpcProtocolClient;
+          const { environmentRegistry, supervisor } = yield* makeTestRuntime(
+            clientFor(false),
+            clientFor(true),
+          );
+          const result = yield* createPullRequestRouter()(WS_METHODS.pullRequestsSummary, {
+            projectId: ProjectId.make("project-1"),
+            repository: "acme/web",
+            number: 7,
+          }).pipe(
+            Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+            Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+          );
+          if (source === "offline") {
+            expect(result).toEqual({ state: "open" });
+            expect(calls).toEqual(["origin", "local", "origin", "held"]);
+          } else {
+            expect(result).toBeNull();
+            expect(calls).toEqual(["origin", "local"]);
+          }
+          expect(interrupted).toBe(source === "pending");
+        }),
+      ),
+  );
+}
+
+it.live(
+  "refreshes identity before writes and invalidates prior readers across router instances",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let originAccountId = "123";
+        const mutations: { environment: string; expectedAccountId: string }[] = [];
+        const invalidations: { environment: string; input: unknown }[] = [];
+        const identities: string[] = [];
+        const clientFor = (local: boolean) => {
+          const environment = local ? "local" : "origin";
+          return {
+            [WS_METHODS.pullRequestsRouting]: () =>
+              Effect.sync(() => {
+                identities.push(environment);
+                return {
+                  host: "github.com",
+                  provider: "github",
+                  viewer: "maria-rcks",
+                  accountId: local ? "123" : originAccountId,
+                };
+              }),
+            [WS_METHODS.pullRequestsSummary]: () => (local ? Effect.succeed(null) : Effect.never),
+            [WS_METHODS.pullRequestsRunAction]: (input: { expectedAccountId: string }) =>
+              Effect.sync(() => {
+                mutations.push({ environment, expectedAccountId: input.expectedAccountId });
+              }),
+            [WS_METHODS.pullRequestsInvalidate]: (input: unknown) =>
+              Effect.sync(() => {
+                invalidations.push({ environment, input });
+              }),
+          } as unknown as WsRpcProtocolClient;
+        };
+        const { environmentRegistry, supervisor } = yield* makeTestRuntime(
+          clientFor(false),
+          clientFor(true),
+        );
+        const reference = {
+          projectId: ProjectId.make("project-1"),
+          repository: "acme/web",
+          number: 7,
+        };
+        const hostedReference = { ...reference, host: "github.com", allowStale: false };
+        const route = createPullRequestRouter();
+        yield* Effect.gen(function* () {
+          yield* route(WS_METHODS.pullRequestsSummary, reference);
+          originAccountId = "456";
+          yield* route(WS_METHODS.pullRequestsRunAction, { ...reference, action: "merge" });
+
+          expect(identities.filter((environment) => environment === "origin")).toHaveLength(2);
+          expect(mutations).toEqual([{ environment: "origin", expectedAccountId: "456" }]);
+          expect(invalidations).toEqual(
+            expect.arrayContaining([
+              { environment: "origin", input: { reference: expect.objectContaining(reference) } },
+              { environment: "origin", input: { reference: hostedReference } },
+              { environment: "local", input: { reference: hostedReference } },
+              { environment: "origin", input: {} },
+              { environment: "local", input: {} },
+            ]),
+          );
+
+          invalidations.length = 0;
+          const refresh = createPullRequestRouter();
+          yield* refresh(WS_METHODS.pullRequestsInvalidate, { reference });
+          expect(invalidations).toContainEqual({
+            environment: "local",
+            input: { reference: hostedReference },
+          });
+
+          invalidations.length = 0;
+          yield* refresh(WS_METHODS.pullRequestsInvalidate, {});
+          expect(invalidations).toContainEqual({ environment: "local", input: {} });
+        }).pipe(
+          Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        );
+      }),
+    ),
+);
 
 it.effect("keeps concurrent diff file reads on different hosts separate", () =>
   Effect.scoped(

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -249,7 +249,7 @@ const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (
   return { runtime, atoms, registry, environmentRegistry, supervisor };
 });
 
-for (const source of ["pending", "failed", "offline"] as const) {
+for (const source of ["pending", "pending-local", "failed", "offline"] as const) {
   it.live(
     source === "offline"
       ? "returns held source data only after both fresh paths fail"
@@ -276,7 +276,7 @@ for (const source of ["pending", "failed", "offline"] as const) {
                   }
                   expect(input.allowStale).toBe(false);
                   if (local && source !== "offline") return null;
-                  if (source !== "pending")
+                  if (source !== "pending" && source !== "pending-local")
                     return yield* new PullRequestOperationError({
                       operation: "summary",
                       detail: "github unreachable",
@@ -293,6 +293,7 @@ for (const source of ["pending", "failed", "offline"] as const) {
           const { environmentRegistry, supervisor } = yield* makeTestRuntime(
             clientFor(false),
             clientFor(true),
+            source === "pending-local",
           );
           const result = yield* createPullRequestRouter()(WS_METHODS.pullRequestsSummary, {
             projectId: ProjectId.make("project-1"),
@@ -309,7 +310,7 @@ for (const source of ["pending", "failed", "offline"] as const) {
             expect(result).toBeNull();
             expect(calls).toEqual(["origin", "local"]);
           }
-          expect(interrupted).toBe(source === "pending");
+          expect(interrupted).toBe(source === "pending" || source === "pending-local");
         }),
       ),
   );

--- a/packages/client-runtime/src/state/pullRequests.test.ts
+++ b/packages/client-runtime/src/state/pullRequests.test.ts
@@ -18,12 +18,15 @@ import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
 import {
   AVAILABLE_CONNECTION_STATE,
+  ConnectionTransientError,
   PrimaryConnectionTarget,
+  SshConnectionTarget,
   type PreparedConnection,
   type SupervisorConnectionState,
 } from "../connection/model.ts";
 import * as EnvironmentRegistry from "../connection/registry.ts";
-import type { ConnectionCatalogEntry } from "../connection/catalog.ts";
+import { SshConnectionProfile, type ConnectionCatalogEntry } from "../connection/catalog.ts";
+import { ConnectionProfileStore } from "../connection/profileStore.ts";
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 import type { RpcSession } from "../rpc/session.ts";
@@ -34,6 +37,14 @@ import {
 import { PullRequestDiffLoader } from "./pullRequestDiffHttp.ts";
 import { executeAtomQuery } from "./runtime.ts";
 import { createPullRequestRouter } from "./pullRequestRouting.ts";
+import { GitHubRoutingPermissions } from "../connection/githubRoutingPermissions.ts";
+
+const trustedRouting = {
+  get: () => Effect.succeed("read-write" as const),
+  changes: Stream.empty,
+  set: () => Effect.void,
+  forget: () => Effect.void,
+};
 
 class MutationRefused extends Data.TaggedError("MutationRefused") {}
 
@@ -47,6 +58,8 @@ for (const scenario of [
   "keeps mutations on an old origin server without retrying them",
   "skips an old alternate server before dispatching a mutation",
   "returns a successful mutation when source invalidation stalls",
+  "does not dispatch after routing permission is revoked during the probe",
+  "preserves a local source account rejection when alternate accounts differ",
 ] as const) {
   (scenario === "returns a successful mutation when source invalidation stalls"
     ? it.live
@@ -55,26 +68,41 @@ for (const scenario of [
       Effect.gen(function* () {
         const calls: string[] = [];
         const inputs: unknown[] = [];
-        const mismatch = scenario === "falls back before mutation when the local account differs";
+        let trusted = true;
+        const switchedAccount =
+          scenario === "preserves a local source account rejection when alternate accounts differ";
+        const mismatch =
+          scenario === "falls back before mutation when the local account differs" ||
+          switchedAccount;
         const ambiguous = scenario === "never retries an ambiguous mutation failure";
         const reading =
           scenario === "returns a fast source read without checking alternate identities";
         const single = scenario === "keeps single-environment requests free of identity lookups";
-        const localOrigin = scenario === "keeps a local origin ahead of another local environment";
+        const localOrigin =
+          scenario === "keeps a local origin ahead of another local environment" || switchedAccount;
         const oldOrigin =
           scenario === "keeps mutations on an old origin server without retrying them";
         const oldAlternate =
           scenario === "skips an old alternate server before dispatching a mutation";
         const failure = new PullRequestOperationError({
-          operation: "runAction",
+          operation: switchedAccount ? "routeIdentity" : "runAction",
           detail: "connection lost after dispatch",
         });
         const clientFor = (local: boolean) => {
           const name = local ? "local" : "origin";
           return {
-            [WS_METHODS.pullRequestsRouting]: () =>
+            [local ? WS_METHODS.pullRequestsRoutingIdentity : WS_METHODS.pullRequestsRouting]: (
+              input: unknown,
+            ) =>
               Effect.gen(function* () {
+                if (local) expect(input).toEqual({ host: "github.com" });
                 calls.push(`${name}:identity`);
+                if (
+                  local &&
+                  scenario ===
+                    "does not dispatch after routing permission is revoked during the probe"
+                )
+                  trusted = false;
                 if ((!local && oldOrigin) || (local && oldAlternate)) {
                   return yield* Effect.die(
                     `Unknown request tag: ${WS_METHODS.pullRequestsRouting}`,
@@ -91,6 +119,12 @@ for (const scenario of [
               Effect.gen(function* () {
                 calls.push(`${name}:mutation`);
                 inputs.push(input);
+                if (
+                  !local &&
+                  switchedAccount &&
+                  (input as { expectedAccountId?: string }).expectedAccountId === "123"
+                )
+                  return yield* failure;
                 if (local && ambiguous) return yield* failure;
               }),
             [WS_METHODS.pullRequestsSummary]: (input: { allowStale?: boolean }) =>
@@ -131,11 +165,19 @@ for (const scenario of [
             : route(WS_METHODS.pullRequestsRunAction, input)
         ).pipe(
           Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(GitHubRoutingPermissions, {
+            ...trustedRouting,
+            get: () => Effect.succeed(trusted ? "read-write" : "off"),
+          }),
           Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
           Effect.result,
         );
 
-        if (ambiguous) {
+        if (switchedAccount) {
+          expect(result).toMatchObject({ _tag: "Failure", failure });
+          expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["origin:mutation"]);
+          expect(inputs).toEqual([{ ...input, expectedAccountId: "123" }]);
+        } else if (ambiguous) {
           expect(result).toMatchObject({ _tag: "Failure", failure });
           expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["local:mutation"]);
         } else {
@@ -145,7 +187,7 @@ for (const scenario of [
               "origin:mutation",
             ]);
           } else if (reading) expect(calls).toEqual(["origin:read"]);
-          else if (mismatch || localOrigin || oldOrigin || oldAlternate)
+          else if (mismatch || localOrigin || oldOrigin || oldAlternate || !trusted)
             expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["origin:mutation"]);
           else {
             expect(calls.filter((call) => call.endsWith(":mutation"))).toEqual(["local:mutation"]);
@@ -258,6 +300,226 @@ const makeTestRuntime = Effect.fn("makeTestRuntime")(function* (
   return { runtime, atoms, registry, environmentRegistry, supervisor };
 });
 
+for (const permission of ["default", "origin-off", "destination-off", "read-only"] as const) {
+  it.effect(`does not probe another environment with ${permission} routing permission`, () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const calls: string[] = [];
+        const failure = new PullRequestOperationError({
+          operation: "summary",
+          detail: "source failed",
+        });
+        const client = {
+          [WS_METHODS.pullRequestsSummary]: () =>
+            Effect.suspend(() => {
+              calls.push("source-read");
+              return Effect.fail(failure);
+            }),
+          [WS_METHODS.pullRequestsRunAction]: () =>
+            Effect.sync(() => {
+              calls.push("source-write");
+            }),
+        } as unknown as WsRpcProtocolClient;
+        const alternate = {
+          [WS_METHODS.pullRequestsRoutingIdentity]: () =>
+            Effect.die("untrusted environment was contacted"),
+        } as unknown as WsRpcProtocolClient;
+        const { environmentRegistry, supervisor } = yield* makeTestRuntime(client, alternate);
+        const ref = {
+          projectId: ProjectId.make("project-1"),
+          repository: "private/repo",
+          number: 7,
+        };
+        const request = Effect.gen(function* () {
+          const route = createPullRequestRouter();
+          if (permission !== "read-only")
+            yield* route(WS_METHODS.pullRequestsSummary, ref).pipe(Effect.flip);
+          yield* route(WS_METHODS.pullRequestsRunAction, { ...ref, action: "merge" });
+        }).pipe(
+          Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        );
+        yield* permission === "default"
+          ? request
+          : request.pipe(
+              Effect.provideService(GitHubRoutingPermissions, {
+                ...trustedRouting,
+                get: (entry) =>
+                  Effect.succeed(
+                    permission === "read-only"
+                      ? "read"
+                      : (entry.target.environmentId === TARGET.environmentId) ===
+                          (permission === "origin-off")
+                        ? "off"
+                        : "read-write",
+                  ),
+              }),
+            );
+        expect(calls).toEqual(
+          permission === "read-only" ? ["source-write"] : ["source-read", "source-write"],
+        );
+      }),
+    ),
+  );
+}
+
+for (const side of ["origin", "destination"] as const) {
+  for (const stored of ["matching", "changed", "missing", "unavailable", "failed"] as const) {
+    it.effect(`checks the current ${side} SSH profile before routing with ${stored} storage`, () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const calls: string[] = [];
+          const identity = {
+            host: "github.com",
+            provider: "github",
+            viewer: "maria",
+            accountId: "123",
+          };
+          const client = {
+            [WS_METHODS.pullRequestsRouting]: () =>
+              Effect.sync(() => {
+                calls.push("source-probe");
+                return identity;
+              }),
+            [WS_METHODS.pullRequestsRunAction]: (input: { expectedAccountId?: string }) =>
+              Effect.gen(function* () {
+                if (input.expectedAccountId !== undefined) {
+                  return yield* new PullRequestOperationError({
+                    operation: "routeIdentity",
+                    detail: "Source guard refused.",
+                  });
+                }
+                calls.push("source-write");
+              }),
+            [WS_METHODS.pullRequestsInvalidate]: () => Effect.void,
+          } as unknown as WsRpcProtocolClient;
+          const alternate = {
+            [WS_METHODS.pullRequestsRoutingIdentity]: () =>
+              Effect.sync(() => {
+                calls.push("alternate-probe");
+                return identity;
+              }),
+            [WS_METHODS.pullRequestsRunAction]: () =>
+              Effect.sync(() => {
+                calls.push("alternate-write");
+              }),
+            [WS_METHODS.pullRequestsInvalidate]: () => Effect.void,
+          } as unknown as WsRpcProtocolClient;
+          const { environmentRegistry, supervisor } = yield* makeTestRuntime(client, alternate);
+          const environmentId =
+            side === "origin" ? TARGET.environmentId : EnvironmentId.make("local-environment");
+          const profile = new SshConnectionProfile({
+            connectionId: "ssh-1",
+            environmentId,
+            label: "SSH",
+            target: { alias: "work", hostname: "work.example.test", username: "maria", port: 22 },
+          });
+          yield* SubscriptionRef.update(environmentRegistry.entries, (entries) =>
+            new Map(entries).set(environmentId, {
+              target: new SshConnectionTarget({
+                environmentId,
+                connectionId: profile.connectionId,
+                label: "SSH",
+              }),
+              profile: Option.some(profile),
+            }),
+          );
+          const read = Effect.suspend(() =>
+            stored === "failed"
+              ? Effect.fail(
+                  new ConnectionTransientError({
+                    reason: "remote-unavailable",
+                    detail: "Profile storage unavailable.",
+                  }),
+                )
+              : Effect.succeed(
+                  stored === "missing"
+                    ? Option.none()
+                    : Option.some(
+                        stored === "changed"
+                          ? new SshConnectionProfile({
+                              ...profile,
+                              target: { ...profile.target, hostname: "replacement.example.test" },
+                            })
+                          : profile,
+                      ),
+                ),
+          );
+          const route = createPullRequestRouter()(WS_METHODS.pullRequestsRunAction, {
+            projectId: ProjectId.make("project-1"),
+            repository: "private/repo",
+            number: 7,
+            action: "merge",
+          }).pipe(
+            Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+            Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+            // This also represents a user enabling the stale catalog entry after re-resolution.
+            Effect.provideService(GitHubRoutingPermissions, trustedRouting),
+          );
+          yield* stored === "unavailable"
+            ? route
+            : route.pipe(
+                Effect.provideService(ConnectionProfileStore, {
+                  get: () => read,
+                  put: () => Effect.die("unused"),
+                  remove: () => Effect.die("unused"),
+                }),
+              );
+          expect(calls).toEqual(
+            stored === "matching"
+              ? ["source-probe", "alternate-probe", "alternate-write"]
+              : ["source-write"],
+          );
+        }),
+      ),
+    );
+  }
+}
+
+for (const probe of ["origin", "alternate"] as const) {
+  it.live(`bounds a stalled ${probe} metadata probe without repeating a strict source read`, () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let sourceReads = 0;
+        const identity = {
+          host: "github.com",
+          provider: "github",
+          viewer: "maria",
+          accountId: "123",
+        };
+        const client = {
+          [WS_METHODS.pullRequestsRouting]: () =>
+            probe === "origin" ? Effect.never : Effect.succeed(identity),
+          [WS_METHODS.pullRequestsSummary]: () =>
+            Effect.suspend(() => {
+              sourceReads += 1;
+              return Effect.fail(
+                new PullRequestOperationError({ operation: "summary", detail: "source failed" }),
+              );
+            }),
+        } as unknown as WsRpcProtocolClient;
+        const alternate = {
+          [WS_METHODS.pullRequestsRoutingIdentity]: () => Effect.never,
+        } as unknown as WsRpcProtocolClient;
+        const { environmentRegistry, supervisor } = yield* makeTestRuntime(client, alternate);
+        const error = yield* createPullRequestRouter()(WS_METHODS.pullRequestsSummary, {
+          projectId: ProjectId.make("project-1"),
+          repository: "acme/web",
+          number: 7,
+          allowStale: false,
+        }).pipe(
+          Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+          Effect.provideService(GitHubRoutingPermissions, trustedRouting),
+          Effect.flip,
+        );
+        expect(error._tag).toBe("PullRequestOperationError");
+        expect(sourceReads).toBe(1);
+      }),
+    ),
+  );
+}
+
 for (const source of ["pending", "pending-local", "failed", "offline"] as const) {
   it.live(
     source === "offline"
@@ -270,13 +532,14 @@ for (const source of ["pending", "pending-local", "failed", "offline"] as const)
           const calls: string[] = [];
           const clientFor = (local: boolean) =>
             ({
-              [WS_METHODS.pullRequestsRouting]: () =>
-                Effect.succeed({
-                  host: "github.com",
-                  provider: "github",
-                  viewer: "maria-rcks",
-                  accountId: "123",
-                }),
+              [local ? WS_METHODS.pullRequestsRoutingIdentity : WS_METHODS.pullRequestsRouting]:
+                () =>
+                  Effect.succeed({
+                    host: "github.com",
+                    provider: "github",
+                    viewer: "maria-rcks",
+                    accountId: "123",
+                  }),
               [WS_METHODS.pullRequestsSummary]: (input: { allowStale?: boolean }) =>
                 Effect.gen(function* () {
                   calls.push(local ? "local" : input.allowStale === false ? "origin" : "held");
@@ -310,11 +573,12 @@ for (const source of ["pending", "pending-local", "failed", "offline"] as const)
             number: 7,
           }).pipe(
             Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+            Effect.provideService(GitHubRoutingPermissions, trustedRouting),
             Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
           );
           if (source === "offline") {
             expect(result).toEqual({ state: "open" });
-            expect(calls).toEqual(["origin", "local", "origin", "held"]);
+            expect(calls).toEqual(["origin", "local", "held"]);
           } else {
             expect(result).toBeNull();
             expect(calls).toEqual(["origin", "local"]);
@@ -330,7 +594,7 @@ it.live("keeps source workspace metadata when an alternate answers a detail read
     Effect.gen(function* () {
       const clientFor = (local: boolean) =>
         ({
-          [WS_METHODS.pullRequestsRouting]: () =>
+          [local ? WS_METHODS.pullRequestsRoutingIdentity : WS_METHODS.pullRequestsRouting]: () =>
             Effect.succeed({
               host: "github.com",
               provider: "github",
@@ -359,6 +623,7 @@ it.live("keeps source workspace metadata when an alternate answers a detail read
         number: 7,
       }).pipe(
         Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+        Effect.provideService(GitHubRoutingPermissions, trustedRouting),
         Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
       );
       expect(result).toEqual({
@@ -383,7 +648,7 @@ it.live(
         const clientFor = (local: boolean) => {
           const environment = local ? "local" : "origin";
           return {
-            [WS_METHODS.pullRequestsRouting]: () =>
+            [local ? WS_METHODS.pullRequestsRoutingIdentity : WS_METHODS.pullRequestsRouting]: () =>
               Effect.sync(() => {
                 identities.push(environment);
                 return {
@@ -445,6 +710,7 @@ it.live(
           expect(invalidations).toContainEqual({ environment: "local", input: {} });
         }).pipe(
           Effect.provideService(EnvironmentRegistry.EnvironmentRegistry, environmentRegistry),
+          Effect.provideService(GitHubRoutingPermissions, trustedRouting),
           Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
         );
       }),

--- a/packages/client-runtime/src/state/pullRequests.ts
+++ b/packages/client-runtime/src/state/pullRequests.ts
@@ -21,6 +21,7 @@ import {
   createEnvironmentRpcSubscriptionAtomFamily,
   createEnvironmentQueryAtomFamily,
 } from "./runtime.ts";
+import { createPullRequestRouter } from "./pullRequestRouting.ts";
 import { PullRequestDiffLoader } from "./pullRequestDiffHttp.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
@@ -99,9 +100,11 @@ export function createLinkedPullRequestSummaryAtomFamily<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
   refreshes = createPullRequestRefreshAtomFamily(runtime),
 ) {
+  const routedRequest = createPullRequestRouter();
   return createEnvironmentRpcQueryAtomFamily(runtime, {
     label: "environment-data:pull-requests:linked-summary",
     tag: WS_METHODS.pullRequestsSummary,
+    execute: (input) => routedRequest(WS_METHODS.pullRequestsSummary, input),
     staleTimeMs: 60_000,
     refreshIntervalMs: 60_000,
     idleTtlMs: LINKED_PULL_REQUEST_IDLE_TTL_MS,
@@ -114,9 +117,11 @@ export function createPullRequestStackAtomFamily<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
   refreshes = createPullRequestRefreshAtomFamily(runtime),
 ) {
+  const routedRequest = createPullRequestRouter();
   return createEnvironmentRpcQueryAtomFamily(runtime, {
     label: "environment-data:pull-requests:stack",
     tag: WS_METHODS.pullRequestsStack,
+    execute: (input) => routedRequest(WS_METHODS.pullRequestsStack, input),
     staleTimeMs: 60_000,
     idleTtlMs: LINKED_PULL_REQUEST_IDLE_TTL_MS,
     refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
@@ -148,6 +153,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
 ) {
   const refreshes = createPullRequestRefreshAtomFamily(runtime);
   const commandScheduler = createAtomCommandScheduler();
+  const routedRequest = createPullRequestRouter();
   const serialPerEnvironment = {
     mode: "serial",
     key: ({ environmentId }: { readonly environmentId: string }) => environmentId,
@@ -156,6 +162,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:activity",
       tag: WS_METHODS.pullRequestsActivity,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsActivity, input),
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
     }),
@@ -164,6 +171,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:detail",
       tag: WS_METHODS.pullRequestsDetail,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsDetail, input),
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
     }),
@@ -172,6 +180,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:label-candidates",
       tag: WS_METHODS.pullRequestsLabelCandidates,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsLabelCandidates, input),
       staleTimeMs: 60_000,
     }),
   );
@@ -179,6 +188,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:reviewer-candidates",
       tag: WS_METHODS.pullRequestsReviewerCandidates,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsReviewerCandidates, input),
       staleTimeMs: 60_000,
     }),
   );
@@ -187,6 +197,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     linkedThreads: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:linked-threads",
       tag: WS_METHODS.pullRequestsLinkedThreads,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsLinkedThreads, input),
       staleTimeMs: 0,
       refreshIntervalMs: 10_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
@@ -194,6 +205,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     list: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:list",
       tag: WS_METHODS.pullRequestsList,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsList, input),
       staleTimeMs: 30_000,
       refreshTrigger: ({ environmentId, input }) =>
         input.cursors === undefined ? refreshes({ environmentId, input: {} }) : undefined,
@@ -207,6 +219,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     listStats: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:pull-requests:list-stats",
       tag: WS_METHODS.pullRequestsListStats,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsListStats, input),
       staleTimeMs: 60_000,
       refreshTrigger: ({ environmentId }) => refreshes({ environmentId, input: {} }),
     }),
@@ -215,6 +228,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     threadComments: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:thread-comments",
       tag: WS_METHODS.pullRequestsThreadComments,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsThreadComments, input),
       scheduler: commandScheduler,
       concurrency: {
         mode: "singleFlight",
@@ -241,6 +255,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     diffFileContents: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:diff-file-contents",
       tag: WS_METHODS.pullRequestsDiffFileContents,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsDiffFileContents, input),
       scheduler: commandScheduler,
       concurrency: {
         mode: "singleFlight",
@@ -261,24 +276,28 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     runAction: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:run-action",
       tag: WS_METHODS.pullRequestsRunAction,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsRunAction, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
     update: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:update",
       tag: WS_METHODS.pullRequestsUpdate,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsUpdate, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
     comment: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:comment",
       tag: WS_METHODS.pullRequestsComment,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsComment, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
     updateComment: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:update-comment",
       tag: WS_METHODS.pullRequestsUpdateComment,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsUpdateComment, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
       onSuccess: ({ environmentId, input: { projectId, host, repository, number } }, registry) =>
@@ -294,12 +313,14 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     submitReview: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:submit-review",
       tag: WS_METHODS.pullRequestsSubmitReview,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsSubmitReview, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
     replyToThread: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:reply-to-thread",
       tag: WS_METHODS.pullRequestsReplyToThread,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsReplyToThread, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
@@ -313,6 +334,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     requestReviewers: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:request-reviewers",
       tag: WS_METHODS.pullRequestsRequestReviewers,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsRequestReviewers, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
       onSuccess: (target, registry) =>
@@ -389,6 +411,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     setLabels: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-labels",
       tag: WS_METHODS.pullRequestsSetLabels,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsSetLabels, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
       onSuccess: (target, registry) =>
@@ -424,12 +447,14 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     setThreadResolution: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-thread-resolution",
       tag: WS_METHODS.pullRequestsSetThreadResolution,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsSetThreadResolution, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
     setReaction: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:set-reaction",
       tag: WS_METHODS.pullRequestsSetReaction,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsSetReaction, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),
@@ -441,6 +466,7 @@ export function createPullRequestEnvironmentAtoms<R, E>(
     invalidate: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:pull-requests:invalidate",
       tag: WS_METHODS.pullRequestsInvalidate,
+      execute: (input) => routedRequest(WS_METHODS.pullRequestsInvalidate, input),
       scheduler: commandScheduler,
       concurrency: serialPerEnvironment,
     }),

--- a/packages/client-runtime/src/state/runtime.ts
+++ b/packages/client-runtime/src/state/runtime.ts
@@ -11,6 +11,8 @@ import type { ConnectionAttemptError } from "../connection/model.ts";
 import { EnvironmentNotRegisteredError, EnvironmentRegistry } from "../connection/registry.ts";
 import {
   type EnvironmentRpcInput,
+  type EnvironmentRpcSuccess,
+  type EnvironmentRpcFailure,
   type EnvironmentRpcStreamFailure,
   type EnvironmentRpcStreamValue,
   type EnvironmentSubscriptionRpcTag,
@@ -588,7 +590,12 @@ export function createEnvironmentSubscriptionAtomFamily<R, ER, Input, A, E>(
 
 export function createEnvironmentCommand<R, ER, Input, A, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, ER>,
-  options: EnvironmentCommandAtomOptions<Input, A, E, EnvironmentSupervisor | R>,
+  options: EnvironmentCommandAtomOptions<
+    Input,
+    A,
+    E,
+    EnvironmentSupervisor | EnvironmentRegistry | R
+  >,
 ) {
   return createRuntimeCommand(runtime, {
     label: options.label,
@@ -607,6 +614,13 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
   options: {
     readonly label: string;
     readonly tag: TTag;
+    readonly execute?: (
+      input: EnvironmentRpcInput<TTag>,
+    ) => Effect.Effect<
+      EnvironmentRpcSuccess<TTag>,
+      EnvironmentRpcFailure<TTag> | EnvironmentRpcUnavailableError,
+      EnvironmentSupervisor | EnvironmentRegistry
+    >;
     readonly staleTimeMs?: number;
     readonly idleTtlMs?: number;
     readonly refreshIntervalMs?: number;
@@ -624,7 +638,8 @@ export function createEnvironmentRpcQueryAtomFamily<R, ER, TTag extends Environm
       ? {}
       : { refreshIntervalMs: options.refreshIntervalMs }),
     ...(options.refreshTrigger === undefined ? {} : { refreshTrigger: options.refreshTrigger }),
-    execute: (input: EnvironmentRpcInput<TTag>) => request(options.tag, input),
+    execute: (input: EnvironmentRpcInput<TTag>) =>
+      options.execute?.(input) ?? request(options.tag, input),
   });
 }
 
@@ -665,6 +680,13 @@ export function createEnvironmentRpcCommand<R, ER, TTag extends EnvironmentUnary
   options: {
     readonly label: string;
     readonly tag: TTag;
+    readonly execute?: (
+      input: EnvironmentRpcInput<TTag>,
+    ) => Effect.Effect<
+      EnvironmentRpcSuccess<TTag>,
+      EnvironmentRpcFailure<TTag> | EnvironmentRpcUnavailableError,
+      EnvironmentSupervisor | EnvironmentRegistry
+    >;
     readonly scheduler?: AtomCommandScheduler;
     readonly concurrency?: AtomCommandConcurrency<{
       readonly environmentId: EnvironmentIdType;
@@ -695,7 +717,7 @@ export function createEnvironmentRpcCommand<R, ER, TTag extends EnvironmentUnary
         environmentId,
         input,
       };
-      return request(options.tag, input).pipe(
+      return (options.execute?.(input) ?? request(options.tag, input)).pipe(
         Effect.tap(() => options.onSuccess?.(target, registry) ?? Effect.void),
         Effect.ensuring(options.onSettled?.(target, registry) ?? Effect.void),
       );

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -657,6 +657,8 @@ export const PullRequestRoutingResult = Schema.Struct({
   host: TrimmedNonEmptyString,
   provider: SourceControlProviderKind,
   viewer: TrimmedNonEmptyString,
+  projectTitle: TrimmedNonEmptyString,
+  workspaceRoot: TrimmedNonEmptyString,
 });
 export type PullRequestRoutingResult = typeof PullRequestRoutingResult.Type;
 

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -643,10 +643,22 @@ export type PullRequestListResult = typeof PullRequestListResult.Type;
 export const PullRequestRef = Schema.Struct({
   projectId: ProjectId,
   host: Schema.optional(TrimmedNonEmptyString),
+  /** Refuse a routed operation unless this GitHub account still owns the active credential. */
+  expectedAccountId: Schema.optional(TrimmedNonEmptyString),
+  /** Let another environment answer when this one's cached response has expired. */
+  allowStale: Schema.optional(Schema.Boolean),
   repository: TrimmedNonEmptyString,
   number: PositiveInt,
 });
 export type PullRequestRef = typeof PullRequestRef.Type;
+
+export const PullRequestRoutingResult = Schema.Struct({
+  accountId: TrimmedNonEmptyString,
+  host: TrimmedNonEmptyString,
+  provider: SourceControlProviderKind,
+  viewer: TrimmedNonEmptyString,
+});
+export type PullRequestRoutingResult = typeof PullRequestRoutingResult.Type;
 
 export const PullRequestLinkedThreadsResult = Schema.Struct({
   threads: Schema.Array(

--- a/packages/contracts/src/pullRequest.ts
+++ b/packages/contracts/src/pullRequest.ts
@@ -652,6 +652,20 @@ export const PullRequestRef = Schema.Struct({
 });
 export type PullRequestRef = typeof PullRequestRef.Type;
 
+/** Account discovery never needs the originating project's private repository metadata. */
+export const PullRequestRoutingIdentityInput = Schema.Struct({
+  host: TrimmedNonEmptyString,
+});
+export type PullRequestRoutingIdentityInput = typeof PullRequestRoutingIdentityInput.Type;
+
+export const PullRequestRoutingIdentityResult = Schema.Struct({
+  accountId: TrimmedNonEmptyString,
+  host: TrimmedNonEmptyString,
+  provider: Schema.Literal("github"),
+  viewer: TrimmedNonEmptyString,
+});
+export type PullRequestRoutingIdentityResult = typeof PullRequestRoutingIdentityResult.Type;
+
 export const PullRequestRoutingResult = Schema.Struct({
   accountId: TrimmedNonEmptyString,
   host: TrimmedNonEmptyString,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -115,6 +115,7 @@ import {
   PullRequestOperationError,
   PullRequestReactionInput,
   PullRequestRef,
+  PullRequestRoutingResult,
   PullRequestStack,
   PullRequestLinkedThreadsResult,
   PullRequestSummary,
@@ -371,6 +372,7 @@ export const WS_METHODS = {
   pullRequestsList: "pullRequests.list",
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsSummary: "pullRequests.summary",
+  pullRequestsRouting: "pullRequests.routing",
   pullRequestsStack: "pullRequests.stack",
   pullRequestsLinkedThreads: "pullRequests.linkedThreads",
   pullRequestsDetail: "pullRequests.detail",
@@ -669,6 +671,12 @@ const WsPullRequestsListRpc = Rpc.make(WS_METHODS.pullRequestsList, {
 const WsPullRequestsListStatsRpc = Rpc.make(WS_METHODS.pullRequestsListStats, {
   payload: PullRequestListStatsInput,
   success: PullRequestListStatsResult,
+  error: PullRequestRpcError,
+});
+
+const WsPullRequestsRoutingRpc = Rpc.make(WS_METHODS.pullRequestsRouting, {
+  payload: PullRequestRef,
+  success: PullRequestRoutingResult,
   error: PullRequestRpcError,
 });
 
@@ -1316,6 +1324,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsListRpc,
   WsPullRequestsListStatsRpc,
   WsPullRequestsSummaryRpc,
+  WsPullRequestsRoutingRpc,
   WsPullRequestsStackRpc,
   WsPullRequestsLinkedThreadsRpc,
   WsPullRequestsDetailRpc,

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -116,6 +116,8 @@ import {
   PullRequestReactionInput,
   PullRequestRef,
   PullRequestRoutingResult,
+  PullRequestRoutingIdentityInput,
+  PullRequestRoutingIdentityResult,
   PullRequestStack,
   PullRequestLinkedThreadsResult,
   PullRequestSummary,
@@ -373,6 +375,7 @@ export const WS_METHODS = {
   pullRequestsListStats: "pullRequests.listStats",
   pullRequestsSummary: "pullRequests.summary",
   pullRequestsRouting: "pullRequests.routing",
+  pullRequestsRoutingIdentity: "pullRequests.routingIdentity",
   pullRequestsStack: "pullRequests.stack",
   pullRequestsLinkedThreads: "pullRequests.linkedThreads",
   pullRequestsDetail: "pullRequests.detail",
@@ -677,6 +680,12 @@ const WsPullRequestsListStatsRpc = Rpc.make(WS_METHODS.pullRequestsListStats, {
 const WsPullRequestsRoutingRpc = Rpc.make(WS_METHODS.pullRequestsRouting, {
   payload: PullRequestRef,
   success: PullRequestRoutingResult,
+  error: PullRequestRpcError,
+});
+
+const WsPullRequestsRoutingIdentityRpc = Rpc.make(WS_METHODS.pullRequestsRoutingIdentity, {
+  payload: PullRequestRoutingIdentityInput,
+  success: PullRequestRoutingIdentityResult,
   error: PullRequestRpcError,
 });
 
@@ -1325,6 +1334,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsPullRequestsListStatsRpc,
   WsPullRequestsSummaryRpc,
   WsPullRequestsRoutingRpc,
+  WsPullRequestsRoutingIdentityRpc,
   WsPullRequestsStackRpc,
   WsPullRequestsLinkedThreadsRpc,
   WsPullRequestsDetailRpc,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2)
       expo-audio:
-        specifier: ~57.0.4
+        specifier: 57.0.4
         version: 57.0.4(patch_hash=fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a)(expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-auth-session:
         specifier: ~57.0.10


### PR DESCRIPTION
GitHub PR details, merged status, checks, and review actions can use another connected environment when the original environment is slow or cannot reach GitHub. Disabled environments are excluded. Routing is off by default: this client must explicitly trust both environments for reads or for reads and actions, and both must verify the same GitHub account and host.

Alternate discovery sends only the host. Each routed operation pins its verified credential through provider calls and background refreshes, partitions caches by credential, and never retries an ambiguous mutation. Revocation applies across browser windows; changed or unavailable SSH destinations fail closed. Web, desktop, and both mobile environment settings expose the same permissions.

Current head: 359 focused tests passed on Blacksmith (267 server, 88 client, 4 web), plus server/client/web/mobile/desktop typechecks and scoped lint. Permission enable/revoke was exercised in the merged web settings. A fresh real-client PR detail request reached the GitHub provider but was rate-limited; native iOS/Android and packaged Windows/macOS runtime remain unverified.

Prior validation at `28a32c30d9` used two actual servers for fallback, host-only discovery, revocation, account mismatch, and mutation non-replay. Seven disposable PRs merged successfully, including through the web client, and all benchmark workflows passed. The repository was deleted afterward.

Three real provider merges per version, same machine and workload, baseline `25da986037` versus `28a32c30d9`. Candidate total time includes credential verification; the first candidate also makes a cold `/user` request.

| median metric | baseline | candidate | change |
| --- | ---: | ---: | ---: |
| permission check | 1,066 ms | 381 ms | -64% |
| permission check + merge | 3,561 ms | 3,092 ms | -13% |
| gh invocations per merge | 4 | 3 | -25% |

Additional actual-RPC measurements compare the pre-audit router `d2ba61e054` with `28a32c30d9` against the same candidate servers: warm routed reads 7 → 6 ms (5 samples), invalidated reads 1,964 → 1,900 ms (3 samples), and recovery past a stalled first alternate's identity probe >8,000 → 2,388 ms (one fault case). Transport faults were injected around real RPC clients, not by blocking GitHub's network. Millisecond-scale differences and live GitHub latency are noisy; when both source data and source identity stall, routing cannot safely discover an alternate account.

![client-owned github routing permissions and revocation](https://uploads-production-47e4.up.railway.app/files/ee71e1bc-276b-4d9b-b06c-8e53b2e89502/t3-trim-permissions.gif)

![real disposable pr merge with passed checks and merged status](https://uploads-production-47e4.up.railway.app/files/8f635200-9a56-447e-ad4a-23f031a08698/t3-security-merge.gif)

Two independent `gpt-6-astra` reviewers approve `12c88ba57c`, with no blocking findings. CI passes. Macroscope requires human review under its policy for credential-sensitive changes; its correctness check passes.

Implemented with `gpt-6` using Codex.
