### PR TITLE
feat(web): add an opt-in shortcut to reopen the latest browser URL

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -183,7 +183,7 @@ import {
 } from "../previewStateStore";
 import { previewRuntimeTabId } from "../browser/previewRuntimeTabId";
 import { BrowserSettingsReadError } from "../browser/openFileInPreview";
-import { addBrowserSurface } from "./preview/addBrowserSurface";
+import { addBrowserSurface, openRecentBrowserSurface } from "./preview/addBrowserSurface";
 import { closePreviewSession } from "./preview/closePreviewSession";
 import { ThreadPreviewMiniPlayer } from "./preview/ThreadPreviewMiniPlayer";
 import { subscribePreviewAction } from "./preview/previewActionBus";
@@ -4834,8 +4834,23 @@ export default function ChatView(props: ChatViewProps) {
     () =>
       subscribePreviewAction((action) => {
         if (action === "toggle-panel") togglePreviewPanel();
+        if (action === "open-recent" && activeThreadRef && isPreviewSupportedInRuntime()) {
+          void openRecentBrowserSurface({ threadRef: activeThreadRef, openPreview }).then(
+            (result) => {
+              if (result._tag !== "Failure" || isAtomCommandInterrupted(result)) return;
+              const error = squashAtomCommandFailure(result);
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Unable to open browser",
+                  description: error instanceof Error ? error.message : "An error occurred.",
+                }),
+              );
+            },
+          );
+        }
       }),
