### PR TITLE
fix(web): preserve checkout when opening project settings

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,3 +1,4 @@
+import { projectSettingsSearch } from "../projectSettingsNavigation";
 import { useLoadBalancedEnvironment } from "../hooks/useLoadBalancedEnvironment";
 import { visibleThreadPullRequests } from "@t3tools/shared/threadPullRequests";
 import type { UsageLimitSourceSnapshots } from "@t3tools/contracts";
@@ -2072,12 +2073,12 @@ export default function ChatView(props: ChatViewProps) {
       ? deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings)
       : undefined;
   const handleOpenDraftProjectSettings = useCallback(() => {
-    if (!activeDraftLogicalProjectKey) return;
+    if (!activeDraftLogicalProjectKey || !activeProject) return;
     void navigate({
-      to: "/projects/$projectKey",
-      params: { projectKey: activeDraftLogicalProjectKey },
+      to: "/settings/projects",
+      search: projectSettingsSearch(activeDraftLogicalProjectKey, activeProject),
     });
-  }, [activeDraftLogicalProjectKey, navigate]);
+  }, [activeDraftLogicalProjectKey, activeProject, navigate]);
   const activeEnvironmentShell = useEnvironmentQuery(
     activeThread ? environmentShell.stateAtom(activeThread.environmentId) : null,
   );

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { projectSettingsSearch } from "../projectSettingsNavigation";
+
 import { threadPullRequestLinkMode } from "@t3tools/client-runtime/thread-pull-request-compatibility";
 import { visibleThreadPullRequests } from "@t3tools/shared/threadPullRequests";
 
@@ -1846,9 +1848,15 @@ function OpenCommandPaletteDialog(props: {
       description: contextualProjectGroup.displayName,
       icon: <FolderIcon className={ITEM_ICON_CLASS} />,
       run: async () => {
+        const project = contextualProjectRef
+          ? projectByKey.get(
+              `${contextualProjectRef.environmentId}:${contextualProjectRef.projectId}`,
+            )
+          : undefined;
+        if (contextualProjectRef && !project) return;
         await navigate({
-          to: "/projects/$projectKey",
-          params: { projectKey: contextualProjectGroup.projectKey },
+          to: "/settings/projects",
+          search: projectSettingsSearch(contextualProjectGroup.projectKey, project),
         });
       },
     });

--- a/apps/web/src/components/LegacySidebar.tsx
+++ b/apps/web/src/components/LegacySidebar.tsx
@@ -1,3 +1,4 @@
+import { projectSettingsSearch } from "../projectSettingsNavigation";
 import { useSupportsMultiplePullRequests } from "~/hooks/useSupportsMultiplePullRequests";
 import { GitPullRequestIcon } from "lucide-react";
 import { resolveThreadCurrentPullRequestLink } from "@t3tools/shared/threadPullRequests";
@@ -2254,10 +2255,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
 
       if (clicked === "project-settings") {
+        if (!threadProject) return;
         if (isMobile) setOpenMobile(false);
         void router.navigate({
-          to: "/projects/$projectKey",
-          params: { projectKey: project.projectKey },
+          to: "/settings/projects",
+          search: projectSettingsSearch(project.projectKey, threadProject),
         });
         return;
       }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { projectSettingsSearch } from "../projectSettingsNavigation";
 import { useSupportsMultiplePullRequests } from "~/hooks/useSupportsMultiplePullRequests";
 import { resolveThreadCurrentPullRequestLink } from "@t3tools/shared/threadPullRequests";
 import { useAtomValue } from "@effect/atom-react";
