### PR TITLE
fix(web): keep long commands inside the Add Action dialog

### DIFF
--- a/apps/web/src/components/ui/textarea.test.tsx
+++ b/apps/web/src/components/ui/textarea.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { Textarea } from "./textarea";
+
+describe("textarea", () => {
+  it("wraps long unbroken values instead of growing past its container", () => {
+    const html = renderToStaticMarkup(
+      <Textarea defaultValue='ln -s "$HOME/Code/example-project/a-very-long-directory-name/another-long-directory-name/src/config/Secrets.swift" "src/config/Secrets.swift"' />,
+    );
+
+    expect(html).toContain("min-w-0");
+    expect(html).toContain("max-w-full");
+    expect(html).toContain("wrap-anywhere");
+  });
+});

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -28,7 +28,7 @@ function Textarea({ className, size = "default", unstyled = false, ...props }: T
         render={(defaultProps) => (
           <textarea
             className={cn(
-              "field-sizing-content min-h-17.5 w-full rounded-[inherit] px-[calc(--spacing(3)-1px)] py-[calc(--spacing(1.5)-1px)] outline-none max-sm:min-h-20.5",
+              "field-sizing-content min-h-17.5 w-full min-w-0 max-w-full rounded-[inherit] px-[calc(--spacing(3)-1px)] py-[calc(--spacing(1.5)-1px)] outline-none wrap-anywhere max-sm:min-h-20.5",
               size === "sm" &&
                 "min-h-16.5 px-[calc(--spacing(2.5)-1px)] py-[calc(--spacing(1)-1px)] max-sm:min-h-19.5",
               size === "lg" && "min-h-18.5 py-[calc(--spacing(2)-1px)] max-sm:min-h-21.5",


### PR DESCRIPTION
## What Changed

The shared `Textarea` control now gets `min-w-0 max-w-full` and `wrap-anywhere`, so a long value wraps in place and grows the field vertically instead of sideways.

## Why

Fixes #11443.

Pasting a long unbroken path into the Command field stretched the whole Add Action form past the dialog. The right edge of every control was clipped and a horizontal scrollbar appeared under the form.

The control is a flex item inside the `inline-flex` wrapper span. That wrapper is shrink-to-fit, so the control's `width: 100%` is indefinite and its automatic minimum size falls back to the content-based minimum, which `field-sizing: content` derives from the longest unbreakable run in the value. The surrounding `fieldset` carries the UA `min-width: min-content`, so that width propagated to the entire form and overflowed the `max-w-lg` popup.

`min-w-0` drops the automatic minimum, `max-w-full` keeps the field inside the wrapper, and `overflow-wrap: anywhere` gives a long path a break opportunity. Display only. The stored command and its intentional line breaks are unchanged. I put the constraint on the shared control rather than a local class on this one field, as suggested on the issue, so the other dialogs that use a textarea get the same protection. I checked the other call sites. They are all freeform text and none rely on horizontal growth.

I left `whitespace-pre-wrap` out: the UA stylesheet already applies it to textareas, so it would be a no-op.

The example command in the issue has hyphens and does not overflow. The path from the screenshot, with no break opportunities, does. Measured unfixed: textarea 599px inside a 462px form. Fixed: 460px.

## UI Changes

Before and after at the same window size, with the command from the issue screenshot:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Yash121l/t3code/7dfbe4ccd9f53a11d4ea9293b366afbf234bc7b6/t3code-11443/before.png) | ![after](https://raw.githubusercontent.com/Yash121l/t3code/7dfbe4ccd9f53a11d4ea9293b366afbf234bc7b6/t3code-11443/after.png) |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (no motion involved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea behavior for long, unbroken text by preventing content from overflowing its container.
  * Text now wraps appropriately within the available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->