### PR TITLE
test(server): cover PR project-shell edge cases on getProjectShells

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -99,6 +99,35 @@ it.effect("reads project shells without loading threads or resolving excluded pr
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("orders project shells by created_at regardless of insertion order", () => {
+  const layer = OrchestrationProjectionSnapshotQueryLive.pipe(
+    Layer.provide(ThreadBackgroundLiveness.layer),
+    Layer.provide(ThreadPlanProgress.layer),
+    Layer.provide(
+      Layer.succeed(RepositoryIdentityResolver.RepositoryIdentityResolver, {
+        resolve: () => Effect.succeed(null),
+      }),
+    ),
+    Layer.provideMerge(SqlitePersistenceMemory),
+  );
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const query = yield* ProjectionSnapshotQuery;
+    // Inserted later-first on purpose: the query must return ORDER BY created_at ASC,
+    // project_id ASC rather than rowid order.
+    yield* sql`INSERT INTO projection_projects
+      (project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at)
+      VALUES
+      ('order-late', 'Later', '/order-late', '[]', '2026-09-02T00:00:00Z', '2026-09-02T00:00:00Z', NULL),
+      ('order-early', 'Earlier', '/order-early', '[]', '2026-09-01T00:00:00Z', '2026-09-01T00:00:00Z', NULL)`;
+    const shells = yield* query.getProjectShells();
+    assert.deepStrictEqual(
+      shells.map((shell) => shell.id),
+      [asProjectId("order-early"), asProjectId("order-late")],
+    );
+  }).pipe(Effect.provide(layer));
+});
+
 const projectionSnapshotLayer = it.layer(
   OrchestrationProjectionSnapshotQueryLive.pipe(
     Layer.provide(ThreadBackgroundLiveness.layer),

--- a/apps/server/src/pullRequest/PullRequestService.test.ts
+++ b/apps/server/src/pullRequest/PullRequestService.test.ts
@@ -4556,3 +4556,137 @@ it.effect("keeps Azure continuation cursors separate for repositories with the s
     assert.deepStrictEqual(seen, ["/org-b"]);
   }),
 );
