### PR TITLE
fix(web): erase terminal cursor fringes between blinks

### DIFF
--- a/apps/web/src/terminal/ghostty/renderer.test.ts
+++ b/apps/web/src/terminal/ghostty/renderer.test.ts
@@ -71,10 +71,73 @@ describe("ghosttyTextRunEnd", () => {
 });
 
 describe("renderGhosttySnapshot", () => {
+  it.each([1, 1.25, 1.5, 2])("keeps cursor and row edges on device pixels at %sx", (scale) => {
+    const rectangles: [number, number, number, number][] = [];
+    const context = {
+      getTransform: () => ({ d: scale }),
+      fillRect: (...rect: [number, number, number, number]) => rectangles.push(rect),
+      set fillStyle(_value: string) {},
+      set textBaseline(_value: string) {},
+    } as unknown as CanvasRenderingContext2D;
+    const snapshot: GhosttySnapshot = {
+      cols: 3,
+      rows: 3,
+      foreground: { r: 255, g: 255, b: 255 },
+      background: { r: 0, g: 0, b: 0 },
+      cursor: { r: 255, g: 255, b: 255 },
+      cursorX: 1,
+      cursorY: 1,
+      cursorVisible: true,
+      cursorBlinking: true,
+      cursorStyle: 1,
+      dirtyRows: new Set([0, 1, 2]),
+      rowData: [0, 1, 2].map(() => ({
+        cells: [cell(""), cell(""), cell("")],
+        text: "",
+        isWrapContinuation: false,
+        wrapsToNext: false,
+      })),
+    };
+    const options = {
+      context,
+      snapshot,
+      metrics: { width: 8, height: 17, baseline: 12 },
+      fontSize: 12,
+      fontFamily: "monospace",
+      padding: 4,
+      originY: 5,
+      forceFull: false,
+    };
+
+    renderGhosttySnapshot({ ...options, cursorOn: true });
+
+    expect(rectangles).toHaveLength(4);
+    for (const [, top, , height] of rectangles) {
+      expect(top * scale).toBeCloseTo(Math.round(top * scale), 10);
+      expect((top + height) * scale).toBeCloseTo(Math.round((top + height) * scale), 10);
+    }
+    for (let row = 0; row < 2; row += 1) {
+      const [, top, , height] = rectangles[row]!;
+      expect(top + height).toBe(rectangles[row + 1]![1]);
+    }
+    const middleRow = rectangles[1]!;
+    expect(rectangles[3]).toEqual([12, middleRow[1], 8, middleRow[3]]);
+
+    rectangles.length = 0;
+    renderGhosttySnapshot({
+      ...options,
+      snapshot: { ...snapshot, dirtyRows: new Set() },
+      cursorOn: false,
+      previousCursorY: 1,
+    });
+    expect(rectangles).toEqual([middleRow]);
+  });
+
   it("underlines every cell in a hovered wrapped link", () => {
     const fillRectCalls: number[][] = [];
     const context = {
       canvas: { width: 200, height: 80 },
+      getTransform: () => ({ d: 1 }),
       beginPath: () => {},
       clip: () => {},
       fillRect: (...args: number[]) => fillRectCalls.push(args),
@@ -131,6 +194,7 @@ describe("renderGhosttySnapshot", () => {
     const fillTextCalls: unknown[][] = [];
     const context = {
       canvas: { width: 200, height: 40 },
+      getTransform: () => ({ d: 1 }),
       beginPath: () => {},
       clip: () => {},
       fillRect: () => {},
@@ -180,6 +244,7 @@ describe("renderGhosttySnapshot", () => {
     const fillTextCalls: unknown[][] = [];
     const context = {
       canvas: { width: 200, height: 40 },
+      getTransform: () => ({ d: 1 }),
       beginPath: () => {},
       clip: () => {},
       fillRect: () => {},
@@ -234,6 +299,7 @@ describe("renderGhosttySnapshot", () => {
     const clearedRows: number[] = [];
     const context = {
       canvas: { width: 200, height: 80 },
+      getTransform: () => ({ d: 1 }),
       beginPath: () => {},
       clip: () => {},
       fillRect: (_left: number, top: number, _width: number, height: number) => {

--- a/apps/web/src/terminal/ghostty/renderer.ts
+++ b/apps/web/src/terminal/ghostty/renderer.ts
@@ -122,6 +122,9 @@ export function renderGhosttySnapshot(options: {
   const selectionBackground = options.selectionBackground ?? DEFAULT_SELECTION_BACKGROUND;
   const hoveredLinkRange = options.hoveredLinkRange ?? null;
   const originY = options.originY ?? padding;
+  const scaleY = context.getTransform().d;
+  // Shared device-pixel edges let a dirty row erase its cursor without touching its neighbors.
+  const rowTop = (row: number) => Math.round((originY + row * metrics.height) * scaleY) / scaleY;
   const rowsToDraw = forceFull
     ? Array.from({ length: snapshot.rows }, (_, index) => index)
     : [...snapshot.dirtyRows];
@@ -149,10 +152,11 @@ export function renderGhosttySnapshot(options: {
   for (const rowIndex of rowsToDraw) {
     const row = snapshot.rowData[rowIndex];
     if (!row) continue;
-    const top = originY + rowIndex * metrics.height;
+    const top = rowTop(rowIndex);
+    const height = rowTop(rowIndex + 1) - top;
 
     context.fillStyle = cssColor(snapshot.background);
-    context.fillRect(padding, top, snapshot.cols * metrics.width, metrics.height);
+    context.fillRect(padding, top, snapshot.cols * metrics.width, height);
 
     let backgroundStart = 0;
     while (backgroundStart < row.cells.length) {
@@ -175,11 +179,11 @@ export function renderGhosttySnapshot(options: {
         const width = (backgroundEnd - backgroundStart) * metrics.width;
         if (!ghosttyColorsEqual(first.background, snapshot.background)) {
           context.fillStyle = cssColor(first.background);
-          context.fillRect(left, top, width, metrics.height);
+          context.fillRect(left, top, width, height);
         }
         if (first.selected) {
           context.fillStyle = selectionBackground;
-          context.fillRect(left, top, width, metrics.height);
+          context.fillRect(left, top, width, height);
         }
       }
       backgroundStart = backgroundEnd;
@@ -205,7 +209,7 @@ export function renderGhosttySnapshot(options: {
           padding + runStart * metrics.width,
           top,
           (runEnd - runStart) * metrics.width,
-          metrics.height,
+          height,
         );
         context.clip();
         context.font = fontForCell(first, fontSize, fontFamily);
@@ -235,10 +239,10 @@ export function renderGhosttySnapshot(options: {
       context.fillStyle = cssColor(cell.foreground);
       const left = padding + column * metrics.width;
       if (cell.underline || hoveredLink) {
-        context.fillRect(left, top + metrics.height - 2, metrics.width, 1);
+        context.fillRect(left, top + height - 2, metrics.width, 1);
       }
       if (cell.strikethrough) {
-        context.fillRect(left, top + Math.floor(metrics.height * 0.55), metrics.width, 1);
+        context.fillRect(left, top + Math.floor(height * 0.55), metrics.width, 1);
       }
       if (cell.overline) context.fillRect(left, top + 1, metrics.width, 1);
     }
@@ -246,21 +250,22 @@ export function renderGhosttySnapshot(options: {
 
   if (cursorOn && snapshot.cursorVisible && snapshot.cursorX >= 0 && snapshot.cursorY >= 0) {
     const left = padding + snapshot.cursorX * metrics.width;
-    const top = originY + snapshot.cursorY * metrics.height;
+    const top = rowTop(snapshot.cursorY);
+    const height = rowTop(snapshot.cursorY + 1) - top;
     context.fillStyle = cssColor(snapshot.cursor);
     if (!focused) {
       // An unfocused terminal draws a hollow cursor so the active pane is obvious.
       context.strokeStyle = cssColor(snapshot.cursor);
-      context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, metrics.height - 1);
+      context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, height - 1);
     } else if (snapshot.cursorStyle === 0) {
-      context.fillRect(left, top, 2, metrics.height);
+      context.fillRect(left, top, 2, height);
     } else if (snapshot.cursorStyle === 2) {
-      context.fillRect(left, top + metrics.height - 2, metrics.width, 2);
+      context.fillRect(left, top + height - 2, metrics.width, 2);
     } else if (snapshot.cursorStyle === 3) {
       context.strokeStyle = cssColor(snapshot.cursor);
-      context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, metrics.height - 1);
+      context.strokeRect(left + 0.5, top + 0.5, metrics.width - 1, height - 1);
     } else {
-      context.fillRect(left, top, metrics.width, metrics.height);
+      context.fillRect(left, top, metrics.width, height);
       const cell = snapshot.rowData[snapshot.cursorY]?.cells[snapshot.cursorX];
       if (cell?.text) {
         context.font = fontForCell(cell, fontSize, fontFamily);

--- a/apps/web/src/terminal/ghostty/surface.test.ts
+++ b/apps/web/src/terminal/ghostty/surface.test.ts
@@ -99,6 +99,7 @@ describe("GhosttyTerminalSurface visibility", () => {
     const mount = new TerminalTestElement();
     const context = {
       canvas,
+      getTransform: () => ({ d: 1 }),
       beginPath() {},
       clip() {},
       rect() {},


### PR DESCRIPTION
## What changed

Snap terminal row boundaries to device pixels and use those same boundaries for the cursor, backgrounds, selection, and text clipping. Adjacent rows share an edge, so repainting the cursor row does not touch its neighbors.

The production change is confined to the shared web/desktop renderer. Blink timing, product defaults, and the terminal protocol stay unchanged. Mobile uses its separate native renderer.

## Why

At fractional display scales, repainting an antialiased row boundary blends over the cursor edge instead of fully erasing it. This leaves faint horizontal lines during the blink's off phase. Pixel-aligned boundaries fix that without repainting the entire terminal on every blink.

Closes #11402.

```mermaid
flowchart LR
    A[Cursor on] --> B[Blink off]
    B --> C[Repaint cursor row]
    C --> D[Shared pixel edges erase the cursor completely]
```

## UI changes

Before/after Chromium reproduction using the actual renderer from `b1e223e2b0` and this branch, with identical input. The PNGs are captured at 2x density; the inset enlarges the original canvas pixels 8x. These are isolated renderer captures, not full-app screenshots.

| Before | After |
| --- | --- |
| ![Cursor edges remain during blink off](https://github.com/Lucenx9/t3code/releases/download/evidence-terminal-cursor-48311fb4d5/before.png) | ![Cursor disappears completely](https://github.com/Lucenx9/t3code/releases/download/evidence-terminal-cursor-48311fb4d5/after.png) |

[Short before/after video](https://github.com/Lucenx9/t3code/releases/download/evidence-terminal-cursor-48311fb4d5/cursor-blink.mp4). [Full comparison and integrated-terminal evidence](https://github.com/Lucenx9/t3code/releases/tag/evidence-terminal-cursor-48311fb4d5).

### Verification

- 66 focused tests pass in `renderer.test.ts` and `surface.test.ts`. The new geometry tests fail at 125% and 150% on the base renderer.
- Web package typecheck and targeted lint/format checks pass.
- All 97 real-canvas comparisons pass after the fix, covering four cursor styles, light/dark themes, text, selections, adjacent rows, four display scales, and a fractional CSS origin.
- Tested the full app in Chromium with isolated state and synthetic shell output. At 125%, the live cursor leaves no residual pixels, including after scrollback appears.
- Scoped Fallow audit passes with one thread and no introduced findings. Existing findings were left untouched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5. Harness: OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal rendering across different display scales by aligning row boundaries to device pixels.
  - Corrected row heights for backgrounds, selections, text, decorations, and cursor rendering to maintain consistent vertical alignment.
  - Limited cursor updates to the affected row when appropriate, improving repaint behavior.

- **Tests**
  - Added coverage for pixel alignment, contiguous row boundaries, and targeted cursor repainting across multiple display scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->