### PR TITLE
feat(swift-ios): pin and snooze threads from the same swipe

### DIFF
--- a/apps/swift-ios/Features/Workspace/DailyUXModels.swift
+++ b/apps/swift-ios/Features/Workspace/DailyUXModels.swift
@@ -1177,6 +1177,11 @@ extension FeatureThread {
         return boundary > now ? boundary : nil
     }
 
+    var canSnoozeNow: Bool {
+        canToggleSnooze && state != .queued
+            && state != .waitingForApproval && state != .waitingForInput
+    }
+
     func isEffectivelySnoozed(at now: Date) -> Bool {
         guard let snoozedUntil, snoozedUntil > now else { return false }
         if state == .waitingForApproval || state == .waitingForInput {

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -43,6 +43,9 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         configuration.trailingSwipeActionsConfigurationProvider = { [weak coordinator = context.coordinator] indexPath in
             coordinator?.trailingSwipeActions(at: indexPath)
         }
+        configuration.leadingSwipeActionsConfigurationProvider = { [weak coordinator = context.coordinator] indexPath in
+            coordinator?.leadingSwipeActions(at: indexPath)
+        }
 
         let collectionView = UICollectionView(
             frame: .zero,
@@ -311,6 +314,26 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             // thread; rows with nothing to settle keep the full swipe disabled.
             configuration.performsFirstActionWithFullSwipe =
                 HomeThreadSwipeAction.performsFullSwipe(with: actions)
+            return configuration
+        }
+
+        func leadingSwipeActions(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+            guard case let .thread(thread, _, _, isArchived, _, _) = item(at: indexPath) else {
+                return nil
+            }
+
+            let actions = HomeThreadSwipeAction.leadingActions(
+                for: thread,
+                isArchived: isArchived
+            )
+            guard !actions.isEmpty else { return nil }
+            let configuration = UISwipeActionsConfiguration(
+                actions: actions.map { contextualAction($0, for: thread) }
+            )
+            // The leading edge only ever carries the pin toggle, which is
+            // reversible, so a full swipe can run it directly.
+            configuration.performsFirstActionWithFullSwipe =
+                HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions)
             return configuration
         }
 
@@ -937,14 +960,15 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     }
 }
 
-/// The trailing swipe actions a Home row offers, resolved as data so the row's
+/// The swipe actions a Home row offers, resolved as data so the row's
 /// gesture semantics stay deterministic and testable without hosting a
 /// collection view. Order is outermost-first, matching
