### PR TITLE
fix(server): avoid extra round trips for terminal output

### DIFF
--- a/apps/server/src/terminal/OutputProtocol.test.ts
+++ b/apps/server/src/terminal/OutputProtocol.test.ts
@@ -1,0 +1,79 @@
+import { assert, describe, it } from "@effect/vitest";
+import { WS_METHODS } from "@t3tools/contracts";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import * as TestClock from "effect/testing/TestClock";
+import { Rpc, RpcGroup, RpcMessage, RpcSerialization, RpcServer } from "effect/unstable/rpc";
+
+import { withTerminalOutputWindow } from "./OutputProtocol.ts";
+
+describe("terminal output window", () => {
+  for (const { tag, size, limit } of [
+    { tag: WS_METHODS.terminalAttach, size: 1, limit: 8 },
+    { tag: WS_METHODS.subscribeTerminalEvents, size: 1, limit: 8 },
+    { tag: WS_METHODS.terminalAttach, size: 64 * 1024, limit: 1 },
+    { tag: WS_METHODS.subscribeTerminalMetadata, size: 1, limit: 1 },
+  ]) {
+    it.effect(`limits ${tag} with ${size}-byte values to ${limit} pending chunks`, () =>
+      Effect.gen(function* () {
+        const group = RpcGroup.make(Rpc.make(tag, { success: Schema.String, stream: true }));
+        const output = yield* Queue.unbounded<string>();
+        const responses = yield* Queue.unbounded<RpcMessage.FromServerEncoded>();
+        const receive = yield* Deferred.make<Parameters<RpcServer.Protocol["Service"]["run"]>[0]>();
+        const protocol = yield* RpcServer.Protocol.make((write) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(receive, write);
+            const serialization = yield* RpcSerialization.RpcSerialization;
+            return {
+              disconnects: yield* Queue.unbounded<number>(),
+              send: (_clientId, response) => Queue.offer(responses, response),
+              end: () => Effect.void,
+              clientIds: Effect.succeed(new Set([0])),
+              initialMessage: Effect.succeedNone,
+              supportsAck: true,
+              supportsTransferables: false,
+              supportsSpanPropagation: false,
+              supportsNotifications: true,
+              codecFor: serialization.codecFor,
+            };
+          }),
+        );
+        yield* RpcServer.make(group).pipe(
+          Effect.provide(group.toLayerHandler(tag, () => Stream.fromQueue(output))),
+          Effect.provideService(RpcServer.Protocol, withTerminalOutputWindow(protocol)),
+          Effect.forkScoped,
+        );
+        const write = yield* Deferred.await(receive);
+        yield* write(0, { _tag: "Request", id: "1", tag, payload: null, headers: [] });
+
+        for (let index = 0; index < limit; index++) {
+          const value = String(index).repeat(size);
+          yield* Queue.offer(output, value);
+          yield* TestClock.adjust(0);
+          assert.equal(yield* Queue.size(responses), 1);
+          assert.deepEqual(yield* Queue.take(responses), {
+            _tag: "Chunk",
+            requestId: "1",
+            values: [value],
+          });
+        }
+        yield* Queue.offer(output, "i".repeat(size));
+        yield* TestClock.adjust(0);
+        assert.equal(yield* Queue.size(responses), 0);
+        yield* write(0, { _tag: "Ack", requestId: "1" });
+        const resumed = yield* Queue.take(responses);
+        assert.equal(resumed._tag, "Chunk");
+        if (resumed._tag === "Chunk") assert.deepEqual(resumed.values, ["i".repeat(size)]);
+
+        yield* Queue.offer(output, "j");
+        yield* TestClock.adjust(0);
+        assert.equal(yield* Queue.size(responses), 0);
+        yield* write(0, { _tag: "Interrupt", requestId: "1" });
+        assert.equal((yield* Queue.take(responses))._tag, "Exit");
+      }).pipe(Effect.provide(RpcSerialization.layerJson), Effect.scoped),
+    );
+  }
+});

