### PR TITLE
fix(composer): keep focus after command selection

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -198,6 +198,7 @@ export function NewTaskDraftScreen(props: {
     });
   const queuesInsteadOfStarting = !environmentConnected || attachmentsUploading;
   const promptInputRef = useRef<ComposerEditorHandle>(null);
+  const focusPromptEditor = useCallback(() => promptInputRef.current?.focus(), []);
   const loadedBranchesProjectKeyRef = useRef<string | null>(null);
   const [isComposerFocused, setIsComposerFocused] = useState(false);
   const [previewVideo, setPreviewVideo] = useState<VideoPreviewSource | null>(null);
@@ -341,6 +342,7 @@ export function NewTaskDraftScreen(props: {
     enabled: isComposerFocused && !isComposerInteractionLocked,
     onChangeDraftMessage: flow.setPrompt,
     onUpdateInteractionMode: flow.planModeEnabled ? flow.setInteractionMode : undefined,
+    onRequestEditorFocus: focusPromptEditor,
   });
   const voiceInput = useVoiceInputController({
     ownerKey: flow.draftKey,

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -269,6 +269,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
   const bodyText = useScaledTextRole("body");
   const fallbackInputRef = useRef<ComposerEditorHandle>(null);
   const inputRef = props.editorRef ?? fallbackInputRef;
+  const focusEditor = useCallback(() => inputRef.current?.focus(), [inputRef]);
   const [isFocused, setIsFocused] = useState(false);
   const settingsSheetPresentation = useThreadSettingsSheetPresentation({
     editorRef: inputRef,
@@ -359,6 +360,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     // With attachments aboard the pick just inserts the text, so it sends as a prompt.
     onUsageLimits:
       usageLimitsOffered && props.draftAttachments.length === 0 ? openUsageLimits : undefined,
+    onRequestEditorFocus: focusEditor,
   });
   const voiceInput = useVoiceInputController({
     ownerKey: composerOwnerKey,

--- a/apps/mobile/src/features/threads/use-composer-command-menu.ts
+++ b/apps/mobile/src/features/threads/use-composer-command-menu.ts
@@ -156,6 +156,7 @@ export function useComposerCommandMenu({
   onChangeDraftMessage,
   onUpdateInteractionMode,
   onUsageLimits,
+  onRequestEditorFocus,
 }: {
   readonly draftMessage: string;
   readonly ownerKey: string | null;
@@ -171,6 +172,7 @@ export function useComposerCommandMenu({
   readonly onUpdateInteractionMode?: (mode: ProviderInteractionMode) => void;
   /** Picking /usage-limits is the action itself; the draft keeps nothing of it. */
   readonly onUsageLimits?: () => void;
+  readonly onRequestEditorFocus?: () => void;
 }) {
   const [selection, setSelection] = useState(() => composerSelectionAtEnd(draftMessage));
   const previousOwnerKeyRef = useRef(ownerKey);
@@ -437,10 +439,12 @@ export function useComposerCommandMenu({
       if (result.interactionMode !== null) {
         onUpdateInteractionMode?.(result.interactionMode);
       }
+      onRequestEditorFocus?.();
     },
     [
       draftMessage,
       onChangeDraftMessage,
+      onRequestEditorFocus,
       onUpdateInteractionMode,
       onUsageLimits,
       selectedProviderStatus?.showInteractionModeToggle,

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -155,6 +155,9 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
       onMouseMove={() => {
         if (!props.isActive) props.onHighlight(props.item.id);
       }}
+      onPointerDown={(event) => {
+        event.preventDefault();
+      }}
       onMouseDown={(event) => {
         event.preventDefault();
       }}


### PR DESCRIPTION
## What Changed

- Prevent command menu pointer interactions from blurring the web composer.
- Restore native editor focus after selecting a skill, command, or file.
- Apply the native fix to existing threads and new task drafts.

## Why

Selecting an item from the composer menu could dismiss the keyboard and require another tap before typing could continue. Preventing the initial blur on web and explicitly restoring focus on native keeps the interaction consistent across both surfaces.

## UI Changes

No visual changes. The composer now remains focused after a menu selection.

Fixes #10956

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved composer command-menu behavior on mobile by restoring focus to the message editor after selecting an option.
  - Prevented command-menu interactions on web from unexpectedly moving focus away from the composer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->