### PR TITLE
fix(web): require a connection to edit keybindings

### DIFF
--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1357,6 +1357,8 @@ export function KeybindingsSettingsPanel() {
   const whenVariables = useMemo(() => buildWhenVariableOptions(), []);
 
   useEffect(() => {
+    if (connectedEnvironments.length === 0) return;
+
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       const isMod = event.metaKey || event.ctrlKey;
       if (!isMod || event.altKey || event.key.toLowerCase() !== "f") return;
@@ -1379,7 +1381,7 @@ export function KeybindingsSettingsPanel() {
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [connectedEnvironments.length]);
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
@@ -1499,6 +1501,16 @@ export function KeybindingsSettingsPanel() {
     onReset: resetKeybinding,
     onRemove: removeKeybinding,
   };
+
+  if (connectedEnvironments.length === 0) {
+    return (
+      <SettingsPageContainer>
+        <p role="status" className="text-sm text-muted-foreground">
+          Connect an environment to change keybindings.
+        </p>
+      </SettingsPageContainer>
+    );
+  }
 
   return (
     <SettingsPageContainer>


### PR DESCRIPTION
Settings → Keybindings showed editable defaults with no connected environment. Save then silently returned, leaving the button dirty.

Show a connection notice until the selected scope has a connected environment, matching the existing disconnected settings behavior. This covers all keybinding actions and restores the editor on reconnect. Only register the panel's Find shortcut while the editor is available.

Closes #11448.

Verified: reproduced the silent Save before the fix; browser checks cover disconnect/reconnect, shortcut and condition saves, persistence after reload, Reset, and browser Find. All 87 focused tests, web typecheck, targeted lint/formatting, and React Doctor (100/100) pass. Browser verification used Chrome, including hosted-app mode with a remotely paired local test server; Firefox could not launch locally ("Could not find profile folder").

Web and desktop share this panel. Mobile has no keybindings editor.

Before:

![Save remains enabled with no connected environment](https://github.com/user-attachments/assets/daca57ce-3523-4f19-8939-b16f5a90497b)

After:

![Disconnected keybindings show a connection notice](https://github.com/user-attachments/assets/6fddccd9-d325-4308-83dc-c24423bd4a3f)

Verification:

https://github.com/user-attachments/assets/8fbb1e58-dc34-46fc-9229-82024e4fbba1

Written by GPT-6 in Codex. Reviewed with Claude Opus 5 and Claude Sonnet 5 in Claude Code; findings addressed and final review clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the keybindings settings panel to clearly indicate when no environments are connected.
  * Added a loading message while environment connection details are still being retrieved.
  * Prevented the keyboard shortcut for searching keybindings from activating when no environments are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->