### PR TITLE
fix(opencode): show child sessions in agents panel

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -3889,8 +3889,8 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       ];
 
       const openedEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
+        Stream.filter((event) => event.threadId === threadId && event.type === "request.opened"),
+        Stream.take(1),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -4189,8 +4189,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       ];
 
       const requestedEventsFiber = yield* adapter.streamEvents.pipe(
-        Stream.filter((event) => event.threadId === threadId),
-        Stream.take(3),
+        Stream.filter(
+          (event) => event.threadId === threadId && event.type === "user-input.requested",
+        ),
+        Stream.take(1),
         Stream.runCollect,
         Effect.forkChild,
       );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -2147,7 +2147,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("marks subagents when a child is proven related by ancestry lookup", () =>
+  it.effect("replays an out-of-order child session after ancestry lookup", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
       const threadId = asThreadId("thread-child-ancestry-usage");
@@ -2156,15 +2156,15 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       runtimeMock.state.sessionParentById.set("ses_child", "http://127.0.0.1:9999/session");
       runtimeMock.state.sessionStatus = "busy";
       const busy = promiseWithResolvers<unknown>();
-      const childPermission = promiseWithResolvers<unknown>();
+      const childSession = promiseWithResolvers<unknown>();
       const idle = promiseWithResolvers<unknown>();
-      runtimeMock.state.subscribedEvents = [busy.promise, childPermission.promise, idle.promise];
+      runtimeMock.state.subscribedEvents = [busy.promise, childSession.promise, idle.promise];
 
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter(
           (event) =>
             event.threadId === threadId &&
-            (event.type === "request.opened" || event.type === "turn.completed"),
+            (event.type === "task.started" || event.type === "turn.completed"),
         ),
         Stream.take(2),
         Stream.runCollect,
@@ -2199,10 +2199,10 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       runtimeMock.state.sessionGetObserved = (sessionID) => {
         if (sessionID === "ses_child") requestOpened.resolve(undefined);
       };
-      childPermission.resolve({
-        id: "evt-child-ancestry-permission",
-        type: "permission.asked",
-        properties: permissionRequest("per_child_ancestry", "ses_child"),
+      childSession.resolve({
+        id: "evt-child-ancestry-session",
+        type: "session.created",
+        properties: { info: { id: "ses_child", title: "Child task" } },
       });
       yield* Effect.promise(() => requestOpened.promise);
       yield* Effect.yieldNow;
@@ -2219,7 +2219,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
       NodeAssert.deepEqual(
         events.map((event) => event.type),
-        ["request.opened", "turn.completed"],
+        ["task.started", "turn.completed"],
       );
       const completed = events[1];
       if (completed?.type === "turn.completed") {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -2157,16 +2157,24 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       runtimeMock.state.sessionStatus = "busy";
       const busy = promiseWithResolvers<unknown>();
       const childSession = promiseWithResolvers<unknown>();
+      const childIdle = promiseWithResolvers<unknown>();
       const idle = promiseWithResolvers<unknown>();
-      runtimeMock.state.subscribedEvents = [busy.promise, childSession.promise, idle.promise];
+      runtimeMock.state.subscribedEvents = [
+        busy.promise,
+        childSession.promise,
+        childIdle.promise,
+        idle.promise,
+      ];
 
       const eventsFiber = yield* adapter.streamEvents.pipe(
         Stream.filter(
           (event) =>
             event.threadId === threadId &&
-            (event.type === "task.started" || event.type === "turn.completed"),
+            (event.type === "task.started" ||
+              event.type === "task.completed" ||
+              event.type === "turn.completed"),
         ),
-        Stream.take(2),
+        Stream.take(3),
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -2206,6 +2214,12 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       });
       yield* Effect.promise(() => requestOpened.promise);
       yield* Effect.yieldNow;
+      childIdle.resolve({
+        id: "evt-child-ancestry-idle",
+        type: "session.status",
+        properties: { sessionID: "ses_child", status: { type: "idle" } },
+      });
+      yield* Effect.yieldNow;
       runtimeMock.state.sessionStatus = "idle";
       idle.resolve({
         id: "evt-child-ancestry-idle",
@@ -2219,9 +2233,9 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
       NodeAssert.deepEqual(
         events.map((event) => event.type),
-        ["task.started", "turn.completed"],
+        ["task.started", "task.completed", "turn.completed"],
       );
-      const completed = events[1];
+      const completed = events[2];
       if (completed?.type === "turn.completed") {
         NodeAssert.deepEqual(completed.payload.tokenUsage, {
           usageStatus: "unavailable",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -316,6 +316,14 @@ function isOpenCodeChildRequestEvent(event: OpenCodeSubscribedEvent): boolean {
   }
 }
 
+function isOpenCodeChildSessionEvent(event: OpenCodeSubscribedEvent): boolean {
+  return (
+    event.type === "session.created" ||
+    event.type === "session.updated" ||
+    event.type === "session.deleted"
+  );
+}
+
 const OPENCODE_DEFAULT_TITLE_PATTERN =
   /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -2204,8 +2212,6 @@ export function makeOpenCodeAdapter(
         if (session.parentID && context.relatedSessionIds.has(session.parentID)) {
           addRelatedOpenCodeSession(context, session.id);
         }
-      } else if (event.type === "session.deleted") {
-        context.relatedSessionIds.delete(event.properties.info.id);
       }
 
       const payloadSessionId = openCodeEventSessionId(event);
@@ -2214,7 +2220,7 @@ export function makeOpenCodeAdapter(
       if (
         payloadSessionId !== undefined &&
         !context.relatedSessionIds.has(payloadSessionId) &&
-        isOpenCodeChildRequestEvent(event)
+        (isOpenCodeChildRequestEvent(event) || isOpenCodeChildSessionEvent(event))
       ) {
         if (event.type === "permission.asked") {
           yield* scheduleRequestRelationRetry(context, event);
@@ -2236,7 +2242,7 @@ export function makeOpenCodeAdapter(
       }
       const isChildRequestEvent =
         payloadSessionId !== undefined &&
-        isOpenCodeChildRequestEvent(event) &&
+        (isOpenCodeChildRequestEvent(event) || isOpenCodeChildSessionEvent(event)) &&
         (context.relatedSessionIds.has(payloadSessionId) || isKnownPendingTerminalEvent);
       if (!isParentEvent && !isChildRequestEvent) {
         return;
@@ -2270,7 +2276,48 @@ export function makeOpenCodeAdapter(
       }
 
       switch (event.type) {
+        case "session.created": {
+          if (!isParentEvent) {
+            const session = event.properties.info;
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                itemId: session.id,
+                raw: event,
+              })),
+              type: "task.started",
+              payload: {
+                taskId: session.id,
+                taskType: "local_agent",
+                title: session.title,
+                description: session.title,
+              },
+            });
+          }
+          break;
+        }
         case "session.updated": {
+          if (!isParentEvent) {
+            const session = event.properties.info;
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                itemId: session.id,
+                raw: event,
+              })),
+              type: "task.progress",
+              payload: {
+                taskId: session.id,
+                taskType: "local_agent",
+                title: session.title,
+                description: session.title,
+                summary: session.title,
+                status: "running",
+              },
+            });
+          }
           const title = openCodeEventSessionTitle(event);
           if (title) {
             yield* emit({
@@ -2286,6 +2333,28 @@ export function makeOpenCodeAdapter(
                 },
               },
             });
+          }
+          break;
+        }
+        case "session.deleted": {
+          if (!isParentEvent) {
+            const session = event.properties.info;
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                itemId: session.id,
+                raw: event,
+              })),
+              type: "task.completed",
+              payload: {
+                taskId: session.id,
+                taskType: "local_agent",
+                status: "completed",
+                summary: session.title,
+              },
+            });
+            context.relatedSessionIds.delete(session.id);
           }
           break;
         }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -256,7 +256,10 @@ interface OpenCodeRequestRelationRetry {
 }
 
 interface OpenCodeSessionRelationRetry {
-  readonly events: Array<OpenCodeChildSessionEvent>;
+  readonly events: Array<{
+    readonly event: OpenCodeChildSessionEvent;
+    readonly turnId: TurnId | undefined;
+  }>;
   fiber?: Fiber.Fiber<void, never>;
 }
 
