### PR TITLE
ci: fall back to GitHub-hosted runners outside pingdotgg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,13 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Blacksmith runners only exist under the pingdotgg org. Every job picks its
+# runner with `case(github.repository_owner == 'pingdotgg', <blacksmith>, <github-hosted>)`
+# so forks run the same CI on GitHub-hosted runners. New jobs should do the same.
 jobs:
   check:
     name: Check
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -75,7 +78,7 @@ jobs:
   # limit stays at the default 4 so peak load per runner is unchanged.
   test:
     name: Test
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -115,7 +118,7 @@ jobs:
   # isolation that flag buys is preserved exactly.
   test_server:
     name: Test Server ${{ matrix.shard }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -182,7 +185,7 @@ jobs:
   # for checks that take under 3s, on the critical path of every PR.
   rust:
     name: Rust
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-4vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -216,7 +219,7 @@ jobs:
   # the diff cannot be resolved, the lint runs.
   mobile_native_changes:
     name: Mobile Native Changes
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-2vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 5
     permissions:
       contents: read
@@ -294,7 +297,7 @@ jobs:
     # Skip only on an explicit "no": a gate job that failed or errored leaves the
     # output empty, and that must run the lint rather than silently skip it.
     if: ${{ !cancelled() && needs.mobile_native_changes.outputs.changed != 'false' }}
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-6vcpu-macos-26', 'macos-26') }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -322,7 +325,7 @@ jobs:
 
   release_smoke:
     name: Release Smoke
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/mobile-fingerprint-check.yml
+++ b/.github/workflows/mobile-fingerprint-check.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   fingerprint:
     name: Native fingerprint diff
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   test:
     name: Test (${{ inputs.package || 'all non-server' }})
-    runs-on: blacksmith-8vcpu-windows-2025
+    runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-windows-2025', 'windows-2025') }}
     timeout-minutes: 45
     steps:
       - name: Checkout


### PR DESCRIPTION
## What Changed

Every job in `ci.yml`, `mobile-fingerprint-check.yml`, and `windows-tests.yml` now picks its runner based on the repository owner:

```yaml
runs-on: ${{ case(github.repository_owner == 'pingdotgg', 'blacksmith-8vcpu-ubuntu-2404', 'ubuntu-24.04') }}
```

Under `pingdotgg` the label is byte-for-byte what it was, so nothing about upstream CI changes: same runner sizes, same steps, same cost. Anywhere else it resolves to the equivalent GitHub-hosted runner (`ubuntu-24.04`, `macos-26`, `windows-2025`).

Nine `runs-on` lines plus a short comment above `jobs:` in `ci.yml` pointing the next job at the same pattern.

## Why

Blacksmith runner labels only resolve for the org that owns the Blacksmith account. On a fork, every job in these three workflows queues forever against a label that will never have a runner, so a contributor gets no CI signal at all before opening a PR and cannot tell a real failure from an unschedulable one.

The alternative, a second fork-only workflow file, means two CI definitions that drift. This keeps one file as the single source of truth: forks inherit the same jobs, steps, and ordering, and only the runner label differs.

Scope is limited to the three workflows a fork actually runs without secrets. `release`, `deploy-relay`, `web-preview`, `desktop-macos-preview`, the EAS lanes, AUR, and the showcase workflows are secret- or label-gated and already skip on forks, so converting them would add diff with no fork benefit. `pr-size.yml` and `pr-vouch.yml` were already on `ubuntu-24.04`.

`case()` is a documented GitHub Actions expression function, and keeping the selection inline on `runs-on` means there is no extra gate job on the critical path and no second place for the runner mapping to live.

## Verification

Pushed this branch to a fork and ran the full CI workflow there against a scratch base, so the non-`pingdotgg` path executed for real rather than being reasoned about. Every job scheduled and picked up a runner, confirming the expression resolves and all five fallback labels are valid:

| Job | Fallback runner | Result |
| --- | --- | --- |
| Check | `ubuntu-24.04` | pass |
| Test | `ubuntu-24.04` | pass |
| Test Server 1-3 | `ubuntu-24.04` | pass |
| Rust | `ubuntu-24.04` | pass |
| Mobile Native Changes | `ubuntu-24.04` | pass |
| Mobile Native Static Analysis | `macos-26` | pass |
| Native fingerprint diff | `ubuntu-24.04` | pass |
| Release Smoke | `ubuntu-24.04` | fails, see below |

Release Smoke fails with `ERR_PNPM_UNUSED_PATCH: expo-audio@57.0.4`, which is the pre-existing `main` breakage that #11426 fixes. It fails identically on `main` upstream on Blacksmith, so it is unrelated to runner selection and is left alone here.

Worth calling out that the two apt steps in `Check` and `Test` pass on GitHub-hosted runners. They touch `/etc/apt/blacksmith-ubuntu-mirrors.txt`, but that file is created by `.github/actions/setup-apt-mirrors` on whatever runner it runs on, so nothing there is Blacksmith-specific despite the name.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

---

Opus 5 via T3 Code (Claude Code harness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Continuous integration now runs successfully for both the main repository and forks.
  * Forks use standard GitHub-hosted runners, while the main repository continues using optimized runners where available.
  * Mobile fingerprint checks and Windows tests now support the same runner fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->