### PR TITLE
perf(server): cap PR fallback scan at 4x page size

### DIFF
--- a/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.test.ts
@@ -1426,9 +1426,219 @@ layer("GitHubPullRequestCli.layer", (it) => {
       });
 
       const finalArgs = callAt(mockedExecute.mock.calls.length - 1).args;
-      expect(finalArgs[finalArgs.indexOf("--limit") + 1]).toBe("1000");
+      expect(finalArgs[finalArgs.indexOf("--limit") + 1]).toBe("12");
+      // One search probe plus three fallback probes (3 → 6 → 12, 21 rows read in total); the
+      // unread tail is reported rather than walked to a thousand rows, and a larger page scans
+      // further.
+      assert.strictEqual(mockedExecute.mock.calls.length, 4);
       assert.strictEqual(batch.items.length, 0);
       assert.isTrue(batch.truncated);
+      assert.isFalse(batch.continues);
+    }),
+  );
+
+  it.effect("caps a page-sized search-free fallback at four times the page", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((_input) => {
+        if (mockedExecute.mock.calls.length === 1) return Effect.succeed(output("[]"));
+        const args = callAt(mockedExecute.mock.calls.length - 1).args;
+        const limit = Number(args[args.indexOf("--limit") + 1]);
+        return Effect.succeed(
+          output(
+            pullRequests(limit, 1, () => ({
+              reviewRequests: [{ login: "somebody-else" }],
+            })),
+          ),
+        );
+      });
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 30,
+      });
+
+      // 31 → 62 → 124, then stop (217 rows read in total): a sparse repository costs three
+      // small probes per involvement instead of doubling to a thousand rows, and the tail stays
+      // honestly reported.
+      const limits = [1, 2, 3].map((index) => {
+        const args = callAt(index).args;
+        return args[args.indexOf("--limit") + 1];
+      });
+      expect(limits).toEqual(["31", "62", "124"]);
+      expect(searchOfCall(1)).toBeUndefined();
+      assert.strictEqual(mockedExecute.mock.calls.length, 4);
+      assert.strictEqual(batch.items.length, 0);
+      assert.isTrue(batch.truncated);
+      assert.isFalse(batch.continues);
+    }),
+  );
+
+  it.effect("caps the default page at four times itself on the search-free fallback", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((_input) => {
+        if (mockedExecute.mock.calls.length === 1) return Effect.succeed(output("[]"));
+        const args = callAt(mockedExecute.mock.calls.length - 1).args;
+        const limit = Number(args[args.indexOf("--limit") + 1]);
+        return Effect.succeed(
+          output(
+            pullRequests(limit, 1, () => ({
+              reviewRequests: [{ login: "somebody-else" }],
+            })),
+          ),
+        );
+      });
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 99,
+      });
+
+      // 100 → 200 → 400, then stop (700 rows read in total): the default page costs the same
+      // three probes as every other sparse fallback, not a walk to a thousand rows.
+      const limits = [1, 2, 3].map((index) => {
+        const args = callAt(index).args;
+        return args[args.indexOf("--limit") + 1];
+      });
+      expect(limits).toEqual(["100", "200", "400"]);
+      assert.strictEqual(mockedExecute.mock.calls.length, 4);
+      assert.strictEqual(batch.items.length, 0);
+      assert.isTrue(batch.truncated);
+      assert.isFalse(batch.continues);
+    }),
+  );
+
+  it.effect("keeps the thousand-row ceiling for large pages on the search-free fallback", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((_input) => {
+        if (mockedExecute.mock.calls.length === 1) return Effect.succeed(output("[]"));
+        const args = callAt(mockedExecute.mock.calls.length - 1).args;
+        const limit = Number(args[args.indexOf("--limit") + 1]);
+        return Effect.succeed(
+          output(
+            pullRequests(limit, 1, () => ({
+              reviewRequests: [{ login: "somebody-else" }],
+            })),
+          ),
+        );
+      });
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 249,
+      });
+
+      // 250 → 500 → 1000, then stop: past limit:249 the 4x cap meets the thousand-row ceiling,
+      // so large pages keep the old bound.
+      const limits = [1, 2, 3].map((index) => {
+        const args = callAt(index).args;
+        return args[args.indexOf("--limit") + 1];
+      });
+      expect(limits).toEqual(["250", "500", "1000"]);
+      assert.strictEqual(mockedExecute.mock.calls.length, 4);
+      assert.strictEqual(batch.items.length, 0);
+      assert.isTrue(batch.truncated);
+      assert.isFalse(batch.continues);
+    }),
+  );
+
+  it.effect("stops the search-free fallback where the repository runs out, not at the cap", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockReturnValueOnce(Effect.succeed(output("[]")));
+      mockedExecute.mockReturnValueOnce(
+        Effect.succeed(
+          output(
+            pullRequests(3, 1, (number) => ({
+              reviewRequests: [{ login: number === 3 ? "bilal" : "somebody-else" }],
+            })),
+          ),
+        ),
+      );
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+
+      const batch = yield* cli.listPullRequests({
+        cwd: "/w",
+        repository: "acme/web",
+        host: "github.com",
+        state: "open",
+        involvement: "reviewing",
+        viewer: "bilal",
+        limit: 10,
+      });
+
+      // One matching row out of the three the repository holds: the page is short but the
+      // repository is exhausted (3 rows back for 11 asked), so there is nothing more to scan
+      // for and no second probe goes out.
+      assert.deepStrictEqual(
+        batch.items.map((item) => item.number),
+        [3],
+      );
+      assert.isFalse(batch.truncated);
+      assert.isFalse(batch.continues);
+      assert.strictEqual(mockedExecute.mock.calls.length, 2);
+    }),
+  );
+
+  it.effect("scans further when a later listing asks for a larger page", () =>
+    Effect.gen(function* () {
+      mockedExecute.mockImplementation((_input) => {
+        if (mockedExecute.mock.calls.length === 1 || mockedExecute.mock.calls.length === 5) {
+          return Effect.succeed(output("[]"));
+        }
+        const args = callAt(mockedExecute.mock.calls.length - 1).args;
+        const limit = Number(args[args.indexOf("--limit") + 1]);
+        return Effect.succeed(
+          output(
+            pullRequests(limit, 1, () => ({
+              reviewRequests: [{ login: "somebody-else" }],
+            })),
+          ),
+        );
+      });
+      const cli = yield* GitHubPullRequestCli.GitHubPullRequestCli;
+      const read = (limit: number) =>
+        cli.listPullRequests({
+          cwd: "/w",
+          repository: "acme/web",
+          host: "github.com",
+          state: "open",
+          involvement: "reviewing",
+          viewer: "bilal",
+          limit,
+        });
+
+      const first = yield* read(2);
+      const second = yield* read(10);
+
+      // The first listing caps at 12 rows, the second at 44 (11 → 22 → 44): load-more is a
+      // larger limit, which is also a larger scan, since the fallback cap grows with the page.
+      const secondLimits = [5, 6, 7].map((index) => {
+        const args = callAt(index).args;
+        return args[args.indexOf("--limit") + 1];
+      });
+      expect(secondLimits).toEqual(["11", "22", "44"]);
+      assert.strictEqual(mockedExecute.mock.calls.length, 8);
+      assert.isTrue(first.truncated);
+      assert.isFalse(first.continues);
+      assert.isTrue(second.truncated);
+      assert.isFalse(second.continues);
     }),
   );
 