--- a/apps/server/src/terminal/OutputProtocol.ts
+++ b/apps/server/src/terminal/OutputProtocol.ts
@@ -1,0 +1,67 @@
+import { WS_METHODS } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import type { RpcServer } from "effect/unstable/rpc";
+
+const MAX_PENDING_CHUNKS = 8;
+const MAX_PENDING_BYTES = 64 * 1024;
+const isFull = (sizes: number[]) =>
+  sizes.length >= MAX_PENDING_CHUNKS ||
+  sizes.reduce((total, size) => total + size, 0) >= MAX_PENDING_BYTES;
+
+export function withTerminalOutputWindow(
+  protocol: RpcServer.Protocol["Service"],
+): RpcServer.Protocol["Service"] {
+  const windows = new Map<string, number[]>();
+  let receive: Parameters<RpcServer.Protocol["Service"]["run"]>[0];
+  return {
+    ...protocol,
+    run: (write) => {
+      receive = write;
+      return protocol.run((clientId, message) =>
+        Effect.suspend(() => {
+          if (
+            message._tag === "Request" &&
+            (message.tag === WS_METHODS.terminalAttach ||
+              message.tag === WS_METHODS.subscribeTerminalEvents)
+          ) {
+            const key = `${clientId}:${message.id}`;
+            if (!windows.has(key)) windows.set(key, []);
+          } else if (message._tag === "Ack") {
+            const window = windows.get(`${clientId}:${message.requestId}`);
+            if (window) {
+              const wasFull = isFull(window);
+              window.shift();
+              if (!wasFull || isFull(window)) return Effect.void;
+            }
+          }
+          return write(clientId, message);
+        }),
+      );
+    },
+    send: (clientId, response, transferables) =>
+      Effect.suspend(() => {
+        const send = protocol.send(clientId, response, transferables);
+        if (response._tag === "Exit") {
+          windows.delete(`${clientId}:${response.requestId}`);
+        } else if (response._tag === "Chunk") {
+          const window = windows.get(`${clientId}:${response.requestId}`);
+          if (window) {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            const size = Buffer.byteLength(JSON.stringify(response));
+            window.push(size);
+            if (!isFull(window)) {
+              return send.pipe(
+                Effect.andThen(() =>
+                  receive(clientId, {
+                    _tag: "Ack",
+                    requestId: response.requestId,
+                  }),
+                ),
+              );
+            }
+          }
+        }
+        return send;
+      }),
+  };
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -113,6 +113,7 @@ import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
+import { withTerminalOutputWindow } from "./terminal/OutputProtocol.ts";
 import * as PreviewAutomationBroker from "./mcp/PreviewAutomationBroker.ts";
 import * as DeviceService from "./device/DeviceService.ts";
 import * as PreviewManager from "./preview/Manager.ts";
@@ -3083,8 +3084,14 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         const clientAnalyticsProps = readClientAnalyticsProps(request);
         yield* sessions.recordClientConnection(session.sessionId, clientOrigin);
         yield* analytics.record("client.connected", clientAnalyticsProps);
-        const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
-          disableTracing: true,
+        const rpcWebSocketHttpEffect = yield* Effect.gen(function* () {
+          const { protocol, httpEffect } = yield* RpcServer.makeProtocolWithHttpEffectWebsocket;
+          yield* RpcServer.make(WsRpcGroup, { disableTracing: true }).pipe(
+            Effect.provideService(RpcServer.Protocol, withTerminalOutputWindow(protocol)),
+            Effect.forkScoped,
+          );
+          // @effect-diagnostics-next-line returnEffectInGen:off
+          return httpEffect;
         }).pipe(
           Effect.provide(
             makeWsRpcLayer(


### PR DESCRIPTION
Remote terminal output waits for a client acknowledgement after every RPC stream chunk. That adds a stop-and-wait round trip even when the shell has already echoed the next key.

Allow terminal streams to keep up to eight chunks in flight, pausing once pending output reaches 64 KiB. Keep the existing acknowledgement messages and leave other RPC streams unchanged. This removes the extra wait for interactive output; network travel time still applies.

Verified with 86 terminal tests, five WebSocket terminal route tests, server typecheck, lint, formatting, and a real shell reproduction. Before the fix, the shell history contained `AB` while the client received only `A` until its acknowledgement was released. With the fix, the client received `AB` before that acknowledgement. Browser typing was checked against the updated server.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output streaming over WebSocket connections to prevent excessive buffering.
  - Added backpressure handling so delivery pauses when the pending output window is full and resumes automatically as capacity becomes available.
  - Improved reliability for large or rapid terminal output by keeping buffered data within safe limits.
  - Terminal streams now close cleanly when interrupted, ensuring sessions do not remain open unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->