### PR TITLE
fix(shared): preserve final quoted empty CSV records

### DIFF
--- a/packages/shared/src/delimitedPreview.test.ts
+++ b/packages/shared/src/delimitedPreview.test.ts
@@ -21,6 +21,35 @@ describe("delimited file previews", () => {
       ["", "three"],
     ]);
   });
+  describe.each([",", "\t"] as const)("with delimiter %j", (delimiter) => {
+    it("preserves a final quoted empty record without requiring a line ending", () => {
+      for (const ending of ["", "\n", "\r\n"]) {
+        expect(parseDelimitedPreview(`name\r\nAlice\r\n""${ending}`, delimiter)).toEqual({
+          rows: [["name"], ["Alice"], [""]],
+          truncated: false,
+        });
+      }
+      expect(parseDelimitedPreview('""', delimiter)).toEqual({
+        rows: [[""]],
+        truncated: false,
+      });
+    });
+    it("does not invent records for empty input or a trailing line ending", () => {
+      for (const prefix of ["", "\ufeff"]) {
+        expect(parseDelimitedPreview(prefix, delimiter).rows).toEqual([]);
+        expect(parseDelimitedPreview(`${prefix}name\r\n`, delimiter).rows).toEqual([["name"]]);
+        expect(parseDelimitedPreview(`${prefix}""`, delimiter).rows).toEqual([[""]]);
+      }
+    });
+    it("keeps a quoted empty record at the row limit", () => {
+      const text = `${"name\n".repeat(99)}""`;
+      const preview = parseDelimitedPreview(text, delimiter);
+      expect(preview.rows).toHaveLength(100);
+      expect(preview.rows.at(-1)).toEqual([""]);
+      expect(preview.truncated).toBe(false);
+      expect(parseDelimitedPreview(`${text}\nextra`, delimiter).truncated).toBe(true);
+    });
+  });
   it("bounds rows, columns and cell length and reports partial content", () => {
     const table = parseDelimitedPreview(
       Array.from({ length: 101 }, () =>

--- a/packages/shared/src/delimitedPreview.ts
+++ b/packages/shared/src/delimitedPreview.ts
@@ -16,12 +16,13 @@ export function parseDelimitedPreview(text: string, delimiter: "," | "\t") {
   let cell = "";
   let quoted = false;
   let truncated = false;
+  let rowStart = text.charCodeAt(0) === 0xfeff ? 1 : 0;
   const endCell = () => {
     if (row.length < 30) row.push(cell);
     else truncated = true;
     cell = "";
   };
-  for (let index = text.charCodeAt(0) === 0xfeff ? 1 : 0; index < text.length; index++) {
+  for (let index = rowStart; index < text.length; index++) {
     const char = text[index];
     if (char === '"') {
       if (quoted && text[index + 1] === '"') {
@@ -41,12 +42,13 @@ export function parseDelimitedPreview(text: string, delimiter: "," | "\t") {
         rows.push(row);
         row = [];
         if (char === "\r" && text[index + 1] === "\n") index++;
+        rowStart = index + 1;
         if (rows.length === 100) return { rows, truncated: truncated || index < text.length - 1 };
       }
     } else if (cell.length < 2000) cell += char;
     else truncated = true;
   }
-  if (cell.length || row.length) {
+  if (rowStart < text.length) {
     endCell();
     rows.push(row);
   }


### PR DESCRIPTION
## What changed

Keep the final quoted empty record in CSV and TSV table previews when the file has no trailing line ending. The parser now tracks the start of the source row instead of using decoded cell content to decide whether a final record exists.

## Why

For `name\r\nAlice\r\n""`, the preview drops the last row and reports complete content. Adding a final CRLF makes that same row appear. A final record without a line ending is valid CSV, including a quoted empty field. See [RFC 4180, section 2](https://www.rfc-editor.org/rfc/rfc4180.html#section-2).

```mermaid
flowchart LR
    A[Final quoted empty record without a line ending] --> B[Before: empty decoded buffers]
    B --> C[Row omitted]
    A --> D[After: source row still present]
    D --> E[Row retained]
```

This changes only the shared parser and its focused tests. The web and desktop attachment and workspace table previews use it. Mobile does not currently render this table component. File contents, source view, wire contracts, product defaults, and preview limits are unchanged.

## Verification

- The six new regression tests fail on the base commit. All nine tests pass with the fix.
- `vp test run packages/shared/src/delimitedPreview.test.ts --maxWorkers=1 --no-file-parallelism`
- `vp lint packages/shared/src/delimitedPreview.ts packages/shared/src/delimitedPreview.test.ts`
- `vp fmt --check packages/shared/src/delimitedPreview.ts packages/shared/src/delimitedPreview.test.ts`
- `tsc --noEmit -p packages/shared/tsconfig.json` passes. Existing Effect suggestions remain in unrelated files.
- 504 generated round-trip cases pass across both delimiters, LF/CRLF/CR, BOM, quoted line breaks, empty fields, and the 100-row limit.
- Fallow review scoped to `packages/shared`, one thread: low risk, no new APIs, dependencies, or diagnostic suppressions. No structural decisions flagged. Consumers outside that package were checked in source.

## UI changes

Captured in the running T3 web app with Chromium at 2× device scale. The same draft attachment contains `Participant\r\nAlice\r\nBob\r\n""`, without a final newline. The before capture uses the parser from `b1e223e2b0`; the after capture uses `caaf8daa44`. No styles or components were changed for the captures.

Before: two data rows. The final empty record is missing.

![Before: only Alice and Bob appear](https://github.com/Lucenx9/t3code/releases/download/evidence-csv-empty-record-caaf8daa44/before.png)

After: three data rows. The empty row below Bob is retained.

![After: the empty row below Bob is retained](https://github.com/Lucenx9/t3code/releases/download/evidence-csv-empty-record-caaf8daa44/after.png)

[Source view showing the quoted empty fourth line](https://github.com/Lucenx9/t3code/releases/download/evidence-csv-empty-record-caaf8daa44/source.png). Switching back to the table preserves all three data rows.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No animation or timing changes, so a video is not applicable

Model: GPT-5 family. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delimited data previews for BOM-prefixed input, empty records, trailing line endings, and quoted empty values.
  * Corrected row-limit and truncation handling to ensure previews include the appropriate remaining data.

* **Tests**
  * Added coverage for empty input, BOM handling, row limits, trailing line endings, quoted empty records, and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->