### PR TITLE
fix(mobile): preserve Material You native review colors

### DIFF
--- a/apps/mobile/src/features/review/nativeReviewDiffAdapter.test.ts
+++ b/apps/mobile/src/features/review/nativeReviewDiffAdapter.test.ts
@@ -217,6 +217,23 @@ describe("getCachedNativeReviewDiffData", () => {
 });
 
 describe("createNativeReviewDiffTheme", () => {
+  it.each([
+    ["#00000000", "#ffffff"],
+    ["#00000080", "#7f7f7f"],
+    ["#000000ff", "#000000"],
+    ["#000000", "#000000"],
+    ["rgba(0, 0, 0, 0.5)", "#808080"],
+    ["rgb(0, 0, 0)", "#000000"],
+  ])("flattens %s over the screen color", (sheet, expected) => {
+    const theme = createNativeReviewDiffTheme("light", "material-you", {
+      ...appTheme("t3-code", "light"),
+      "--color-screen": "#FFFFFFFF",
+      "--color-sheet": sheet,
+    });
+
+    expect(theme.background).toBe(expected);
+  });
+
   it("serializes every native color as cross-platform opaque hex", () => {
     for (const themeId of MOBILE_THEME_IDS) {
       for (const appearance of ["light", "dark"] as const) {

--- a/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
+++ b/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
@@ -19,7 +19,7 @@ import type { ReviewInlineComment } from "./reviewCommentSelection";
 
 const NATIVE_REVIEW_MAX_WORD_DIFF_RANGE_COUNT = 4;
 const NATIVE_REVIEW_MAX_WORD_DIFF_COVERAGE = 0.45;
-const NATIVE_HEX_COLOR = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})$/i;
+const NATIVE_HEX_COLOR = /^#([\da-f]{2})([\da-f]{2})([\da-f]{2})([\da-f]{2})?$/i;
 const NATIVE_RGBA_COLOR =
   /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/;
 
@@ -44,15 +44,20 @@ export function buildNativeReviewSnippetRows(
 
 function opaqueNativeHexColor(color: string, background: string): string {
   const hex = NATIVE_HEX_COLOR.exec(color);
-  if (hex) return color;
+  if (hex && hex[4] === undefined) return color;
 
-  const rgba = NATIVE_RGBA_COLOR.exec(color);
+  const components = hex ?? NATIVE_RGBA_COLOR.exec(color);
   const backgroundHex = NATIVE_HEX_COLOR.exec(background);
-  if (!rgba || !backgroundHex) return background;
+  if (!components || !backgroundHex) return background;
 
-  const alpha = rgba[4] === undefined ? 1 : Math.min(1, Math.max(0, Number(rgba[4])));
+  const alpha =
+    components[4] === undefined
+      ? 1
+      : hex
+        ? Number.parseInt(components[4], 16) / 255
+        : Math.min(1, Math.max(0, Number(components[4])));
   const channels = [1, 2, 3].map((index) => {
-    const foreground = Number(rgba[index]);
+    const foreground = hex ? Number.parseInt(components[index], 16) : Number(components[index]);
     const behind = Number.parseInt(backgroundHex[index], 16);
     return Math.round(foreground * alpha + behind * (1 - alpha));
   });

--- a/apps/mobile/src/lib/materialYouTheme.test.ts
+++ b/apps/mobile/src/lib/materialYouTheme.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { getMobileThemeRuntimeVariables } from "./mobileThemeVariables";
 import type { MaterialYouPalette } from "./materialYouPalette";
 import { materialYouPaletteToMobileThemeVariables } from "./materialYouTheme";
+import { createNativeReviewDiffTheme } from "../features/review/nativeReviewDiffAdapter";
 
 const palette: MaterialYouPalette = {
   primary: "#6750A4FF",
@@ -31,6 +32,31 @@ const palette: MaterialYouPalette = {
 };
 
 describe("Material You system colors", () => {
+  it.each(["light", "dark"] as const)(
+    "preserves %s colors in native review surfaces",
+    (appearance) => {
+      const variables = materialYouPaletteToMobileThemeVariables(
+        palette,
+        appearance,
+        getMobileThemeRuntimeVariables("t3-code", appearance),
+      );
+      const theme = createNativeReviewDiffTheme(appearance, "material-you", variables);
+
+      expect(theme).toMatchObject({
+        background: "#f7f2fa",
+        headerBackground: "#f7f2fa",
+        text: "#1c1b1f",
+        mutedText: "#49454f",
+        hunkText: "#6750a4",
+        hunkBackground: "#e1dce4",
+        border: appearance === "dark" ? "#e0dbe5" : "#dad4df",
+      });
+      for (const color of Object.values(theme)) {
+        expect(color).toMatch(/^#[\da-f]{6}$/i);
+      }
+    },
+  );
+
   it("overrides the selected theme without mutating its base variables", () => {
     const base = getMobileThemeRuntimeVariables("t3-code", "dark");
     const snapshot = { ...base };


### PR DESCRIPTION
## What Changed

Accept `#RRGGBBAA` in the native review color converter and blend its alpha channel onto the existing background. Keep sending opaque `#RRGGBB` to both native implementations.

## Why

Android Material You supplies eight-digit colors. The converter only recognized six-digit hex and RGB/RGBA strings, so the background, text, line numbers, and hunk colors fell back to the same screen token. Unhighlighted text and labels could disappear against the background.

The fix stays in the converter shared by these mobile views. Web, desktop, providers, and wire contracts are unchanged.

```mermaid
flowchart LR
    A[Material You palette] --> B[Convert to opaque native colors]
    B --> C[Review diffs]
    B --> D[Comment snippets]
    B --> E[Source file previews]
```

## Testing

- 19 focused tests pass across `nativeReviewDiffAdapter.test.ts` and `materialYouTheme.test.ts`, using one worker. Seven regression cases failed before the fix.
- Coverage includes the Material You palette mapper under both appearances, transparent and opaque alpha endpoints, partial-alpha blending, and existing RGB/RGBA and six-digit inputs.
- Targeted lint, formatting, and TypeScript checks pass. The scoped TypeScript check includes Node types for the test helper that reads the theme stylesheet.

## UI Changes

Android device verification and before/after screenshots are missing. No Android SDK or emulator was available, and T3 device access was disabled. The author chose to submit with this limitation disclosed. The reproduction above is automated color-conversion coverage, not a device rendering test.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- No motion, timing, or interaction changes

Implemented with GPT-5 in Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native review diff themes now correctly render semi-transparent hexadecimal colors against the screen background.
  * Color handling is more consistent across hexadecimal, RGB, and RGBA formats.
  * Material You themes now display the expected colors in both light and dark appearances.

* **Tests**
  * Added coverage for color transparency and Material You theme rendering across supported formats and appearances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->