+
+it.effect("resolves projects through the narrow project queries, never the shell snapshot", () =>
+  Effect.gen(function* () {
+    let shellSnapshotCalls = 0;
+    const projectShellByIdCalls: Array<string> = [];
+    const projectShellsCalls: Array<ReadonlyArray<ProjectId> | undefined> = [];
+    const projects = [
+      project({ id: "p1", title: "t3code", workspaceRoot: "/a", repository: "pingdotgg/t3code" }),
+      project({ id: "p2", title: "other", workspaceRoot: "/b", repository: "pingdotgg/other" }),
+    ];
+    const service = yield* PullRequestService.make.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(
+            PullRequestProviderRegistry,
+            fromProviders([
+              fakeProvider("github", {
+                getChangeRequest: () => Effect.succeed(hostedChangeRequest("Body", 3)),
+              }),
+            ]),
+          ),
+          Layer.mock(SourceControlProviderRegistry.SourceControlProviderRegistry)({
+            resolveHandle: () => Effect.die("Unexpected provider refinement"),
+          }),
+          Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
+            getShellSnapshot: () => {
+              shellSnapshotCalls += 1;
+              return Effect.die("PullRequestService must not read getShellSnapshot");
+            },
+            getProjectShellById: (projectId) => {
+              projectShellByIdCalls.push(projectId as string);
+              const match = projects.find((candidate) => candidate.id === projectId);
+              return Effect.succeed(match === undefined ? Option.none() : Option.some(match));
+            },
+            getProjectShells: (projectIds) => {
+              projectShellsCalls.push(projectIds);
+              return Effect.succeed(
+                projects.filter((candidate) => projectIds?.includes(candidate.id) ?? true),
+              );
+            },
+          }),
+          SourceControlRateLimit.layer,
+          Layer.effect(PullRequestReadCache.PullRequestReadCache, PullRequestReadCache.make).pipe(
+            Layer.provide(Persistence.layerKvs),
+            Layer.provide(KeyValueStore.layerMemory),
+            Layer.provide(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    // A panel open fans out across single-project reads; each one resolves its own project
+    // by id instead of hydrating every thread in the workspace.
+    const detail = yield* service.detail({
+      projectId: "p1" as ProjectId,
+      repository: "pingdotgg/t3code",
+      number: 1,
+    });
+    assert.strictEqual(detail.projectId, "p1");
+    assert.deepStrictEqual(projectShellByIdCalls, ["p1"]);
+    assert.strictEqual(projectShellsCalls.length, 0);
+
+    // Workspace-wide reads list the project shells instead. Number 2 has no recorded row
+    // stats (detail recorded number 1 above), so listStats takes its uncached path.
+    yield* service.listStats({
+      refs: [{ projectId: "p1" as ProjectId, repository: "pingdotgg/t3code", number: 2 }],
+    });
+    yield* service.list({ state: "open" });
+
+    assert.strictEqual(shellSnapshotCalls, 0);
+    assert.strictEqual(projectShellsCalls.length, 2);
+    assert.deepStrictEqual(projectShellsCalls, [undefined, undefined]);
+  }),
+);
+
+it.effect("fails a single-project read as unsupported when its row is deleted", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      // Deleted rows stay excluded in SQL, so getProjectShellById resolves to none — the same
+      // empty shell set the shell snapshot produced with its in-memory filter before.
+      projects: [],
+      providers: [fakeProvider("github")],
+    });
+
+    const error = yield* service
+      .detail({ projectId: "p1" as ProjectId, repository: "pingdotgg/t3code", number: 1 })
+      .pipe(Effect.flip);
+
+    assert.strictEqual(error._tag, "PullRequestUnavailableError");
+    assert.strictEqual(
+      error._tag === "PullRequestUnavailableError" ? error.reason : null,
+      "provider-unsupported",
+    );
+  }),
+);
+
+it.effect("applies projectId and projectIds together as an intersection", () =>
+  Effect.gen(function* () {
+    const service = yield* makeService({
+      projects: [
+        project({ id: "p1", title: "web", workspaceRoot: "/a", repository: "acme/web" }),
+        project({ id: "p2", title: "docs", workspaceRoot: "/b", repository: "acme/docs" }),
+      ],
+      providers: [
+        fakeProvider("github", {
+          listChangeRequests: () =>
+            Effect.succeed({
+              items: [changeRequest(1, "2026-07-02T00:00:00Z")],
+              truncated: false,
+              continues: false,
+            }),
+        }),
+      ],
+    });
+
+    // The single-row read resolves p1 by id, then the projectIds filter still applies.
+    const disjoint = yield* service.list({
+      state: "open",
+      projectId: "p1" as ProjectId,
+      projectIds: ["p2" as ProjectId],
+    });
+    assert.deepStrictEqual(disjoint.entries, []);
+
+    const overlapping = yield* service.list({
+      state: "open",
+      projectId: "p1" as ProjectId,
+      projectIds: ["p1" as ProjectId, "p2" as ProjectId],
+    });
+    assert.deepStrictEqual(
+      overlapping.entries.map((entry) => entry.projectId),
+      ["p1"],
+    );
+  }),
+);


### PR DESCRIPTION
## Summary

Upstream #11299 landed the same workspace-scan fix this branch originally implemented, with the getProjectShells(projectIds) shape. The duplicate listActiveProjectShells implementation is dropped in favor of #11299. Merged state of this PR is tests-only.

## What changed

Keeps only the incremental tests #11299 lacks: narrow-query fanout (the service never reads getShellSnapshot), deleted-singleton failing as provider-unsupported, projectId plus projectIds intersection, and created_at ordering on reverse insertion. No production code changes.

## Validation

- PullRequestService.test.ts plus ProjectionSnapshotQuery.test.ts: 148 passed
- t3 typecheck clean

## Measured impact

Compared with main-latest.json from main commit b1e223e2b (which includes #11299), using the focused snapshot suite:

| PR RPC project reads | Main (#11299) | This PR | Change |
| --- | ---: | ---: | ---: |
| SQL statements | 1 (narrow) | 1 (narrow) | unchanged, now pinned |
| getShellSnapshot calls (fanout test) | unasserted | 0 | +1 regression guard |
| Focused tests | 144 pass | 148 pass | +4 edge tests |

The production saving (5-statement snapshot down to 1 narrow read per PR RPC) ships via #11299; this PR locks the edge cases it lacks. Coverage: SPAWN-ASSERTED.

Built with Muse Spark (opencode/muse-spark-1.3) via implement and audit subagent loops with strict branch-audit reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure projects appear in consistent creation-date and ID order.
  * Added coverage for pull request details, statistics, and lists using streamlined project lookups.
  * Added validation for unavailable projects and combined project filters in pull request lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->