### PR TITLE
fix(web): separate adjacent highlighted list items by 1px

### DIFF
--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -65,6 +65,7 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxListVirtualized,
+  ComboboxItemSeparator,
   ComboboxPopup,
   ComboboxStatus,
   ComboboxTrigger,
@@ -834,6 +835,7 @@ export function BranchToolbarBranchSelector({
                       : "branch"
                 }
                 renderItem={({ item, index }) => renderPickerItem(item, index)}
+                ItemSeparatorComponent={ComboboxItemSeparator}
                 estimatedItemSize={28}
                 drawDistance={336}
                 onLayout={() => {

--- a/apps/web/src/components/settings/FontFamilyPicker.tsx
+++ b/apps/web/src/components/settings/FontFamilyPicker.tsx
@@ -8,6 +8,7 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxListVirtualized,
+  ComboboxItemSeparator,
   ComboboxPopup,
   ComboboxTrigger,
 } from "../ui/combobox";
@@ -238,9 +239,10 @@ export function FontFamilyPicker({
                 data={items}
                 keyExtractor={(item) => item}
                 renderItem={({ item, index }) => renderItem(item, index)}
+                ItemSeparatorComponent={ComboboxItemSeparator}
                 estimatedItemSize={30}
                 drawDistance={360}
-                style={{ height: Math.min(items.length * 30, 288) }}
+                style={{ height: Math.min(items.length * 30 + Math.max(0, items.length - 1), 288) }}
               />
             </ComboboxListVirtualized>
           </div>

--- a/apps/web/src/components/ui/autocomplete.tsx
+++ b/apps/web/src/components/ui/autocomplete.tsx
@@ -125,6 +125,7 @@ function AutocompleteItem({ className, children, ...props }: AutocompletePrimiti
   return (
     <AutocompletePrimitive.Item
       className={cn(
+        "[[role=option]+&]:mt-px",
         "flex min-h-8 cursor-default select-none items-center rounded-sm px-2 py-1 text-base outline-none hover:bg-accent data-disabled:pointer-events-none data-selected:bg-accent/50 data-selected:text-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground [&[data-highlighted][data-selected]]:bg-accent [&[data-highlighted][data-selected]]:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='text-'])]:text-muted-foreground",
         className,
       )}

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -221,6 +221,7 @@ function ComboboxItem({
   return (
     <ComboboxPrimitive.Item
       className={cn(
+        "[[role=option]+&]:mt-px",
         "flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base outline-none hover:bg-accent data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-selected:bg-foreground/[0.08] data-selected:text-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground [&[data-highlighted][data-selected]]:bg-accent [&[data-highlighted][data-selected]]:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
@@ -238,6 +239,11 @@ function ComboboxItem({
       </div>
     </ComboboxPrimitive.Item>
   );
+}
+
+/** A gap between virtualized options, measured by the list that owns their layout. */
+function ComboboxItemSeparator() {
+  return <div aria-hidden="true" className="h-px" />;
 }
 
 function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.Props) {
@@ -419,6 +425,7 @@ export {
   ComboboxPopup,
   ComboboxItem,
   ComboboxSeparator,
+  ComboboxItemSeparator,
   ComboboxGroup,
   ComboboxGroupLabel,
   ComboboxEmpty,

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -86,6 +86,7 @@ function MenuItem({
   return (
     <MenuPrimitive.Item
       className={cn(
+        "[[role^=menuitem]+&]:mt-px",
         "[&>svg]:-mx-0.5 flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive-foreground data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg:not([class*='size-'])]:size-4.5 sm:[&>svg:not([class*='size-'])]:size-4 [&>svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:[&>svg:not([class*='text-'])]:text-current [&>svg]:pointer-events-none [&>svg]:shrink-0",
         className,
       )}
@@ -110,6 +111,7 @@ function MenuCheckboxItem({
     <MenuPrimitive.CheckboxItem
       checked={checked}
       className={cn(
+        "[[role^=menuitem]+&]:mt-px",
         "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center gap-2 rounded-sm py-1 ps-2 text-base text-foreground outline-none data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         variant === "switch" ? "grid-cols-[1fr_auto] gap-4 pe-1.5" : "grid-cols-[1rem_1fr] pe-4",
         className,
@@ -166,6 +168,7 @@ function MenuRadioItem({
   return (
     <MenuPrimitive.RadioItem
       className={cn(
+        "[[role^=menuitem]+&]:mt-px",
         "[&_svg]:-mx-0.5 flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base text-foreground outline-none data-checked:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
@@ -252,6 +255,7 @@ function MenuSubTrigger({
   return (
     <MenuPrimitive.SubmenuTrigger
       className={cn(
+        "[[role^=menuitem]+&]:mt-px",
         // Leading-icon treatment matches `MenuItem`: a sub-trigger sits in the
         // same column as the items around it, so its icon has to align and dim
         // with theirs. Scoped away from the last child because the chevron is

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -187,6 +187,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
+        "[[role=option]+&]:mt-px",
         "flex min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-pointer items-center rounded-sm px-2 py-1 text-base outline-none data-selected:bg-foreground/[0.08] data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}


### PR DESCRIPTION
## What Changed

Add a 1px gap between adjacent menu and listbox options so a hovered or keyboard-highlighted row stays visually separate from the selected row. This covers menu actions, radio and checkbox items, submenu triggers, selects, comboboxes, and the command palette.

Virtualized branch and font pickers use a measured item separator. The font picker’s height calculation includes those separators.

## Why

In the Reasoning menu, the selected row and the neighboring hovered row currently touch, making their backgrounds run together. The same issue occurs in the shared option components.

Sibling selectors add space only between neighboring options, preserving row heights, popup padding, labels, and section separators. Virtualized rows use the list’s separator API so scrolling accounts for the extra pixel. Existing sidebar and model-picker spacing is preserved.

## UI Changes

| Before | After |
| --- | --- |
| ![Selected Low and hovered Medium before the fix](https://github.com/user-attachments/assets/8d591b15-071c-4ac2-b894-e6b462117a50) | ![The same state with a 1px gap](https://github.com/user-attachments/assets/143ffb3f-ca18-4424-9065-a7cae3e0f987) |

https://github.com/user-attachments/assets/9d9fda29-6d1e-437d-a60d-75019421391b

## Validation

- Web package typecheck passed; existing Effect suggestions remain.
- Targeted lint and formatting passed. Lint reports seven warnings on unchanged code in the branch and font pickers.
- Verified the Reasoning menu and branch picker in the isolated web app: exactly 1 CSS pixel between rows; 28px row heights retained.
- Browser verification of the actual shared components covered mixed menu items, groups, section separators, submenus, select keyboard selection, command keyboard navigation, filtering and clearing, light/dark themes, and 1px spacing after scrolling a 100-row virtualized list. At a 390px viewport, menu rows retained their 32px height.
- Web and Electron share these components. The native React Native UI is unaffected; no separate Electron or native-device run was performed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-6 Astra. Harness: Codex desktop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved visual spacing between items in branch selection, font selection, autocomplete, menus, and dropdown lists.
  * Added consistent separators and small gaps between adjacent options for clearer list organization.
  * Updated selection popups to accommodate the added spacing without clipping content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->