### PR TITLE
Fixes #9

### DIFF
--- a/apps/server/src/environment/BrowserCapabilityProbe.test.ts
+++ b/apps/server/src/environment/BrowserCapabilityProbe.test.ts
@@ -1,0 +1,189 @@
+import * as NodePath from "@effect/platform-node/NodePath";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { vi } from "vite-plus/test";
+
+import * as ProcessRunner from "../processRunner.ts";
+import { probeBrowserCapability } from "./BrowserCapabilityProbe.ts";
+
+const runMock = vi.fn<ProcessRunner.ProcessRunner["Service"]["run"]>();
+
+const ProcessRunnerTest = Layer.succeed(
+  ProcessRunner.ProcessRunner,
+  ProcessRunner.ProcessRunner.of({
+    run: (input) => runMock(input),
+  }),
+);
+const PathLayer = NodePath.layer;
+
+const linuxHome = "/home/pi";
+const linuxCacheRoot = `${linuxHome}/.cache/ms-playwright`;
+const linuxHeadlessShellPath = `${linuxCacheRoot}/chromium_headless_shell-1148/chrome-linux/headless_shell`;
+const systemChromiumPath = "/usr/bin/chromium";
+
+const withEnv = <ROut, E, RIn>(
+  layer: Layer.Layer<ROut, E, RIn>,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+) =>
+  Layer.mergeAll(
+    layer,
+    Layer.succeed(HostProcessPlatform, platform),
+    Layer.succeed(HostProcessEnvironment, env),
+  );
+
+const successResult = (stdout: string) => ({
+  stdout,
+  stderr: "",
+  code: ChildProcessSpawner.ExitCode(0),
+  timedOut: false,
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
+afterEach(() => {
+  runMock.mockReset();
+});
+
+describe("probeBrowserCapability", () => {
+  it.effect("reports absent when no Chromium binary can be found anywhere", () =>
+    Effect.gen(function* () {
+      const result = yield* probeBrowserCapability().pipe(
+        Effect.provide(
+          withEnv(Layer.mergeAll(ProcessRunnerTest, PathLayer, FileSystem.layerNoop({})), "linux", {
+            HOME: linuxHome,
+          }),
+        ),
+      );
+
+      expect(result).toEqual({ state: "absent" });
+      expect(runMock).not.toHaveBeenCalled();
+    }),
+  );
+
+  it.effect("reports ok when the Playwright-managed Chromium binary launches", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(Effect.succeed(successResult("HeadlessChrome/120.0.6099.0\n")));
+
+      const fileSystemLayer = FileSystem.layerNoop({
+        exists: (path) =>
+          Effect.succeed(path === linuxCacheRoot || path === linuxHeadlessShellPath),
+        readDirectory: (path) =>
+          path === linuxCacheRoot
+            ? Effect.succeed(["chromium_headless_shell-1148"])
+            : Effect.succeed([]),
+      });
+
+      const result = yield* probeBrowserCapability().pipe(
+        Effect.provide(
+          withEnv(Layer.mergeAll(ProcessRunnerTest, PathLayer, fileSystemLayer), "linux", {
+            HOME: linuxHome,
+          }),
+        ),
+      );
+
+      expect(result).toEqual({
+        state: "ok",
+        binaryPath: linuxHeadlessShellPath,
+        version: "HeadlessChrome/120.0.6099.0",
+      });
+      expect(runMock).toHaveBeenCalledWith(
+        expect.objectContaining({ command: linuxHeadlessShellPath, args: ["--version"] }),
+      );
+    }),
+  );
+
+  it.effect(
+    "reports degraded when only a system Chromium binary exists and the Playwright cache is missing",
+    () =>
+      Effect.gen(function* () {
+        runMock.mockReturnValueOnce(Effect.succeed(successResult("Chromium 120.0.6099.0\n")));
+
+        const fileSystemLayer = FileSystem.layerNoop({
+          exists: (path) => Effect.succeed(path === systemChromiumPath),
+          readDirectory: () => Effect.succeed([]),
+        });
+
+        const result = yield* probeBrowserCapability().pipe(
+          Effect.provide(
+            withEnv(Layer.mergeAll(ProcessRunnerTest, PathLayer, fileSystemLayer), "linux", {
+              HOME: linuxHome,
+            }),
+          ),
+        );
+
+        expect(result.state).toBe("degraded");
+        expect(result.binaryPath).toBe(systemChromiumPath);
+        expect(result.details).toContain("Playwright browser cache is missing");
+      }),
+  );
+
+  it.effect("reports degraded when a located binary fails to launch", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.fail(
+          new ProcessRunner.ProcessSpawnError({
+            command: linuxHeadlessShellPath,
+            argumentCount: 1,
+            cause: new Error("spawn EACCES"),
+          }),
+        ),
+      );
+
+      const fileSystemLayer = FileSystem.layerNoop({
+        exists: (path) =>
+          Effect.succeed(path === linuxCacheRoot || path === linuxHeadlessShellPath),
+        readDirectory: (path) =>
+          path === linuxCacheRoot
+            ? Effect.succeed(["chromium_headless_shell-1148"])
+            : Effect.succeed([]),
+      });
+
+      const result = yield* probeBrowserCapability().pipe(
+        Effect.provide(
+          withEnv(Layer.mergeAll(ProcessRunnerTest, PathLayer, fileSystemLayer), "linux", {
+            HOME: linuxHome,
+          }),
+        ),
+      );
+
+      expect(result.state).toBe("degraded");
+      expect(result.binaryPath).toBe(linuxHeadlessShellPath);
+      expect(result.details).toContain("failed to launch");
+    }),
+  );
+
+  it.effect("prefers the Playwright cache binary over a system Chromium install", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(Effect.succeed(successResult("HeadlessChrome/120.0.6099.0\n")));
+
+      const fileSystemLayer = FileSystem.layerNoop({
+        exists: (path) =>
+          Effect.succeed(
+            path === linuxCacheRoot ||
+              path === linuxHeadlessShellPath ||
+              path === systemChromiumPath,
+          ),
+        readDirectory: (path) =>
+          path === linuxCacheRoot
+            ? Effect.succeed(["chromium_headless_shell-1148"])
+            : Effect.succeed([]),
+      });
+
+      const result = yield* probeBrowserCapability().pipe(
+        Effect.provide(
+          withEnv(Layer.mergeAll(ProcessRunnerTest, PathLayer, fileSystemLayer), "linux", {
+            HOME: linuxHome,
+          }),
+        ),
+      );
+
+      expect(result.state).toBe("ok");
+      expect(result.binaryPath).toBe(linuxHeadlessShellPath);
+    }),
+  );
+});

