### PR TITLE
feat(web): tint image chips with their average color

### DIFF
--- a/apps/web/src/components/contextChipParts.tsx
+++ b/apps/web/src/components/contextChipParts.tsx
@@ -191,6 +191,7 @@ export function ImageChipButton({
   suffix?: string | null;
 }) {
   const [sample, setSample] = useState<{ url: string; color: string | undefined }>();
+  const [corsFailedUrl, setCorsFailedUrl] = useState<string>();
   const accent = sample?.url === previewUrl ? sample?.color : undefined;
   return (
     <Button
@@ -208,9 +209,11 @@ export function ImageChipButton({
       {previewUrl ? (
         <img
           key={previewUrl}
+          crossOrigin={corsFailedUrl === previewUrl ? undefined : "anonymous"}
           src={previewUrl}
           alt=""
           className="size-3.5 shrink-0 rounded-sm object-cover"
+          onError={() => setCorsFailedUrl(previewUrl)}
           onLoad={(event) =>
             setSample({ url: previewUrl, color: averageImageColor(event.currentTarget) })
           }

--- a/apps/web/src/components/contextChipParts.tsx
+++ b/apps/web/src/components/contextChipParts.tsx
@@ -1,6 +1,12 @@
 import type { PullRequestContextMetadata } from "@t3tools/contracts";
 import { CircleDashedIcon, FilmIcon, GitPullRequestIcon, ImageIcon } from "lucide-react";
-import type { ComponentProps, MouseEvent, ReactNode } from "react";
+import {
+  useState,
+  type ComponentProps,
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 
 import { cn } from "~/lib/utils";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
@@ -139,6 +145,34 @@ export function PullRequestChip(props: {
   );
 }
 
+/** Sample the loaded thumbnail once; transparent pixels should not darken its accent. */
+function averageImageColor(image: HTMLImageElement): string | undefined {
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 16;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    context.drawImage(image, 0, 0, 16, 16);
+    const { data } = context.getImageData(0, 0, 16, 16);
+    let red = 0;
+    let green = 0;
+    let blue = 0;
+    let alpha = 0;
+    for (let index = 0; index < data.length; index += 4) {
+      const weight = data[index + 3]!;
+      red += data[index]! * weight;
+      green += data[index + 1]! * weight;
+      blue += data[index + 2]! * weight;
+      alpha += weight;
+    }
+    if (alpha === 0) return;
+    return `rgb(${Math.round(red / alpha)} ${Math.round(green / alpha)} ${Math.round(blue / alpha)})`;
+  } catch {
+    // Cross-origin or unavailable pixels keep the default image tone and preview action.
+    return;
+  }
+}
+
 export function ImageChipButton({
   name,
   previewUrl,
@@ -146,6 +180,7 @@ export function ImageChipButton({
   labelClassName,
   size,
   suffix,
+  style,
   ...props
 }: ComponentProps<"button"> & {
   name: string;
@@ -155,6 +190,8 @@ export function ImageChipButton({
   size: string;
   suffix?: string | null;
 }) {
+  const [sample, setSample] = useState<{ url: string; color: string | undefined }>();
+  const accent = sample?.url === previewUrl ? sample?.color : undefined;
   return (
     <Button
       variant="chip"
@@ -165,10 +202,19 @@ export function ImageChipButton({
         "cursor-zoom-in",
       )}
       aria-label={`Image attachment, ${name}, ${size}`}
+      style={{ ...style, ...(accent ? { "--context-chip-accent": accent } : {}) } as CSSProperties}
       {...props}
     >
       {previewUrl ? (
-        <img src={previewUrl} alt="" className="size-3.5 shrink-0 rounded-sm object-cover" />
+        <img
+          key={previewUrl}
+          src={previewUrl}
+          alt=""
+          className="size-3.5 shrink-0 rounded-sm object-cover"
+          onLoad={(event) =>
+            setSample({ url: previewUrl, color: averageImageColor(event.currentTarget) })
+          }
+        />
       ) : (
         <ImageIcon
           className={cn(


### PR DESCRIPTION
image attachment chips now use the image's average color in the composer and sent messages. a 16×16 sample of the existing thumbnail supplies the accent, weighted by opacity; unavailable or unreadable images keep the existing fallback. anonymous cors supports remote image sampling, with a plain-image retry when cors is unavailable. chip styling and preview actions stay intact.

verified a real codex turn with two uploaded images, matching composer/transcript colors, and image expansion. 102 existing tests, web typecheck, scoped lint, and browser checks for transparency, image replacement, and failed images passed. a different-origin client sampled a real signed t3 attachment to the same color; a cors-denied image displayed successfully through the fallback. web/desktop share this component; native mobile chips are outside this change.

before, dark:

![all context chips before, dark theme](https://uploads-production-47e4.up.railway.app/files/1b53e03e-847a-4311-ab87-e445c2a1cbcc/browser-screenshot-t3-sff-tailda84d5-ts-net-mtywztue-ff65a625.png)

after, dark:

![all context chips after, dark theme](https://uploads-production-47e4.up.railway.app/files/52a1c13e-6684-4f41-a77d-4261ae02d101/browser-screenshot-t3-sff-tailda84d5-ts-net-mtyx2db2-1baa40a0.png)

before, light:

![all context chips before, light theme](https://uploads-production-47e4.up.railway.app/files/51675c72-aa5e-4abc-96be-d3280f6866e8/browser-screenshot-t3-sff-tailda84d5-ts-net-mtyx0au2-f2a07ba8.png)

after, light:

![all context chips after, light theme](https://uploads-production-47e4.up.railway.app/files/718fb943-f9bc-4569-9223-d813df11bc92/browser-screenshot-t3-sff-tailda84d5-ts-net-mtyx24my-fc9995f9.png)

visual inventory renders the actual chip components with sample context. integration was checked separately in the real app.

model: gpt-6-astra. harness: codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Context chip buttons now use a thumbnail-based accent color when available.
  * Custom styles are preserved when the accent color is applied.
  * Thumbnails that cannot be loaded or processed retain the default appearance.
  * Accent colors update based on the associated thumbnail URL, providing more consistent visual context across chip buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->