### PR TITLE
fix(server): keep distinct local Git remotes separate

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1794,6 +1794,31 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect("ensureRemote keeps local repositories with different suffixes separate", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const path = yield* Path.Path;
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const firstUrl = path.join(cwd, "Repo");
+        const secondUrl = path.join(cwd, "Repo.git");
+        yield* git(cwd, ["init", "--bare", firstUrl]);
+        yield* git(cwd, ["init", "--bare", secondUrl]);
+        yield* git(cwd, ["remote", "add", "origin", firstUrl]);
+
+        assert.equal(
+          yield* driver.ensureRemote({ cwd, preferredName: "origin", url: secondUrl }),
+          "origin-1",
+        );
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin"]), firstUrl);
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin-1"]), secondUrl);
+        assert.equal(
+          yield* driver.ensureRemote({ cwd, preferredName: "again", url: secondUrl }),
+          "origin-1",
+        );
+      }),
+    );
+
     it.effect("ensureRemote reuses an existing remote across ssh/https transport variants", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1794,6 +1794,24 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("remote operations", () => {
+    it.effect("ensureRemote keeps drive-relative Windows remote paths separate", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const firstUrl = "C:Repos\\Repo";
+        const secondUrl = "C:Repos\\Repo.git";
+        yield* git(cwd, ["remote", "add", "origin", firstUrl]);
+
+        assert.equal(
+          yield* driver.ensureRemote({ cwd, preferredName: "origin", url: secondUrl }),
+          "origin-1",
+        );
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin"]), firstUrl);
+        assert.equal(yield* git(cwd, ["remote", "get-url", "origin-1"]), secondUrl);
+      }),
+    );
+
     it.effect("ensureRemote keeps local repositories with different suffixes separate", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -12,6 +12,20 @@ import {
 } from "./git.ts";
 
 describe("normalizeGitRemoteUrl", () => {
+  it.each([
+    ["/repos/Repo", "/repos/Repo.git"],
+    ["/repos/Repo.git", "/repos/repo.git"],
+    ["Repo", "Repo.git"],
+    ["./Repo.git", "./repo.git"],
+    ["C:\\Repos\\Repo", "C:\\Repos\\Repo.git"],
+    ["file:///repos/Repo", "file:///repos/Repo.git"],
+    [" Repo.git", "Repo.git"],
+  ])("keeps distinct local remote paths %s and %s", (left, right) => {
+    expect(normalizeGitRemoteUrl(left)).toBe(left);
+    expect(normalizeGitRemoteUrl(right)).toBe(right);
+    expect(normalizeGitRemoteUrl(left)).not.toBe(normalizeGitRemoteUrl(right));
+  });
+
   it("canonicalizes equivalent GitHub remotes across protocol variants", () => {
     expect(normalizeGitRemoteUrl("git@github.com:T3Tools/T3Code.git")).toBe(
       "github.com/t3tools/t3code",

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -16,6 +16,8 @@ describe("normalizeGitRemoteUrl", () => {
     ["/repos/Repo", "/repos/Repo.git"],
     ["/repos/Repo.git", "/repos/repo.git"],
     ["Repo", "Repo.git"],
+    ["repos/team:one/Repo.git", "repos/team:one/repo"],
+    ["repos\\team:one\\Repo.git", "repos\\team:one\\repo"],
     ["./Repo.git", "./repo.git"],
     ["C:\\Repos\\Repo", "C:\\Repos\\Repo.git"],
     ["file:///repos/Repo", "file:///repos/Repo.git"],

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -16,6 +16,8 @@ describe("normalizeGitRemoteUrl", () => {
     ["/repos/Repo", "/repos/Repo.git"],
     ["/repos/Repo.git", "/repos/repo.git"],
     ["Repo", "Repo.git"],
+    ["C:Repos\\Repo", "C:Repos\\Repo.git"],
+    ["C:Repos/Repo", "C:Repos/Repo.git"],
     ["repos/team:one/Repo.git", "repos/team:one/repo"],
     ["repos\\team:one\\Repo.git", "repos\\team:one\\repo"],
     ["./Repo.git", "./repo.git"],

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -112,6 +112,11 @@ export function isTemporaryWorktreeBranch(refName: string): boolean {
  * Normalize a git remote URL into a stable comparison key.
  */
 export function normalizeGitRemoteUrl(value: string): string {
+  // Filesystem paths can name distinct repositories by case, whitespace, or a
+  // .git suffix. Hosted repository aliases must not collapse those paths.
+  if (!value.includes(":") || /^(?:[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|file:\/\/)/i.test(value)) {
+    return value;
+  }
   const normalized = value
     .trim()
     .replace(/\/+$/g, "")

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -114,7 +114,13 @@ export function isTemporaryWorktreeBranch(refName: string): boolean {
 export function normalizeGitRemoteUrl(value: string): string {
   // Filesystem paths can name distinct repositories by case, whitespace, or a
   // .git suffix. Hosted repository aliases must not collapse those paths.
-  if (!value.includes(":") || /^(?:[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|file:\/\/)/i.test(value)) {
+  const colon = value.indexOf(":");
+  const separator = value.search(/[\\/]/);
+  if (
+    colon === -1 ||
+    (separator !== -1 && separator < colon) ||
+    /^(?:[a-z]:[\\/]|file:\/\/)/i.test(value)
+  ) {
     return value;
   }
   const normalized = value

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -119,7 +119,7 @@ export function normalizeGitRemoteUrl(value: string): string {
   if (
     colon === -1 ||
     (separator !== -1 && separator < colon) ||
-    /^(?:[a-z]:[\\/]|file:\/\/)/i.test(value)
+    /^(?:[a-z]:|file:\/\/)/i.test(value)
   ) {
     return value;
   }


### PR DESCRIPTION
Repository comparison currently applies hosted-URL normalization to local Git remotes: it lowercases their paths and removes `.git`. Two separate local repositories such as `/repos/Repo` and `/repos/Repo.git` consequently share a key, so `ensureRemote` can silently reuse the wrong remote.

Keep filesystem remote paths literal, including POSIX, Windows, relative, and file-URL forms. Hosted GitHub/GitLab transport aliases still normalize as before. The integration regression creates both bare repositories and verifies that remote selection keeps them separate.

Validation: 29 shared Git tests and the initial 270 server tests covering remote operations, GitManager, repository identity, and session scanning pass. Shared/server typechecks and targeted lint pass. The remote-selection regression fails before the fix. Follow-up coverage for drive-relative Windows paths passes all 11 remote-operation tests; shared/server typechecks and targeted lint pass.

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Windows drive-relative Git paths, including paths using either slash style.
  - Local repository paths are now preserved without unwanted changes such as removing `.git` or altering letter case.
  - Distinct local remotes are correctly recognized and retained, with additional remotes assigned unique names when needed.
  - Existing matching remotes continue to be reused instead of creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->