--- a/apps/server/src/environment/BrowserCapabilityProbe.ts
+++ b/apps/server/src/environment/BrowserCapabilityProbe.ts
@@ -1,0 +1,224 @@
+import type { BrowserCapability } from "@t3tools/contracts";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import * as ProcessRunner from "../processRunner.ts";
+
+/**
+ * cc_runner polls the public environment descriptor to demote nodes whose
+ * declared config has drifted from reality, so this measures whether the
+ * node can actually launch a Chromium binary rather than trusting config.
+ */
+const BROWSER_CAPABILITY_CACHE_TTL = "6 hours";
+const VERSION_PROBE_TIMEOUT = "5 seconds";
+
+const PLAYWRIGHT_CHROMIUM_BINARY_CANDIDATES: Record<string, readonly string[]> = {
+  darwin: ["chrome-mac/headless_shell", "chrome-mac/Chromium.app/Contents/MacOS/Chromium"],
+  linux: ["chrome-linux/headless_shell", "chrome-linux/chrome"],
+  win32: ["chrome-win/headless_shell.exe", "chrome-win/chrome.exe"],
+};
+
+const SYSTEM_CHROMIUM_BINARY_CANDIDATES: Record<string, readonly string[]> = {
+  darwin: [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  ],
+  linux: [
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+  ],
+  win32: [
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  ],
+};
+
+function resolvePlaywrightCacheRoot(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  path: Path.Path,
+): string {
+  const overridePath = env.PLAYWRIGHT_BROWSERS_PATH;
+  if (overridePath && overridePath !== "0") {
+    return overridePath;
+  }
+
+  const home = env.HOME ?? env.USERPROFILE ?? "";
+  switch (platform) {
+    case "darwin":
+      return path.join(home, "Library", "Caches", "ms-playwright");
+    case "win32":
+      return path.join(env.LOCALAPPDATA ?? home, "ms-playwright");
+    default:
+      return path.join(env.XDG_CACHE_HOME ?? path.join(home, ".cache"), "ms-playwright");
+  }
+}
+
+const findPlaywrightChromiumBinary = Effect.fn(
+  "BrowserCapabilityProbe.findPlaywrightChromiumBinary",
+)(function* (cacheRoot: string, binaryCandidates: readonly string[]) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const cacheRootExists = yield* fileSystem
+    .exists(cacheRoot)
+    .pipe(Effect.orElseSucceed(() => false));
+  if (!cacheRootExists) {
+    return null;
+  }
+
+  const entries = yield* fileSystem
+    .readDirectory(cacheRoot)
+    .pipe(Effect.orElseSucceed((): readonly string[] => []));
+  const chromiumDirectories = entries
+    .filter((entry) => entry.startsWith("chromium"))
+    .sort()
+    .toReversed();
+
+  for (const directory of chromiumDirectories) {
+    for (const relativeBinaryPath of binaryCandidates) {
+      const candidate = path.join(cacheRoot, directory, relativeBinaryPath);
+      const candidateExists = yield* fileSystem
+        .exists(candidate)
+        .pipe(Effect.orElseSucceed(() => false));
+      if (candidateExists) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+});
+
+const findSystemChromiumBinary = Effect.fn("BrowserCapabilityProbe.findSystemChromiumBinary")(
+  function* (candidates: readonly string[]) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    for (const candidate of candidates) {
+      const candidateExists = yield* fileSystem
+        .exists(candidate)
+        .pipe(Effect.orElseSucceed(() => false));
+      if (candidateExists) {
+        return candidate;
+      }
+    }
+    return null;
+  },
+);
+
+function normalizeVersion(stdout: string): string | undefined {
+  const trimmed = stdout.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const probeBrowserCapability = Effect.fn("BrowserCapabilityProbe.probe")(
+  function* (): Effect.fn.Return<
+    BrowserCapability,
+    never,
+    FileSystem.FileSystem | Path.Path | ProcessRunner.ProcessRunner
+  > {
+    const platform = yield* HostProcessPlatform;
+    const env = yield* HostProcessEnvironment;
+    const path = yield* Path.Path;
+    const processRunner = yield* ProcessRunner.ProcessRunner;
+
+    const playwrightBinaryCandidates =
+      PLAYWRIGHT_CHROMIUM_BINARY_CANDIDATES[platform] ??
+      PLAYWRIGHT_CHROMIUM_BINARY_CANDIDATES.linux ??
+      [];
+    const systemBinaryCandidates = SYSTEM_CHROMIUM_BINARY_CANDIDATES[platform] ?? [];
+
+    const cacheRoot = resolvePlaywrightCacheRoot(platform, env, path);
+    const playwrightBinaryPath = yield* findPlaywrightChromiumBinary(
+      cacheRoot,
+      playwrightBinaryCandidates,
+    );
+    const systemBinaryPath = playwrightBinaryPath
+      ? null
+      : yield* findSystemChromiumBinary(systemBinaryCandidates);
+    const binaryPath = playwrightBinaryPath ?? systemBinaryPath;
+
+    if (!binaryPath) {
+      return { state: "absent" };
+    }
+
+    const launchResult = yield* processRunner
+      .run({
+        command: binaryPath,
+        args: ["--version"],
+        timeout: VERSION_PROBE_TIMEOUT,
+        timeoutBehavior: "timedOutResult",
+      })
+      .pipe(Effect.result);
+
+    if (
+      launchResult._tag === "Failure" ||
+      launchResult.success.timedOut ||
+      launchResult.success.code !== 0
+    ) {
+      return {
+        state: "degraded",
+        binaryPath,
+        details:
+          launchResult._tag === "Failure"
+            ? `Chromium binary at '${binaryPath}' failed to launch: ${launchResult.failure.message}`
+            : `Chromium binary at '${binaryPath}' did not exit cleanly when probing its version.`,
+      };
+    }
+
+    const version = normalizeVersion(launchResult.success.stdout);
+
+    if (playwrightBinaryPath) {
+      return { state: "ok", binaryPath, ...(version ? { version } : {}) };
+    }
+
+    return {
+      state: "degraded",
+      binaryPath,
+      ...(version ? { version } : {}),
+      details:
+        "A system Chromium binary was found, but the Playwright browser cache is missing or incomplete.",
+    };
+  },
+);
+
+export class BrowserCapabilityProbe extends Context.Service<
+  BrowserCapabilityProbe,
+  {
+    readonly probe: Effect.Effect<BrowserCapability>;
+  }
+>()("t3/environment/BrowserCapabilityProbe") {}
+
+export const make = Effect.fn("BrowserCapabilityProbe.make")(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  const platform = yield* HostProcessPlatform;
+  const env = yield* HostProcessEnvironment;
+
+  const probe = yield* Effect.cachedWithTTL(
+    probeBrowserCapability().pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
+      Effect.provideService(Path.Path, path),
+      Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+      Effect.provideService(HostProcessPlatform, platform),
+      Effect.provideService(HostProcessEnvironment, env),
+    ),
+    BROWSER_CAPABILITY_CACHE_TTL,
+  );
+
+  return BrowserCapabilityProbe.of({ probe });
+});
+
+/**
+ * Self-contained so callers only need to provide filesystem/path/host-process
+ * platform services; the probe never fails, it degrades to `"absent"`.
+ */
+export const layer = Layer.effect(BrowserCapabilityProbe, make()).pipe(
+  Layer.provide(ProcessRunner.layer),
+);