-    [togglePreviewPanel],
+    [activeThreadRef, openPreview, togglePreviewPanel],
   );
   const persistThreadSettingsForNextTurn = useCallback(
     async (input: {

--- a/apps/web/src/components/preview/addBrowserSurface.test.ts
+++ b/apps/web/src/components/preview/addBrowserSurface.test.ts
@@ -7,17 +7,19 @@ import {
   type ScopedThreadRef,
 } from "@t3tools/contracts";
 import { AsyncResult } from "effect/unstable/reactivity";
+import * as Cause from "effect/Cause";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   applyPreviewServerSnapshot,
+  rememberPreviewUrl,
   readThreadPreviewState,
   resetPreviewStateForTests,
 } from "~/previewStateStore";
 import { selectThreadRightPanelState, useRightPanelStore } from "~/rightPanelStore";
 import { __setClientSettingsForTests } from "~/hooks/useSettings";
 
-import { addBrowserSurface } from "./addBrowserSurface";
+import { addBrowserSurface, openRecentBrowserSurface } from "./addBrowserSurface";
 
 const threadRef = {
   environmentId: "local" as ScopedThreadRef["environmentId"],
@@ -79,5 +81,68 @@ describe("addBrowserSurface", () => {
         threadRef,
       ).surfaces.map((surface) => surface.id),
     ).toEqual(["browser:tab-1", "browser:tab-2"]);
+  });
+});
+
+describe("openRecentBrowserSurface", () => {
+  it("opens only one tab for overlapping shortcut invocations", async () => {
+    let tabNumber = 0;
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot(`tab-${++tabNumber}`)));
+    await Promise.all([
+      openRecentBrowserSurface({ threadRef, openPreview }),
+      openRecentBrowserSurface({ threadRef, openPreview }),
+    ]);
+    expect(openPreview).toHaveBeenCalledTimes(1);
+    expect(Object.keys(readThreadPreviewState(threadRef).sessions)).toEqual(["tab-1"]);
+  });
+
+  it("allows another shortcut attempt after opening fails", async () => {
+    const openPreview = vi.fn(async () =>
+      AsyncResult.failure<PreviewSessionSnapshot, Error>(Cause.fail(new Error("Open failed"))),
+    );
+    await openRecentBrowserSurface({ threadRef, openPreview });
+    await openRecentBrowserSurface({ threadRef, openPreview });
+    expect(openPreview).toHaveBeenCalledTimes(2);
+  });
+
+  it("opens a blank browser when the thread has no URL", async () => {
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot("tab-1")));
+    await openRecentBrowserSurface({ threadRef, openPreview });
+    expect(openPreview.mock.calls).toHaveLength(1);
+    expect(readThreadPreviewState(threadRef).activeTabId).toBe("tab-1");
+    expect(readThreadPreviewState(threadRef).recentlySeenUrls).toEqual([]);
+  });
+
+  it("restores the most recent URL without borrowing another thread's history", async () => {
+    rememberPreviewUrl(threadRef, "https://example.com/old");
+    rememberPreviewUrl(threadRef, "https://example.com/recent");
+    rememberPreviewUrl(
+      { ...threadRef, threadId: "other" as ScopedThreadRef["threadId"] },
+      "https://other.com/",
+    );
+    const openPreview = vi.fn(async (_input: PreviewOpenInput) =>
+      AsyncResult.success(snapshot("tab-2")),
+    );
+    await openRecentBrowserSurface({ threadRef, openPreview: ({ input }) => openPreview(input) });
+    expect(openPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://example.com/recent", threadId: threadRef.threadId }),
+    );
+  });
+
+  it("reopens the tab with the most recent URL and never toggles it closed", async () => {
+    const existing = {
+      ...snapshot("tab-1"),
+      navStatus: { _tag: "Success" as const, url: "https://example.com/", title: "Example" },
+    };
+    applyPreviewServerSnapshot(threadRef, existing);
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot("tab-2")));
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await openRecentBrowserSurface({ threadRef, openPreview });
+      expect(
+        selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef)
+          .activeSurfaceId,
+      ).toBe("browser:tab-1");
+    }
+    expect(openPreview).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/preview/addBrowserSurface.ts
+++ b/apps/web/src/components/preview/addBrowserSurface.ts
@@ -2,12 +2,17 @@ import {
   mapAtomCommandResult,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
+import { scopedThreadKey } from "@t3tools/client-runtime/environment";
+import { AsyncResult } from "effect/unstable/reactivity";
 import type { ScopedThreadRef } from "@t3tools/contracts";
 
 import type { BrowserSettingsReadError, OpenPreviewMutation } from "~/browser/openFileInPreview";
+import { readThreadPreviewState } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
 
 import { openPreviewSession } from "./openPreviewSession";
+
+const pendingRecentBrowserThreads = new Set<string>();
 
 /** Creates a new browser tab. Reopening an existing tab is a separate UI action. */
 export async function addBrowserSurface<E>(input: {
@@ -15,13 +20,43 @@ export async function addBrowserSurface<E>(input: {
   readonly openPreview: OpenPreviewMutation<E>;
   /** Omit to use the configured default profile. */
   readonly profileId?: string | undefined;
+  readonly url?: string | undefined;
 }): Promise<AtomCommandResult<void, E | BrowserSettingsReadError>> {
   const result = await openPreviewSession({
     openPreview: input.openPreview,
     threadRef: input.threadRef,
+    ...(input.url === undefined ? {} : { url: input.url }),
     ...(input.profileId === undefined ? {} : { profileId: input.profileId }),
   });
   return mapAtomCommandResult(result, (snapshot) => {
     useRightPanelStore.getState().openBrowser(input.threadRef, snapshot.tabId);
   });
+}
+
+/** Reuses the most recently visited tab, or restores its URL after it was closed. */
+export async function openRecentBrowserSurface<E>(input: {
+  readonly threadRef: ScopedThreadRef;
+  readonly openPreview: OpenPreviewMutation<E>;
+}): Promise<AtomCommandResult<void, E | BrowserSettingsReadError>> {
+  const state = readThreadPreviewState(input.threadRef);
+  const url = state.recentlySeenUrls[0];
+  const existing = url
+    ? Object.values(state.sessions).find(
+        (session) => session.navStatus._tag !== "Idle" && session.navStatus.url === url,
+      )
+    : state.activeTabId
+      ? state.sessions[state.activeTabId]
+      : undefined;
+  if (existing) {
+    useRightPanelStore.getState().openBrowser(input.threadRef, existing.tabId);
+    return AsyncResult.success(undefined);
+  }
+  const key = scopedThreadKey(input.threadRef);
+  if (pendingRecentBrowserThreads.has(key)) return AsyncResult.success(undefined);
+  pendingRecentBrowserThreads.add(key);
+  try {
+    return await addBrowserSurface({ ...input, url });
+  } finally {
+    pendingRecentBrowserThreads.delete(key);
+  }
 }

--- a/apps/web/src/components/preview/previewActionBus.ts
+++ b/apps/web/src/components/preview/previewActionBus.ts
@@ -7,6 +7,7 @@
  */
 export type PreviewAction =
   | "toggle-panel"
+  | "open-recent"
   | "refresh"
   | "focus-url"
   | "zoom-in"

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -17,6 +17,13 @@ import {
 } from "./KeybindingsSettings.logic";
 
 describe("KeybindingsSettings.logic", () => {
+  it("offers the recent browser command without assigning a default shortcut", () => {
+    expect(buildKeybindingCommandOptions([])).toContain("preview.openRecent");
+    expect(
+      DEFAULT_RESOLVED_KEYBINDINGS.some((binding) => binding.command === "preview.openRecent"),
+    ).toBe(false);
+  });
+
   it("builds searchable rows with readable key and when values", () => {
     const rows = buildKeybindingRows(
       [

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -108,7 +108,7 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      if (command === "preview.toggle") {
+      if (command === "preview.toggle" || command === "preview.openRecent") {
         event.preventDefault();
         event.stopPropagation();
         if (!routeThreadRef) return;
@@ -122,7 +122,9 @@ function ChatRouteGlobalShortcuts() {
           );
           return;
         }
-        dispatchPreviewAction("toggle-panel");
+        if (command !== "preview.openRecent" || !event.repeat) {
+          dispatchPreviewAction(command === "preview.openRecent" ? "open-recent" : "toggle-panel");
+        }
         return;
       }
 

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -60,6 +60,11 @@ shortcut; assign one in **Settings → Keybindings**.
 `chat.newLocal` skips that chooser. Both use your
 [new-thread defaults](./thread-sidebar.md#start-a-thread).
 
+`preview.openRecent` opens the right sidebar's in-app browser at the thread's
+most recent browser URL, or a blank browser if none is available. It reuses an
+existing tab for that URL. Assign a shortcut in **Settings → Keybindings**; none
+is assigned by default. The in-app browser requires a supported desktop runtime.
+
 ## Reserved shortcuts
 
 In the desktop app, `mod+w` closes the focused terminal or the active right-panel

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -19,8 +19,14 @@ const decode = <S extends Schema.Top>(
     never
   >;
 
+const decodeKeybindingsConfig = Schema.decodeUnknownSync(KeybindingsConfig);
 const decodeResolvedRule = Schema.decodeUnknownEffect(ResolvedKeybindingRule as never);
 const encodeResolvedKeybindings = Schema.encodeEffect(ResolvedKeybindingsConfig);
+
+it("accepts the opt-in recent preview shortcut", () => {
+  const rules = [{ key: "mod+shift+o", command: "preview.openRecent", when: "!terminalFocus" }];
+  assert.deepStrictEqual(decodeKeybindingsConfig(rules), rules);
+});
 
 it.effect("parses keybinding rules", () =>
   Effect.gen(function* () {

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -63,6 +63,7 @@ export const STATIC_KEYBINDING_COMMANDS = [
   "rightPanel.close",
   "diff.toggle",
   "preview.toggle",
+  "preview.openRecent",
   "preview.refresh",
   "preview.focusUrl",
   "preview.zoomIn",


### PR DESCRIPTION
## What Changed

Adds `preview.openRecent` as an unassigned command in Settings → Keybindings. It opens the active thread's most recently visited in-app browser URL in the right sidebar, reuses a matching tab, or opens a blank browser when the thread has no browser history.

## Why

The existing browser toggle only opens or closes the panel. This command restores the last visited URL after its tab has been closed and keeps the browser open when invoked again. Overlapping shortcut requests for the same thread are ignored while its first open is pending. History and tab selection remain scoped to the active environment and thread.

## Validation

- 47 focused contract, keybinding settings, and preview tests passed on this branch.
- Regression coverage checks overlapping invocations and retry after a failed open.
- Web typecheck passed; targeted lint reported only existing warnings.
- Verified in the local ARM64 desktop app: assignment, blank history, reopening a closed tab at its latest URL, repeated invocation without duplicate tabs, and isolation between threads.
- Uses the existing supported-desktop-runtime guard. Standalone web and mobile do not gain an embedded browser; provider adapters and server behavior are unchanged.
- As with existing app shortcuts, keyboard focus inside the embedded webpage is owned by that webpage.

## UI Changes

Before invoking the shortcut, after closing the browser tab:

![Browser panel closed](https://github.com/user-attachments/assets/463a6949-c928-4a02-bb7f-2eab9eab7d1f)

After invoking the configured shortcut:

![Latest browser URL restored](https://github.com/user-attachments/assets/1d990cd7-b334-45d4-bd0f-5a320c0e4c5e)

A thread without browser history:

![Blank browser for a thread without history](https://github.com/user-attachments/assets/647b6fb1-9327-4981-89d9-a41bb830d99b)

Implemented and verified with GPT-6 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open Recent” preview command that opens the thread’s most recent browser URL, or a blank browser when none is available.
  * Reuses an existing tab when possible and prevents duplicate openings.
  * Added support for assigning a custom keyboard shortcut; no shortcut is assigned by default.
  * Added an “open-recent” preview action, available in supported desktop environments.

* **Documentation**
  * Documented the new command, behavior, and runtime requirements in the keybindings guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->