### PR TITLE
test(web): pin pull-request stats delta on paginated scroll

### DIFF
--- a/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestList.logic.test.ts
@@ -293,6 +293,94 @@ describe("visible pull request line-count targets", () => {
       }),
     ).toEqual([]);
   });
+
+  it("requests only the newly appended row after a paginated scroll when earlier rows are cached", () => {
+    const loaded = Array.from({ length: 99 }, (_, index) =>
+      entry({ additions: 0, deletions: 0, number: index + 1 }),
+    );
+    const cachedStats = mergePullRequestDiffStats(
+      new Map(),
+      loaded.map((item) => ({
+        environmentId: ENV_1,
+        projectId: item.projectId,
+        number: item.number,
+        additions: 4,
+        deletions: 2,
+      })),
+    );
+    const scrolled = [...loaded, entry({ additions: 0, deletions: 0, number: 100 })];
+    const scrolledByKey = new Map(scrolled.map((item) => [pullRequestEntryKey(item), item]));
+    const hundredthKey = pullRequestEntryKey(scrolled[99]!);
+
+    // Eager sorts (ready/largest/smallest) scan every loaded row: the cache filters 1..99.
+    const eagerDelta = pullRequestStatsRequestBatches({
+      entriesByKey: scrolledByKey,
+      candidateKeys: new Set(),
+      policy: "eager",
+      activeBatches: [],
+      statsByRow: cachedStats,
+    });
+    expect(eagerDelta).toHaveLength(1);
+    expect(eagerDelta.flatMap((batch) => batch.input.refs.map((ref) => ref.number))).toEqual([100]);
+
+    // Date sorts only observe the entered viewport row.
+    const visibleDelta = pullRequestStatsRequestBatches({
+      entriesByKey: scrolledByKey,
+      candidateKeys: new Set([hundredthKey]),
+      policy: "visible",
+      activeBatches: [],
+      statsByRow: cachedStats,
+    });
+    expect(visibleDelta).toHaveLength(1);
+    expect(visibleDelta.flatMap((batch) => batch.input.refs.map((ref) => ref.number))).toEqual([
+      100,
+    ]);
+  });
+
+  it("skips rows already requested in flight after a paginated scroll before their counts arrive", () => {
+    const loaded = Array.from({ length: 99 }, (_, index) =>
+      entry({ additions: 0, deletions: 0, number: index + 1 }),
+    );
+    const loadedByKey = new Map(loaded.map((item) => [pullRequestEntryKey(item), item]));
+    const active = pullRequestStatsRequestBatches({
+      entriesByKey: loadedByKey,
+      candidateKeys: new Set(),
+      policy: "eager",
+      activeBatches: [],
+      statsByRow: new Map(),
+    });
+    expect(active.flatMap((batch) => batch.input.refs.map((ref) => ref.number))).toEqual(
+      loaded.map((item) => item.number),
+    );
+
+    const scrolled = [...loaded, entry({ additions: 0, deletions: 0, number: 100 })];
+    const scrolledByKey = new Map(scrolled.map((item) => [pullRequestEntryKey(item), item]));
+    const hundredthKey = pullRequestEntryKey(scrolled[99]!);
+
+    // The in-flight request covers 1..99, so only row 100 is new even with an empty cache.
+    const eagerDelta = pullRequestStatsRequestBatches({
+      entriesByKey: scrolledByKey,
+      candidateKeys: new Set(),
+      policy: "eager",
+      activeBatches: active,
+      statsByRow: new Map(),
+    });
+    expect(eagerDelta).toHaveLength(1);
+    expect(eagerDelta.flatMap((batch) => batch.input.refs.map((ref) => ref.number))).toEqual([100]);
+
+    // The entered viewport row 100 is not in flight, so it is still requested.
+    const visibleDelta = pullRequestStatsRequestBatches({
+      entriesByKey: scrolledByKey,
+      candidateKeys: new Set([hundredthKey]),
+      policy: "visible",
+      activeBatches: active,
+      statsByRow: new Map(),
+    });
+    expect(visibleDelta).toHaveLength(1);
+    expect(visibleDelta.flatMap((batch) => batch.input.refs.map((ref) => ref.number))).toEqual([
+      100,
+    ]);
+  });
 });
 
 describe("pull request involvement filtering", () => {


### PR DESCRIPTION
## Summary

The PR stats path used to refetch the whole visible set on every scroll page, re-requesting up to hundreds of already-counted rows. That bug has since been fixed on main (entered-only candidates plus missing-only batch keys), but nothing pinned the behavior.

## What changed

Test-only change. Adds isolated regression tests proving a paginated scroll from 99 cached rows to 100 requests only row 100, via the stats cache and via the in-flight request set independently.

## Validation

- pullRequestList.logic.test.ts: 120 passed (2 new isolated delta cases)
- No product code touched

## Measured impact

Compared with main-latest.json from main commit b1e223e2b, using the focused stats-delta suite:

| Scroll: 99 cached + row 100 | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| Refs requested | 1 (delta) | 1 (delta) | unchanged, now pinned |
| Focused tests | 14 pass | 16 pass | +2 regression guards |

The delta behavior already on main is now locked by two isolated tests (cache-filtered and in-flight-filtered). Every enforced ceiling passes. Coverage: SPAWN-ASSERTED.

Built with Muse Spark (opencode/muse-spark-1.3) via implement and audit subagent loops with strict branch-audit reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for pull request list scrolling and line-count statistics.
  * Verified that previously cached or in-flight rows are not requested again when a new row becomes visible.
  * Confirmed consistent request behavior across eager and viewport-based loading policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->