### PR TITLE
perf(shared): reuse validated Windows executable lookups

### DIFF
--- a/packages/shared/src/shell.spawn.test.ts
+++ b/packages/shared/src/shell.spawn.test.ts
@@ -1,0 +1,84 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import { it } from "@effect/vitest";
+import { afterEach, expect, vi } from "vite-plus/test";
+import * as Effect from "effect/Effect";
+import { HostProcessPlatform } from "./hostProcess.ts";
+import { resolveSpawnCommand } from "./shell.ts";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return { ...original, statSync: vi.fn(original.statSync) };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const mockExecutables = (paths: Set<string>) =>
+  vi.mocked(NodeFS.statSync).mockImplementation((path) => {
+    if (!paths.has(String(path))) throw new Error("ENOENT");
+    return { isFile: () => true } as NodeFS.Stats;
+  });
+
+it.effect("reuses a Windows PATH scan while validating the selected executable", () =>
+  Effect.gen(function* () {
+    const paths = new Set(["C:\\tools\\cache-probe.exe"]);
+    const stat = mockExecutables(paths);
+    const env = { PATH: "C:\\missing;C:\\tools", PATHEXT: ".EXE;.CMD" };
+    const first = yield* resolveSpawnCommand("cache-probe", ["one"], { env });
+    expect(first.command).toBe("C:\\tools\\cache-probe.exe");
+    expect(stat.mock.calls.length).toBeGreaterThan(1);
+    stat.mockClear();
+    const second = yield* resolveSpawnCommand("cache-probe", ["two"], { env });
+    expect(second).toEqual({ command: first.command, args: ["two"], shell: false });
+    expect(stat.mock.calls.map(([path]) => path)).toEqual([first.command]);
+
+    paths.delete(first.command);
+    paths.add("C:\\missing\\cache-probe.cmd");
+    const replacement = yield* resolveSpawnCommand("cache-probe", [], { env });
+    expect(replacement.shell).toBe(true);
+    expect(replacement.command).toContain("cache-probe.cmd");
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);
+
+it.effect("expires Windows spawn scans so newly preferred executables are discovered", () =>
+  Effect.gen(function* () {
+    const now = vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const paths = new Set(["C:\\second\\expiring-probe.exe"]);
+    mockExecutables(paths);
+    const env = { PATH: "C:\\first;C:\\second", PATHEXT: ".EXE" };
+    expect((yield* resolveSpawnCommand("expiring-probe", [], { env })).command).toBe(
+      "C:\\second\\expiring-probe.exe",
+    );
+    paths.add("C:\\first\\expiring-probe.exe");
+    now.mockReturnValue(11_001);
+    expect((yield* resolveSpawnCommand("expiring-probe", [], { env })).command).toBe(
+      "C:\\first\\expiring-probe.exe",
+    );
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);
+
+it.effect("does not cache missing commands or share scans across PATH and PATHEXT", () =>
+  Effect.gen(function* () {
+    const paths = new Set<string>();
+    mockExecutables(paths);
+    const env = { PATH: "C:\\one", PATHEXT: ".EXE" };
+    expect((yield* resolveSpawnCommand("environment-probe", [], { env })).command).toBe(
+      "environment-probe",
+    );
+    paths.add("C:\\one\\environment-probe.exe");
+    expect((yield* resolveSpawnCommand("environment-probe", [], { env })).command).toBe(
+      "C:\\one\\environment-probe.exe",
+    );
+    paths.add("C:\\two\\environment-probe.exe");
+    expect(
+      (yield* resolveSpawnCommand("environment-probe", [], { env: { ...env, PATH: "C:\\two" } }))
+        .command,
+    ).toBe("C:\\two\\environment-probe.exe");
+    paths.add("C:\\one\\environment-probe.cmd");
+    expect(
+      (yield* resolveSpawnCommand("environment-probe", [], {
+        env: { ...env, PATHEXT: ".CMD;.EXE" },
+      })).shell,
+    ).toBe(true);
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -92,6 +92,15 @@ export type SpawnExecutableResolver = (
   env: NodeJS.ProcessEnv,
 ) => string | undefined;
 
+// Spawns often resolve the same CLI several times in one operation. Retain
+// positive PATH scans briefly, but check the selected file on every cache hit.
+const spawnExecutableCache = new Map<
+  string,
+  { readonly path: string; readonly expiresAt: number }
+>();
+const SPAWN_EXECUTABLE_CACHE_TTL_MS = 1_000;
+const SPAWN_EXECUTABLE_CACHE_MAX_ENTRIES = 512;
+
 function resolveSpawnExecutableWithNode(
   command: string,
   platform: NodeJS.Platform,
@@ -121,12 +130,36 @@ function resolveSpawnExecutableWithNode(
     return candidates.find(isExecutable);
   }
 
+  const cacheKey = JSON.stringify([
+    platform,
+    readEnvPath(env),
+    windowsPathExtensions,
+    command,
+    process.cwd(),
+  ]);
+  const now = performance.now();
+  const cached = spawnExecutableCache.get(cacheKey);
+  if (cached !== undefined) {
+    if (cached.expiresAt > now && isExecutable(cached.path)) return cached.path;
+    spawnExecutableCache.delete(cacheKey);
+  }
+
   for (const pathEntry of (readEnvPath(env) ?? "").split(pathDelimiterForPlatform(platform))) {
     const normalizedPathEntry = stripWrappingQuotes(pathEntry.trim());
     if (normalizedPathEntry.length === 0) continue;
     for (const candidate of candidates) {
       const candidatePath = path.join(normalizedPathEntry, candidate);
-      if (isExecutable(candidatePath)) return candidatePath;
+      if (isExecutable(candidatePath)) {
+        if (spawnExecutableCache.size >= SPAWN_EXECUTABLE_CACHE_MAX_ENTRIES) {
+          const oldest = spawnExecutableCache.keys().next().value;
+          if (oldest !== undefined) spawnExecutableCache.delete(oldest);
+        }
+        spawnExecutableCache.set(cacheKey, {
+          path: candidatePath,
+          expiresAt: now + SPAWN_EXECUTABLE_CACHE_TTL_MS,
+        });
+        return candidatePath;
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
Every Windows process launch walks PATH × PATHEXT again, including repeated `git` and provider commands within one operation.

Cache successful executable lookups for one second, keyed by command, platform, PATH, PATHEXT, and working directory. Each hit still checks the chosen file; removing it immediately triggers a fresh scan. Explicit paths and missing commands bypass caching, and the cache is bounded to 512 entries. A new higher-priority executable is discovered after the short TTL.

Addresses the repeated PATH scans in #11221. Git launcher selection is outside this change.

Validation: 36 shared shell tests pass. The regression reduces a repeated fixture lookup from six stat calls to one and covers removed executables, environment changes, expiry, and immediate discovery after a miss. It fails against the original resolver. Shared-package typecheck and targeted lint pass; Windows wall-clock performance was not measured locally.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Windows command resolution by caching recent executable lookups.
  * Revalidates cached results and refreshes them when executables change or cache entries expire.
  * Limits cached lookup data to prevent unbounded growth.

* **Bug Fixes**
  * Ensures command resolution remains accurate when PATH or PATHEXT settings differ.
  * Falls back to `.cmd` commands when a previously detected executable is no longer available.

* **Tests**
  * Added coverage for Windows-specific command resolution and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->