### PR TITLE
feat(web): add an opt-in shortcut to rename the active thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6309,10 +6309,10 @@ export default function ChatView(props: ChatViewProps) {
       if (!command) return;
 
       if (command === "thread.rename") {
+        if (!isServerThread || !activeThreadRef) return;
         event.preventDefault();
         event.stopPropagation();
-        if (!event.repeat && isServerThread && activeThreadRef)
-          requestThreadRename(activeThreadRef);
+        if (!event.repeat) requestThreadRename(activeThreadRef);
         return;
       }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -163,6 +163,7 @@ import {
 } from "../types";
 import { useTheme } from "../hooks/useTheme";
 import { writeTextToClipboard } from "../hooks/useCopyToClipboard";
+import { requestThreadRename } from "../threadRenameBus";
 import { isCommandPaletteOpen } from "../commandPaletteBus";
 import { subscribeSnapShotComposerFocus } from "../lib/desktopSnapShot";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
@@ -6306,6 +6307,14 @@ export default function ChatView(props: ChatViewProps) {
         context: shortcutContext,
       });
       if (!command) return;
+
+      if (command === "thread.rename") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!event.repeat && isServerThread && activeThreadRef)
+          requestThreadRename(activeThreadRef);
+        return;
+      }
 
       if (command === "thread.copyReference") {
         event.preventDefault();

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -46,6 +46,7 @@ import {
   WorkspaceBreadcrumbItem,
   WorkspaceBreadcrumbSeparator,
 } from "../WorkspaceBreadcrumb";
+import { subscribeThreadRename } from "../../threadRenameBus";
 import { cn } from "~/lib/utils";
 
 interface ChatHeaderProps {
@@ -189,6 +190,10 @@ export const ChatHeader = memo(function ChatHeader({
     renameCommittedRef.current = false;
     setRenaming({ threadId: activeThreadId, title: activeThreadTitle });
   }, [activeThreadId, activeThreadTitle]);
+  useEffect(() => {
+    if (!isServerThread) return;
+    return subscribeThreadRename(activeThreadRef, startRename);
+  }, [activeThreadRef, isServerThread, startRename]);
   const commitRename = useCallback(
     (title: string) => {
       setRenaming(null);

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -206,12 +206,15 @@ describe("KeybindingsSettings.logic", () => {
         "chat.new",
         "rightPanel.toggleMaximized",
         "thread.stop",
+        "thread.rename",
         "script.setup-db.run",
       ]),
     );
-    expect(DEFAULT_RESOLVED_KEYBINDINGS.some((binding) => binding.command === "thread.stop")).toBe(
-      false,
-    );
+    for (const command of ["thread.stop", "thread.rename"]) {
+      expect(DEFAULT_RESOLVED_KEYBINDINGS.some((binding) => binding.command === command)).toBe(
+        false,
+      );
+    }
   });
 
   it("reports unknown when variables without rejecting parseable expressions", () => {

--- a/apps/web/src/threadRenameBus.ts
+++ b/apps/web/src/threadRenameBus.ts
@@ -1,0 +1,21 @@
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+
+const EVENT_NAME = "t3code:thread-rename";
+
+/** Routes the active thread shortcut to its existing inline title editor. */
+export function requestThreadRename(threadRef: ScopedThreadRef): void {
+  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: scopedThreadKey(threadRef) }));
+}
+
+export function subscribeThreadRename(
+  threadRef: ScopedThreadRef,
+  listener: () => void,
+): () => void {
+  const key = scopedThreadKey(threadRef);
+  const handler = (event: Event) => {
+    if ((event as CustomEvent<string>).detail === key) listener();
+  };
+  window.addEventListener(EVENT_NAME, handler);
+  return () => window.removeEventListener(EVENT_NAME, handler);
+}

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -56,6 +56,9 @@ a shortcut.
 `thread.stop` interrupts the running turn in the focused thread. It has no default
 shortcut; assign one in **Settings → Keybindings**.
 
+`thread.rename` edits the active thread's title. It has no default shortcut;
+assign one in **Settings → Keybindings**.
+
 `chat.new` may ask you to choose a project when there is more than one.
 `chat.newLocal` skips that chooser. Both use your
 [new-thread defaults](./thread-sidebar.md#start-a-thread).

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -19,6 +19,7 @@ const decode = <S extends Schema.Top>(
     never
   >;
 
+const decodeKeybindingsConfig = Schema.decodeUnknownSync(KeybindingsConfig);
 const decodeResolvedRule = Schema.decodeUnknownEffect(ResolvedKeybindingRule as never);
 const encodeResolvedKeybindings = Schema.encodeEffect(ResolvedKeybindingsConfig);
 
@@ -302,3 +303,8 @@ it.effect("drops unknown fields in resolved keybinding rules", () =>
     }),
   ),
 );
+
+it("accepts the opt-in thread rename shortcut", () => {
+  const rules = [{ key: "mod+shift+r", command: "thread.rename", when: "!terminalFocus" }];
+  assert.deepStrictEqual(decodeKeybindingsConfig(rules), rules);
+});

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -36,6 +36,7 @@ export type ModelPickerJumpKeybindingCommand =
 
 const THREAD_KEYBINDING_COMMANDS = [
   "thread.stop",
+  "thread.rename",
   "thread.previous",
   "thread.next",
   "thread.copyReference",


### PR DESCRIPTION
## What Changed

Adds `thread.rename` as an unassigned command in Settings → Keybindings. A configured shortcut opens the active thread's existing inline title editor; Enter saves and Escape cancels.

## Why

Renaming a thread currently requires using the pointer. The shortcut reuses the existing editor and persistence flow, and ignores repeated keydown events. When the active thread cannot be renamed, the shortcut leaves the key event unhandled so contextual actions such as Escape can still run.

## Validation

- 82 focused shortcut, contract, and keybinding settings tests passed on this branch.
- Web typecheck passed; targeted lint reported only existing warnings.
- Verified in the local ARM64 desktop app: assignment, opening the editor, saving with Enter, cancelling with Escape, and persistence after switching threads.
- Applies to web and desktop keyboard handling. No mobile UI, provider adapter, or server behavior changes.

## UI Changes

Before invoking the shortcut:

![Thread before rename](https://github.com/user-attachments/assets/95882260-bdce-4415-b275-c6607533257e)

After invoking the configured shortcut:

![Existing inline editor opened by the shortcut](https://github.com/user-attachments/assets/e9fc015b-3017-4bab-b0d2-dff5e541cf69)

After saving:

![Saved thread title](https://github.com/user-attachments/assets/891b6ecd-6915-4e2b-b007-72317497cc22)

Implemented and verified with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for assigning a keyboard shortcut to rename the active server thread.
  - Triggering the shortcut opens the thread’s inline rename flow.
  - Rename shortcuts are ignored for threads that cannot be renamed.

- **Documentation**
  - Documented the `thread.rename` command and clarified that it has no default shortcut.

- **Tests**
  - Added coverage for configuring and resolving the optional thread rename command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->