### PR TITLE
fix(mobile): pin expo-audio so the release smoke patch stays in use

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,7 +75,7 @@
     "effect": "catalog:",
     "expo": "~57.0.18",
     "expo-asset": "~57.0.15",
-    "expo-audio": "~57.0.4",
+    "expo-audio": "57.0.4",
     "expo-auth-session": "~57.0.10",
     "expo-blur": "~57.0.2",
     "expo-build-properties": "~57.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2)
       expo-audio:
-        specifier: ~57.0.4
+        specifier: 57.0.4
         version: 57.0.4(patch_hash=fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a)(expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-auth-session:
         specifier: ~57.0.10


### PR DESCRIPTION
## Problem

The Release Smoke job fails on every PR (for example [#8419](https://github.com/pingdotgg/t3code/actions/runs/34698145445/job/103565088499?pr=8419)):

```
[ERR_PNPM_UNUSED_PATCH] The following patches were not used: expo-audio@57.0.4
Error: Command failed: vp install --lockfile-only --ignore-scripts
```

`scripts/release-smoke.ts` deletes `pnpm-lock.yaml` and re-resolves from scratch. expo-audio 57.0.5 was published on 2026-09-11, so the `~57.0.4` range now resolves to 57.0.5 and the `expo-audio@57.0.4` patch in `pnpm-workspace.yaml` is unused. Main CI was green earlier the same day because the release was not out yet.

## Fix

Pin `expo-audio` to the exact `57.0.4` in `apps/mobile/package.json`, matching how `expo-sharing` is already pinned for its patch. The lockfile specifier is updated to match; the resolved version and patch hash are unchanged.

Note: `@react-native-menu/menu` is `^2.0.0` with a `2.0.0` patch and has the same latent risk, left as is to keep this PR to one concern.

Fable 5.1 via Claude Code in T3 Code



Closes #11437
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the mobile app’s audio package version to ensure consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
