### PR TITLE
feat(web): show processed tokens below the composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2671,6 +2671,7 @@ export default function ChatView(props: ChatViewProps) {
     () => deriveLatestContextWindowSnapshot(threadActivities),
     [threadActivities],
   );
+  const totalProcessedTokens = activeContextWindow?.totalProcessedTokens ?? null;
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
   // Native subagent fold: memoized by activity-list identity, shared by the
   // Agents surface, live strip, and workflow cards. v2Projection is null
@@ -8839,7 +8840,7 @@ export default function ChatView(props: ChatViewProps) {
               >
                 <div
                   data-chat-composer-stack="true"
-                  className="group/composer-stack pointer-events-auto relative z-10 mx-auto w-full max-w-3xl"
+                  className="group/composer-stack pointer-events-auto relative z-10 mx-auto w-full max-w-3xl [--chat-composer-drawer-inset:1.375rem]"
                 >
                   {isDraftHeroState ? (
                     <div className="absolute inset-x-0 bottom-full z-0">
@@ -9049,6 +9050,18 @@ export default function ChatView(props: ChatViewProps) {
                         </div>
                       </div>
                     </ComposerSurface.Shell>
+                    {totalProcessedTokens !== null && totalProcessedTokens > 0 && (
+                      <div
+                        className={cn(
+                          "mt-0.5 bg-background text-right text-[11px] leading-4 text-muted-foreground tabular-nums",
+                          showComposerContextStrip
+                            ? "mx-(--chat-composer-drawer-inset) px-3.5"
+                            : "mx-px px-3 sm:px-4",
+                        )}
+                      >
+                        {formatContextWindowTokens(totalProcessedTokens)} tokens
+                      </div>
+                    )}
                     <div
                       aria-hidden
                       className="h-[calc(env(safe-area-inset-bottom)+1rem)] sm:h-[calc(env(safe-area-inset-bottom)+1.25rem)]"

--- a/apps/web/src/components/chat/ComposerSurface.tsx
+++ b/apps/web/src/components/chat/ComposerSurface.tsx
@@ -14,7 +14,7 @@ function Shell({
       data-with-context={contextStrip || undefined}
       className={cn(
         "@container/composer-surface group/composer-surface relative isolate mx-auto w-full max-w-3xl",
-        "[--chat-composer-drawer-inset:1.375rem] [--chat-composer-glass-surface:var(--card)] [--chat-composer-outline:rgb(0_0_0/8%)]",
+        "[--chat-composer-glass-surface:var(--card)] [--chat-composer-outline:rgb(0_0_0/8%)]",
         "dark:[--chat-composer-glass-surface:var(--surface-raised)] dark:[--chat-composer-highlight:rgb(255_255_255/3%)] dark:[--chat-composer-outline:color-mix(in_srgb,var(--color-white)_5%,transparent)]",
         "[html[data-theme-id]_&]:[--chat-composer-glass-surface:var(--app-theme-surface-raised)] [html[data-theme-id]_&]:[--chat-composer-outline:var(--app-theme-toolbar-border)]",
         "dark:[html[data-theme-id]:not([data-theme-id=t3-chat])_&]:[--chat-composer-highlight:color-mix(in_srgb,var(--app-theme-input)_12%,transparent)] dark:[html[data-theme-id]:not([data-theme-id=t3-chat])_&]:[--chat-composer-outline:color-mix(in_srgb,var(--app-theme-input)_30%,var(--background))]",


### PR DESCRIPTION
## What changed

Show a compact count such as `123k tokens` just below the web and desktop composer, with a 2px gap. Align it with the send button, or with the branch name and chevron when the Local checkout strip is visible.

`ChatView` reads the existing normalized snapshot and reuses `formatContextWindowTokens`. The rendering condition is:

```tsx
{totalProcessedTokens !== null && totalProcessedTokens > 0 && (
	// Counter row; alignment classes omitted.
	<div>{formatContextWindowTokens(totalProcessedTokens)} tokens</div>
)}
```

The existing drawer inset moves to the common composer-stack wrapper so the strip and counter share it. No new state, subscriptions, dependencies, or changes to providers, contracts, persistence, or native mobile.

## Why

It matters to have a persistent visual indication of how "worn-out" a thread is while deciding whether to continue in it or start fresh. Sidebar age measures elapsed time. Processed tokens measure how much usage the thread has accumulated. A young thread can already have processed millions of tokens, while an older thread may have seen very little work. These measurements complement each other, and age alone leaves that distinction invisible.

Keeping the count beside the composer makes this signal available at the moment the user writes the next prompt. It shows the latest provider-reported `totalProcessedTokens`, so it is a usage signal rather than a measure of response quality or a guaranteed lifetime total. Providers that omit the total produce no counter. The display remains visible when the context-window meter is disabled.

## UI changes

Before:

![Composer before the token counter](https://github.com/gfdelarue/t3code/releases/download/composer-token-counter-evidence/before-expanded.png)

After, aligned with the send button:

![Composer with processed tokens](https://github.com/gfdelarue/t3code/releases/download/composer-token-counter-evidence/after-aligned-desktop.png)

After, with Local checkout visible:

![Token counter aligned with the branch chevron](https://github.com/gfdelarue/t3code/releases/download/composer-token-counter-evidence/after-branch-aligned-desktop.png)

## Verification

- Five existing `contextWindow.test.ts` tests passed.
- Web typecheck, focused lint, formatting, and `git diff --check` passed. Existing lint warnings are unchanged.
- Chromium verified populated and missing totals, thread switching and reload, light and dark themes, expanded and collapsed composers, and layouts at 1280px and 390px. The counter matched the send button or branch-chevron right edge exactly.
- User completed visual acceptance before this PR. Separate Electron execution and the repository-wide suite were not run locally.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a token usage counter below the chat composer when tokens have been processed.
  - Positioned the counter to remain aligned with the composer, including when the context strip is visible.

- **Style**
  - Updated chat composer spacing and layout behavior to support the token counter without disrupting existing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->