@@ -362,6 +365,7 @@ interface OpenCodeSessionContext {
   readonly resolvedRequestIds: Set<string>;
   readonly autoRepliedRequestIds: Set<string>;
   readonly emittedTerminalRequestIds: Set<string>;
+  readonly terminalChildSessionIds: Set<string>;
   readonly requestRelationRetries: Map<string, OpenCodeRequestRelationRetry>;
   readonly sessionRelationRetries: Map<string, OpenCodeSessionRelationRetry>;
   readonly pendingPermissions: Map<string, PermissionRequest>;
@@ -2058,28 +2062,36 @@ export function makeOpenCodeAdapter(
       function* (context: OpenCodeSessionContext, event: OpenCodeChildSessionEvent) {
         const sessionId = openCodeEventSessionId(event);
         if (sessionId === undefined) return;
+        const turnId = context.activeTurnId;
         const existing = context.sessionRelationRetries.get(sessionId);
         if (existing) {
-          existing.events.push(event);
+          existing.events.push({ event, turnId });
           return;
         }
-        const retry: OpenCodeSessionRelationRetry = { events: [event] };
+        const retry: OpenCodeSessionRelationRetry = { events: [{ event, turnId }] };
         context.sessionRelationRetries.set(sessionId, retry);
         const run = Effect.gen(function* () {
           let retryCount = 0;
           while (context.sessionRelationRetries.get(sessionId) === retry) {
-            const related = yield* isRelatedOpenCodeSession(context, sessionId).pipe(
-              Effect.orElseSucceed(() => false),
+            const relation = yield* isRelatedOpenCodeSession(context, sessionId).pipe(
+              Effect.match({
+                onFailure: () => "unknown" as const,
+                onSuccess: (related) => (related ? "related" : "unrelated") as const,
+              }),
             );
             if (context.sessionRelationRetries.get(sessionId) !== retry) return;
-            if (related) {
+            if (relation === "unrelated") {
               context.sessionRelationRetries.delete(sessionId);
-              for (const replayEvent of retry.events) {
+              return;
+            }
+            if (relation === "related") {
+              context.sessionRelationRetries.delete(sessionId);
+              for (const { event: replayEvent, turnId: replayTurnId } of retry.events) {
                 const replaySession =
                   replayEvent.type === "session.status" ? undefined : replayEvent.properties.info;
                 const base = yield* buildEventBase({
                   threadId: context.session.threadId,
-                  turnId: context.activeTurnId,
+                  turnId: replayTurnId,
                   itemId: sessionId,
                   raw: replayEvent,
                 });
@@ -2113,6 +2125,8 @@ export function makeOpenCodeAdapter(
                 ) {
                   continue;
                 } else {
+                  if (context.terminalChildSessionIds.has(sessionId)) continue;
+                  context.terminalChildSessionIds.add(sessionId);
                   yield* emit({
                     ...base,
                     type: "task.completed",
@@ -2123,7 +2137,7 @@ export function makeOpenCodeAdapter(
                       summary: replaySession?.title ?? "Completed",
                     },
                   });
-                  context.relatedSessionIds.delete(sessionId);
+                  return;
                 }
               }
               return;
@@ -2748,6 +2762,8 @@ export function makeOpenCodeAdapter(
           if (!isParentEvent) {
             if (event.properties.status.type === "idle") {
               const sessionId = event.properties.sessionID;
+              if (context.terminalChildSessionIds.has(sessionId)) break;
+              context.terminalChildSessionIds.add(sessionId);
               yield* emit({
                 ...(yield* buildEventBase({
                   threadId: context.session.threadId,
@@ -3191,6 +3207,7 @@ export function makeOpenCodeAdapter(
           resolvedRequestIds: new Set(),
           autoRepliedRequestIds: new Set(),
           emittedTerminalRequestIds: new Set(),
+          terminalChildSessionIds: new Set(),
           requestRelationRetries: new Map(),
           sessionRelationRetries: new Map(),
           pendingPermissions: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -329,7 +329,8 @@ function isOpenCodeChildSessionEvent(event: OpenCodeSubscribedEvent): boolean {
   return (
     event.type === "session.created" ||
     event.type === "session.updated" ||
-    event.type === "session.deleted"
+    event.type === "session.deleted" ||
+    event.type === "session.status"
   );
 }
 
@@ -2311,7 +2312,11 @@ export function makeOpenCodeAdapter(
         !context.relatedSessionIds.has(payloadSessionId) &&
         (isOpenCodeChildRequestEvent(event) || isOpenCodeChildSessionEvent(event))
       ) {
-        if (isOpenCodeChildSessionEvent(event)) {
+        if (
+          event.type === "session.created" ||
+          event.type === "session.updated" ||
+          event.type === "session.deleted"
+        ) {
           yield* scheduleChildSessionRelationRetry(context, event);
           return;
         } else if (event.type === "permission.asked") {
@@ -2725,6 +2730,27 @@ export function makeOpenCodeAdapter(
         }
 
         case "session.status": {
+          if (!isParentEvent) {
+            if (event.properties.status.type === "idle") {
+              const sessionId = event.properties.sessionID;
+              yield* emit({
+                ...(yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  itemId: sessionId,
+                  raw: event,
+                })),
+                type: "task.completed",
+                payload: {
+                  taskId: sessionId,
+                  taskType: "local_agent",
+                  status: "completed",
+                  summary: "Completed",
+                },
+              });
+            }
+            break;
+          }
           if (event.properties.status.type === "busy" || event.properties.status.type === "retry") {
             if (turnId === undefined) {
               break;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -247,7 +247,7 @@ type OpenCodeRoutedRequestEvent = OpenCodeAskedRequestEvent | OpenCodeTerminalRe
 
 type OpenCodeChildSessionEvent = Extract<
   OpenCodeSubscribedEvent,
-  { readonly type: "session.created" | "session.updated" | "session.deleted" }
+  { readonly type: "session.created" | "session.updated" | "session.deleted" | "session.status" }
 >;
 
 interface OpenCodeRequestRelationRetry {
@@ -256,6 +256,7 @@ interface OpenCodeRequestRelationRetry {
 }
 
 interface OpenCodeSessionRelationRetry {
+  readonly events: Array<OpenCodeChildSessionEvent>;
   fiber?: Fiber.Fiber<void, never>;
 }
 
@@ -2055,62 +2056,75 @@ export function makeOpenCodeAdapter(
 
     const scheduleChildSessionRelationRetry = Effect.fn("scheduleChildSessionRelationRetry")(
       function* (context: OpenCodeSessionContext, event: OpenCodeChildSessionEvent) {
-        const session = event.properties.info;
-        if (context.sessionRelationRetries.has(session.id)) return;
-        const retry: OpenCodeSessionRelationRetry = {};
-        context.sessionRelationRetries.set(session.id, retry);
+        const sessionId = openCodeEventSessionId(event);
+        if (sessionId === undefined) return;
+        const existing = context.sessionRelationRetries.get(sessionId);
+        if (existing) {
+          existing.events.push(event);
+          return;
+        }
+        const retry: OpenCodeSessionRelationRetry = { events: [event] };
+        context.sessionRelationRetries.set(sessionId, retry);
         const run = Effect.gen(function* () {
           let retryCount = 0;
-          while (context.sessionRelationRetries.get(session.id) === retry) {
-            const related = yield* isRelatedOpenCodeSession(context, session.id).pipe(
+          while (context.sessionRelationRetries.get(sessionId) === retry) {
+            const related = yield* isRelatedOpenCodeSession(context, sessionId).pipe(
               Effect.orElseSucceed(() => false),
             );
-            if (context.sessionRelationRetries.get(session.id) !== retry) return;
+            if (context.sessionRelationRetries.get(sessionId) !== retry) return;
             if (related) {
-              context.sessionRelationRetries.delete(session.id);
-              const turnId = context.activeTurnId;
-              const base = yield* buildEventBase({
-                threadId: context.session.threadId,
-                turnId,
-                itemId: session.id,
-                raw: event,
-              });
-              if (event.type === "session.created") {
-                yield* emit({
-                  ...base,
-                  type: "task.started",
-                  payload: {
-                    taskId: session.id,
-                    taskType: "local_agent",
-                    title: session.title,
-                    description: session.title,
-                  },
+              context.sessionRelationRetries.delete(sessionId);
+              for (const replayEvent of retry.events) {
+                const replaySession =
+                  replayEvent.type === "session.status" ? undefined : replayEvent.properties.info;
+                const base = yield* buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId: context.activeTurnId,
+                  itemId: sessionId,
+                  raw: replayEvent,
                 });
-              } else if (event.type === "session.updated") {
-                yield* emit({
-                  ...base,
-                  type: "task.progress",
-                  payload: {
-                    taskId: session.id,
-                    taskType: "local_agent",
-                    title: session.title,
-                    description: session.title,
-                    summary: session.title,
-                    status: "running",
-                  },
-                });
-              } else {
-                yield* emit({
-                  ...base,
-                  type: "task.completed",
-                  payload: {
-                    taskId: session.id,
-                    taskType: "local_agent",
-                    status: "completed",
-                    summary: session.title,
-                  },
-                });
-                context.relatedSessionIds.delete(session.id);
+                if (replayEvent.type === "session.created") {
+                  yield* emit({
+                    ...base,
+                    type: "task.started",
+                    payload: {
+                      taskId: sessionId,
+                      taskType: "local_agent",
+                      title: replaySession.title,
+                      description: replaySession.title,
+                    },
+                  });
+                } else if (replayEvent.type === "session.updated") {
+                  yield* emit({
+                    ...base,
+                    type: "task.progress",
+                    payload: {
+                      taskId: sessionId,
+                      taskType: "local_agent",
+                      title: replaySession.title,
+                      description: replaySession.title,
+                      summary: replaySession.title,
+                      status: "running",
+                    },
+                  });
+                } else if (
+                  replayEvent.type === "session.status" &&
+                  replayEvent.properties.status.type !== "idle"
+                ) {
+                  continue;
+                } else {
+                  yield* emit({
+                    ...base,
+                    type: "task.completed",
+                    payload: {
+                      taskId: sessionId,
+                      taskType: "local_agent",
+                      status: "completed",
+                      summary: replaySession?.title ?? "Completed",
+                    },
+                  });
+                  context.relatedSessionIds.delete(sessionId);
+                }
               }
               return;
             }
@@ -2122,8 +2136,8 @@ export function makeOpenCodeAdapter(
           Effect.catchCause(() => Effect.void),
           Effect.ensuring(
             Effect.sync(() => {
-              if (context.sessionRelationRetries.get(session.id) === retry) {
-                context.sessionRelationRetries.delete(session.id);
+              if (context.sessionRelationRetries.get(sessionId) === retry) {
+                context.sessionRelationRetries.delete(sessionId);
               }
             }),
           ),
@@ -2315,7 +2329,8 @@ export function makeOpenCodeAdapter(
         if (
           event.type === "session.created" ||
           event.type === "session.updated" ||
-          event.type === "session.deleted"
+          event.type === "session.deleted" ||
+          event.type === "session.status"
         ) {
           yield* scheduleChildSessionRelationRetry(context, event);
           return;

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -245,8 +245,17 @@ type OpenCodeAskedRequestEvent = Extract<
 
 type OpenCodeRoutedRequestEvent = OpenCodeAskedRequestEvent | OpenCodeTerminalRequestEvent;
 
+type OpenCodeChildSessionEvent = Extract<
+  OpenCodeSubscribedEvent,
+  { readonly type: "session.created" | "session.updated" | "session.deleted" }
+>;
+
 interface OpenCodeRequestRelationRetry {
   warned: boolean;
+  fiber?: Fiber.Fiber<void, never>;
+}
+
+interface OpenCodeSessionRelationRetry {
   fiber?: Fiber.Fiber<void, never>;
 }
 
@@ -352,6 +361,7 @@ interface OpenCodeSessionContext {
   readonly autoRepliedRequestIds: Set<string>;
   readonly emittedTerminalRequestIds: Set<string>;
   readonly requestRelationRetries: Map<string, OpenCodeRequestRelationRetry>;
+  readonly sessionRelationRetries: Map<string, OpenCodeSessionRelationRetry>;
   readonly pendingPermissions: Map<string, PermissionRequest>;
   readonly pendingQuestions: Map<string, QuestionRequest>;
   readonly messageRoleById: Map<string, "user" | "assistant">;
@@ -2042,6 +2052,85 @@ export function makeOpenCodeAdapter(
       retry.fiber = yield* run.pipe(Effect.forkIn(context.sessionScope));
     });
 
+    const scheduleChildSessionRelationRetry = Effect.fn("scheduleChildSessionRelationRetry")(
+      function* (context: OpenCodeSessionContext, event: OpenCodeChildSessionEvent) {
+        const session = event.properties.info;
+        if (context.sessionRelationRetries.has(session.id)) return;
+        const retry: OpenCodeSessionRelationRetry = {};
+        context.sessionRelationRetries.set(session.id, retry);
+        const run = Effect.gen(function* () {
+          let retryCount = 0;
+          while (context.sessionRelationRetries.get(session.id) === retry) {
+            const related = yield* isRelatedOpenCodeSession(context, session.id).pipe(
+              Effect.orElseSucceed(() => false),
+            );
+            if (context.sessionRelationRetries.get(session.id) !== retry) return;
+            if (related) {
+              context.sessionRelationRetries.delete(session.id);
+              const turnId = context.activeTurnId;
+              const base = yield* buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                itemId: session.id,
+                raw: event,
+              });
+              if (event.type === "session.created") {
+                yield* emit({
+                  ...base,
+                  type: "task.started",
+                  payload: {
+                    taskId: session.id,
+                    taskType: "local_agent",
+                    title: session.title,
+                    description: session.title,
+                  },
+                });
+              } else if (event.type === "session.updated") {
+                yield* emit({
+                  ...base,
+                  type: "task.progress",
+                  payload: {
+                    taskId: session.id,
+                    taskType: "local_agent",
+                    title: session.title,
+                    description: session.title,
+                    summary: session.title,
+                    status: "running",
+                  },
+                });
+              } else {
+                yield* emit({
+                  ...base,
+                  type: "task.completed",
+                  payload: {
+                    taskId: session.id,
+                    taskType: "local_agent",
+                    status: "completed",
+                    summary: session.title,
+                  },
+                });
+                context.relatedSessionIds.delete(session.id);
+              }
+              return;
+            }
+            const delayMs = Math.min(250 * 2 ** retryCount, 5_000);
+            retryCount += 1;
+            yield* Effect.sleep(`${delayMs} millis`);
+          }
+        }).pipe(
+          Effect.catchCause(() => Effect.void),
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (context.sessionRelationRetries.get(session.id) === retry) {
+                context.sessionRelationRetries.delete(session.id);
+              }
+            }),
+          ),
+        );
+        retry.fiber = yield* run.pipe(Effect.forkIn(context.sessionScope));
+      },
+    );
+
     const schedulePendingRequestRecovery = Effect.fn("schedulePendingRequestRecovery")(function* (
       context: OpenCodeSessionContext,
     ) {
@@ -2222,7 +2311,10 @@ export function makeOpenCodeAdapter(
         !context.relatedSessionIds.has(payloadSessionId) &&
         (isOpenCodeChildRequestEvent(event) || isOpenCodeChildSessionEvent(event))
       ) {
-        if (event.type === "permission.asked") {
+        if (isOpenCodeChildSessionEvent(event)) {
+          yield* scheduleChildSessionRelationRetry(context, event);
+          return;
+        } else if (event.type === "permission.asked") {
           yield* scheduleRequestRelationRetry(context, event);
         } else if (event.type === "question.asked") {
           yield* scheduleRequestRelationRetry(context, event);
@@ -3059,6 +3151,7 @@ export function makeOpenCodeAdapter(
           autoRepliedRequestIds: new Set(),
           emittedTerminalRequestIds: new Set(),
           requestRelationRetries: new Map(),
+          sessionRelationRetries: new Map(),
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),
           textPartsByMessageId: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -2318,7 +2318,7 @@ export function makeOpenCodeAdapter(
               },
             });
           }
-          const title = openCodeEventSessionTitle(event);
+          const title = isParentEvent ? openCodeEventSessionTitle(event) : undefined;
           if (title) {
             yield* emit({
               ...(yield* buildEventBase({


### PR DESCRIPTION
OpenCode reports spawned sub-agents as child sessions, but the adapter only forwarded their tool and request events. Because it did not emit the shared task lifecycle events, the Agents panel had no roster entries and the activity appeared only in the chat.

Translate related child-session create, update, and delete events into task lifecycle events. This lets the existing Agents panel show OpenCode sub-agents with their title and running/completed state without changing the chat timeline behavior.

Includes focused OpenCode adapter coverage; all 110 adapter tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added lifecycle tracking for child sessions.
  - Child-session creation and updates now report task start and progress events, including when events arrive out of order.
  - Child-session completion now reports task completion, including for deleted or idle sessions.
  - Idle child sessions emit completion events before parent session updates.

- **Bug Fixes**
  - Improved event routing and retry handling to associate child-session updates with the correct parent session and prevent duplicate completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->