### PR TITLE
fix(server): require explicit inline preview screenshots

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -178,7 +178,7 @@ it.effect.each([{}, { includeImage: false }])(
 );
 
 it.effect.each([
-  { mode: "default", input: {}, images: true },
+  { mode: "default", input: {}, images: false },
   { mode: "explicit image", input: { includeImage: true }, images: true },
   { mode: "text only", input: { includeImage: false }, images: false },
 ])("returns fresh $mode snapshots on repeated MCP calls", ({ input, images }) =>
@@ -282,12 +282,7 @@ it.effect.each([
           Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
           Effect.provideService(McpSchema.McpServerClient, client),
         );
-      expect(nextDefault.content.map((content) => content.type)).toEqual([
-        "text",
-        "text",
-        "text",
-        "image",
-      ]);
+      expect(nextDefault.content.map((content) => content.type)).toEqual(["text", "text", "text"]);
       expect(nextDefault.structuredContent).toEqual({ ...page, title: "Snapshot 7", screenshot });
       expect(requests).toBe(7);
     }),
@@ -316,34 +311,39 @@ it.effect("rejects non-boolean snapshot image options before selecting a browser
   }).pipe(Effect.provide(TestLayer)),
 );
 
-it.effect("saves the snapshot PNG on request and reports its path", () =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      const config = yield* ServerConfig.ServerConfig;
-      const fileSystem = yield* FileSystem.FileSystem;
-      const path = yield* Path.Path;
-      const inputs = yield* serveSnapshots("mcp-save-client", snapshotResult);
+it.effect.each([{}, { includeImage: false }, { includeImage: true }])(
+  "saves the snapshot PNG independently of image inclusion %#",
+  (imageOptions) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const config = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const inputs = yield* serveSnapshots("mcp-save-client", snapshotResult);
 
-      const snapshot = yield* callSnapshot({ save: true });
+        const snapshot = yield* callSnapshot({ save: true, ...imageOptions });
+        expect(snapshot.content.some((part) => part.type === "image")).toBe(
+          "includeImage" in imageOptions && imageOptions.includeImage === true,
+        );
 
-      expect(snapshot.isError).toBe(false);
-      // The browser never receives the server-only `save` flag.
-      expect(inputs).toEqual([{}]);
-      const structured = snapshot.structuredContent as { readonly screenshotPath?: string };
-      const screenshotPath = structured.screenshotPath;
-      expect(typeof screenshotPath).toBe("string");
-      expect(path.dirname(screenshotPath!)).toBe(config.browserArtifactsDir);
-      expect(path.basename(screenshotPath!)).toMatch(
-        /^browser-screenshot-example-test-[0-9a-z]+-[0-9a-f]{8}\.png$/,
-      );
-      expect(Buffer.from(yield* fileSystem.readFile(screenshotPath!)).toString()).toBe("png");
-      const [, text] = snapshot.content;
-      expect(text?.type === "text" ? text.text : "").toContain(screenshotPath);
+        expect(snapshot.isError).toBe(false);
+        // The browser never receives the server-only `save` flag.
+        expect(inputs).toEqual([{}]);
+        const structured = snapshot.structuredContent as { readonly screenshotPath?: string };
+        const screenshotPath = structured.screenshotPath;
+        expect(typeof screenshotPath).toBe("string");
+        expect(path.dirname(screenshotPath!)).toBe(config.browserArtifactsDir);
+        expect(path.basename(screenshotPath!)).toMatch(
+          /^browser-screenshot-example-test-[0-9a-z]+-[0-9a-f]{8}\.png$/,
+        );
+        expect(Buffer.from(yield* fileSystem.readFile(screenshotPath!)).toString()).toBe("png");
+        const [, text] = snapshot.content;
+        expect(text?.type === "text" ? text.text : "").toContain(screenshotPath);
 
-      const unsaved = yield* callSnapshot({});
-      expect(unsaved.structuredContent).not.toHaveProperty("screenshotPath");
-    }),
-  ).pipe(Effect.provide(TestLayer)),
+        const unsaved = yield* callSnapshot({});
+        expect(unsaved.structuredContent).not.toHaveProperty("screenshotPath");
+      }),
+    ).pipe(Effect.provide(TestLayer)),
 );
 
 it.effect("reports a tagged error when the screenshot cannot be saved", () =>
@@ -717,7 +717,7 @@ it.effect("registers annotated tools and preserves authenticated request context
           Effect.provideService(McpSchema.McpServerClient, client),
         );
       expect(snapshot.isError).toBe(false);
-      expect(snapshot.content.some((content) => content.type === "image")).toBe(true);
+      expect(snapshot.content.some((content) => content.type === "image")).toBe(false);
       expect(snapshot.structuredContent).toMatchObject({
         screenshot: { mimeType: "image/png", width: 10, height: 5 },
       });

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -426,9 +426,9 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                           text: `Snapshot text was bounded. Omitted: ${bounded.omitted.join("; ")}.`,
                         },
                       ]),
-                  ...(payload?.includeImage === false
-                    ? []
-                    : [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]),
+                  ...(payload?.includeImage === true
+                    ? [{ type: "image" as const, data: png, mimeType: screenshot.mimeType }]
+                    : []),
                 ],
               });
             }),

--- a/apps/server/src/mcp/toolkits/preview/tools.ts
+++ b/apps/server/src/mcp/toolkits/preview/tools.ts
@@ -119,13 +119,13 @@ const PreviewSetAppearanceTool = safeBrowserTool(
 export const PreviewSnapshotTool = readonlyBrowserTool(
   Tool.make("preview_snapshot", {
     description:
-      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, action history, and a PNG screenshot. Set includeImage=false for text-only output with the same page metadata. Set save=true to also write the PNG to disk and get screenshotPath back; embed that path in your reply as ![alt](screenshotPath) so the user sees it. This is the only way to show the user a screenshot; the image in the tool result is not saved anywhere.",
+      "Inspect a page before interacting. Pass tabId to inspect a specific tab; omit it to use this agent session's current tab. Returns page state, semantic elements, diagnostics, and action history as text by default. Set includeImage=true only when you need to inspect the screenshot visually; inline images remain in provider history. Set save=true to write the PNG to disk and get screenshotPath back; embed that path in your reply as ![alt](screenshotPath) so the user sees it. This is the only way to show the user a screenshot; the image in the tool result is not saved anywhere.",
     parameters: Schema.Struct({
       ...PreviewAutomationTabTargetInput.fields,
       includeImage: Schema.optional(
         Schema.Boolean.annotate({
           description:
-            "Include the PNG image in the tool response. Defaults to true. Set false for text-only output.",
+            "Include the PNG image in the tool response for visual inspection. Defaults to false; text and page metadata are returned either way.",
         }),
       ),
       save: Schema.optional(


### PR DESCRIPTION
Default `preview_snapshot` calls add PNGs to provider history even when the agent only needs page structure. Providers that reject inline images can then reject every later turn in that session.

Return text and page metadata by default, and require `includeImage: true` for an inline PNG. `save: true` still writes the screenshot and returns its path independently of image inclusion. The tool description explains both options.

Fixes #11295. This prevents new default snapshots from embedding images; existing provider history is outside this change.

Validation: 17 MCP tests cover repeated default and explicit image calls, saved PNG bytes, metadata, and invalid options. The updated regressions failed against the old default. Server typecheck and targeted lint pass.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Snapshot previews now return text and page metadata by default, without embedded screenshots.
  - Screenshots are included only when `includeImage=true`.
  - Image persistence remains available across all image-inclusion options.
  - Preview documentation now reflects the updated default behavior and image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->