### PR TITLE
fix(server): preserve spaces in Git remote URLs

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1794,6 +1794,31 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect("ensureRemote preserves local remote URLs containing spaces", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const path = yield* Path.Path;
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const existingUrl = path.join(cwd, "local remote (fetch).git");
+        const newUrl = path.join(cwd, "another remote.git");
+        yield* git(cwd, ["remote", "add", "origin", existingUrl]);
+        yield* git(cwd, ["remote", "set-url", "--push", "origin", newUrl]);
+
+        assert.equal(
+          yield* driver.ensureRemote({ cwd, preferredName: "origin", url: existingUrl }),
+          "origin",
+        );
+        assert.equal(
+          yield* driver.ensureRemote({ cwd, preferredName: "origin", url: newUrl }),
+          "origin-1",
+        );
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin"]), existingUrl);
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin-1"]), newUrl);
+        assert.equal(yield* git(cwd, ["remote", "get-url", "--push", "origin"]), newUrl);
+      }),
+    );
+
     it.effect("ensureRemote reuses an existing remote across ssh/https transport variants", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1800,7 +1800,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const path = yield* Path.Path;
         yield* initRepoWithCommit(cwd);
         const driver = yield* GitVcsDriver.GitVcsDriver;
-        const existingUrl = path.join(cwd, "local remote (fetch).git");
+        const existingUrl = " local remote (fetch).git ";
         const newUrl = path.join(cwd, "another remote.git");
         yield* git(cwd, ["remote", "add", "origin", existingUrl]);
         yield* git(cwd, ["remote", "set-url", "--push", "origin", newUrl]);
@@ -1813,7 +1813,10 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
           yield* driver.ensureRemote({ cwd, preferredName: "origin", url: newUrl }),
           "origin-1",
         );
-        assert.equal(yield* git(cwd, ["remote", "get-url", "origin"]), existingUrl);
+        assert.equal(
+          yield* git(cwd, ["config", "--null", "--get-regexp", "^remote\\.origin\\.url$"]),
+          `remote.origin.url\n${existingUrl}\0`,
+        );
         assert.equal(yield* git(cwd, ["remote", "get-url", "origin-1"]), newUrl);
         assert.equal(yield* git(cwd, ["remote", "get-url", "--push", "origin"]), newUrl);
       }),

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1794,6 +1794,32 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect.each(["\n", "\r\n"])(
+      "ensureRemote reads remote output with %j line endings",
+      (ending) =>
+        Effect.gen(function* () {
+          const url = "/repos/local remote.git";
+          const spawner = ChildProcessSpawner.make((command) =>
+            Effect.sync(() => {
+              assert.ok(ChildProcess.isStandardCommand(command));
+              if (command.args.includes("rev-parse")) return makeNonRepositoryHandle();
+              assert.deepEqual(command.args.slice(-2), ["remote", "-v"]);
+              return makeSuccessfulHandle(
+                `origin\t${url} (fetch)${ending}origin\t${url} (push)${ending}`,
+              );
+            }),
+          );
+          const driver = yield* makeGitVcsDriverCore().pipe(
+            Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+            Effect.provide(ServerConfigLayer),
+          );
+          assert.equal(
+            yield* driver.ensureRemote({ cwd: "/repo", preferredName: "fork", url }),
+            "origin",
+          );
+        }),
+    );
+
     it.effect("ensureRemote preserves local remote URLs containing spaces", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -305,7 +305,7 @@ function sanitizeRemoteName(value: string): string {
 
 function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   const remotes = new Map<string, string>();
-  for (const line of stdout.split("\n")) {
+  for (const line of stdout.split(/\r?\n/)) {
     const match = /^(\S+)\t(.+) \((fetch|push)\)$/.exec(line);
     if (!match) continue;
     const [, remoteName = "", remoteUrl = "", direction = ""] = match;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -306,9 +306,7 @@ function sanitizeRemoteName(value: string): string {
 function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   const remotes = new Map<string, string>();
   for (const line of stdout.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.length === 0) continue;
-    const match = /^(\S+)\s+(.+)\s+\((fetch|push)\)$/.exec(trimmed);
+    const match = /^(\S+)\t(.+) \((fetch|push)\)$/.exec(line);
     if (!match) continue;
     const [, remoteName = "", remoteUrl = "", direction = ""] = match;
     if (direction !== "fetch" || remoteName.length === 0 || remoteUrl.length === 0) {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -308,7 +308,7 @@ function parseRemoteFetchUrls(stdout: string): Map<string, string> {
   for (const line of stdout.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.length === 0) continue;
-    const match = /^(\S+)\s+(\S+)\s+\((fetch|push)\)$/.exec(trimmed);
+    const match = /^(\S+)\s+(.+)\s+\((fetch|push)\)$/.exec(trimmed);
     if (!match) continue;
     const [, remoteName = "", remoteUrl = "", direction = ""] = match;
     if (direction !== "fetch" || remoteName.length === 0 || remoteUrl.length === 0) {


### PR DESCRIPTION
A local Git remote URL containing spaces is omitted when T3 parses `git remote -v`. Reusing that remote then fails with “remote origin already exists,” and adding a different remote cannot choose a free name.

Preserve spaces in the URL field while distinguishing fetch and push entries, accepting both LF and CRLF line endings. The regression uses real Git remotes to verify reuse, collision suffixing, and a separate push URL without changing the existing remote.

Validation: all 67 GitVcsDriverCore tests, server typecheck, and targeted lint pass. The new regression fails before the parser fix. Follow-up: all 12 remote-operation tests, including LF/CRLF cases, pass with server typecheck and targeted lint.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git remote information across different line-ending formats.
  * Preserved spaces in remote URLs during parsing.
* **Tests**
  * Added coverage for LF and CRLF output, URLs containing spaces, suffixed remotes, and push URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->