### PR TITLE
fix(web): preserve preview focus on window return

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -2180,6 +2180,10 @@ describe("shouldRefocusComposerOnWindowFocus", () => {
     expect(shouldRefocusComposerOnWindowFocus(element("DIV", { role: "textbox" }))).toBe(false);
   });
 
+  it.each(["IFRAME", "WEBVIEW"])("leaves a focused %s preview alone", (tagName) => {
+    expect(shouldRefocusComposerOnWindowFocus(element(tagName))).toBe(false);
+  });
+
   it("leaves a focused terminal alone in the drawer and the right panel", () => {
     expect(
       shouldRefocusComposerOnWindowFocus(element("BUTTON", { within: "data-terminal-owner" })),

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1350,6 +1350,8 @@ export function shouldRefocusComposerOnWindowFocus(
     activeElement.tagName === "INPUT" ||
     activeElement.tagName === "TEXTAREA" ||
     activeElement.tagName === "SELECT" ||
+    activeElement.tagName === "IFRAME" ||
+    activeElement.tagName === "WEBVIEW" ||
     activeElement.isContentEditable === true ||
     activeElement.getAttribute("role") === "textbox"
   ) {


### PR DESCRIPTION
## What changed

Leave focused iframe and Electron webview previews alone when the window-return handler checks whether to refocus the composer. This adds two tag checks to the existing predicate and covers both with regression tests.

## Why

Returning to T3 by clicking an input in an embedded preview can move focus straight back to the composer. Window activation schedules a refocus check, the click focuses the frame, and the check then treats that frame as a place from which it can take focus. This is a timing-dependent race, not a failure on every window return.

The parent document sees IFRAME or WEBVIEW, not the input inside it. Treating those elements as input owners preserves the user's click without changing the refocus scheduling.

```mermaid
flowchart LR
    A[Return by clicking a preview input] --> B[Before: queued check refocuses composer]
    B --> C[Typing goes to the composer]
    A --> D[After: preserve frame focus]
    D --> E[Typing stays in the preview]
```

Scheduling and the existing button, field, dialog and terminal behavior are unchanged. The shared web/desktop code changes; native mobile and mobile viewports do not use this handler.

This concerns the user's return to the window, not the agent keyboard dispatch corrected by #11354.

## Verification

- Both new regression cases fail on the base commit. All 145 tests in `ChatView.logic.test.ts` pass with the fix.
- From `apps/web`: `vp test run --project unit src/components/ChatView.logic.test.ts --maxWorkers=1 --no-file-parallelism`.
- Targeted lint and formatting checks pass for the two changed files.
- `tsc --noEmit -p apps/web/tsconfig.json` passes, with existing Effect suggestions in unrelated files.
- Fallow review of `apps/web`, with one parser thread, reports low risk. No dependencies, exports or diagnostic suppressions are added.
- In Chromium, the preview retains focus after the fix, including three repeat activation-click checks. Returning from an ordinary button still refocuses the composer.

## UI changes

Captured in the running T3 web client with an isolated thread and HTML fixture. Start with the composer focused and the terminal drawer closed, activate another window, then return by clicking the preview input and type without clicking again.

| Before | After |
| --- | --- |
| ![Typing lands in the composer](https://github.com/Lucenx9/t3code/releases/download/evidence-preview-focus-93c283bc36/before-final.png) | ![Typing stays in the preview](https://github.com/Lucenx9/t3code/releases/download/evidence-preview-focus-93c283bc36/after-final.png) |

[23-second interaction video after the fix](https://github.com/Lucenx9/t3code/releases/download/evidence-preview-focus-93c283bc36/after-final.mp4). PNGs are 2880 × 1800 at 2× density.

Verification limits: Chromium used native X11 window activation/clicks with Playwright focus emulation disabled, not dispatched DOM focus events. The local asset response omitted `Content-Type`, so the browser test supplied `text/html` for this one fixture response. The app and focus handler were otherwise unchanged. Plain tab return did not reproduce the bug. Electron's WEBVIEW exception has predicate coverage, not an end-to-end desktop verification.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5 family. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved focus in embedded frames and web views when the application window regains focus, preventing unintended composer refocusing.
  * Improved focus behavior for users interacting with embedded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->