@@ -2446,13 +2447,16 @@ export default function Sidebar() {
   }, [clearSelection, projectScopeKey]);
 
   const openProjectSettings = useCallback(
-    (projectGroup: SidebarProjectSnapshot) => {
+    (
+      projectGroup: SidebarProjectSnapshot,
+      project?: Pick<EnvironmentProject, "environmentId" | "workspaceRoot">,
+    ) => {
       if (isMobile) {
         setOpenMobile(false);
       }
       void router.navigate({
-        to: "/projects/$projectKey",
-        params: { projectKey: projectGroup.projectKey },
+        to: "/settings/projects",
+        search: projectSettingsSearch(projectGroup.projectKey, project),
       });
     },
     [isMobile, router, setOpenMobile],
@@ -4033,7 +4037,8 @@ export default function Sidebar() {
                   projectRef.projectId === thread.projectId,
               ),
             );
-            if (projectGroup) openProjectSettings(projectGroup);
+            const project = projectByKey.get(`${thread.environmentId}:${thread.projectId}`);
+            if (projectGroup && project) openProjectSettings(projectGroup, project);
             return;
           }
           case "new-thread-on-branch": {

--- a/apps/web/src/components/settings/ProjectSettingsPanel.logic.ts
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.logic.ts
@@ -1,7 +1,20 @@
+import type { SidebarProjectSnapshot } from "../../sidebarProjectGrouping";
+
 export function projectGroupTitleNeedsUpdate(
   memberTitles: ReadonlyArray<string>,
   nextTitle: string,
   wasEdited: boolean,
 ): boolean {
   return wasEdited && memberTitles.some((title) => title !== nextTitle);
+}
+
+export function projectSettingsRepresentative(
+  group: SidebarProjectSnapshot,
+  members = group.memberProjects,
+) {
+  return (
+    members.find(
+      (member) => member.environmentId === group.environmentId && member.id === group.id,
+    ) ?? members[0]!
+  );
 }

--- a/apps/web/src/components/settings/ProjectSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProjectSettingsPanel.tsx
@@ -39,7 +39,10 @@ import {
   ProjectFaviconPickerDialog,
 } from "./ProjectFaviconPickerDialog";
 import { ProjectActionsSettings } from "./ProjectActionsSettings";
-import { projectGroupTitleNeedsUpdate } from "./ProjectSettingsPanel.logic";
+import {
+  projectGroupTitleNeedsUpdate,
+  projectSettingsRepresentative,
+} from "./ProjectSettingsPanel.logic";
 import { useSettingsProjectGroups } from "./useSettingsProjectGroups";
 
 const ProjectIconPickerDialog = lazy(() =>
@@ -139,11 +142,12 @@ export function ProjectSettingsPanel({
         This checkout is no longer available in the selected project and environment.
       </p>
     );
+  const representative = projectSettingsRepresentative(selected, members);
   const scopedGroup = {
     ...selected,
     memberProjects: members,
-    environmentId: members[0]!.environmentId,
-    id: members[0]!.id,
+    environmentId: representative.environmentId,
+    id: representative.id,
   };
   return (
     <ProjectDetail
@@ -168,10 +172,7 @@ function ProjectDetail({
     () => new Map(environments.map((environment) => [environment.environmentId, environment])),
     [environments],
   );
-  const representative =
-    group.memberProjects.find(
-      (member) => environmentById.get(member.environmentId)?.serverConfig != null,
-    ) ?? group.memberProjects[0]!;
+  const representative = projectSettingsRepresentative(group);
   const threads = useThreadShells();
   const updateProject = useAtomCommand(projectEnvironment.update, { reportFailure: false });
   const deleteProject = useAtomCommand(projectEnvironment.delete, { reportFailure: false });

--- a/apps/web/src/hooks/useThreadActionMenu.ts
+++ b/apps/web/src/hooks/useThreadActionMenu.ts
@@ -1,3 +1,4 @@
+import { projectSettingsSearch } from "../projectSettingsNavigation";
 import { scopeProjectRef, scopedThreadKey } from "@t3tools/client-runtime/environment";
 import {
   type AtomCommandResult,
@@ -201,8 +202,8 @@ export function useThreadActionMenu(input: {
               logicalProjectKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
               deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings);
             void router.navigate({
-              to: "/projects/$projectKey",
-              params: { projectKey },
+              to: "/settings/projects",
+              search: projectSettingsSearch(projectKey, project),
             });
             return;
           }

--- a/apps/web/src/projectSettingsNavigation.test.ts
+++ b/apps/web/src/projectSettingsNavigation.test.ts
@@ -1,0 +1,82 @@
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+import { buildSidebarProjectSnapshots } from "./sidebarProjectGrouping";
+import { projectSettingsSearch } from "./projectSettingsNavigation";
+import { projectSettingsRepresentative } from "./components/settings/ProjectSettingsPanel.logic";
+
+const primary = EnvironmentId.make("primary");
+const remote = EnvironmentId.make("remote");
+const projects = [
+  { environmentId: remote, id: ProjectId.make("remote"), workspaceRoot: "/work/repo" },
+  { environmentId: primary, id: ProjectId.make("default"), workspaceRoot: "/work/repo" },
+  { environmentId: primary, id: ProjectId.make("gold"), workspaceRoot: "/work/repo-gold" },
+].map((project) => ({
+  ...project,
+  title: "repo",
+  repositoryIdentity: {
+    canonicalKey: "github.com/example/repo",
+    locator: {
+      source: "git-remote" as const,
+      remoteName: "origin",
+      remoteUrl: "https://github.com/example/repo.git",
+    },
+    provider: "github",
+    owner: "example",
+    name: "repo",
+    displayName: "repo",
+  },
+  defaultModelSelection: null,
+  scripts: [],
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  faviconPath: project.id === "gold" ? "gold.png" : null,
+}));
+const group = buildSidebarProjectSnapshots({
+  projects,
+  settings: { sidebarProjectGroupingMode: "repository", sidebarProjectGroupingOverrides: {} },
+  primaryEnvironmentId: primary,
+  resolveEnvironmentLabel: () => null,
+})[0]!;
+
+describe("project settings checkout context", () => {
+  it("keeps the exact checkout when the same machine has two copies", () => {
+    const project = group.memberProjects.find((member) => member.id === "gold")!;
+    const search = projectSettingsSearch(group.projectKey, project);
+    const members = group.memberProjects.filter(
+      (member) =>
+        member.environmentId === search.machine && member.physicalProjectKey === search.checkout,
+    );
+    expect(members).toEqual([project]);
+    expect(projectSettingsRepresentative(group, members).faviconPath).toBe("gold.png");
+  });
+
+  it("keeps a remote checkout instead of selecting the primary machine", () => {
+    expect(projectSettingsSearch(group.projectKey, projects[0])).toEqual({
+      project: group.projectKey,
+      machine: remote,
+      checkout: "remote:/work/repo",
+    });
+  });
+
+  it("keeps the physical scope when duplicate records have different project IDs", () => {
+    const duplicate = { ...projects[2]!, id: ProjectId.make("old-gold") };
+    expect(projectSettingsSearch(group.projectKey, duplicate)).toEqual(
+      projectSettingsSearch(group.projectKey, projects[2]),
+    );
+  });
+
+  it("leaves a group action unscoped", () => {
+    expect(projectSettingsSearch(group.projectKey)).toEqual({
+      project: group.projectKey,
+      machine: undefined,
+      checkout: undefined,
+    });
+  });
+
+  it("uses the sidebar representative even when another member sorts first", () => {
+    const gold = group.memberProjects.find((member) => member.id === "gold")!;
+    expect(
+      projectSettingsRepresentative({ ...group, environmentId: gold.environmentId, id: gold.id }),
+    ).toBe(gold);
+  });
+});

--- a/apps/web/src/projectSettingsNavigation.ts
+++ b/apps/web/src/projectSettingsNavigation.ts
@@ -1,0 +1,13 @@
+import type { EnvironmentProject } from "@t3tools/client-runtime/state/shell";
+import { derivePhysicalProjectKey } from "./logicalProject";
+
+export function projectSettingsSearch(
+  projectKey: string,
+  project?: Pick<EnvironmentProject, "environmentId" | "workspaceRoot">,
+) {
+  return {
+    project: projectKey,
+    machine: project?.environmentId,
+    checkout: project ? derivePhysicalProjectKey(project) : undefined,
+  };
+}

--- a/docs/user/project-settings.md
+++ b/docs/user/project-settings.md
@@ -41,10 +41,14 @@ on each selected environment, and reset returns to the environment's shared list
 For workspace mode, a project's `t3.json` preference applies when the project has no override.
 Browser access changes apply when an agent session next starts.
 
+Opening **Project settings** from a thread selects that thread's environment and checkout.
+Opening it from a project group keeps the whole group selected. Group settings show the same
+project icon as the sidebar, including when that checkout's environment is offline.
+
 ## Project icons
 
 Select the project and open Project to choose an icon, emoji, or image. The choice applies to
-every checkout in the project group and appears on connected clients. Choose **Automatic** to let
+the selected checkouts and appears on connected clients. Choose **Automatic** to let
 T3 Code detect an icon again.
 
 ## Keep the default branch current


### PR DESCRIPTION
## What Changed

Opening Project settings from a thread now selects that thread's environment and physical checkout. Project-group actions remain group-wide. Settings also uses the sidebar's representative instead of selecting the first connected checkout.

## Why

Two checkouts of the same repository can have different icons and defaults. Thread actions previously discarded the checkout before navigating, so Settings could display and edit another copy. The shared navigation helper preserves environment/path identity across the sidebar, legacy sidebar, thread menu, draft view, and contextual command palette, including duplicate project records.

## Validation

- Eight focused navigation and settings tests pass. Restoring the old behavior makes three regressions fail.
- Web typecheck passes; focused new-file lint passes with warnings denied.
- Independent checks exercise the actual Sidebar and command-palette callbacks, including historical duplicate IDs and offline representatives.
- Integrated browser verification passed against an isolated fleet build with two copies of the same repository: the gold checkout previously opened group-wide settings showing default blue and a fallback icon; after the fix it opens its own settings with the loaded icon and gold accent. Saving changed only the selected checkout, preserving the other copy and its icon path.
- The fleet-only accent editor is used as a visible diagnostic; it is not part of this upstream change. Screenshots and an interaction recording were captured locally; attachment upload was unavailable in the signed-out browser.

GPT-6-Astra via Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project settings now open with the relevant environment and checkout selected from project, thread, sidebar, and command palette actions.
  * Project group settings preserve the full group selection and display the matching project icon, including when an environment is offline.

* **Documentation**
  * Updated project settings guidance to describe environment, checkout, group selection, and icon behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->