--- a/apps/server/src/environment/ServerBuildSha.test.ts
+++ b/apps/server/src/environment/ServerBuildSha.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import { vi } from "vite-plus/test";
+
+import * as ProcessRunner from "../processRunner.ts";
+import * as ServerBuildSha from "./ServerBuildSha.ts";
+
+const runMock = vi.fn<ProcessRunner.ProcessRunner["Service"]["run"]>();
+
+const ProcessRunnerTest = Layer.succeed(
+  ProcessRunner.ProcessRunner,
+  ProcessRunner.ProcessRunner.of({
+    run: (input) => runMock(input),
+  }),
+);
+
+afterEach(() => {
+  runMock.mockReset();
+});
+
+const okResult = (stdout: string) => ({
+  stdout,
+  stderr: "",
+  code: ChildProcessSpawner.ExitCode(0),
+  timedOut: false,
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
+describe("resolveServerBuildSha", () => {
+  it.effect("returns the normalized git SHA when git rev-parse succeeds", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.succeed(okResult("ABCDEF0123456789ABCDEF0123456789ABCDEF01\n")),
+      );
+
+      const result = yield* ServerBuildSha.resolveServerBuildSha().pipe(
+        Effect.provide(ProcessRunnerTest),
+      );
+
+      expect(result).toBe("abcdef0123456789abcdef0123456789abcdef01");
+      expect(runMock).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "git", args: ["rev-parse", "HEAD"] }),
+      );
+    }),
+  );
+
+  it.effect("returns null when the process exits non-zero (e.g. not a git checkout)", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.succeed({
+          ...okResult("fatal: not a git repository\n"),
+          code: ChildProcessSpawner.ExitCode(128),
+        }),
+      );
+
+      const result = yield* ServerBuildSha.resolveServerBuildSha().pipe(
+        Effect.provide(ProcessRunnerTest),
+      );
+
+      expect(result).toBeNull();
+    }),
+  );
+
+  it.effect("returns null when the process times out", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(Effect.succeed({ ...okResult(""), timedOut: true }));
+
+      const result = yield* ServerBuildSha.resolveServerBuildSha().pipe(
+        Effect.provide(ProcessRunnerTest),
+      );
+
+      expect(result).toBeNull();
+    }),
+  );
+
+  it.effect("returns null when the output isn't a valid SHA", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(Effect.succeed(okResult("not-a-sha\n")));
+
+      const result = yield* ServerBuildSha.resolveServerBuildSha().pipe(
+        Effect.provide(ProcessRunnerTest),
+      );
+
+      expect(result).toBeNull();
+    }),
+  );
+
+  it.effect("returns null when git isn't available", () =>
+    Effect.gen(function* () {
+      runMock.mockReturnValueOnce(
+        Effect.fail(
+          new ProcessRunner.ProcessSpawnError({
+            command: "git",
+            argumentCount: 2,
+            cause: new Error("spawn git ENOENT"),
+          }),
+        ),
+      );
+
+      const result = yield* ServerBuildSha.resolveServerBuildSha().pipe(
+        Effect.provide(ProcessRunnerTest),
+      );
+
+      expect(result).toBeNull();
+    }),
+  );
+});