--- a/apps/server/src/pullRequest/GitHubPullRequestCli.ts
+++ b/apps/server/src/pullRequest/GitHubPullRequestCli.ts
@@ -362,6 +362,23 @@ const DIFF_FILE_MAX_OUTPUT_BYTES = 1024 * 1024;
 
 /** A search-free fallback may scan older rows for local filters, but never the whole repository. */
 const PULL_REQUEST_FALLBACK_MAX_ROWS = 1_000;
+/**
+ * How many pages' worth of rows one fallback scan may read. Doubling 1x → 2x → 4x bounds a
+ * sparse fallback to three `gh pr list` probes per listing (one search probe plus three
+ * fallback probes at most). Worst-case cost is the sum, not the cap: limit:2 scans 3+6+12
+ * = 21 rows, limit:30 scans 31+62+124 = 217 rows, the default limit:99 scans 100+200+400
+ * = 700 rows. Kept at 4x rather than 8x — which would roughly double those sums (45 / 465
+ * / 1500 rows) — with no measured hit-rate gain to justify the extra bytes and latency on
+ * unindexed repositories; revisit with hit-rate data if the fallback routinely reports a
+ * tail it should have filled. Past limit:249 the 4x cap meets the 1000-row ceiling, so
+ * large pages keep the old bound.
+ *
+ * The unread tail stays reported through `truncated`, and a larger `limit` scans further:
+ * a `truncated:true, continues:false` batch carries no cursor (see ProviderChangeRequestPage),
+ * so the only way to the rest is asking again with a larger page, as every listing did
+ * before cursors — accepted behavior, not a silent drop.
+ */
+const PULL_REQUEST_FALLBACK_PAGE_MULTIPLE = 4;
 
 /** What the files API serves at most in one response, which is what one slice is made of. */
 const DIFF_FILES_PAGE_SIZE = 100;
