### PR TITLE
fix(web): terminal drawer collapses fully when dragged past its minimum

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -957,6 +957,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [panelTerminalIds, serverOrderedTerminalIds, terminalUiState.terminalIds],
   );
   const storeSetTerminalHeight = useTerminalUiStateStore((state) => state.setTerminalHeight);
+  const storeSetTerminalOpen = useTerminalUiStateStore((state) => state.setTerminalOpen);
   const storeSplitTerminal = useTerminalUiStateStore((state) => state.splitTerminal);
   const storeSplitTerminalVertical = useTerminalUiStateStore(
     (state) => state.splitTerminalVertical,
@@ -1019,6 +1020,12 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       storeSetTerminalHeight(threadRef, height);
     },
     [storeSetTerminalHeight, threadRef],
+  );
+  const setTerminalCollapsed = useCallback(
+    (collapsed: boolean) => {
+      storeSetTerminalOpen(threadRef, !collapsed);
+    },
+    [storeSetTerminalOpen, threadRef],
   );
 
   const splitTerminal = useCallback(() => {
@@ -1200,6 +1207,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
           onActiveTerminalChange={activateTerminal}
           onCloseTerminal={closeTerminal}
           onHeightChange={setTerminalHeight}
+          onCollapsedChange={setTerminalCollapsed}
           onAddTerminalContext={handleAddTerminalContext}
           terminalLabelsById={terminalLabelsById}
           terminalLaunchLocationsById={terminalLaunchLocationsById}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -90,7 +90,7 @@ import {
   TYPOGRAPHY_ADVANCED_STORAGE_KEY,
 } from "../appearanceFonts";
 
-const MIN_DRAWER_HEIGHT = 180;
+const MIN_DRAWER_HEIGHT = 48;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
 
 function maxDrawerHeight(): number {
@@ -1010,6 +1010,7 @@ interface ThreadTerminalDrawerProps {
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
   onHeightChange: (height: number) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
   /** Prefer server-provided tab titles when present (e.g. active subprocess name). */
@@ -1071,6 +1072,7 @@ export default function ThreadTerminalDrawer({
   onActiveTerminalChange,
   onCloseTerminal,
   onHeightChange,
+  onCollapsedChange,
   onAddTerminalContext,
   keybindings,
   terminalLabelsById,
@@ -1115,6 +1117,7 @@ export default function ThreadTerminalDrawer({
     startHeight: number;
   } | null>(null);
   const didResizeDuringDragRef = useRef(false);
+  const collapsedDuringDragRef = useRef(false);
 
   const normalizedTerminalIds = useMemo(() => {
     const normalizedIds: string[] = [];
@@ -1311,6 +1314,7 @@ export default function ThreadTerminalDrawer({
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
     didResizeDuringDragRef.current = false;
+    collapsedDuringDragRef.current = false;
     resizeStateRef.current = {
       pointerId: event.pointerId,
       startY: event.clientY,
@@ -1323,9 +1327,19 @@ export default function ThreadTerminalDrawer({
       const resizeState = resizeStateRef.current;
       if (!resizeState || resizeState.pointerId !== event.pointerId) return;
       event.preventDefault();
-      const clampedHeight = clampDrawerHeight(
-        resizeState.startHeight + (resizeState.startY - event.clientY),
-      );
+      const nextHeight = resizeState.startHeight + (resizeState.startY - event.clientY);
+      if (nextHeight < MIN_DRAWER_HEIGHT) {
+        if (!collapsedDuringDragRef.current) {
+          collapsedDuringDragRef.current = true;
+          onCollapsedChange?.(true);
+        }
+        return;
+      }
+      if (collapsedDuringDragRef.current) {
+        collapsedDuringDragRef.current = false;
+        onCollapsedChange?.(false);
+      }
+      const clampedHeight = clampDrawerHeight(nextHeight);
       if (clampedHeight === drawerHeightRef.current) {
         return;
       }
@@ -1333,7 +1347,7 @@ export default function ThreadTerminalDrawer({
       drawerHeightRef.current = clampedHeight;
       setDrawerHeight(clampedHeight);
     },
-    [setDrawerHeight],
+    [onCollapsedChange, setDrawerHeight],
   );
 
   const handleResizePointerEnd = useCallback(


### PR DESCRIPTION
## What Changed

- Lowered the bottom terminal drawer's resize floor from 180px to 48px. This matched VS Codes behavior and leaves min 1 line aviable in the terminal.
- Dragging past the floor now closes the drawer through the existing terminalOpen state; dragging back up reopens mid-gesture. Reopening restores the last height since a collapsed height is never persisted.

## Why

The drawer could not shrink below 180px and could not be collapsed by dragging. Closing for real (instead of leaving a 0px drawer) keeps the toggle, keybindings, and focus consistent.

## UI Changes
Before:
<img width="1007" height="418" alt="image" src="https://github.com/user-attachments/assets/ced203dd-2218-475e-8af0-45c8ed1dcceb" />

After:
<img width="495" height="204" alt="image" src="https://github.com/user-attachments/assets/1f49b07d-c944-45a8-9ada-5d4a7c1efc22" />

https://github.com/user-attachments/assets/b61b40cb-d0fb-4cfe-a8d0-f49423ea84e4


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Built with Muse Spark 1.3 (via T3 Code with OpenCode).