### PR TITLE
perf(server): reuse origin metadata within PR lookups

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1014,6 +1014,25 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("reads a shared origin only once when verifying a warm branch PR lookup", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/origin-read"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/origin-read"]);
+      const gitConfigReads: string[] = [];
+      const { manager, ghCalls } = yield* makeManager({ gitConfigReads });
+      yield* manager.branchPullRequest({ cwd: repoDir, branch: "feature/origin-read" });
+      gitConfigReads.length = 0;
+      const previousGhCalls = ghCalls.length;
+      yield* manager.branchPullRequest({ cwd: repoDir, branch: "feature/origin-read" });
+      expect(gitConfigReads.filter((key) => key === "remote.origin.url")).toHaveLength(1);
+      expect(ghCalls).toHaveLength(previousGhCalls);
+    }),
+  );
+
   it.effect("turn-end refresh finds a new PR and keeps known PRs cached", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1315,17 +1315,20 @@ export const make = Effect.gen(function* () {
     };
   });
 
+  const resolveHeadAndOriginRepositories = (cwd: string, remoteName: string | null) => {
+    const origin = resolveRemoteRepositoryContext(cwd, "origin");
+    return remoteName === "origin"
+      ? origin.pipe(Effect.map((repository) => [repository, repository] as const))
+      : Effect.all([resolveRemoteRepositoryContext(cwd, remoteName), origin], {
+          concurrency: "unbounded",
+        });
+  };
+
   const resolvePrLookupRepositoryIdentity = Effect.fn("resolvePrLookupRepositoryIdentity")(
     function* (cwd: string, branch: string, remoteNameOverride?: string) {
       const remoteName =
         remoteNameOverride ?? (yield* readConfigValueNullable(cwd, `branch.${branch}.remote`));
-      const [headRemote, targetRemote] = yield* Effect.all(
-        [
-          resolveRemoteRepositoryContext(cwd, remoteName),
-          resolveRemoteRepositoryContext(cwd, "origin"),
-        ],
-        { concurrency: "unbounded" },
-      );
+      const [headRemote, targetRemote] = yield* resolveHeadAndOriginRepositories(cwd, remoteName);
       return {
         remoteName,
         headRemoteUrlKey:
@@ -1349,12 +1352,9 @@ export const make = Effect.gen(function* () {
     const shouldProbeLocalBranchSelector =
       headBranchFromUpstream.length === 0 || headBranch === details.branch;
 
-    const [remoteRepository, originRepository] = yield* Effect.all(
-      [
-        resolveRemoteRepositoryContext(cwd, remoteName),
-        resolveRemoteRepositoryContext(cwd, "origin"),
-      ],
-      { concurrency: "unbounded" },
+    const [remoteRepository, originRepository] = yield* resolveHeadAndOriginRepositories(
+      cwd,
+      remoteName,
     );
 
     const isCrossRepository =


### PR DESCRIPTION
Repeated PR lookups resolve the head remote and origin independently, even when both are `origin`. This spawns two identical Git config reads during cache verification.

Reuse the origin repository result within each lookup when it is also the head remote. Distinct remotes still resolve concurrently, and every request still checks current remote identity. This addresses the duplicate-read portion of #11220.

Validation: all 113 GitManager tests pass, including a regression that fails before the fix (two origin reads) and passes afterward (one). Server typecheck and targeted lint pass.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeated pull request lookups for the same branch by reusing cached repository data.
  * Reduced redundant remote repository checks during branch and pull request resolution.

* **Tests**
  * Added regression coverage to verify cached data is reused for repeated lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->