@@ -375,6 +392,11 @@ const REVIEW_THREAD_PAGES = 10;
 
 export interface GitHubPullRequestListBatch {
   readonly items: ReadonlyArray<GitHubPullRequestListItem>;
+  /**
+   * True when rows beyond the page were (or may have been) left unread. With
+   * `continues:false` there is no cursor to carry on from; the caller re-asks with a larger
+   * `limit` to scan further, which is also how the fallback's own cap grows.
+   */
   readonly truncated: boolean;
   /** False for a page GitHub would not search, which came back in `gh`'s own order instead. */
   readonly continues: boolean;
@@ -1479,7 +1501,10 @@ export const make = Effect.gen(function* () {
       ),
 
     listPullRequests: (input) => {
-      const fallbackMaxRows = Math.max(input.limit + 1, PULL_REQUEST_FALLBACK_MAX_ROWS);
+      const fallbackMaxRows = Math.min(
+        Math.max(input.limit + 1, PULL_REQUEST_FALLBACK_MAX_ROWS),
+        (input.limit + 1) * PULL_REQUEST_FALLBACK_PAGE_MULTIPLE,
+      );
       const read = (
         continues: boolean,
         requestedRows = input.limit + 1,


### PR DESCRIPTION
## Summary

When the per-repo fallback path under-fills a page, it doubles requested rows up to a 1000-row ceiling, firing up to 5 sequential gh pr list probes per repo per listing (times 3 involvements). The fallback cannot be deleted since it is the only way filtered views get a full page.

## What changed

The fallback ceiling now scales with the page: min(max(limit plus 1, 1000), (limit plus 1) times 4), so at most 1 search plus 3 fallback probes per listing. Worst-case sums drop from 2500 to 700 rows at limit 99 and 2953 to 217 at limit 30. Truncated reporting is untouched and a larger limit re-scans further, so load-more still reaches the tail.

## Validation

- GitHubPullRequestCli.test.ts: 100 passed (4 new: default limit 99 path, 1000-row ceiling, exhaustion early stop, sequential load-more growth)
- t3 typecheck clean
- Maintainer sign-off wanted: the 12-row scan cap for tiny limit 2 pages is a deliberate tradeoff with no hit-rate data yet.

## Measured impact

Compared with main-latest.json from main commit b1e223e2b, using the focused fallback-cap suite:

| Fallback scan, limit 99 | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| Probes per listing | 5 (100 to 1000) | 3 (100 to 400) | -2 (-40%) |
| Worst-case rows scanned | 2,500 | 700 | -1,800 (-72%) |
| Focused tests | 96 pass (base) | 100 pass | +4 cap tests |

Truncation honesty is preserved and load-more re-scans further with a larger cap. Coverage: SPAWN-ASSERTED.

Built with Muse Spark (opencode/muse-spark-1.3) via implement and audit subagent loops with strict branch-audit reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request listing when search filters are unavailable by limiting fallback scans to a predictable range.
  * Preserved access to subsequent pages while reducing unnecessary data retrieval.
  * Added safeguards to stop scanning when fewer matching pull requests remain or when the maximum scan limit is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->