### PR TITLE
perf(server): limit Windows process details to tracked processes

### DIFF
--- a/native/resource-monitor/src/main.rs
+++ b/native/resource-monitor/src/main.rs
@@ -455,34 +455,35 @@ impl Collector {
         roots.insert(config.root_pid);
         let tracked = select_tracked_pids(&rows, &roots);
         let tracked_process_count = tracked.len();
-        let process_details = if !tracked.is_empty() {
-            let monitor_pid = Pid::from_u32(std::process::id());
-            let mut detail_pids = tracked
-                .iter()
-                .copied()
-                .map(Pid::from_u32)
-                .collect::<Vec<_>>();
-            if !tracked.contains(&monitor_pid.as_u32()) {
-                detail_pids.push(monitor_pid);
-            }
-            // Detail fields need no baseline. Drop command data and OS handles after each sample.
-            let mut details = System::new();
-            details.refresh_processes_specifics(
-                ProcessesToUpdate::Some(&detail_pids),
-                true,
-                process_refresh_kind().without_cpu(),
-            );
-            // This process cannot be replaced during collection. Its start time
-            // exposes any boot-epoch shift between the two System instances.
-            let start_time_offset = self.system.process(monitor_pid).and_then(|process| {
-                details.process(monitor_pid).map(|detail| {
-                    i128::from(detail.start_time()) - i128::from(process.start_time())
-                })
-            });
-            Some((details, start_time_offset))
-        } else {
-            None
-        };
+        let process_details =
+            if cfg!(any(target_os = "linux", target_os = "windows")) && !tracked.is_empty() {
+                let monitor_pid = Pid::from_u32(std::process::id());
+                let mut detail_pids = tracked
+                    .iter()
+                    .copied()
+                    .map(Pid::from_u32)
+                    .collect::<Vec<_>>();
+                if !tracked.contains(&monitor_pid.as_u32()) {
+                    detail_pids.push(monitor_pid);
+                }
+                // Detail fields need no baseline. Drop command data and OS handles after each sample.
+                let mut details = System::new();
+                details.refresh_processes_specifics(
+                    ProcessesToUpdate::Some(&detail_pids),
+                    true,
+                    process_refresh_kind().without_cpu(),
+                );
+                // This process cannot be replaced during collection. Its start time
+                // exposes any boot-epoch shift between the two System instances.
+                let start_time_offset = self.system.process(monitor_pid).and_then(|process| {
+                    details.process(monitor_pid).map(|detail| {
+                        i128::from(detail.start_time()) - i128::from(process.start_time())
+                    })
+                });
+                Some((details, start_time_offset))
+            } else {
+                None
+            };
         let sample_details = process_details
             .as_ref()
             .map_or(&self.system, |(details, _)| details);
@@ -562,7 +563,13 @@ impl Collector {
 
 // Keep CPU baselines separate. Even a metadata refresh resets Linux process times.
 fn process_discovery_refresh_kind() -> ProcessRefreshKind {
-    ProcessRefreshKind::nothing().with_cpu().without_tasks()
+    // sysinfo's macOS process discovery still reads command data, and its
+    // temporary System instances retain Mach ports. Keep that platform on one System.
+    if cfg!(any(target_os = "linux", target_os = "windows")) {
+        ProcessRefreshKind::nothing().with_cpu().without_tasks()
+    } else {
+        process_refresh_kind()
+    }
 }
 
 fn process_refresh_kind() -> ProcessRefreshKind {
@@ -1021,8 +1028,10 @@ mod tests {
             .system
             .process(Pid::from_u32(std::process::id()))
             .expect("current process discovered");
-        assert!(unselected.cmd().is_empty());
-        assert_eq!(unselected.memory(), 0);
+        if cfg!(any(target_os = "linux", target_os = "windows")) {
+            assert!(unselected.cmd().is_empty());
+            assert_eq!(unselected.memory(), 0);
+        }
 
         config.root_pid = std::process::id();
         let snapshot = collector.sample(&config, None);
@@ -1040,8 +1049,10 @@ mod tests {
             .system
             .process(Pid::from_u32(config.root_pid))
             .expect("selected process still discovered");
-        assert!(baseline.cmd().is_empty());
-        assert_eq!(baseline.memory(), 0);
+        if cfg!(any(target_os = "linux", target_os = "windows")) {
+            assert!(baseline.cmd().is_empty());
+            assert_eq!(baseline.memory(), 0);
+        }
     }
 
     #[test]

--- a/native/resource-monitor/src/main.rs
+++ b/native/resource-monitor/src/main.rs
@@ -455,7 +455,7 @@ impl Collector {
         roots.insert(config.root_pid);
         let tracked = select_tracked_pids(&rows, &roots);
         let tracked_process_count = tracked.len();
-        let process_details = if cfg!(target_os = "linux") && !tracked.is_empty() {
+        let process_details = if !tracked.is_empty() {
             let monitor_pid = Pid::from_u32(std::process::id());
             let mut detail_pids = tracked
                 .iter()
@@ -562,11 +562,7 @@ impl Collector {
 
 // Keep CPU baselines separate. Even a metadata refresh resets Linux process times.
 fn process_discovery_refresh_kind() -> ProcessRefreshKind {
-    if cfg!(target_os = "linux") {
-        ProcessRefreshKind::nothing().with_cpu().without_tasks()
-    } else {
-        process_refresh_kind()
-    }
+    ProcessRefreshKind::nothing().with_cpu().without_tasks()
 }
 
 fn process_refresh_kind() -> ProcessRefreshKind {
@@ -1021,6 +1017,12 @@ mod tests {
             external_processes: HashMap::new(),
         };
         assert!(collector.sample(&config, None).processes.is_empty());
+        let unselected = collector
+            .system
+            .process(Pid::from_u32(std::process::id()))
+            .expect("current process discovered");
+        assert!(unselected.cmd().is_empty());
+        assert_eq!(unselected.memory(), 0);
 
         config.root_pid = std::process::id();
         let snapshot = collector.sample(&config, None);
@@ -1033,6 +1035,13 @@ mod tests {
         assert!(!process.command.is_empty());
         assert!(process.resident_bytes > 0);
         assert!(process.cpu_percent.is_finite());
+        // Snapshot details must not accumulate in the process-table baseline.
+        let baseline = collector
+            .system
+            .process(Pid::from_u32(config.root_pid))
+            .expect("selected process still discovered");
+        assert!(baseline.cmd().is_empty());
+        assert_eq!(baseline.memory(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Windows resource sampling reads command lines, memory, and disk counters for every process, even though snapshots only report the T3 process tree.

Use the existing Linux split on Windows: retain CPU baselines for process discovery, then read detailed fields only for selected processes in a temporary collector. This preserves CPU history and background sampling while avoiding unrelated command-line and memory reads.

Addresses the process-inspection cost in #11222. This does not add a telemetry off switch or promise to eliminate handles needed for CPU discovery.

Validation: all 17 native collector tests pass on Linux, including a strengthened real-process test that selects a previously untracked process and verifies details never accumulate in the discovery baseline. Windows x64 and macOS arm64 cross-target checks pass; rustfmt passes. Windows runtime performance was not measured locally. macOS keeps its existing collector: the pinned sysinfo implementation cannot avoid those discovery reads and does not safely release temporary System host ports.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource monitoring behavior across platforms.
  * Process-level detail updates now work consistently on Linux and Windows.
  * Other supported platforms retain baseline process information while avoiding unsupported detail refreshes.
  * Platform-specific sampling checks have been aligned to improve reliability and prevent inaccurate process data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->