### PR TITLE
fix(web): prevent duplicate diff file ids

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -955,14 +955,10 @@ export default function DiffPanel({
                       (node): node is HTMLElement =>
                         node instanceof HTMLElement && node.hasAttribute("data-diffs-header"),
                     );
-                    const headerFilePath = header
-                      ?.querySelector("[data-title]")
-                      ?.textContent?.trim();
-                    if (!headerFilePath) return;
-                    const file = codeViewFiles.find(
-                      (candidate) => candidate.filePath === headerFilePath,
-                    );
-                    if (file) toggleDiffFileCollapsed(file.fileKey);
+                    const fileKey =
+                      header?.querySelector<HTMLElement>("[data-diff-file-key]")?.dataset
+                        .diffFileKey;
+                    if (fileKey) toggleDiffFileCollapsed(fileKey);
                   }}
                 >
                   <AnnotatableCodeView
@@ -974,8 +970,11 @@ export default function DiffPanel({
                     sectionId={reviewSectionId}
                     sectionTitle={reviewSectionTitle}
                     composerDraftTarget={composerDraftTarget}
-                    renderHeaderFilenameSuffix={(fileDiff) => (
-                      <DiffFilePathCopyButton filePath={resolveFileDiffPath(fileDiff)} />
+                    renderHeaderFilenameSuffix={(fileDiff, fileKey) => (
+                      <>
+                        <span data-diff-file-key={fileKey} />
+                        <DiffFilePathCopyButton filePath={resolveFileDiffPath(fileDiff)} />
+                      </>
                     )}
                     renderHeaderPrefix={(fileDiff, fileKey, collapsed) => {
                       const filePath = resolveFileDiffPath(fileDiff);

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -35,7 +35,7 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useTheme } from "../hooks/useTheme";
 import {
   buildFileDiffContentVersion,
-  buildFileDiffIdentityKey,
+  buildFileDiffIdentityKeys,
   getDiffCollapseIconClassName,
   getDiffLineStat,
   getRenderablePatch,
@@ -416,15 +416,14 @@ export default function DiffPanel({
       }),
     );
   }, [renderablePatch]);
-  const renderableFileEntries = useMemo(
-    () =>
-      renderableFiles.map((fileDiff) => ({
-        fileDiff,
-        fileKey: buildFileDiffIdentityKey(fileDiff),
-        fileVersion: buildFileDiffContentVersion(fileDiff),
-      })),
-    [renderableFiles],
-  );
+  const renderableFileEntries = useMemo(() => {
+    const fileKeys = buildFileDiffIdentityKeys(renderableFiles);
+    return renderableFiles.map((fileDiff, index) => ({
+      fileDiff,
+      fileKey: fileKeys[index]!,
+      fileVersion: buildFileDiffContentVersion(fileDiff),
+    }));
+  }, [renderableFiles]);
   const codeViewFiles = useMemo(
     () =>
       renderableFileEntries.map(({ fileDiff, fileKey, fileVersion }) => {

--- a/apps/web/src/components/diffs/AnnotatableCodeView.tsx
+++ b/apps/web/src/components/diffs/AnnotatableCodeView.tsx
@@ -86,7 +86,7 @@ interface AnnotatableCodeViewProps {
   options: StyledDiffCodeViewOptions<DiffCommentAnnotationGroup>;
   viewerRef?: Ref<AnnotatableCodeViewHandle>;
   className?: string;
-  renderHeaderFilenameSuffix: (fileDiff: FileDiffMetadata) => ReactNode;
+  renderHeaderFilenameSuffix: (fileDiff: FileDiffMetadata, fileKey: string) => ReactNode;
   renderHeaderPrefix: (
     fileDiff: FileDiffMetadata,
     fileKey: string,
@@ -255,7 +255,7 @@ export function AnnotatableCodeView({
         onGutterUtilityClick: beginComment,
       }}
       renderHeaderFilenameSuffix={(item) =>
-        item.type === "diff" ? renderHeaderFilenameSuffix(item.fileDiff) : null
+        item.type === "diff" ? renderHeaderFilenameSuffix(item.fileDiff, item.id) : null
       }
       renderHeaderPrefix={(item) =>
         item.type === "diff"

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildFileDiffContentVersion,
   buildFileDiffIdentityKey,
+  buildFileDiffIdentityKeys,
   buildFileDiffRenderKey,
   buildPatchCacheKey,
   getDiffLineStat,
@@ -147,6 +148,25 @@ describe("diff file reconciliation", () => {
     expect(buildFileDiffContentVersion(afterChanged)).not.toBe(
       buildFileDiffContentVersion(beforeChanged),
     );
+  });
+
+  it("disambiguates repeated file identities without dropping either diff", () => {
+    const filePatch = [
+      "diff --git a/scripts/push-release.sh b/scripts/push-release.sh",
+      "--- a/scripts/push-release.sh",
+      "+++ b/scripts/push-release.sh",
+      "@@ -1 +1 @@",
+      "-before",
+      "+after",
+    ].join("\n");
+    const parsed = getRenderablePatch(`${filePatch}\n${filePatch}`);
+    expect(parsed?.kind).toBe("files");
+    if (parsed?.kind !== "files") return;
+
+    const keys = buildFileDiffIdentityKeys(parsed.files);
+    expect(parsed.files).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+    expect(keys[0]).toBe(buildFileDiffIdentityKey(parsed.files[0]!));
   });
 });
 

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -167,6 +167,16 @@ export function buildFileDiffIdentityKey(fileDiff: FileDiffMetadata): string {
   return `${resolveFileDiffPreviousPath(fileDiff)}\u0000${resolveFileDiffPath(fileDiff)}`;
 }
 
+export function buildFileDiffIdentityKeys(files: ReadonlyArray<FileDiffMetadata>): string[] {
+  const occurrences = new Map<string, number>();
+  return files.map((file) => {
+    const identity = buildFileDiffIdentityKey(file);
+    const occurrence = occurrences.get(identity) ?? 0;
+    occurrences.set(identity, occurrence + 1);
+    return occurrence === 0 ? identity : `${identity}\u0000${occurrence}`;
+  });
+}
+
 export function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
   const cacheKey = fileDiff.cacheKey;
   if (!cacheKey) return `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;


### PR DESCRIPTION
Opening a diff with repeated records for the same file could crash with:

```text
Error: CodeView.addItem: duplicate id "<file>\0<file>"
```

The diff panel derived each CodeView item ID only from the file's previous and current paths, so repeated records received identical IDs.

Keep the existing path-based ID for the first record and append an occurrence number only when that identity repeats. This preserves every diff record and leaves IDs and behavior unchanged for normal patches.

Adds a regression test covering repeated records for the same file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of repeated file entries in diffs so each occurrence receives a distinct identity.
  - Ensured duplicate file changes render separately and reliably.
  - Improved diff header interactions so selecting a repeated file opens the correct file content.

- **Tests**
  - Added coverage verifying that repeated file diffs are preserved, rendered separately, and assigned unique identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->