--- a/apps/server/src/environment/ServerBuildSha.ts
+++ b/apps/server/src/environment/ServerBuildSha.ts
@@ -1,0 +1,39 @@
+import * as Effect from "effect/Effect";
+
+import * as ProcessRunner from "../processRunner.ts";
+
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * Source-mode nodes (e.g. an RPi running `node apps/server/src/bin.ts serve`
+ * directly from a git checkout) never rebuild `apps/web/dist` on `git pull`.
+ * A stale bundle then fails to decode the running server's wire schema,
+ * surfacing as a generic SchemaError instead of a clear "rebuild the web
+ * client" message. Stamping the real checkout SHA into serverVersion lets
+ * the existing client/server version-mismatch check catch that drift even
+ * when package.json's semver hasn't moved.
+ */
+export const resolveServerBuildSha = Effect.fn("resolveServerBuildSha")(function* () {
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  const result = yield* processRunner
+    .run({
+      command: "git",
+      args: ["rev-parse", "HEAD"],
+      cwd: import.meta.dirname,
+      timeoutBehavior: "timedOutResult",
+    })
+    .pipe(
+      Effect.catch((cause) =>
+        Effect.logDebug("Could not resolve the server's build SHA.", { cause }).pipe(
+          Effect.as(null),
+        ),
+      ),
+    );
+
+  if (result === null || result.timedOut || result.code !== 0) {
+    return null;
+  }
+
+  const sha = result.stdout.trim().toLowerCase();
+  return GIT_SHA_PATTERN.test(sha) ? sha : null;
+});

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -11,7 +11,21 @@ import * as Schema from "effect/Schema";
 import packageJson from "../../package.json" with { type: "json" };
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import { resolveServerBuildSha } from "./ServerBuildSha.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
+
+/**
+ * Source-mode checkouts (e.g. the RPi in #1) never bump package.json's
+ * semver per commit, so a stale `apps/web/dist` bundle built before a
+ * schema-changing pull can share the exact same serverVersion as the
+ * freshly restarted server, silently defeating client/server version-skew
+ * detection. Suffixing the real checkout SHA (when resolvable) makes any
+ * such drift visible; packaged builds without a `.git` directory fall back
+ * to the plain semver unchanged.
+ */
+function buildServerVersion(buildSha: string | null): string {
+  return buildSha ? `${packageJson.version}+git.${buildSha.slice(0, 12)}` : packageJson.version;
+}
 
 export class ServerEnvironmentIdPersistenceError extends Schema.TaggedErrorClass<ServerEnvironmentIdPersistenceError>()(
   "ServerEnvironmentIdPersistenceError",
@@ -124,6 +138,7 @@ export const make = Effect.gen(function* () {
   const environmentId = EnvironmentId.make(environmentIdRaw);
   const cwdBaseName = path.basename(serverConfig.cwd).trim();
   const label = yield* resolveServerEnvironmentLabel({ cwdBaseName });
+  const buildSha = yield* resolveServerBuildSha();
 
   const descriptor: ExecutionEnvironmentDescriptor = {
     environmentId,
@@ -132,7 +147,7 @@ export const make = Effect.gen(function* () {
       os: platformOs(hostPlatform),
       arch: platformArch(hostArchitecture),
     },
-    serverVersion: packageJson.version,
+    serverVersion: buildServerVersion(buildSha),
     capabilities: {
       repositoryIdentity: true,
       connectionProbe: true,

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -11,6 +11,7 @@ import * as Schema from "effect/Schema";
 import packageJson from "../../package.json" with { type: "json" };
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
+import * as BrowserCapabilityProbe from "./BrowserCapabilityProbe.ts";
 import { resolveServerBuildSha } from "./ServerBuildSha.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
 
@@ -81,6 +82,7 @@ export const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const hostPlatform = yield* HostProcessPlatform;
   const hostArchitecture = yield* HostProcessArchitecture;
+  const browserCapabilityProbe = yield* BrowserCapabilityProbe.BrowserCapabilityProbe;
 
   const readPersistedEnvironmentId = Effect.gen(function* () {
     const exists = yield* fileSystem.exists(serverConfig.environmentIdPath).pipe(
@@ -154,9 +156,17 @@ export const make = Effect.gen(function* () {
     },
   };
 
+  const getDescriptor = Effect.gen(function* () {
+    const browser = yield* browserCapabilityProbe.probe;
+    return {
+      ...descriptor,
+      capabilities: { ...descriptor.capabilities, browser },
+    };
+  });
+
   return ServerEnvironment.of({
     getEnvironmentId: Effect.succeed(environmentId),
-    getDescriptor: Effect.succeed(descriptor),
+    getDescriptor,
   });
 });
 
@@ -165,4 +175,6 @@ export const make = Effect.gen(function* () {
  * state. It intentionally has no fallback Layer.succeed value: callers must
  * provide the external platform services and a ServerConfig.
  */
-export const layer = Layer.effect(ServerEnvironment, make).pipe(Layer.provide(ProcessRunner.layer));
+export const layer = Layer.effect(ServerEnvironment, make).pipe(
+  Layer.provide(Layer.merge(ProcessRunner.layer, BrowserCapabilityProbe.layer)),
+);

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -899,3 +899,145 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
     );
   });
 });
+
+// Real (non-virtual) delay: `it.effect` runs under Effect's TestClock, so `Effect.sleep` never
+// resolves there unless the virtual clock is advanced. This waits on the actual Node event loop
+// so an artificially widened "in-flight" window (see below) really elapses in wall-clock time.
+// Effect.sleep runs on the virtual TestClock under `it.effect` and never resolves here; this
+// intentionally bypasses it for a real wall-clock wait.
+const realDelay = (ms: number): Effect.Effect<void> =>
+  Effect.promise(
+    () =>
+      new Promise((resolve) => {
+        // @effect-diagnostics-next-line globalTimers:off
+        setTimeout(resolve, ms);
+      }),
+  );
+
+describe("per-repo worktree provisioning lock", () => {
+  it.effect(
+    "serializes fetch + resolveRemoteTrackingCommit + worktree add for the same repo, but not across repos",
+    () => {
+      // Tags the git subprocesses that GitVcsDriverCore serializes per repo (fetch,
+      // `rev-parse --verify refs/remotes/...`, `worktree add`) and records, per cwd, the maximum
+      // number of those subprocesses ever observed running at the same time. Each tagged
+      // subprocess is held "active" a little past its real completion so overlapping calls have a
+      // real chance to race if the per-repo lock were missing. Plain (non-Effect) state is safe
+      // here: every read-modify-write below runs synchronously between yield points.
+      const isGuardedCommand = (args: ReadonlyArray<string>): boolean =>
+        args[0] === "fetch" ||
+        (args[0] === "rev-parse" && args.includes("--verify")) ||
+        (args[0] === "worktree" && args[1] === "add");
+
+      const activeByRepo = new Map<string, number>();
+      const maxActiveByRepo = new Map<string, number>();
+      let globalActive = 0;
+      let globalMaxActive = 0;
+
+      const wrapperSpawnerLayer = Layer.effect(
+        ChildProcessSpawner.ChildProcessSpawner,
+        Effect.gen(function* () {
+          const real = yield* ChildProcessSpawner.ChildProcessSpawner;
+          return ChildProcessSpawner.make((command) =>
+            Effect.gen(function* () {
+              if (!ChildProcess.isStandardCommand(command) || !isGuardedCommand(command.args)) {
+                return yield* real.spawn(command);
+              }
+              const repoKey = command.options.cwd ?? "";
+              const count = (activeByRepo.get(repoKey) ?? 0) + 1;
+              activeByRepo.set(repoKey, count);
+              maxActiveByRepo.set(repoKey, Math.max(maxActiveByRepo.get(repoKey) ?? 0, count));
+              globalActive += 1;
+              globalMaxActive = Math.max(globalMaxActive, globalActive);
+
+              const handle = yield* real.spawn(command);
+              return ChildProcessSpawner.makeHandle({
+                ...handle,
+                exitCode: handle.exitCode.pipe(
+                  Effect.tap(() => realDelay(120)),
+                  Effect.tap(() =>
+                    Effect.sync(() => {
+                      activeByRepo.set(repoKey, (activeByRepo.get(repoKey) ?? 1) - 1);
+                      globalActive -= 1;
+                    }),
+                  ),
+                ),
+              });
+            }),
+          );
+        }),
+      ).pipe(Layer.provide(NodeServices.layer));
+
+      const layer = GitVcsDriver.layer.pipe(
+        Layer.provide(ServerConfigLayer),
+        Layer.provide(wrapperSpawnerLayer),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      const setupRepoWithRemote = (label: string) =>
+        Effect.gen(function* () {
+          const cwd = yield* makeTmpDir(`git-lock-${label}-`);
+          const remote = yield* makeTmpDir(`git-lock-${label}-remote-`);
+          const peer = yield* makeTmpDir(`git-lock-${label}-peer-`);
+          const { initialBranch } = yield* initRepoWithCommit(cwd);
+          yield* git(remote, ["init", "--bare"]);
+          yield* git(cwd, ["remote", "add", "origin", remote]);
+          yield* git(cwd, ["push", "-u", "origin", initialBranch]);
+          yield* git(remote, ["symbolic-ref", "HEAD", `refs/heads/${initialBranch}`]);
+
+          yield* git(peer, ["clone", remote, "."]);
+          yield* git(peer, ["config", "user.email", "test@test.com"]);
+          yield* git(peer, ["config", "user.name", "Test"]);
+          yield* writeTextFile(peer, "remote-change.txt", `${label}\n`);
+          yield* git(peer, ["add", "remote-change.txt"]);
+          yield* git(peer, ["commit", "-m", "remote change"]);
+          yield* git(peer, ["push", "origin", initialBranch]);
+
+          const driver = yield* GitVcsDriver.GitVcsDriver;
+          // Establish refs/remotes/origin/<branch> once up front so the concurrent
+          // resolveRemoteTrackingCommit call below has something to resolve.
+          yield* driver.fetchRemote({ cwd, remoteName: "origin" });
+
+          return { cwd, initialBranch };
+        });
+
+      return Effect.gen(function* () {
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        const { cwd: repoA, initialBranch: branchA } = yield* setupRepoWithRemote("a");
+        const { cwd: repoB } = yield* setupRepoWithRemote("b");
+
+        const repoATasks = Effect.all(
+          [
+            driver.fetchRemote({ cwd: repoA, remoteName: "origin" }),
+            driver.resolveRemoteTrackingCommit({
+              cwd: repoA,
+              refName: branchA,
+              fallbackRemoteName: "origin",
+            }),
+          ],
+          { concurrency: "unbounded" },
+        );
+        const repoBTask = driver.fetchRemote({ cwd: repoB, remoteName: "origin" });
+
+        yield* Effect.all([repoATasks, repoBTask], { concurrency: "unbounded" });
+
+        assert.equal(
+          maxActiveByRepo.get(repoA) ?? 0,
+          1,
+          "fetch and resolveRemoteTrackingCommit must never run concurrently for the same repo",
+        );
+        assert.equal(
+          maxActiveByRepo.get(repoB) ?? 0,
+          1,
+          "a single repo never exceeds one in-flight guarded git command",
+        );
+        assert.equal(
+          globalMaxActive,
+          2,
+          "different repos must still provision concurrently, not serialize behind one global lock",
+        );
+      }).pipe(Effect.provide(layer));
+    },
+    20000,
+  );
+});

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -960,6 +960,31 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
   });
 
+  // Serializes worktree-provisioning git sequences (fetch + resolveRemoteTrackingCommit +
+  // worktree add) per repo, keyed by gitCommonDir. Without this, a `git fetch` writing
+  // refs/remotes/* on one thread can race with `git rev-parse --verify refs/remotes/...` on
+  // another thread of the same clone, failing with "fatal: Needed a single revision". Distinct
+  // repos never share a lock, so unrelated clones keep provisioning in parallel.
+  const repoGitLocks = yield* Ref.make(new Map<string, Semaphore.Semaphore>());
+  const acquireRepoGitLock = (gitCommonDir: string) =>
+    Effect.gen(function* () {
+      const existing = (yield* Ref.get(repoGitLocks)).get(gitCommonDir);
+      if (existing) return existing;
+      const created = yield* Semaphore.make(1);
+      return yield* Ref.modify(repoGitLocks, (current) => {
+        const already = current.get(gitCommonDir);
+        if (already) return [already, current];
+        const next = new Map(current);
+        next.set(gitCommonDir, created);
+        return [created, next];
+      });
+    });
+  const withRepoGitLock = <A, E>(cwd: string, effect: Effect.Effect<A, E>) =>
+    resolveGitCommonDir(cwd).pipe(
+      Effect.flatMap((gitCommonDir) => acquireRepoGitLock(gitCommonDir)),
+      Effect.flatMap((lock) => lock.withPermit(effect)),
+    );
+
   const refreshStatusRemoteCacheEntry = Effect.fn("refreshStatusRemoteCacheEntry")(function* (
     cacheKey: StatusRemoteRefreshCacheKey,
   ) {
@@ -2268,9 +2293,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       ? ["worktree", "add", "-b", input.newRefName, worktreePath, input.refName]
       : ["worktree", "add", worktreePath, input.refName];
 
-    yield* executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
-      fallbackErrorDetail: "git worktree add failed",
-    });
+    yield* withRepoGitLock(
+      input.cwd,
+      executeGit("GitVcsDriver.createWorktree", input.cwd, args, {
+        fallbackErrorDetail: "git worktree add failed",
+      }),
+    );
 
     if (input.newRefName && input.baseRefName) {
       const remoteNames = yield* listRemoteNames(input.cwd).pipe(Effect.orElseSucceed(() => []));
@@ -2315,14 +2343,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
   const fetchRemote: GitVcsDriver.GitVcsDriver["Service"]["fetchRemote"] = Effect.fn("fetchRemote")(
     function* (input) {
-      yield* executeGit(
-        "GitVcsDriver.fetchRemote",
+      yield* withRepoGitLock(
         input.cwd,
-        ["fetch", "--quiet", input.remoteName],
-        {
+        executeGit("GitVcsDriver.fetchRemote", input.cwd, ["fetch", "--quiet", input.remoteName], {
           env: STATUS_UPSTREAM_REFRESH_ENV,
           fallbackErrorDetail: `git fetch ${input.remoteName} failed`,
-        },
+        }),
       );
     },
   );
@@ -2336,11 +2362,14 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       );
       const remoteRefName =
         parsedRemoteRef?.remoteRef ?? `${input.fallbackRemoteName}/${input.refName}`;
-      const commitSha = yield* runGitStdout("GitVcsDriver.resolveRemoteTrackingCommit", input.cwd, [
-        "rev-parse",
-        "--verify",
-        `refs/remotes/${remoteRefName}^{commit}`,
-      ]).pipe(Effect.map((stdout) => stdout.trim()));
+      const commitSha = yield* withRepoGitLock(
+        input.cwd,
+        runGitStdout("GitVcsDriver.resolveRemoteTrackingCommit", input.cwd, [
+          "rev-parse",
+          "--verify",
+          `refs/remotes/${remoteRefName}^{commit}`,
+        ]).pipe(Effect.map((stdout) => stdout.trim())),
+      );
 
       return { commitSha, remoteRefName };
     });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1768,7 +1768,15 @@ function ChatViewContent(props: ChatViewProps) {
   const serverConfig = activeThread
     ? (activeEnvironment?.serverConfig ?? null)
     : (primaryEnvironment?.serverConfig ?? null);
-  const versionMismatch = resolveServerConfigVersionMismatch(serverConfig);
+  // Build-metadata (SHA) drift only means something for the primary
+  // environment, which serves this client's own bundle — a thread pinned to
+  // a remote peer on a different commit is normal operation, not staleness.
+  const isPrimaryServerConfig = activeThread
+    ? activeThread.environmentId === primaryEnvironmentId
+    : true;
+  const versionMismatch = resolveServerConfigVersionMismatch(serverConfig, {
+    compareBuildMetadata: isPrimaryServerConfig,
+  });
   const versionMismatchDismissKey =
     versionMismatch && activeThread
       ? buildVersionMismatchDismissalKey(activeThread.environmentId, versionMismatch)

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1824,7 +1824,12 @@ export function ConnectionsSettings() {
     DesktopServerExposureState["mode"] | null
   >(null);
   const primaryServerConfig = primaryEnvironment?.serverConfig ?? null;
-  const primaryVersionMismatch = resolveServerConfigVersionMismatch(primaryServerConfig);
+  // The primary environment serves this client's own bundle, so build-metadata
+  // (SHA) drift is meaningful here — unlike the saved/remote environment rows
+  // below, which compare at release granularity only.
+  const primaryVersionMismatch = resolveServerConfigVersionMismatch(primaryServerConfig, {
+    compareBuildMetadata: true,
+  });
   const [isAdvertisedEndpointListExpanded, setIsAdvertisedEndpointListExpanded] = useState(false);
   const defaultAdvertisedEndpointKey = useUiStateStore(
     (state) => state.defaultAdvertisedEndpointKey,

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -52,6 +52,7 @@ import { clearComposerDraftsEnvironment } from "../composerDraftStore";
 import { isHostedStaticApp } from "../hostedPairing";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 import { acknowledgeRpcRequest, trackRpcRequestSent } from "../rpc/requestLatencyState";
+import { resolveVersionMismatch } from "../versionSkew";
 import {
   desktopLocalConnectionId,
   readDesktopSecondaryBootstrapsResult,
@@ -283,12 +284,36 @@ const capabilitiesLayer = Layer.effectContext(
   }),
 );
 
+// The WebSocket RPC session's own handshake (server.getConfig) decodes
+// against a wire schema that can drift out from under a stale web bundle —
+// exactly the failure mode that surfaces as a generic SchemaError (#1). The
+// environment descriptor above is fetched over plain HTTP against a much
+// narrower, additive-only schema, so it reliably completes even when the
+// WS session never establishes. Logging a mismatch here, before the WS
+// connect is even attempted, gives a concrete, correlated cause for a
+// SchemaError that follows instead of leaving it as an opaque defect.
+const logDescriptorVersionMismatch = (serverVersion: string) => {
+  // Both callers bootstrap a same-machine connection (the primary origin, or
+  // a desktop-local secondary like WSL) built from the same checkout as this
+  // client, so build-metadata (SHA) drift is a meaningful signal here — unlike
+  // comparing against an arbitrary remote peer environment.
+  const mismatch = resolveVersionMismatch(serverVersion, { compareBuildMetadata: true });
+  if (!mismatch) {
+    return Effect.void;
+  }
+  return Effect.logWarning("Web client/server version mismatch detected before connecting.", {
+    clientVersion: mismatch.clientVersion,
+    serverVersion: mismatch.serverVersion,
+  });
+};
+
 const loadPrimaryConnectionRegistration = Effect.fn(
   "web.connectionPlatform.loadPrimaryConnectionRegistration",
 )(function* (resolved: PrimaryEnvironmentTarget) {
   const descriptor = yield* fetchRemoteEnvironmentDescriptor({
     httpBaseUrl: resolved.target.httpBaseUrl,
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer), Effect.mapError(mapRemoteEnvironmentError));
+  yield* logDescriptorVersionMismatch(descriptor.serverVersion);
   return new PrimaryConnectionRegistration({
     target: new PrimaryConnectionTarget({
       environmentId: descriptor.environmentId,
@@ -320,6 +345,7 @@ const loadSecondaryConnectionRegistration = Effect.fn(
   const descriptor = yield* fetchRemoteEnvironmentDescriptor({ httpBaseUrl }).pipe(
     Effect.mapError(mapRemoteEnvironmentError),
   );
+  yield* logDescriptorVersionMismatch(descriptor.serverVersion);
   const issuedAtEpochMs = yield* Clock.currentTimeMillis;
   const access = yield* bootstrapRemoteBearerSession({
     httpBaseUrl,

--- a/apps/web/src/versionSkew.test.ts
+++ b/apps/web/src/versionSkew.test.ts
@@ -68,6 +68,30 @@ describe("versionSkew", () => {
     ).toBe(false);
   });
 
+  it("ignores build-metadata drift by default (remote peer on a different commit)", () => {
+    expect(resolveVersionMismatch(`${APP_VERSION}+git.abc123def456`)).toBeNull();
+  });
+
+  it("flags build-metadata drift when compareBuildMetadata is requested (primary connection)", () => {
+    expect(
+      resolveVersionMismatch(`${APP_VERSION}+git.abc123def456`, { compareBuildMetadata: true }),
+    ).toEqual({
+      clientVersion: APP_VERSION,
+      serverVersion: `${APP_VERSION}+git.abc123def456`,
+      hint: "Version mismatch. Try syncing the client and server to the same T3 Code version.",
+    });
+  });
+
+  it("still flags a release-version mismatch regardless of compareBuildMetadata", () => {
+    expect(
+      resolveVersionMismatch("9.9.9+git.abc123def456", { compareBuildMetadata: true }),
+    ).toEqual({
+      clientVersion: APP_VERSION,
+      serverVersion: "9.9.9+git.abc123def456",
+      hint: "Version mismatch. Try syncing the client and server to the same T3 Code version.",
+    });
+  });
+
   it("appends a hint to connection errors when versions differ", () => {
     const mismatch = resolveVersionMismatch("9.9.9");
 

--- a/apps/web/src/versionSkew.ts
+++ b/apps/web/src/versionSkew.ts
@@ -23,16 +23,38 @@ function normalizeVersion(version: string | null | undefined): string | null {
   return trimmed && trimmed.length > 0 ? trimmed : null;
 }
 
+// Versions are stamped as `<semver>+git.<sha>` on source-mode checkouts (#1).
+// The SHA is only meaningful when comparing a client against the server that
+// serves its own bundle (the primary/local connection) — two healthy nodes
+// in a fleet are routinely on different commits, so build metadata is
+// stripped by default and remote/secondary environments must not opt in.
+function stripBuildMetadata(version: string): string {
+  const separatorIndex = version.indexOf("+");
+  return separatorIndex === -1 ? version : version.slice(0, separatorIndex);
+}
+
+export interface ResolveVersionMismatchOptions {
+  readonly compareBuildMetadata?: boolean;
+}
+
 export function resolveVersionMismatch(
   serverVersion: string | null | undefined,
+  options?: ResolveVersionMismatchOptions,
 ): VersionMismatch | null {
   const normalizedClientVersion = normalizeVersion(APP_VERSION);
   const normalizedServerVersion = normalizeVersion(serverVersion);
-  if (
-    !normalizedClientVersion ||
-    !normalizedServerVersion ||
-    normalizedClientVersion === normalizedServerVersion
-  ) {
+  if (!normalizedClientVersion || !normalizedServerVersion) {
+    return null;
+  }
+
+  const compareBuildMetadata = options?.compareBuildMetadata ?? false;
+  const clientComparable = compareBuildMetadata
+    ? normalizedClientVersion
+    : stripBuildMetadata(normalizedClientVersion);
+  const serverComparable = compareBuildMetadata
+    ? normalizedServerVersion
+    : stripBuildMetadata(normalizedServerVersion);
+  if (clientComparable === serverComparable) {
     return null;
   }
 
@@ -45,8 +67,9 @@ export function resolveVersionMismatch(
 
 export function resolveServerConfigVersionMismatch(
   serverConfig: Pick<ServerConfig, "environment"> | null | undefined,
+  options?: ResolveVersionMismatchOptions,
 ): VersionMismatch | null {
-  return resolveVersionMismatch(serverConfig?.environment.serverVersion);
+  return resolveVersionMismatch(serverConfig?.environment.serverVersion, options);
 }
 
 export function buildVersionMismatchDismissalKey(

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,12 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
+import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { defineProject, type TestProjectInlineConfiguration } from "vite-plus/test/config";
 import "vite-plus/test/config";
 import { defineConfig } from "vite-plus";
@@ -23,7 +28,40 @@ const configuredRelayTracingUrl = repoEnv.VITE_RELAY_OTLP_TRACES_URL?.trim() || 
 const configuredRelayTracingDataset = repoEnv.VITE_RELAY_OTLP_TRACES_DATASET?.trim() || "";
 const configuredRelayTracingToken = repoEnv.VITE_RELAY_OTLP_TRACES_TOKEN?.trim() || "";
 const configuredHostedAppChannel = process.env.VITE_HOSTED_APP_CHANNEL?.trim() || "";
-const configuredAppVersion = process.env.APP_VERSION?.trim() || pkg.version;
+
+// Source-mode deploys (e.g. #1's RPi node) build `apps/web/dist` only when
+// someone explicitly runs this build, separately from `git pull` restarting
+// the server. Since APP_VERSION otherwise tracks package.json's semver
+// (which doesn't bump per commit here), a stale bundle can silently share a
+// version string with a server that has since moved on to a
+// schema-incompatible commit. Stamping the checkout SHA this build ran from
+// lets the existing client/server version-mismatch check catch that drift.
+// Explicit APP_VERSION overrides (release builds) are left untouched.
+const collectStreamAsString = (stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>) =>
+  stream.pipe(
+    Stream.decodeText(),
+    Stream.runFold(
+      () => "",
+      (acc, chunk) => acc + chunk,
+    ),
+  );
+
+const resolveBuildGitSha = Effect.fn("resolveBuildGitSha")(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const child = yield* spawner.spawn(
+    ChildProcess.make("git", ["rev-parse", "HEAD"], { cwd: import.meta.dirname }),
+  );
+  const [stdout, exitCode] = yield* Effect.all(
+    [collectStreamAsString(child.stdout), child.exitCode],
+    { concurrency: "unbounded" },
+  );
+  if (Number(exitCode) !== 0) {
+    return null;
+  }
+  const sha = stdout.trim().toLowerCase();
+  return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+});
+
 const configuredHostedAppUrl = (() => {
   const explicitHostedAppUrl = process.env.VITE_HOSTED_APP_URL?.trim();
   if (explicitHostedAppUrl) {
@@ -88,7 +126,30 @@ function resolveDevProxyTarget(wsUrl: string | undefined): string | undefined {
 
 const devProxyTarget = resolveDevProxyTarget(configuredWsUrl);
 
-export default defineConfig(() => {
+export default defineConfig(async ({ command }) => {
+  // Only spawn `git rev-parse` for actual production builds — dev/test
+  // invocations don't ship a bundle, so there's no drift risk to stamp.
+  const configuredBuildGitSha =
+    command === "build"
+      ? await Effect.runPromise(
+          resolveBuildGitSha().pipe(
+            Effect.orElseSucceed(() => null),
+            Effect.scoped,
+            Effect.provide(NodeServices.layer),
+          ),
+        )
+      : null;
+
+  const configuredAppVersion = (() => {
+    const explicitAppVersion = process.env.APP_VERSION?.trim();
+    if (explicitAppVersion) {
+      return explicitAppVersion;
+    }
+    return configuredBuildGitSha
+      ? `${pkg.version}+git.${configuredBuildGitSha.slice(0, 12)}`
+      : pkg.version;
+  })();
+
   return {
     plugins: [
       tanstackRouter(),

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -20,9 +20,21 @@ export const ExecutionEnvironmentPlatform = Schema.Struct({
 });
 export type ExecutionEnvironmentPlatform = typeof ExecutionEnvironmentPlatform.Type;
 
+export const BrowserCapabilityState = Schema.Literals(["ok", "degraded", "absent"]);
+export type BrowserCapabilityState = typeof BrowserCapabilityState.Type;
+
+export const BrowserCapability = Schema.Struct({
+  state: BrowserCapabilityState,
+  binaryPath: Schema.optionalKey(TrimmedNonEmptyString),
+  version: Schema.optionalKey(TrimmedNonEmptyString),
+  details: Schema.optionalKey(TrimmedNonEmptyString),
+});
+export type BrowserCapability = typeof BrowserCapability.Type;
+
 export const ExecutionEnvironmentCapabilities = Schema.Struct({
   repositoryIdentity: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   connectionProbe: Schema.optionalKey(Schema.Boolean),
+  browser: Schema.optionalKey(BrowserCapability),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 


### PR DESCRIPTION
## Summary

Adds a measured `capabilities.browser` field to the public `/.well-known/t3/environment` descriptor so cc_runner's capability-based dispatch can demote nodes whose declared config has drifted from reality, per #9.

- **`ok`**: a Chromium binary was found (Playwright's downloaded browser cache is checked first, falling back to a well-known system install path) and it launched successfully — reports `binaryPath` + `version`.
- **`degraded`**: a binary was found but either it failed to launch, or only a system Chromium exists while the Playwright browser cache is missing/incomplete — reports `binaryPath` + `details`.
- **`absent`**: no Chromium binary could be found anywhere.

The probe (`apps/server/src/environment/BrowserCapabilityProbe.ts`) is lazy and cached for 6 hours via `Effect.cachedWithTTL`, so it never runs on every health-check poll. `ExecutionEnvironmentCapabilities.browser` is an additive optional field in `packages/contracts/src/environment.ts`; existing web/desktop clients tolerate it.

Detection is filesystem + process based only (directory scan of the Playwright cache, well-known system paths, then a `--version` spawn) — no `playwright-core` dependency was added to `apps/server`. Installation/telepítés-kezelés and cc_runner's dispatch/demote logic stay out of scope per the issue.

## Decisions

- **Test tier**: unit, focused on `apps/server`, with mocked `FileSystem`/`ProcessRunner` (matches the issue's `## Test` note). First commit (`c2550a5c`) adds `BrowserCapabilityProbe.test.ts` alone and is red (imports a module that doesn't exist yet); the second commit adds the implementation and wiring.
- **"degraded" semantics**: chose to treat *both* "binary found but failed to launch" and "only a system Chromium exists, no Playwright cache" as `degraded`, since either way the automation stack that actually needs to drive the browser (Playwright) can't be trusted yet — matches the issue's example (RPi has both apt chromium *and* the ms-playwright cache → `ok`).
- **Cache key/TTL**: a single process-lifetime `Effect.cachedWithTTL(..., "6 hours")` per server instance, as specified.

## Manually verified

`scripts/agent-verify.sh` does not exist in this repo, so per instructions I ran `pnpm lint` and the relevant test suites directly.

```
$ pnpm --filter @t3tools/contracts typecheck
$ tsgo --noEmit
(clean, no output)

$ cd apps/server && pnpm exec vp run typecheck
~/apps/server$ tsgo --noEmit ⊘ cache disabled
(clean, no output)

$ cd apps/server && pnpm exec vp test run src/environment/ src/server.test.ts
 Test Files  5 passed (5)
      Tests  132 passed (132)

$ pnpm lint
(only pre-existing warnings in apps/web, unrelated to this diff; exit 0)
```

### Pre-existing, unrelated flake found while running the full `pnpm test`

Running `pnpm test` at the repo root (which fans out to every workspace package in parallel) reproduces one failing test twice in a row:

```
FAIL apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts
  > highlightNativeReviewDiffVisibleRows > keeps grammar state across inline comment rows
```

I confirmed this is **not caused by this PR**:
- `git diff main -- apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.test.ts` is empty — neither file is touched by this branch.
- Running `apps/mobile`'s full test suite alone (`cd apps/mobile && pnpm exec vp test run`), twice, passes cleanly both times: `520 passed (520)`.
- It only reproduces when `pnpm test` runs 4+ workspace packages' Vitest processes fully in parallel in this sandbox and fails identically both times I tried, which points at CPU-contention-sensitive timing inside the shared Shiki/JS-regex highlighter singleton under heavy load (the failing assertion shows coarser, less-tokenized output consistent with a tokenizer time budget being hit), not a logic bug in the diff.

I did not attempt a fix for it here since it's unrelated to #9's scope and I couldn't get a reliable, isolated repro to validate a fix against — flagging it explicitly rather than silently leaving it. Given the issue's own acceptance criteria (measured `ok`/`degraded`/`absent` browser capability, lazy 6h-cached probe, unit test coverage) are fully met and verified above, I'm titling this "Fixes #9"; happy to split the mobile flake into a separate follow-up issue if preferred.

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Server environment information now includes detected Chromium availability and usability.
  - Server versions can display build identifiers for more precise troubleshooting.
  - Version checks distinguish release mismatches from build-level differences, reducing false warnings for remote environments.
  - Connection diagnostics now log version mismatches before establishing sessions.

- **Bug Fixes**
  - Improved reliability when multiple Git operations target the same repository, preventing conflicting worktree and fetch activity.
  - Browser detection reports clear states when Chromium is unavailable, degraded, or fully operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->