### PR TITLE
fix(server): distinguish hosting probe timeouts from missing CLIs

### DIFF
--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { ChildProcessSpawner } from "effect/unstable/process";
-import { VcsProcessSpawnError } from "@t3tools/contracts";
+import { VcsProcessSpawnError, VcsProcessTimeoutError } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -14,6 +14,7 @@ import * as BitbucketApi from "./BitbucketApi.ts";
 import * as GitHubCli from "./GitHubCli.ts";
 import * as GitLabCli from "./GitLabCli.ts";
 import * as SourceControlDiscovery from "./SourceControlDiscovery.ts";
+import { probeSourceControlProvider } from "./SourceControlProviderDiscovery.ts";
 import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.ts";
 
 const sourceControlProviderRegistryTestLayer = (input: {
@@ -281,3 +282,62 @@ Logged in to gitlab.com as gitlab-user
     );
   }).pipe(Effect.provide(testLayer));
 });
+
+it.effect.each(["gh", "glab", "az"])(
+  "reports a timed-out %s version probe without claiming the executable is missing",
+  (command) =>
+    Effect.gen(function* () {
+      const calls: VcsProcess.VcsProcessInput[] = [];
+      const probe = (timedOut: boolean) =>
+        probeSourceControlProvider({
+          cwd: "/workspace",
+          spec: {
+            type: "cli",
+            kind: "github",
+            label: "Hosting CLI",
+            executable: command,
+            versionArgs: ["--version"],
+            authArgs: ["auth", "status"],
+            installHint: "Install the CLI",
+            parseAuth: () => ({
+              status: "authenticated",
+              account: Option.some("account"),
+              host: Option.none(),
+              detail: Option.none(),
+            }),
+          },
+          process: {
+            run: (input) => {
+              calls.push(input);
+              return timedOut
+                ? Effect.fail(
+                    new VcsProcessTimeoutError({
+                      operation: input.operation,
+                      command,
+                      cwd: input.cwd,
+                      timeoutMs: input.timeoutMs!,
+                    }),
+                  )
+                : Effect.succeed(processOutput("CLI 1.0"));
+            },
+          },
+        });
+      const failed = yield* probe(true);
+      assert.strictEqual(failed.status, "available");
+      assert.strictEqual(failed.auth.status, "unknown");
+      assert.strictEqual(Option.isNone(failed.version), true);
+      assert.match(Option.getOrThrow(failed.auth.detail), /timed out.*5000ms/);
+      assert.deepStrictEqual(failed.detail, failed.auth.detail);
+      assert.strictEqual(calls.length, 1);
+
+      const recovered = yield* probe(false);
+      assert.strictEqual(recovered.status, "available");
+      assert.strictEqual(recovered.auth.status, "authenticated");
+      assert.strictEqual(Option.getOrThrow(recovered.version), "CLI 1.0");
+      assert.strictEqual(Option.isNone(recovered.detail), true);
+      assert.deepStrictEqual(
+        calls.slice(1).map((call) => call.args),
+        [["--version"], ["auth", "status"]],
+      );
+    }),
+);

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -200,7 +200,9 @@ function probeCli(input: {
           kind: input.spec.kind,
           label: input.spec.label,
           executable: input.spec.executable,
-          status: "missing" as const,
+          // A response deadline is not evidence that the executable is absent.
+          status:
+            cause._tag === "VcsProcessTimeoutError" ? ("available" as const) : ("missing" as const),
           version: Option.none<string>(),
           installHint: input.spec.installHint,
           detail: detailFromCause(cause),
@@ -239,10 +241,15 @@ export function probeSourceControlProvider(input: {
     cwd: input.cwd,
   }).pipe(
     Effect.flatMap((item) => {
-      if (item.status !== "available") {
+      if (item.status !== "available" || Option.isSome(item.detail)) {
         return Effect.succeed({
           ...item,
-          auth: unknownAuth("Hosting integration command was not found on the server PATH."),
+          auth: unknownAuth(
+            Option.getOrElse(
+              item.detail,
+              () => "Hosting integration command was not found on the server PATH.",
+            ),
+          ),
         } satisfies SourceControlProviderDiscoveryItem);
       }
 


### PR DESCRIPTION
A slow `gh`, `glab`, or `az` version probe is reported as a missing executable, and Settings tells the user to install a CLI that is already present.

Keep a timed-out CLI in the available category with unknown authentication and the actual timeout diagnostic. Skip the auth probe after that failed version check. A later successful scan clears the error and verifies authentication normally; spawn failures remain missing.

Fixes #10728. The existing client presentation shows the verification diagnostic without a client or contract change.

Validation: 16 discovery and registry tests pass, including failing-before/passing-after timeout and recovery cases for all three CLIs. Server typecheck and targeted lint pass.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Source control tools that exceed the version-check time limit are now correctly shown as available rather than missing.
  - Permission-related and other unexpected errors no longer incorrectly mark tools as missing.
  - Timeout and provider details are surfaced for clearer diagnostic information.
  - Authentication status now preserves relevant provider details when it cannot be determined.
  - Successful follow-up checks continue to report detected versions and authentication status accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->