### PR TITLE
feat(swift-ios): let iPad users hide the thread-list sidebar

### DIFF
--- a/apps/swift-ios/Features/Workspace/WorkspaceView.swift
+++ b/apps/swift-ios/Features/Workspace/WorkspaceView.swift
@@ -35,6 +35,8 @@ struct WorkspaceThreadSelection: Equatable {
 
 public struct WorkspaceView: View {
     @SwiftUI.Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @SwiftUI.Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @SwiftUI.Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Bindable var model: FeatureRootModel
     private let navigationRequest: FeatureWorkspaceNavigationRequest?
@@ -59,6 +61,7 @@ public struct WorkspaceView: View {
     @State private var deletingThread: FeatureThread?
     @State private var renameTitle = ""
     @State private var sidebarBoundaryNow = Date.now
+    @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var preferredCompactColumn = NavigationSplitViewColumn.sidebar
     @State private var homePresentationCache = HomePresentationCache()
     @FocusState private var isSearchFocused: Bool
@@ -131,7 +134,10 @@ public struct WorkspaceView: View {
     }
 
     public var body: some View {
-        NavigationSplitView(preferredCompactColumn: $preferredCompactColumn) {
+        NavigationSplitView(
+            columnVisibility: $columnVisibility,
+            preferredCompactColumn: $preferredCompactColumn
+        ) {
             sidebar
                 .navigationSplitViewColumnWidth(
                     min: T3Metrics.minimumSidebarWidth,
@@ -140,6 +146,21 @@ public struct WorkspaceView: View {
                 )
         } detail: {
             detail
+                .toolbar {
+                    // The sidebar column hides its own navigation bar, so the
+                    // system reveal control only appears while the sidebar is
+                    // hidden; this button exists solely to hide it.
+                    if horizontalSizeClass == .regular && columnVisibility != .detailOnly {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button("Hide sidebar", systemImage: "sidebar.leading") {
+                                withAnimation(reduceMotion ? nil : .default) {
+                                    columnVisibility = .detailOnly
+                                }
+                            }
+                            .accessibilityIdentifier("detail-sidebar-toggle")
+                        }
+                    }
+                }
         }
         .navigationSplitViewStyle(.balanced)
         .sheet(isPresented: $showingNewTask) {
@@ -669,6 +690,7 @@ public struct WorkspaceView: View {
             guard model.snapshot.projects.contains(where: { $0.id == id }) else { return }
             dismissTransientPresentations()
             selectedProjectID = id
+            columnVisibility = .doubleColumn
             closeSelectedThread()
         case let .newTask(projectID):
             if let projectID,


### PR DESCRIPTION
## Summary

On iPad the workspace `NavigationSplitView` had no `columnVisibility` binding, so the thread-list sidebar floated over the detail column with no way to dismiss it — SwiftUI never injected a sidebar toggle (the sidebar column hides its own navigation bar), and tapping outside did not close it.

- Bind `columnVisibility` on the workspace `NavigationSplitView` so the sidebar is a real collapsible column.
- Add a `Hide sidebar` toolbar button (`sidebar.leading`, `.topBarLeading`) in the detail column, gated to `horizontalSizeClass == .regular` and rendered only while the sidebar is visible — while hidden, SwiftUI's own reveal control is the single way back, so there is exactly one control in each state.
- Project deep links now set `columnVisibility = .doubleColumn` so a `t3code://projects/...` link that arrives while the sidebar is hidden reveals the filtered list it points at (previously it silently changed selection with nothing visible).
- The hide animation honors Reduce Motion.
- Compact (iPhone) navigation is unchanged — `preferredCompactColumn` still drives the collapsed stack, and the button never renders at compact width.

This shape also matches Apple's new iPhone Duo guidance (HIG "Designing for iPhone Duo", 2026-09-09): a symbol-only, titled toolbar item in the detail column automatically relocates into the Duo's vertical side bar, while the compact outer display keeps single-column navigation via the existing `preferredCompactColumn` path.

## Verification

iPad Pro 11-inch (M4) Simulator, iOS 26.5, Debug build against a disposable local server:

| Sidebar shown | Sidebar hidden |
|---|---|
| ![Sidebar visible with Hide sidebar button](https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/after-shown.png) | ![Sidebar hidden; system reveal control at top left](https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/after-hidden.png) |

Hide → reveal cycle (GIF): ![Toggle cycle](https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/toggle-cycle.gif) — full MP4: https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/toggle-cycle.mp4

Dark appearance verified as well: [hidden state](https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/after-hidden-dark.png)

iPhone 16 Pro Simulator (iOS 26.5): compact navigation verified — no toggle renders, project selection and thread list behave as before: [compact layout](https://raw.githubusercontent.com/saphid/t3code/evidence/swiftui-ipad-sidebar-20260912/ipad-sidebar/iphone-compact.png)

## Test plan

- [x] `xcodebuild` Debug build succeeds and runs on iPad and iPhone simulators
- [x] iPad: hide via new toolbar button, reveal via system control, repeat cycle
- [x] iPhone: compact navigation unaffected
- [ ] CI: SwiftUI iOS workflow

Notes: verified in portrait only (Simulator rotation unavailable headlessly); landscape uses the same regular-width path. Pro Max-class iPhones in landscape report regular width and will also show the button — consistent with standard split-view behavior.

Made with Devin (swe-2-high, T3 Code/Cursor harness).
