### PR TITLE
fix(web): tighten sidebar search and footer spacing

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4323,7 +4323,7 @@ export default function Sidebar() {
         fixedHeader={
           // Lifted above the stage backdrop, whose fade bleeds below the
           // header and would otherwise paint across the search row's outline.
-          <SidebarGroup className="relative z-[1] p-[var(--sidebar-content-inset)]">
+          <SidebarGroup className="relative z-[1] p-[var(--sidebar-content-inset)] pt-1">
             <SidebarThreadHeader
               searchFieldRef={headerSearchRef}
               hasProjects={projectGroups.length > 0}

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -342,7 +342,7 @@ export function SettingsSidebarNav({ pathname }: { pathname: string }) {
           )}
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter className="p-[var(--sidebar-content-inset)]">
+      <SidebarFooter className="px-[var(--sidebar-content-inset)] py-1">
         <Suspense fallback={null}>
           <T3ConnectSidebarSignIn />
         </Suspense>

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -223,7 +223,7 @@ export const SidebarUtilityMenu = memo(function SidebarUtilityMenu() {
 
 export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   return (
-    <SidebarFooter className="p-[var(--sidebar-content-inset)]">
+    <SidebarFooter className="px-[var(--sidebar-content-inset)] py-1">
       <SidebarProviderUpdatePill />
       <SidebarUpdateArchitectureWarning />
       <SidebarUtilityMenu />

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -703,7 +703,7 @@ function SidebarContent({
         hideScrollbars
         scrollFade
         scrollFadePadding={false}
-        className="h-auto min-h-0 flex-1"
+        className="h-auto min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:[--fade-size:0.75rem]"
       >
         <div
           // Reordered rows must not pull the viewport to their new position.


### PR DESCRIPTION
Reduces sidebar search top padding from 8px to 4px, footer vertical padding from 8px to 4px, and both sidebar scroll fades from 24px to 12px. The settings sidebar uses the same footer and fade spacing; button sizes and actions stay unchanged.

Verified populated sidebar scrolling, both list boundaries, search/clear, settings/back, usage/back, light/dark themes and narrow mobile web layout. Web typecheck, scoped lint, and all 7 existing sidebar tests pass with existing warnings. Native desktop and mobile were not exercised; no provider behavior changes.

Before spacing:

![populated dark sidebar before spacing reduction](https://uploads-production-47e4.up.railway.app/files/12c93606-3237-4e50-a50e-7df3ebef40ae/sidebar-populated-dark-before.png)

After spacing:

![populated dark sidebar after spacing reduction](https://uploads-production-47e4.up.railway.app/files/98a3e465-321f-4301-9ce9-48fc2db4ce21/sidebar-populated-dark-after.png)

Scroll fades, before and after:

![sidebar scrolling with 24px fades before and 12px fades after](https://uploads-production-47e4.up.railway.app/files/0ce77c48-5cf8-43f4-8afe-aa3cda0c0188/sidebar-fades-comparison.gif)

Implemented with GPT-6 in Codex.