-/// `UISwipeActionsConfiguration`, which lays trailing actions out from the
-/// trailing edge inward and runs the first action on a full swipe.
+/// `UISwipeActionsConfiguration`, which lays actions out from the swiped
+/// edge inward and runs the first action on a full swipe.
 enum HomeThreadSwipeAction: Equatable {
     case delete
     case restore
+    case pin
     case unpin
     case settle
     case reopen
@@ -995,14 +1019,33 @@ enum HomeThreadSwipeAction: Equatable {
         return actions
     }
 
-    /// The full swipe is armed only when the edge action settles or reopens.
-    /// Nothing else may run from the gesture alone.
+    /// The leading swipe is a dedicated pin toggle, mirroring the context
+    /// menu's availability: archived rows offer nothing on this edge.
+    static func leadingActions(
+        for thread: FeatureThread,
+        isArchived: Bool
+    ) -> [HomeThreadSwipeAction] {
+        guard !isArchived, thread.canTogglePin else { return [] }
+        return [thread.pinnedAt != nil ? .unpin : .pin]
+    }
+
+    /// The trailing full swipe is armed only when the edge action settles or
+    /// reopens. Nothing else may run from that gesture alone.
     static func performsFullSwipe(with actions: [HomeThreadSwipeAction]) -> Bool {
         actions.first?.isSettlement ?? false
     }
 
+    /// The leading full swipe is armed only for the reversible pin toggle.
+    static func performsLeadingFullSwipe(with actions: [HomeThreadSwipeAction]) -> Bool {
+        actions.first.map(\.isPinToggle) ?? false
+    }
+
     var isSettlement: Bool {
         self == .settle || self == .reopen
+    }
+
+    var isPinToggle: Bool {
+        self == .pin || self == .unpin
     }
 
     var intent: Intent {
@@ -1010,6 +1053,7 @@ enum HomeThreadSwipeAction: Equatable {
         case .delete: .delete
         case .restore: .setArchived(false)
         case .archive: .setArchived(true)
+        case .pin: .setPinned(true)
         case .unpin: .setPinned(false)
         case .settle: .setSettled(true)
         case .reopen: .setSettled(false)
@@ -1020,6 +1064,7 @@ enum HomeThreadSwipeAction: Equatable {
         switch self {
         case .delete: "Delete"
         case .restore: "Restore"
+        case .pin: "Pin"
         case .unpin: "Unpin"
         case .settle: "Settle"
         case .reopen: "Reopen"
@@ -1031,6 +1076,7 @@ enum HomeThreadSwipeAction: Equatable {
         switch self {
         case .delete: "trash"
         case .restore: "arrow.uturn.backward"
+        case .pin: "pin"
         case .unpin: "pin.slash"
         case .settle: "checkmark"
         case .reopen: "arrow.counterclockwise"
@@ -1047,6 +1093,7 @@ enum HomeThreadSwipeAction: Equatable {
         switch self {
         case .delete: nil
         case .restore, .unpin, .reopen: .systemBlue
+        case .pin: .systemOrange
         case .settle: .systemGreen
         case .archive: .systemGray
         }

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -25,6 +25,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     let onRegenerateTitle: (FeatureThread) -> Void
     let onArchive: (FeatureThread, Bool) -> Void
     let onSettle: (FeatureThread, Bool, @escaping (Bool) -> Void) -> Void
+    let onChooseSnooze: (FeatureThread) -> Void
     let onSnooze: (FeatureThread, Date?) -> Void
     let onPin: (FeatureThread, Bool) -> Void
     let onDelete: (FeatureThread) -> Void
@@ -330,8 +331,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             let configuration = UISwipeActionsConfiguration(
                 actions: actions.map { contextualAction($0, for: thread) }
             )
-            // The leading edge only ever carries the pin toggle, which is
-            // reversible, so a full swipe can run it directly.
+            // Pin/Unpin keeps the full swipe; Snooze/Wake requires a button tap.
             configuration.performsFirstActionWithFullSwipe =
                 HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions)
             return configuration
@@ -401,6 +401,10 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                 parent.onPin(thread, pinned)
             case let .setSettled(settled):
                 parent.onSettle(thread, settled) { _ in }
+            case .chooseSnooze:
+                parent.onChooseSnooze(thread)
+            case .wake:
+                parent.onSnooze(thread, nil)
             }
         }
 
@@ -615,9 +619,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                         actions.append(accessibilityAction("Wake", systemImage: "bell") { coordinator in
                             coordinator.parent.onSnooze(thread, nil)
                         })
-                    } else if thread.state != .queued,
-                              thread.state != .waitingForApproval,
-                              thread.state != .waitingForInput {
+                    } else if thread.canSnoozeNow {
                         actions.append(contentsOf: DailyUXSnoozePresets.resolve(now: .now).map { preset in
                             accessibilityAction("Snooze: \(preset.label)", systemImage: "clock") { coordinator in
                                 coordinator.parent.onSnooze(thread, preset.until)
@@ -777,10 +779,7 @@ struct HomeThreadCollectionView: UIViewRepresentable {
                                 self?.parent.onSnooze(thread, preset.until)
                             }
                         }
-                        let snoozeIsDisabled = thread.state == .queued
-                            || thread.state == .waitingForApproval
-                            || thread.state == .waitingForInput
-                        if snoozeIsDisabled {
+                        if !thread.canSnoozeNow {
                             children.forEach { $0.attributes = .disabled }
                         }
                         let snooze = UIMenu(
@@ -973,6 +972,8 @@ enum HomeThreadSwipeAction: Equatable {
     case settle
     case reopen
     case archive
+    case snooze
+    case wake
 
     /// The lifecycle mutation an action requests. Keeping it separate from the
     /// action keeps the swipe wiring verifiable and forces every case through
@@ -982,6 +983,8 @@ enum HomeThreadSwipeAction: Equatable {
         case setArchived(Bool)
         case setPinned(Bool)
         case setSettled(Bool)
+        case chooseSnooze
+        case wake
     }
 
     /// Settlement owns the edge slot on every row that can settle, so a full
@@ -1019,14 +1022,26 @@ enum HomeThreadSwipeAction: Equatable {
         return actions
     }
 
-    /// The leading swipe is a dedicated pin toggle, mirroring the context
-    /// menu's availability: archived rows offer nothing on this edge.
+    /// Pin/Unpin owns the leading edge and full swipe. Snooze/Wake follows it
+    /// when available, using the same eligibility as the context menu.
     static func leadingActions(
         for thread: FeatureThread,
-        isArchived: Bool
+        isArchived: Bool,
+        at now: Date = .now
     ) -> [HomeThreadSwipeAction] {
-        guard !isArchived, thread.canTogglePin else { return [] }
-        return [thread.pinnedAt != nil ? .unpin : .pin]
+        guard !isArchived else { return [] }
+        var actions: [HomeThreadSwipeAction] = []
+        if thread.canTogglePin {
+            actions.append(thread.pinnedAt != nil ? .unpin : .pin)
+        }
+        if thread.canToggleSnooze {
+            if thread.isEffectivelySnoozed(at: now) {
+                actions.append(.wake)
+            } else if thread.canSnoozeNow {
+                actions.append(.snooze)
+            }
+        }
+        return actions
     }
 
     /// The trailing full swipe is armed only when the edge action settles or
@@ -1057,6 +1072,8 @@ enum HomeThreadSwipeAction: Equatable {
         case .unpin: .setPinned(false)
         case .settle: .setSettled(true)
         case .reopen: .setSettled(false)
+        case .snooze: .chooseSnooze
+        case .wake: .wake
         }
     }
 
@@ -1069,6 +1086,8 @@ enum HomeThreadSwipeAction: Equatable {
         case .settle: "Settle"
         case .reopen: "Reopen"
         case .archive: "Archive"
+        case .snooze: "Snooze"
+        case .wake: "Wake"
         }
     }
 
@@ -1081,6 +1100,8 @@ enum HomeThreadSwipeAction: Equatable {
         case .settle: "checkmark"
         case .reopen: "arrow.counterclockwise"
         case .archive: "archivebox"
+        case .snooze: "clock"
+        case .wake: "bell"
         }
     }
 
@@ -1092,10 +1113,11 @@ enum HomeThreadSwipeAction: Equatable {
     var backgroundColor: UIColor? {
         switch self {
         case .delete: nil
-        case .restore, .unpin, .reopen: .systemBlue
+        case .restore, .unpin, .reopen, .wake: .systemBlue
         case .pin: .systemOrange
         case .settle: .systemGreen
         case .archive: .systemGray
+        case .snooze: .systemIndigo
         }
     }
 }

--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -57,6 +57,7 @@ public struct WorkspaceView: View {
     @State private var showingSettings = false
     @State private var renamingThread: FeatureThread?
     @State private var deletingThread: FeatureThread?
+    @State private var snoozingThread: FeatureThread?
     @State private var renameTitle = ""
     @State private var sidebarBoundaryNow = Date.now
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
@@ -300,6 +301,9 @@ public struct WorkspaceView: View {
                 onSettle: { thread, settled, completion in
                     Task { completion(await model.setSettled(thread.id, settled: settled)) }
                 },
+                onChooseSnooze: { thread in
+                    snoozingThread = thread
+                },
                 onSnooze: { thread, until in
                     Task { await model.setSnoozed(thread.id, until: until) }
                 },
@@ -319,6 +323,25 @@ public struct WorkspaceView: View {
             )
         }
         .background(T3Colors.background)
+        .confirmationDialog(
+            "Snooze thread",
+            isPresented: Binding(
+                get: { snoozingThread != nil },
+                set: { if !$0 { snoozingThread = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: snoozingThread
+        ) { thread in
+            ForEach(DailyUXSnoozePresets.resolve(now: .now)) { preset in
+                Button(preset.label) {
+                    snoozingThread = nil
+                    Task { await model.setSnoozed(thread.id, until: preset.until) }
+                }
+            }
+            Button("Cancel", role: .cancel) { snoozingThread = nil }
+        } message: { thread in
+            Text(thread.title)
+        }
     }
 
     @ViewBuilder

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -5,7 +5,7 @@ import UIKit
 @testable import T3Code
 
 @MainActor
-@Suite("Home row trailing swipe actions")
+@Suite("Home row swipe actions")
 struct HomeThreadSwipeActionTests {
     private let now = Date(timeIntervalSince1970: 20_000)
 
@@ -153,6 +153,73 @@ struct HomeThreadSwipeActionTests {
         }
     }
 
+    /// The leading edge is a dedicated pin toggle: it pins a pinnable row and
+    /// reverses on a pinned one, so the gesture and the context menu always
+    /// agree on what is available.
+    @Test
+    func theLeadingSwipeTogglesPinning() {
+        let pinnable = thread(id: "pinnable")
+        #expect(
+            HomeThreadSwipeAction.leadingActions(for: pinnable, isArchived: false) == [.pin]
+        )
+
+        let pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
+        #expect(
+            HomeThreadSwipeAction.leadingActions(for: pinned, isArchived: false) == [.unpin]
+        )
+
+        // Rows that cannot pin and archived rows offer nothing on this edge.
+        var unpinnable = thread(id: "unpinnable")
+        unpinnable.supportsPinning = false
+        #expect(
+            HomeThreadSwipeAction.leadingActions(for: unpinnable, isArchived: false).isEmpty
+        )
+        #expect(
+            HomeThreadSwipeAction.leadingActions(for: pinnable, isArchived: true).isEmpty
+        )
+        #expect(
+            HomeThreadSwipeAction.leadingActions(for: pinned, isArchived: true).isEmpty
+        )
+    }
+
+    /// The leading edge only ever carries the reversible pin toggle, so nothing
+    /// destructive or lifecycle-changing can run from a right swipe. This
+    /// sweeps the same state space as the trailing-edge test.
+    @Test
+    func theLeadingSwipeNeverOffersSettlementOrDelete() {
+        for isSettled in [false, true] {
+            for isPinned in [false, true] {
+                for supportsSettlement in [nil, true, false] as [Bool?] {
+                    for supportsPinning in [nil, true, false] as [Bool?] {
+                        for isArchived in [false, true] {
+                            var candidate = thread(
+                                id: "row",
+                                pinnedAt: isPinned ? now.addingTimeInterval(-30) : nil
+                            )
+                            candidate.isSettled = isSettled
+                            candidate.supportsSettlement = supportsSettlement
+                            candidate.supportsPinning = supportsPinning
+                            candidate.isArchived = isArchived
+
+                            let actions = HomeThreadSwipeAction.leadingActions(
+                                for: candidate,
+                                isArchived: isArchived
+                            )
+
+                            #expect(actions.count <= 1)
+                            #expect(!actions.contains(.delete))
+                            #expect(actions.allSatisfy { $0.isPinToggle })
+                            #expect(
+                                HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions)
+                                    == (actions.first?.isPinToggle ?? false)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Delete must never reach the edge slot, because the edge slot is what a
     /// full swipe runs. This sweeps every pinned/settled/capability/archived
     /// combination rather than trusting the branch order.
@@ -205,6 +272,7 @@ struct HomeThreadSwipeActionTests {
     func actionsRequestExactlyOneLifecycleMutationEach() {
         #expect(HomeThreadSwipeAction.settle.intent == .setSettled(true))
         #expect(HomeThreadSwipeAction.reopen.intent == .setSettled(false))
+        #expect(HomeThreadSwipeAction.pin.intent == .setPinned(true))
         #expect(HomeThreadSwipeAction.unpin.intent == .setPinned(false))
         #expect(HomeThreadSwipeAction.archive.intent == .setArchived(true))
         #expect(HomeThreadSwipeAction.restore.intent == .setArchived(false))
@@ -212,8 +280,13 @@ struct HomeThreadSwipeActionTests {
 
         #expect(HomeThreadSwipeAction.settle.isSettlement)
         #expect(HomeThreadSwipeAction.reopen.isSettlement)
+        #expect(!HomeThreadSwipeAction.pin.isSettlement)
         #expect(!HomeThreadSwipeAction.unpin.isSettlement)
         #expect(!HomeThreadSwipeAction.delete.isSettlement)
+        #expect(HomeThreadSwipeAction.pin.isPinToggle)
+        #expect(HomeThreadSwipeAction.unpin.isPinToggle)
+        #expect(!HomeThreadSwipeAction.settle.isPinToggle)
+        #expect(HomeThreadSwipeAction.pin.backgroundColor == .systemOrange)
 
         // The settlement actions keep the row's existing accent vocabulary and
         // never inherit the destructive style that arms a destructive swipe.

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -182,9 +182,7 @@ struct HomeThreadSwipeActionTests {
         )
     }
 
-    /// The leading edge only ever carries the reversible pin toggle, so nothing
-    /// destructive or lifecycle-changing can run from a right swipe. This
-    /// sweeps the same state space as the trailing-edge test.
+    /// Without snooze support, the leading edge remains the pin toggle.
     @Test
     func theLeadingSwipeNeverOffersSettlementOrDelete() {
         for isSettled in [false, true] {
@@ -218,6 +216,71 @@ struct HomeThreadSwipeActionTests {
                 }
             }
         }
+    }
+
+    @Test
+    func snoozeIsSecondAndPinningStillOwnsTheFullSwipe() {
+        for pinned in [false, true] {
+            var candidate = thread(id: "snooze", pinnedAt: pinned ? now : nil)
+            candidate.supportsSnooze = true
+            let actions = HomeThreadSwipeAction.leadingActions(
+                for: candidate, isArchived: false, at: now
+            )
+            #expect(actions == [pinned ? .unpin : .pin, .snooze])
+            #expect(HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions))
+        }
+    }
+
+    @Test
+    func snoozeWithoutPinSupportRequiresAnExplicitTap() {
+        var candidate = thread(id: "snooze-only")
+        candidate.supportsPinning = false
+        candidate.supportsSnooze = true
+        let actions = HomeThreadSwipeAction.leadingActions(
+            for: candidate, isArchived: false, at: now
+        )
+        #expect(actions == [.snooze])
+        #expect(!HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions))
+    }
+
+    @Test
+    func snoozeRequiresSupportAndDoesNotHideWorkAwaitingInput() {
+        for support in [nil, false, true] as [Bool?] {
+            for state in [FeatureThreadState.queued, .working, .monitoring,
+                          .waitingForApproval, .waitingForInput] {
+                var candidate = thread(id: "busy")
+                candidate.supportsSnooze = support
+                candidate.state = state
+                let actions = HomeThreadSwipeAction.leadingActions(
+                    for: candidate, isArchived: false, at: now
+                )
+                #expect(actions.contains(.snooze) ==
+                    (support == true && (state == .working || state == .monitoring)))
+                #expect(actions.first == .pin)
+                #expect(HomeThreadSwipeAction.performsLeadingFullSwipe(with: actions))
+            }
+        }
+    }
+
+    @Test
+    func wakeUsesEffectiveSnoozeStateAndKeepsPinningFirst() {
+        var candidate = thread(id: "snoozed", pinnedAt: now)
+        candidate.snoozedUntil = now.addingTimeInterval(3600)
+        candidate.supportsSnooze = false
+        #expect(HomeThreadSwipeAction.leadingActions(
+            for: candidate, isArchived: false, at: now
+        ) == [.unpin, .wake])
+        #expect(HomeThreadSwipeAction.leadingActions(
+            for: candidate, isArchived: true, at: now
+        ).isEmpty)
+        #expect(HomeThreadSwipeAction.leadingActions(
+            for: candidate, isArchived: false, at: now.addingTimeInterval(3600)
+        ) == [.unpin, .snooze])
+
+        candidate.state = .waitingForInput
+        #expect(HomeThreadSwipeAction.leadingActions(
+            for: candidate, isArchived: false, at: now
+        ) == [.unpin])
     }
 
     /// Delete must never reach the edge slot, because the edge slot is what a
@@ -1255,6 +1318,7 @@ struct HomeThreadSwipeActionTests {
                 onSettle(thread, settled, completion)
                 if let settlementResult { completion(settlementResult) }
             },
+            onChooseSnooze: { _ in },
             onSnooze: { _, _ in },
             onPin: { _, _ in },
             onDelete: { _ in },


### PR DESCRIPTION
## What Changed

Adds Pin/Unpin and Snooze/Wake to the leading (rightward) swipe on SwiftUI Home rows. Pin/Unpin stays first and remains the full-swipe action. Tapping Snooze opens the existing duration choices; a snoozed row offers Wake in the same position.

The opposite swipe keeps Settle/Reopen and its existing full-swipe behavior. Snooze uses the same eligibility, presets, and server command as the context menu and VoiceOver actions. Queued tasks and tasks awaiting approval or input cannot be snoozed. Snooze-only rows require a button tap.

## Why

Pinning and snoozing previously required the thread actions menu or a long press. Both are now reachable from one swipe, while a full swipe remains a predictable pin toggle.

## UI Changes

Actual iPhone 16 Pro Simulator captures on iOS 26.5, using the same three disposable threads and project filter. Before is upstream `93ca26695e`; After is candidate `143417b1bc` (captured from the identical uncommitted source before committing). Native clipping as the row slides is shown unaltered. No UI mocks or provider turns were used.

### Before: long press, then Snooze and a duration

![Before: snoozing from the context menu](https://github.com/user-attachments/assets/08df17e8-17eb-4a82-83d1-2d11a8254450)

### After: Pin stays first, Snooze is second, and Wake reverses snoozing

![After: reveal Pin and Snooze, dismiss the picker, full-swipe pin and unpin, snooze for an hour, and wake](https://github.com/user-attachments/assets/6ad6d699-9173-4945-8170-165e60b73fc1)

GIFs run at normal speed, 15 fps. The Before GIF removes an idle pause while the menu was open; the After GIF trims the idle tail. Full recordings: [Before](https://github.com/user-attachments/assets/a4b638e7-4c98-4378-aed5-992e15a7445e) · [After](https://github.com/user-attachments/assets/f14cde63-6a72-4511-92b3-5dd2feb23f4f).

<details>
<summary>Full-resolution light and dark screenshots</summary>

### Before — light

![Before: Pin and Snooze in the context menu, light appearance](https://github.com/user-attachments/assets/5aba32b0-b35e-4390-852c-425744b6c859)

### After — light

![After: Pin and Snooze beside the swiped row, light appearance](https://github.com/user-attachments/assets/363f45fc-2816-4ae5-87c1-84bf63b53df3)

### Before — dark

![Before: Pin and Snooze in the context menu, dark appearance](https://github.com/user-attachments/assets/2b200ec3-a85e-41f5-b30d-86f64a8812fe)

### After — dark

![After: Pin and Snooze beside the swiped row, dark appearance](https://github.com/user-attachments/assets/914a07fe-8a67-4f00-965a-f10713260b3b)

</details>

## Verification

Current CI at `143417b1bc`: native tests, Check, Test, server shards, Rust, and Macroscope correctness passed. [Release Smoke](https://github.com/pingdotgg/t3code/actions/runs/34737597627/job/103671626545) failed with `ERR_PNPM_UNUSED_PATCH: expo-audio@57.0.4` while regenerating the lockfile; the release script, manifests, lockfile, and patches are unchanged from the target branch. The same smoke command was reproduced locally against those unchanged target inputs and exited 1 with the same error, so it was not retried as a runner flake. Macroscope's approvability check is neutral because this is a new user-facing feature requiring human review; Cursor Bugbot is paused at the upstream team's spend limit. The PR is not fully green.

- `xcodebuild test -project apps/swift-ios/T3Code.xcodeproj -scheme T3Code -destination 'platform=iOS Simulator,id=CF4A0BBA-0407-47DF-915B-5A295D2B7FA8' -only-testing:T3CodeTests/HomeThreadSwipeActionTests -parallel-testing-enabled NO`, through XcodeBuildMCP with isolated build state: **37 passed, 0 failed, 0 skipped**.
- Built both upstream base and candidate. Integrated Simulator check covered picker dismissal, full-swipe pin/unpin, snooze/wake, and snoozing a pinned row. Read-only SQLite checks confirmed the saved snooze timestamp and the reversed state. Relaunch preserved server state.
- Swift parsing and `git diff --check` passed. Direct Claude Fable 5 high review exited 0 with no high/medium findings; optional test-table, haptic, and presentation suggestions were reviewed. Existing pin haptics are preserved.
- SwiftUI only; no server or wire changes. Physical iPad, VoiceOver screen-reader operation, and relay/tunnel connections were not exercised. Existing unrelated strict-concurrency warnings remain under Swift 5 language mode.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implemented with GPT-6 in the Codex harness; independently reviewed by Claude Fable 5 high in Claude Code.
