### PR TITLE
fix(mobile): render photo library picks to a bounded JPEG off the JS thread

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -91,6 +91,7 @@
     "expo-glass-effect": "~57.0.1",
     "expo-haptics": "~57.0.2",
     "expo-image": "~57.0.3",
+    "expo-image-manipulator": "~57.0.17",
     "expo-image-picker": "~57.0.14",
     "expo-linking": "~57.0.8",
     "expo-network": "~57.0.1",

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
   open: vi.fn(),
   size: vi.fn(),
   readBase64: vi.fn(),
+  manipulate: vi.fn(),
+  release: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => {
@@ -80,6 +82,10 @@ vi.mock("expo-file-system", () => {
 
 vi.mock("expo-image-picker", () => ({ launchImageLibraryAsync: mocks.pickMedia }));
 vi.mock("expo-document-picker", () => ({ getDocumentAsync: mocks.pickFile }));
+vi.mock("expo-image-manipulator", () => ({
+  SaveFormat: { JPEG: "jpeg", PNG: "png", WEBP: "webp" },
+  ImageManipulator: { manipulate: mocks.manipulate },
+}));
 vi.mock("./uuid", () => ({ uuidv4: () => "attachment-id" }));
 
 import {
@@ -106,20 +112,50 @@ describe("composer file attachments", () => {
   });
 
   describe("photo library image conversion", () => {
-    const jpeg = "/9j/2Q==";
+    const rendered = { uri: "file:///cache/ImageManipulator/photo.jpg", base64: "/9j/2Q==" };
     const photo: ImagePickerAsset = {
       uri: "file:///picker/photo.heic",
       type: "image",
       fileName: "photo.HEIC",
       mimeType: "image/heic",
-      fileSize: 20 * 1024 * 1024,
-      base64: jpeg,
-      width: 1,
-      height: 1,
+      fileSize: 4 * 1024 * 1024,
+      width: 4032,
+      height: 3024,
+    };
+    /**
+     * Stands in for the native manipulator: `size` is what decoding the source yields,
+     * `resizes` records every requested resize, and `saved` is what saving returns.
+     */
+    const native = {
+      size: { width: 1, height: 1 },
+      resizes: [] as Array<{ width?: number | null; height?: number | null }>,
+      saved: rendered as { uri: string; base64?: string },
     };
 
+    beforeEach(() => {
+      native.size = { width: 1, height: 1 };
+      native.resizes = [];
+      native.saved = rendered;
+      mocks.manipulate.mockReset();
+      mocks.release.mockReset();
+      mocks.manipulate.mockImplementation(() => {
+        const context = {
+          resize(size: { width?: number | null; height?: number | null }) {
+            native.resizes.push(size);
+            return context;
+          },
+          renderAsync: async () => ({
+            ...native.size,
+            release: mocks.release,
+            saveAsync: async () => native.saved,
+          }),
+        };
+        return context;
+      });
+    });
+
     it.each(["image/heic", "image/heif", undefined])(
-      "attaches the native JPEG conversion with matching metadata when the source MIME is %s",
+      "renders a %s photo to JPEG natively and previews the rendered file",
       async (mimeType) => {
         mocks.pickMedia.mockResolvedValue({
           canceled: false,
@@ -128,6 +164,9 @@ describe("composer file attachments", () => {
 
         const result = await pickComposerImages({ existingCount: 0 });
 
+        expect(mocks.pickMedia).toHaveBeenCalledWith(expect.objectContaining({ base64: false }));
+        expect(mocks.manipulate).toHaveBeenCalledWith(photo.uri);
+        expect(mocks.readBase64).not.toHaveBeenCalled();
         expect(result).toEqual({
           images: [
             {
@@ -136,8 +175,8 @@ describe("composer file attachments", () => {
               name: "photo.jpg",
               mimeType: "image/jpeg",
               sizeBytes: 4,
-              dataUrl: `data:image/jpeg;base64,${jpeg}`,
-              previewUri: `data:image/jpeg;base64,${jpeg}`,
+              dataUrl: `data:image/jpeg;base64,${rendered.base64}`,
+              previewUri: rendered.uri,
             },
           ],
           error: null,
@@ -146,10 +185,25 @@ describe("composer file attachments", () => {
     );
 
     it.each([
+      { size: { width: 4032, height: 3024 }, resizes: [{ width: 2048 }] },
+      { size: { width: 3024, height: 4032 }, resizes: [{ height: 2048 }] },
+      { size: { width: 2048, height: 1536 }, resizes: [] },
+    ])("bounds a $size.width x $size.height photo to a 2048 px longest edge", async (input) => {
+      native.size = input.size;
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
+
+      await pickComposerImages({ existingCount: 0 });
+
+      expect(native.resizes).toEqual(input.resizes);
+      // Every decoded bitmap is released, including the full-size one a resize replaces.
+      expect(mocks.release).toHaveBeenCalledTimes(input.resizes.length + 1);
+    });
+
+    it.each([
       { extension: "png", mimeType: "image/png", base64: "iVBORw0KGgo=" },
       { extension: "gif", mimeType: "image/gif", base64: "R0lGODlh" },
       { extension: "webp", mimeType: "image/webp", base64: "UklGRgQAAABXRUJQ" },
-    ])("preserves original $extension bytes instead of the picker's JPEG", async (original) => {
+    ])("keeps original $extension bytes from the picker file", async (original) => {
       const name = `photo.${original.extension}`;
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
@@ -159,6 +213,8 @@ describe("composer file attachments", () => {
 
       const result = await pickComposerImages({ existingCount: 0 });
 
+      expect(mocks.manipulate).not.toHaveBeenCalled();
+      expect(mocks.readBase64).toHaveBeenCalledWith(photo.uri);
       expect(result.error).toBeNull();
       expect(result.images).toEqual([
         expect.objectContaining({
@@ -166,17 +222,55 @@ describe("composer file attachments", () => {
           mimeType: original.mimeType,
           dataUrl: `data:${original.mimeType};base64,${original.base64}`,
           sizeBytes: Buffer.from(original.base64, "base64").byteLength,
+          previewUri: photo.uri,
         }),
       ]);
     });
 
-    it("checks the converted JPEG size even when the HEIC source was smaller", async () => {
-      const oversized =
-        jpeg.slice(0, 4) + "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4);
+    it("renders a supported original that exceeds the image limit instead of rejecting it", async () => {
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
-        assets: [{ ...photo, fileSize: 42, base64: oversized }],
+        assets: [
+          {
+            ...photo,
+            fileName: "photo.jpg",
+            mimeType: "image/jpeg",
+            fileSize: PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1,
+          },
+        ],
       });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(mocks.manipulate).toHaveBeenCalledWith(photo.uri);
+      expect(result.error).toBeNull();
+      expect(result.images).toEqual([
+        expect.objectContaining({ name: "photo.jpg", mimeType: "image/jpeg", sizeBytes: 4 }),
+      ]);
+    });
+
+    it("measures the picker file when the picker reports no size", async () => {
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [{ ...photo, fileName: "photo.png", mimeType: "image/png", fileSize: undefined }],
+      });
+      mocks.size.mockReturnValue(3);
+      mocks.readBase64.mockResolvedValue("YWJj");
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(mocks.manipulate).not.toHaveBeenCalled();
+      expect(result.images).toEqual([expect.objectContaining({ mimeType: "image/png" })]);
+    });
+
+    it("checks the rendered JPEG against the image limit", async () => {
+      native.saved = {
+        uri: rendered.uri,
+        base64:
+          rendered.base64.slice(0, 4) +
+          "A".repeat(Math.ceil(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / 3) * 4),
+      };
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
 
       await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
         images: [],
@@ -184,19 +278,7 @@ describe("composer file attachments", () => {
       });
     });
 
-    it("does not relabel unconverted HEIC bytes as JPEG", async () => {
-      mocks.pickMedia.mockResolvedValue({
-        canceled: false,
-        assets: [{ ...photo, base64: "AAAAGGZ0eXBoZWlj" }],
-      });
-
-      const result = await pickComposerImages({ existingCount: 0 });
-
-      expect(result.images).toEqual([]);
-      expect(result.error).toContain("not a supported image type");
-    });
-
-    it("retains a converted photo when another original cannot be read", async () => {
+    it("retains a rendered photo when another original cannot be read", async () => {
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
         assets: [{ ...photo, fileName: "missing.gif", mimeType: "image/gif" }, photo],
@@ -208,6 +290,21 @@ describe("composer file attachments", () => {
       expect(result.images).toEqual([expect.objectContaining({ name: "photo.jpg" })]);
       expect(result.error).toBe("Failed to read 'missing.gif'.");
     });
+
+    it("reports a photo the native renderer cannot decode", async () => {
+      mocks.manipulate.mockImplementation(() => ({
+        resize: () => {
+          throw new Error("unreachable");
+        },
+        renderAsync: () => Promise.reject(new Error("corrupt")),
+      }));
+      mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [photo] });
+
+      await expect(pickComposerImages({ existingCount: 0 })).resolves.toEqual({
+        images: [],
+        error: "Failed to read 'photo.HEIC'.",
+      });
+    });
   });
 
   describe("photo library videos", () => {
@@ -217,10 +314,13 @@ describe("composer file attachments", () => {
       fileName: "photo.png",
       mimeType: "image/png",
       fileSize: 3,
-      base64: "YWJj",
       width: 1,
       height: 1,
     };
+
+    beforeEach(() => {
+      mocks.readBase64.mockResolvedValue("YWJj");
+    });
     const video: ImagePickerAsset = {
       uri: "file:///picker/clip.mov",
       type: "video",

--- a/apps/mobile/src/lib/composerFiles.test.ts
+++ b/apps/mobile/src/lib/composerFiles.test.ts
@@ -230,15 +230,9 @@ describe("composer file attachments", () => {
     it("renders a supported original that exceeds the image limit instead of rejecting it", async () => {
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
-        assets: [
-          {
-            ...photo,
-            fileName: "photo.jpg",
-            mimeType: "image/jpeg",
-            fileSize: PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1,
-          },
-        ],
+        assets: [{ ...photo, fileName: "photo.jpg", mimeType: "image/jpeg" }],
       });
+      mocks.size.mockReturnValue(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1);
 
       const result = await pickComposerImages({ existingCount: 0 });
 
@@ -249,18 +243,35 @@ describe("composer file attachments", () => {
       ]);
     });
 
-    it("measures the picker file when the picker reports no size", async () => {
+    it("measures the picker file instead of trusting the reported size", async () => {
+      // A content stream can deliver more bytes than the picker advertises; a supported
+      // original only skips rendering when the file itself measures within the limit.
       mocks.pickMedia.mockResolvedValue({
         canceled: false,
-        assets: [{ ...photo, fileName: "photo.png", mimeType: "image/png", fileSize: undefined }],
+        assets: [{ ...photo, fileName: "photo.png", mimeType: "image/png", fileSize: 42 }],
       });
-      mocks.size.mockReturnValue(3);
-      mocks.readBase64.mockResolvedValue("YWJj");
+      mocks.size.mockReturnValue(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES + 1);
 
       const result = await pickComposerImages({ existingCount: 0 });
 
-      expect(mocks.manipulate).not.toHaveBeenCalled();
-      expect(result.images).toEqual([expect.objectContaining({ mimeType: "image/png" })]);
+      expect(mocks.readBase64).not.toHaveBeenCalled();
+      expect(mocks.manipulate).toHaveBeenCalledWith(photo.uri);
+      expect(result.images).toEqual([expect.objectContaining({ mimeType: "image/jpeg" })]);
+    });
+
+    it("renders a supported original whose size cannot be measured", async () => {
+      mocks.pickMedia.mockResolvedValue({
+        canceled: false,
+        assets: [
+          { ...photo, uri: "content://media/1", fileName: "photo.png", mimeType: "image/png" },
+        ],
+      });
+
+      const result = await pickComposerImages({ existingCount: 0 });
+
+      expect(mocks.readBase64).not.toHaveBeenCalled();
+      expect(mocks.manipulate).toHaveBeenCalledWith("content://media/1");
+      expect(result.images).toEqual([expect.objectContaining({ mimeType: "image/jpeg" })]);
     });
 
     it("checks the rendered JPEG against the image limit", async () => {
@@ -334,7 +345,9 @@ describe("composer file attachments", () => {
 
     it("retains mixed photos and videos, keeping video bytes in durable file storage", async () => {
       mocks.pickMedia.mockResolvedValue({ canceled: false, assets: [image, video] });
-      mocks.size.mockReturnValue(video.fileSize);
+      mocks.size.mockImplementation((uri: string) =>
+        uri.endsWith("clip.mov") ? video.fileSize : 3,
+      );
 
       const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: 50 * 1024 * 1024 });
 
@@ -445,7 +458,7 @@ describe("composer file attachments", () => {
           canceled: false,
           assets: [{ ...video, fileSize: reported }, image],
         });
-        mocks.size.mockReturnValue(stored);
+        mocks.size.mockImplementation((uri: string) => (uri.endsWith("clip.mov") ? stored : 3));
 
         const result = await pickComposerMedia({ existingCount: 0, maxVideoBytes: limit });
 

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -470,22 +470,24 @@ export async function pickComposerMedia(input: {
     }
 
     const name = asset.fileName?.trim() || "image";
-    let sourceBytes = asset.fileSize ?? null;
-    if (sourceBytes === null) {
-      try {
-        const { File } = await import("expo-file-system");
-        sourceBytes = new File(asset.uri).size;
-      } catch {
-        sourceBytes = null;
-      }
+    // The picker's reported size is a hint, not a measurement: Android content streams can
+    // deliver more bytes than they advertise. Only a size read from the file itself decides
+    // whether the original bytes are safe to load into JS.
+    let sourceBytes: number | null = null;
+    try {
+      const { File } = await import("expo-file-system");
+      sourceBytes = new File(asset.uri).size;
+    } catch {
+      sourceBytes = null;
     }
     // Originals the provider can read and that fit the cap pass through byte for byte so
     // transparency and animation survive. Everything else (HEIC/HEIF, oversized JPEGs,
-    // unknown sizes) is rendered to a bounded JPEG off the JS thread.
+    // unmeasurable sources) is rendered to a bounded JPEG off the JS thread.
     const originalMimeType =
       mimeType !== undefined &&
       isProviderSendTurnSupportedImageMimeType(mimeType) &&
       sourceBytes !== null &&
+      sourceBytes > 0 &&
       sourceBytes <= PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
         ? mimeType
         : null;

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -307,6 +307,46 @@ export async function pickComposerFiles(input: {
   return { files: attachments, error };
 }
 
+/**
+ * Longest edge kept when a photo has to be re-encoded. Matches the web composer's
+ * MAX_DIMENSION so every client hands providers the same resolution.
+ */
+const PHOTO_MAX_EDGE = 2048;
+const PHOTO_JPEG_QUALITY = 0.85;
+
+/**
+ * Renders a photo-library pick to a provider-readable JPEG. Decode, downscale, and encode run
+ * natively; only the bounded result crosses the bridge. Camera photos are 12-48 MP HEIC files,
+ * so a full-size conversion is both slow to transfer and far more than a model can use.
+ */
+async function renderPhotoAsJpeg(uri: string): Promise<{ base64: string; uri: string }> {
+  const { ImageManipulator, SaveFormat } = await import("expo-image-manipulator");
+  let image = await ImageManipulator.manipulate(uri).renderAsync();
+  try {
+    const longestEdge = Math.max(image.width, image.height);
+    if (longestEdge > PHOTO_MAX_EDGE) {
+      const resized = await ImageManipulator.manipulate(image)
+        .resize(
+          image.width >= image.height ? { width: PHOTO_MAX_EDGE } : { height: PHOTO_MAX_EDGE },
+        )
+        .renderAsync();
+      image.release();
+      image = resized;
+    }
+    const saved = await image.saveAsync({
+      format: SaveFormat.JPEG,
+      compress: PHOTO_JPEG_QUALITY,
+      base64: true,
+    });
+    if (!saved.base64) {
+      throw new Error("The rendered photo has no bytes.");
+    }
+    return { base64: saved.base64, uri: saved.uri };
+  } finally {
+    image.release();
+  }
+}
+
 async function loadImagePicker() {
   try {
     return await import("expo-image-picker");
@@ -369,7 +409,10 @@ export async function pickComposerMedia(input: {
       mediaTypes: input.maxVideoBytes === undefined ? ["images"] : ["images", "videos"],
       allowsMultipleSelection: true,
       selectionLimit: remainingSlots,
-      base64: true,
+      // Bytes stay in the picker's file until we know how much of them we need. Asking for
+      // base64 here made iOS decode and re-encode every camera photo at full resolution and
+      // hand JS a 10 MB+ string, which stalled the composer for seconds.
+      base64: false,
       quality: 1,
       shouldDownloadFromNetwork: true,
     });
@@ -397,7 +440,7 @@ export async function pickComposerMedia(input: {
       error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} attachments per message.`;
       break;
     }
-    let mimeType = asset.mimeType?.toLowerCase();
+    const mimeType = asset.mimeType?.toLowerCase();
     if (asset.type === "video" || mimeType?.startsWith("video/")) {
       if (input.maxVideoBytes === undefined) {
         error = "Video attachments are unavailable here.";
@@ -426,56 +469,65 @@ export async function pickComposerMedia(input: {
       continue;
     }
 
-    let base64 = asset.base64;
-    if (!base64) {
-      error = `Failed to read '${asset.fileName ?? "image"}'.`;
-      continue;
-    }
-
-    let name = asset.fileName?.trim() || "image";
-    // The iOS picker returns JPEG base64 even when its metadata describes HEIC,
-    // PNG, or GIF. Keep supported originals so transparency and animation survive;
-    // use the native JPEG conversion for formats providers cannot accept.
-    if (base64.startsWith("/9j/")) {
-      if (
-        mimeType &&
-        mimeType !== "image/jpeg" &&
-        isProviderSendTurnSupportedImageMimeType(mimeType)
-      ) {
-        try {
-          const { File } = await import("expo-file-system");
-          base64 = await new File(asset.uri).base64();
-        } catch {
-          error = `Failed to read '${name}'.`;
-          continue;
-        }
-      } else {
-        mimeType = "image/jpeg";
-        if (!/\.jpe?g$/i.test(name)) {
-          name = `${name.replace(/\.[^.]+$/, "")}.jpg`;
-        }
+    const name = asset.fileName?.trim() || "image";
+    let sourceBytes = asset.fileSize ?? null;
+    if (sourceBytes === null) {
+      try {
+        const { File } = await import("expo-file-system");
+        sourceBytes = new File(asset.uri).size;
+      } catch {
+        sourceBytes = null;
       }
     }
-    if (!mimeType || !isProviderSendTurnSupportedImageMimeType(mimeType)) {
-      error = `'${name}' is not a supported image type. Attach GIF, JPEG, PNG, or WebP images.`;
+    // Originals the provider can read and that fit the cap pass through byte for byte so
+    // transparency and animation survive. Everything else (HEIC/HEIF, oversized JPEGs,
+    // unknown sizes) is rendered to a bounded JPEG off the JS thread.
+    const originalMimeType =
+      mimeType !== undefined &&
+      isProviderSendTurnSupportedImageMimeType(mimeType) &&
+      sourceBytes !== null &&
+      sourceBytes <= PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+        ? mimeType
+        : null;
+
+    let image: { base64: string; mimeType: string; name: string; previewUri: string };
+    try {
+      if (originalMimeType !== null) {
+        const { File } = await import("expo-file-system");
+        image = {
+          base64: await new File(asset.uri).base64(),
+          mimeType: originalMimeType,
+          name,
+          previewUri: asset.uri,
+        };
+      } else {
+        const rendered = await renderPhotoAsJpeg(asset.uri);
+        image = {
+          base64: rendered.base64,
+          mimeType: "image/jpeg",
+          name: /\.jpe?g$/i.test(name) ? name : `${name.replace(/\.[^.]+$/, "")}.jpg`,
+          previewUri: rendered.uri,
+        };
+      }
+    } catch {
+      error = `Failed to read '${name}'.`;
       continue;
     }
 
-    const sizeBytes = estimateBase64ByteSize(base64);
+    const sizeBytes = estimateBase64ByteSize(image.base64);
     if (sizeBytes <= 0 || sizeBytes > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-      error = `'${asset.fileName ?? "image"}' exceeds the 10 MB attachment limit.`;
+      error = `'${name}' exceeds the 10 MB attachment limit.`;
       continue;
     }
 
-    const dataUrl = `data:${mimeType};base64,${base64}`;
     attachments.push({
       id: uuidv4(),
       type: "image",
-      name,
-      mimeType,
+      name: image.name,
+      mimeType: image.mimeType,
       sizeBytes,
-      dataUrl,
-      previewUri: mimeType === asset.mimeType?.toLowerCase() ? asset.uri : dataUrl,
+      dataUrl: `data:${image.mimeType};base64,${image.base64}`,
+      previewUri: image.previewUri,
     });
   }
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -17,9 +17,9 @@ message can send. Retry or remove a failed upload. On web and desktop, reloading
 before an upload finishes requires you to attach that file again.
 
 You can drag or paste images into the web or desktop composer. HEIC and HEIF
-photos are converted to JPEG there and when selected from the iOS photo library;
-the image limit applies after conversion. On mobile, you can also send files to
-T3 Code through another app's system share sheet.
+photos are converted to JPEG there and when selected from the mobile photo
+library; photos over the image limit are also resized to fit. On mobile, you can
+also send files to T3 Code through another app's system share sheet.
 
 See [images and videos](#images-and-videos-in-messages) for previewing and saving media.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       expo-image:
         specifier: ~57.0.3
         version: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-image-manipulator:
+        specifier: ~57.0.17
+        version: 57.0.17(expo@57.0.18)
       expo-image-picker:
         specifier: ~57.0.14
         version: 57.0.14(expo@57.0.18)
@@ -7440,6 +7443,11 @@ packages:
 
   expo-image-loader@57.0.1:
     resolution: {integrity: sha512-uhrZKLT/cTl2mXyR28kPpVkS5O+PK9N1QA/07IFM4f5T4g0lTW1JHT3NEWwEEsGFldPmVX4j7LwUVVZxE+woug==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-manipulator@57.0.17:
+    resolution: {integrity: sha512-VpM8qAotTeSIobIAL8RAIDrZKL0jQBK/6O41NnwmdT96sd2wT263DlTbkvQ6RkcFrR9+NZiC5Um7FDBK+jFneg==}
     peerDependencies:
       expo: '*'
 
@@ -17956,6 +17964,11 @@ snapshots:
   expo-image-loader@57.0.1(expo@57.0.18):
     dependencies:
       expo: 57.0.18(fc5a731e35a0144aab60c7305f29cbed)
+
+  expo-image-manipulator@57.0.17(expo@57.0.18):
+    dependencies:
+      expo: 57.0.18(fc5a731e35a0144aab60c7305f29cbed)
+      expo-image-loader: 57.0.1(expo@57.0.18)
 
   expo-image-picker@57.0.14(expo@57.0.18):
     dependencies:


### PR DESCRIPTION
> [!NOTE]
> 🤖 **Claude Fable 5.1 responding on behalf of Nick**

## What Changed

`pickComposerMedia` no longer asks expo-image-picker for base64. Originals the provider can read (PNG, JPEG, GIF, WebP) that fit the 10 MB cap are read from the picker file byte for byte, so transparency and animation survive. Everything else (HEIC/HEIF, JPEGs over the cap, unknown sizes) is rendered natively with `expo-image-manipulator` to a 2048 px longest-edge JPEG at 0.85, matching the web composer's `MAX_DIMENSION`, before the size gate runs. The thumbnail for a rendered photo is the rendered file, never the data URL.

Adds `expo-image-manipulator ~57.0.17` to `apps/mobile`. It is a native module, so this needs a native build, not an OTA.

## Why

Fixes #11427. Attaching a camera photo from the photo library froze the iOS composer: the picker decoded and re-encoded every 12-48 MP HEIC at quality 1.0 and handed JS a 10 MB+ base64 string, and because HEIC gets relabeled `image/jpeg`, `previewUri` fell back to that data URL, which Fabric re-parsed on every layout pass. Typing still worked (native text view) but the editor stopped growing, and send and remove never landed. The draft persisted with the same payload, so relaunch re-froze.

This covers items 1 and 2 from the triage. Item 3 (in-progress state with cancel) is left for a follow-up so this stays one concern; with the native render a pick now finishes in well under a second, so the window that cancel would cover is small. #9727 still owns moving image bytes out of draft JSON.

## Verification

- `vp test run src/lib/composerFiles.test.ts src/lib/composerImages.test.ts` in `apps/mobile`: 55 pass. New cases cover HEIC/HEIF/undefined-mime rendering, the 2048 px bound (landscape, portrait, already small), native handle release, supported originals kept byte for byte, a supported original over the cap being rendered instead of rejected, picker-omitted size, the post-render size gate, and renderer failure.
- `tsc --noEmit` in `apps/mobile`: clean. `vp lint` on touched files: clean.
- Device pass on an iPhone 17 Pro simulator (iOS 26.5, Xcode 26.6) with a real 12 MP iPhone HEIC (4032x3024, 928 KB) added to its photo library: Photo Library pick → thumbnail and a `test-photo.jpg 682 KB` chip within 2 s, send button active. Rendered file on disk is a 1536x2048 JPEG. Typing a three-line prompt grows the editor. Force-quit + relaunch restores the draft with thumbnail, text, and live send. Remove clears the attachment.
- Note on the device pass: the simulator's synthetic taps could not open the attachment `UIMenu` (it anchors under the software keyboard there), so the plus button was pointed at `onPickMedia` directly in a local, uncommitted edit on the test machine only. The code under test (`pickComposerMedia` and the strip) ran unmodified.

## UI Changes

No visual change. The before state is the freeze described in #11427; after is a normal attach.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (none; behavior fix)
- [x] I included a video for animation/interaction changes (n/a)

Work done by Claude Fable 5.1 in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mobile image attachments by reading selected photos directly from the device.
  - Photos in supported formats and within the size limit retain their original format.
  - HEIC/HEIF, unsupported, oversized, or size-unknown images are converted to JPEG and resized to fit attachment limits, with images constrained to a maximum 2048-pixel edge.
  - Improved attachment size detection for more reliable handling of selected media.

- **Documentation**
  - Updated composer guidance to reference the mobile photo library and explain oversized-photo resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->