### PR TITLE
fix(shared): decode Git remote config escapes correctly

### DIFF
--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -53,6 +53,32 @@ describe("normalizeGitRemoteUrl", () => {
 });
 
 describe("parseOriginUrlFromGitConfig", () => {
+  it.each([
+    { value: String.raw`C:\\remote\\`, expected: "C:\\remote\\" },
+    { value: String.raw`/repos/tab\tname.git`, expected: "/repos/tab\tname.git" },
+    { value: String.raw`/repos/line\nname.git`, expected: "/repos/line\nname.git" },
+    { value: String.raw`/repos/back\bspace.git`, expected: "/repos/back\bspace.git" },
+    { value: '" local remote.git "', expected: " local remote.git " },
+    { value: String.raw`"a\"b\\c;d#e" # comment`, expected: 'a"b\\c;d#e' },
+    { value: 'repo  ""', expected: "repo  " },
+  ])("decodes the Git-written value $value without changing its path", ({ value, expected }) => {
+    const config = `[remote "origin"]\n\turl = ${value}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n`;
+    expect(parseOriginUrlFromGitConfig(config)).toBe(expected);
+  });
+
+  it("does not continue a comment ending in a backslash", () => {
+    expect(
+      parseOriginUrlFromGitConfig('# comment\\\n[remote "origin"]\nurl = /repos/Repo.git\n'),
+    ).toBe("/repos/Repo.git");
+  });
+
+  it.each([String.raw`/repos/invalid\q`, '"unterminated'])(
+    "does not invent a remote URL from malformed value %s",
+    (value) => {
+      expect(parseOriginUrlFromGitConfig(`[remote "origin"]\nurl = ${value}\n`)).toBeNull();
+    },
+  );
+
   it("reads the origin url and ignores other remotes", () => {
     const config = [
       "[core]",
@@ -99,7 +125,7 @@ describe("parseOriginUrlFromGitConfig", () => {
       parseOriginUrlFromGitConfig(
         '[remote "origin"]\n\turl = https://github.com/acme/\\\n\t\trepo.git\n',
       ),
-    ).toBe("https://github.com/acme/repo.git");
+    ).toBe("https://github.com/acme/\t\trepo.git");
   });
 
   it("falls back to the first remote when there is no origin", () => {

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -143,28 +143,75 @@ export function normalizeGitRemoteUrl(value: string): string {
   return normalized;
 }
 
-/**
- * Unquote a git config value: strip an inline `#` or `;` comment outside
- * quotes, then drop surrounding quotes and backslash escapes.
- */
-function parseGitConfigValue(raw: string): string {
-  let out = "";
+/** Join continued config lines without consuming escaped backslashes or comments. */
+function gitConfigLines(configText: string): string[] {
+  const lines: string[] = [];
+  const text = configText.replaceAll("\r\n", "\n");
+  let line = "";
   let quoted = false;
-  for (let index = 0; index < raw.length; index += 1) {
-    const char = raw[index]!;
-    if (char === "\\" && index + 1 < raw.length) {
-      out += raw[index + 1];
-      index += 1;
+  let comment = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]!;
+    if (char === "\n") {
+      lines.push(line);
+      line = "";
+      quoted = false;
+      comment = false;
       continue;
     }
-    if (char === '"') {
-      quoted = !quoted;
+    if (char === "\\" && !comment && index + 1 < text.length) {
+      const next = text[++index]!;
+      if (next !== "\n") line += char + next;
       continue;
     }
-    if (!quoted && (char === "#" || char === ";")) break;
-    out += char;
+    if (!comment && char === '"') quoted = !quoted;
+    if (!quoted && (char === "#" || char === ";")) comment = true;
+    line += char;
   }
-  return out.trim();
+  lines.push(line);
+  return lines;
+}
+
+/** Decode Git value escapes, retaining quoted whitespace but dropping trailing comments. */
+function parseGitConfigValue(raw: string): string | null {
+  let out = "";
+  let whitespace = "";
+  let quoted = false;
+  for (let index = 0; index < raw.length; index++) {
+    const char = raw[index]!;
+    if (!quoted && (char === "#" || char === ";")) break;
+    if (!quoted && (char === " " || char === "\t")) {
+      whitespace += char;
+      continue;
+    }
+    out += whitespace;
+    whitespace = "";
+    if (char === "\\") {
+      const next = raw[++index];
+      switch (next) {
+        case "n":
+          out += "\n";
+          break;
+        case "t":
+          out += "\t";
+          break;
+        case "b":
+          out += "\b";
+          break;
+        case '"':
+        case "\\":
+          out += next;
+          break;
+        default:
+          return null;
+      }
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else {
+      out += char;
+    }
+  }
+  return quoted ? null : out;
 }
 
 /**
@@ -176,9 +223,7 @@ export function parseOriginUrlFromGitConfig(configText: string): string | null {
   let section: string | null = null;
   let originUrl: string | null = null;
   let firstRemoteUrl: string | null = null;
-  // A trailing backslash continues the value on the next line.
-  const joined = configText.replace(/\\\r?\n[ \t]*/g, "");
-  for (const rawLine of joined.split(/\r?\n/)) {
+  for (const rawLine of gitConfigLines(configText)) {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) continue;
     // Both `[remote "origin"]` and the legacy `[remote.origin]` form, with an
@@ -197,7 +242,7 @@ export function parseOriginUrlFromGitConfig(configText: string): string | null {
     const match = /^url\s*=\s*(.*)$/i.exec(line);
     if (!match) continue;
     const url = parseGitConfigValue(match[1] ?? "");
-    if (url.length === 0) continue;
+    if (url === null || url.length === 0) continue;
     if (section === "origin") {
       originUrl ??= url;
     } else {


### PR DESCRIPTION
The session scanner's Git config parser treats the last backslash of an escaped Windows path as a line continuation. A Git-written `url = C:\\remote\\` can absorb the following fetch setting and produce the wrong repository URL. Escaped control characters and quoted edge spaces are decoded incorrectly as well.

Join only unescaped continuations outside comments, then decode Git's supported value escapes while retaining quoted whitespace. Malformed escapes and unterminated quotes are ignored. Continuation indentation is preserved, matching Git's parser.

Validation: 28 shared Git tests and 81 session-scanner tests pass; shared typecheck and targeted lint pass. Ten parser assertions fail before the change and pass afterward. Fixtures were checked against real `git config` output and the [Git config syntax](https://git-scm.com/docs/git-config#_syntax).

Model: GPT-6
Harness: Codex in T3 Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git configuration parsing for escaped characters, quoted values, comments, and continued lines.
  - Preserved meaningful whitespace in multi-line remote URLs.
  - Invalid escape sequences and unterminated quoted values are now rejected instead of producing incorrect remote URLs.

- **Tests**
  - Expanded coverage for Git-written values, line continuations, comments, trailing empty values, and malformed configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->