### PR TITLE
fix(server): resolve Windows tools in the child working directory

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -278,7 +278,9 @@ const publishCmd = Command.make(
             yield* Effect.log("[cli] Applied package metadata and publish icon overrides");
 
             const args = createVpPmPublishArgs(config);
-            const spawnCommand = yield* resolveSpawnCommand("vp", ["pm", ...args]);
+            const spawnCommand = yield* resolveSpawnCommand("vp", ["pm", ...args], {
+              cwd: repoRoot,
+            });
 
             yield* Effect.log(`[cli] Running: vp pm ${args.join(" ")}`);
             yield* runCommand(

--- a/apps/server/src/cli/triage.ts
+++ b/apps/server/src/cli/triage.ts
@@ -260,10 +260,14 @@ export const triageCommand = Command.make("triage", {
       }
 
       const model = Option.getOrUndefined(flags.model);
-      const spawnSpec = yield* resolveSpawnCommand(selected.command, [
-        ...(model === undefined ? [] : ["--model", model]),
-        buildTriageLaunchPrompt(promptFilePath),
-      ]);
+      const spawnSpec = yield* resolveSpawnCommand(
+        selected.command,
+        [
+          ...(model === undefined ? [] : ["--model", model]),
+          buildTriageLaunchPrompt(promptFilePath),
+        ],
+        { cwd: scratchDir },
+      );
       yield* Console.log(`Starting ${selected.label}. It will ask what went wrong.\n`);
       const exitCode = yield* runInteractiveSession({ ...spawnSpec, cwd: scratchDir });
       if (exitCode !== 0) {

--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -19,6 +19,7 @@ type ChildProcessCommand = {
   readonly args: ReadonlyArray<string>;
   readonly options: {
     readonly shell?: boolean | string;
+    readonly cwd?: string;
   };
 };
 
@@ -161,6 +162,29 @@ describe("runProcess", () => {
       }),
     );
   });
+
+  it.effect.each([
+    { cwd: "C:\\project", spawnCwd: undefined, expected: "C:\\project" },
+    { cwd: "C:\\logical", spawnCwd: "C:\\actual", expected: "C:\\actual" },
+  ])(
+    "resolves Windows tools in the execution directory $expected",
+    ({ cwd, spawnCwd, expected }) => {
+      const spawner = makeSpawner((command) =>
+        Effect.sync(() => {
+          expect(command.command).toBe(`${expected}\\tool.exe`);
+          expect(command.options.cwd).toBe(expected);
+          return makeHandle({ stdout: "project tool" });
+        }),
+      );
+      return runWith(spawner)({ command: "tool", args: [], cwd, spawnCwd }).pipe(
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.provideService(SpawnExecutableResolution, (_command, _platform, _env, directory) =>
+          directory === expected ? `${directory}\\tool.exe` : undefined,
+        ),
+        Effect.map((result) => expect(result.stdout).toBe("project tool")),
+      );
+    },
+  );
 
   it.effect("preserves resolved spawn context and cause", () =>
     Effect.gen(function* () {

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -291,11 +291,10 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
   const outputMode = input.outputMode ?? "error";
   const truncatedMarker = input.truncatedMarker ?? "";
   const extendEnv = input.env !== undefined;
-  const spawnCommand = yield* resolveSpawnCommand(
-    input.command,
-    input.args,
-    input.env === undefined ? {} : { env: input.env, extendEnv },
-  );
+  const spawnCommand = yield* resolveSpawnCommand(input.command, input.args, {
+    cwd: input.spawnCwd ?? input.cwd,
+    ...(input.env === undefined ? {} : { env: input.env, extendEnv }),
+  });
 
   const child = yield* spawner
     .spawn(

--- a/apps/server/src/provider/Drivers/GrokSkills.ts
+++ b/apps/server/src/provider/Drivers/GrokSkills.ts
@@ -104,6 +104,7 @@ export const discoverGrokSkills = Effect.fn("discoverGrokSkills")(function* (
   const command = grokSettings.binaryPath || "grok";
   const inspectResult = yield* Effect.gen(function* () {
     const spawnCommand = yield* resolveSpawnCommand(command, ["inspect", "--json"], {
+      cwd,
       env: environment,
     });
     return yield* spawnAndCollect(

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -379,7 +379,7 @@ export const withCodexAppServerClient = Effect.fn("withCodexAppServerClient")(fu
   const spawnCommand = yield* resolveSpawnCommand(
     input.binaryPath,
     codexAppServerArgs(input.launchArgs),
-    { env: environment, extendEnv: true },
+    { env: environment, extendEnv: true, cwd: input.cwd },
   );
   const child = yield* spawner
     .spawn(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -1317,6 +1317,7 @@ export const makeCodexSessionRuntime = (
     const extendEnv = options.environment === undefined;
     const appServerArgs = codexSessionAppServerArgs(options.appServerArgs, options.launchArgs);
     const spawnCommand = yield* resolveSpawnCommand(options.binaryPath, appServerArgs, {
+      cwd: options.cwd,
       env,
       extendEnv,
     });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -426,6 +426,7 @@ export const make = (
       );
 
     const spawnCommand = yield* resolveSpawnCommand(options.spawn.command, options.spawn.args, {
+      cwd: options.spawn.cwd,
       ...(options.spawn.env ? { env: options.spawn.env } : {}),
       extendEnv: options.spawn.extendEnv ?? true,
     });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -568,12 +568,21 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const netService = yield* NetService.NetService;
   const hostPlatform = yield* HostProcessPlatform;
-  const resolveCommand = (command: string, args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv) =>
-    resolveSpawnCommand(command, args, env ? { env } : {});
+  const resolveCommand = (
+    command: string,
+    args: ReadonlyArray<string>,
+    env?: NodeJS.ProcessEnv,
+    cwd?: string,
+  ) => resolveSpawnCommand(command, args, { cwd, ...(env ? { env } : {}) });
 
   const runOpenCodeCommand: OpenCodeRuntimeShape["runOpenCodeCommand"] = (input) =>
     Effect.gen(function* () {
-      const spawnCommand = yield* resolveCommand(input.binaryPath, input.args, input.environment);
+      const spawnCommand = yield* resolveCommand(
+        input.binaryPath,
+        input.args,
+        input.environment,
+        input.cwd,
+      );
       const child = yield* spawner.spawn(
         ChildProcess.make(spawnCommand.command, spawnCommand.args, {
           detached: hostPlatform !== "win32",

--- a/apps/server/src/textGeneration/ClaudeTextGeneration.ts
+++ b/apps/server/src/textGeneration/ClaudeTextGeneration.ts
@@ -217,7 +217,7 @@ export const makeClaudeTextGeneration = Effect.fn("makeClaudeTextGeneration")(fu
           "--permission-mode",
           "dontAsk",
         ],
-        { env: claudeEnvironment },
+        { env: claudeEnvironment, cwd: workingDirectory },
       );
       const command = ChildProcess.make(spawnCommand.command, spawnCommand.args, {
         env: claudeEnvironment,

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -214,7 +214,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
           ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
           "-",
         ],
-        { env: resolvedEnvironment },
+        { env: resolvedEnvironment, cwd },
       );
       const command = ChildProcess.make(spawnCommand.command, spawnCommand.args, {
         env: {

--- a/packages/shared/src/shell.spawn-cwd.test.ts
+++ b/packages/shared/src/shell.spawn-cwd.test.ts
@@ -1,0 +1,68 @@
+// @effect-diagnostics nodeBuiltinImport:off - exercise native executable lookup against controlled Windows paths.
+import * as NodeFS from "node:fs";
+import { it } from "@effect/vitest";
+import { afterEach, expect, vi } from "vite-plus/test";
+import * as Effect from "effect/Effect";
+import { HostProcessPlatform } from "./hostProcess.ts";
+import { resolveSpawnCommand } from "./shell.ts";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return { ...original, statSync: vi.fn(original.statSync) };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const mockExecutables = (paths: ReadonlyArray<string>) =>
+  vi.mocked(NodeFS.statSync).mockImplementation((path) => {
+    if (!paths.includes(String(path))) throw new Error("ENOENT");
+    return { isFile: () => true } as NodeFS.Stats;
+  });
+
+it.effect("resolves relative Windows commands from the child directory", () =>
+  Effect.gen(function* () {
+    mockExecutables(["C:\\project\\bin\\tool.cmd"]);
+    const result = yield* resolveSpawnCommand(".\\bin\\tool", ["hello & goodbye"], {
+      cwd: "C:\\project",
+      env: { PATH: "", PATHEXT: ".EXE;.CMD" },
+    });
+    expect(result).toEqual({
+      command: '^"C:\\project\\bin\\tool.cmd^"',
+      args: ['^"hello^ ^&^ goodbye^"'],
+      shell: true,
+    });
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);
+
+it.effect("resolves relative PATH entries separately for each child directory", () =>
+  Effect.gen(function* () {
+    mockExecutables([
+      "C:\\one\\node_modules\\.bin\\tool.exe",
+      "C:\\two\\node_modules\\.bin\\tool.cmd",
+    ]);
+    const env = { PATH: "node_modules\\.bin", PATHEXT: ".EXE;.CMD" };
+    const first = yield* resolveSpawnCommand("tool", [], { cwd: "C:\\one", env });
+    const second = yield* resolveSpawnCommand("tool", [], { cwd: "C:\\two", env });
+    expect(first).toEqual({
+      command: "C:\\one\\node_modules\\.bin\\tool.exe",
+      args: [],
+      shell: false,
+    });
+    expect(second).toEqual({
+      command: '^"C:\\two\\node_modules\\.bin\\tool.cmd^"',
+      args: [],
+      shell: true,
+    });
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);
+
+it.effect("keeps absolute Windows executable paths independent of the child directory", () =>
+  Effect.gen(function* () {
+    mockExecutables(["C:\\tools\\tool.exe"]);
+    const result = yield* resolveSpawnCommand("C:\\tools\\tool.exe", ["plain"], {
+      cwd: "D:\\project",
+      env: { PATH: "", PATHEXT: ".EXE;.CMD" },
+    });
+    expect(result).toEqual({ command: "C:\\tools\\tool.exe", args: ["plain"], shell: false });
+  }).pipe(Effect.provideService(HostProcessPlatform, "win32")),
+);

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -90,12 +90,14 @@ export type SpawnExecutableResolver = (
   command: string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
+  cwd?: string | undefined,
 ) => string | undefined;
 
 function resolveSpawnExecutableWithNode(
   command: string,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
+  cwd: string = process.cwd(),
 ): string | undefined {
   const path = platform === "win32" ? NodePath.win32 : NodePath.posix;
   const windowsPathExtensions = platform === "win32" ? resolveWindowsPathExtensions(env) : [];
@@ -118,14 +120,14 @@ function resolveSpawnExecutableWithNode(
   };
 
   if (command.includes("/") || command.includes("\\")) {
-    return candidates.find(isExecutable);
+    return candidates.map((candidate) => path.resolve(cwd, candidate)).find(isExecutable);
   }
 
   for (const pathEntry of (readEnvPath(env) ?? "").split(pathDelimiterForPlatform(platform))) {
     const normalizedPathEntry = stripWrappingQuotes(pathEntry.trim());
     if (normalizedPathEntry.length === 0) continue;
     for (const candidate of candidates) {
-      const candidatePath = path.join(normalizedPathEntry, candidate);
+      const candidatePath = path.resolve(cwd, normalizedPathEntry, candidate);
       if (isExecutable(candidatePath)) return candidatePath;
     }
   }
@@ -629,7 +631,7 @@ export const resolveCommandPath = Effect.fn("shell.resolveCommandPath")(function
 export const resolveSpawnCommand = Effect.fn("shell.resolveSpawnCommand")(function* (
   command: string,
   args: ReadonlyArray<string>,
-  options: CommandAvailabilityOptions = {},
+  options: CommandAvailabilityOptions & { readonly cwd?: string | undefined } = {},
 ): Effect.fn.Return<ResolvedSpawnCommand> {
   const platform = yield* HostProcessPlatform;
   if (platform !== "win32") {
@@ -644,7 +646,7 @@ export const resolveSpawnCommand = Effect.fn("shell.resolveSpawnCommand")(functi
         ? { ...hostEnvironment, ...options.env }
         : options.env;
   const resolveExecutable = yield* SpawnExecutableResolution;
-  const resolvedCommand = resolveExecutable(command, platform, env) ?? command;
+  const resolvedCommand = resolveExecutable(command, platform, env, options.cwd) ?? command;
   const extension = NodePath.win32.extname(resolvedCommand).toLowerCase();
   if (extension !== ".cmd" && extension !== ".bat") {
     return { command: resolvedCommand, args: [...args], shell: false };


### PR DESCRIPTION
Windows executable discovery currently resolves relative commands and relative PATH entries from the server directory, even when the child will run elsewhere. A project-local command such as `.\bin\tool` can therefore miss its `.cmd` shim or resolve to another project's executable.

Pass the execution directory into spawn resolution and resolve candidates from that directory. Propagate it through provider sessions, text generation, triage, publishing, and the shared process runner; `spawnCwd` takes precedence over the logical working directory. Existing absolute paths and POSIX launch behavior remain supported.

Validation: 36 shared shell tests and 49 server tests pass, with failing-before regressions for relative commands and two different project PATHs. Shared/server typechecks and targeted lint pass. Windows path and shim behavior is tested with controlled filesystem inputs; no Windows runtime was available.

Merge note: #11388 changes the same executable resolver. When combining these PRs, its cache key must use the child working directory introduced here. The two-project PATH regression checks that distinction.

Model: GPT-6
Harness: Codex in T3 Code
