### PR TITLE
fix(desktop): restore SnapShot shortcuts after portal restarts

### DIFF
--- a/apps/desktop/src/snapShot/PortalCaptureShortcut.test.ts
+++ b/apps/desktop/src/snapShot/PortalCaptureShortcut.test.ts
@@ -30,6 +30,20 @@ class FakeBus extends NodeEvents.EventEmitter {
   requestPath = "";
   boundId = "";
   foreignHandle = false;
+  owner = ":1.2";
+
+  changeOwner(owner: string) {
+    const previous = this.owner;
+    this.owner = owner;
+    this.signal(
+      "org.freedesktop.DBus",
+      "NameOwnerChanged",
+      "/org/freedesktop/DBus",
+      ["org.freedesktop.portal.Desktop", previous, owner],
+      "org.freedesktop.DBus",
+      "sss",
+    );
+  }
 
   send(message: Message) {
     this.sends.push(message);
@@ -39,7 +53,7 @@ class FakeBus extends NodeEvents.EventEmitter {
     member: string,
     path: string,
     body: unknown[],
-    sender = ":1.2",
+    sender = this.owner,
     signature = "",
   ) {
     this.emit(
@@ -71,7 +85,7 @@ class FakeBus extends NodeEvents.EventEmitter {
       ]),
     });
   }
-  activate(id = this.boundId, session = this.session, sender = ":1.2") {
+  activate(id = this.boundId, session = this.session, sender = this.owner) {
     this.signal(portal, "Activated", root, [session, id, 1, {}], sender, "osta{sv}");
   }
   async call(message: Message) {
@@ -87,7 +101,7 @@ class FakeBus extends NodeEvents.EventEmitter {
       if (this.registryError) throw this.registryError;
       return reply();
     }
-    if (message.member === "GetNameOwner") return reply([":1.2"]);
+    if (message.member === "GetNameOwner") return reply([this.owner]);
     if (message.member === "Get") return reply([new Variant("u", this.version)]);
     if (message.member === "AddMatch" || message.member === "ConfigureShortcuts") return reply();
     const options = message.body.at(-1) as Record<string, Variant<string>>;
@@ -231,7 +245,9 @@ it("binds only the requested shortcut with a stable ID across sessions", async (
   ]);
   bus.activate();
   expect(capture).toHaveBeenCalledOnce();
-  expect(bus.calls[0]?.member).toBe("Register");
+  expect(bus.calls.find((call) => call.destination !== "org.freedesktop.DBus")?.member).toBe(
+    "Register",
+  );
 });
 
 it("ignores other shortcuts, sessions, and forged activations", async () => {
@@ -376,20 +392,111 @@ it("bounds unanswered consent and cleans up the pending request", async () => {
   expect(vi.getTimerCount()).toBe(0);
 });
 
-it("handles a disappearing portal without keeping a false registered state", async () => {
-  const { bus, client } = start();
+it.each([false, true])(
+  "restores capture after portal restarts, including direct owner replacement (Hyprland: %s)",
+  async (hyprland) => {
+    const { bus, client, capture } = start(new FakeBus(), chord, hyprland);
+    await client.ready;
+    const originalSession = bus.session;
+    const shortcutId = bus.boundId;
+
+    bus.changeOwner("");
+    expect(client.hasSession).toBe(false);
+    expect(client.state).toMatchObject({ shortcutRegistered: false, shortcutPending: true });
+    expect(client.state.shortcutActionRegistered).not.toBe(true);
+    expect(bus.disconnect).not.toHaveBeenCalled();
+    bus.activate(shortcutId, originalSession, ":1.2");
+    expect(capture).not.toHaveBeenCalled();
+
+    for (const owner of [":1.3", ":1.4"]) {
+      bus.changeOwner(owner);
+      await client.ready;
+      expect(client.hasSession).toBe(true);
+      expect(client.state.shortcutPending).toBe(false);
+      expect(bus.boundId).toBe(shortcutId);
+      expect(bus.session).not.toBe(originalSession);
+      bus.activate(shortcutId, originalSession, ":1.2");
+      bus.activate();
+    }
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(bus.calls.filter((call) => call.member === "BindShortcuts")).toHaveLength(3);
+  },
+);
+
+it("abandons an interrupted rebind before registering with the next portal owner", async () => {
+  const { bus, client, capture } = start(new FakeBus(), chord, true);
   await client.ready;
+  bus.autoBind = false;
+  const firstBinding = NodeEvents.EventEmitter.once(bus, "bind");
+  bus.changeOwner(":1.3");
+  await firstBinding;
+  const interrupted = client.ready;
+  const oldSession = bus.session;
+  const oldRequest = bus.requestPath;
+
+  const nextBinding = NodeEvents.EventEmitter.once(bus, "bind");
+  bus.changeOwner(":1.4");
+  await nextBinding;
+  await interrupted;
   bus.signal(
-    "org.freedesktop.DBus",
-    "NameOwnerChanged",
-    "/org/freedesktop/DBus",
-    ["org.freedesktop.portal.Desktop", ":1.2", ""],
-    "org.freedesktop.DBus",
+    "org.freedesktop.portal.Request",
+    "Response",
+    oldRequest,
+    [0, { shortcuts: new Variant("a(sa{sv})", []) }],
+    ":1.3",
   );
-  expect(client.state.shortcutRegistered).toBe(false);
-  expect(client.state.shortcutMessage).toContain("restarted");
-  expect(bus.disconnect).toHaveBeenCalledOnce();
+  bus.respondBind();
+  await client.ready;
+  expect(client.state.shortcutActionRegistered).toBe(true);
+  bus.activate(bus.boundId, oldSession, ":1.3");
+  bus.activate();
+  expect(capture).toHaveBeenCalledOnce();
+  expect(bus.calls.filter((call) => call.member === "BindShortcuts")).toHaveLength(3);
 });
+
+it.each([false, true])(
+  "closing during recovery stops registration and capture (rebind pending: %s)",
+  async (rebinding) => {
+    const { bus, client, capture } = start(new FakeBus(), chord, true);
+    await client.ready;
+    bus.changeOwner("");
+    if (rebinding) {
+      bus.autoBind = false;
+      const binding = NodeEvents.EventEmitter.once(bus, "bind");
+      bus.changeOwner(":1.3");
+      await binding;
+    }
+    client.close();
+    bus.changeOwner(":1.4");
+    bus.respondBind();
+    await client.ready;
+    bus.activate();
+    expect(capture).not.toHaveBeenCalled();
+    expect(client.hasSession).toBe(false);
+    expect(bus.disconnect).toHaveBeenCalledOnce();
+    expect(bus.calls.filter((call) => call.member === "BindShortcuts")).toHaveLength(
+      rebinding ? 2 : 1,
+    );
+  },
+);
+
+it.each([1, 2])(
+  "does not retry a refused rebind when the portal restarts immediately (%s)",
+  async (status) => {
+    const { bus, client, capture } = start();
+    await client.ready;
+    bus.autoBind = false;
+    const binding = NodeEvents.EventEmitter.once(bus, "bind");
+    bus.changeOwner(":1.3");
+    await binding;
+    bus.respondBind(status);
+    bus.changeOwner(":1.4");
+    await client.ready;
+    bus.activate();
+    expect(capture).not.toHaveBeenCalled();
+    expect(bus.calls.filter((call) => call.member === "BindShortcuts")).toHaveLength(2);
+  },
+);
 
 it("accepts old portals without Registry but does not ignore permission denial", async () => {
   const bus = new FakeBus();

--- a/apps/desktop/src/snapShot/PortalCaptureShortcut.ts
+++ b/apps/desktop/src/snapShot/PortalCaptureShortcut.ts
@@ -67,8 +67,10 @@ export class PortalCaptureShortcut {
     shortcutPending: true,
     shortcutMessage: "Waiting for shortcut permission. Approve the desktop prompt if one appears.",
   };
-  readonly ready: Promise<void>;
+  ready: Promise<void>;
   private closed = false;
+  private generation = 0;
+  private reconnecting = false;
   private owner = "";
   private namespace = "";
   private session = "";
@@ -76,12 +78,14 @@ export class PortalCaptureShortcut {
   private version = 0;
   private pending: { path: string; resolve: (body: unknown) => void } | undefined;
   private responses = new Map<string, unknown>();
-  private readonly stopped: Promise<never>;
+  private stopped: Promise<never>;
   private rejectStopped!: (reason: Error) => void;
   private readonly onCapture: () => void;
   private readonly onStateChanged: () => void;
   private readonly bus: MessageBus;
   private readonly managedByHyprland: boolean;
+  private readonly appId: string;
+  private readonly shortcut: SnapShotKeyChord;
 
   constructor(
     appId: string,
@@ -95,6 +99,8 @@ export class PortalCaptureShortcut {
     this.onStateChanged = onStateChanged;
     this.bus = bus;
     this.managedByHyprland = managedByHyprland;
+    this.appId = appId;
+    this.shortcut = shortcut;
     if (managedByHyprland)
       this.state = {
         shortcutRegistered: false,
@@ -107,7 +113,41 @@ export class PortalCaptureShortcut {
     void this.stopped.catch(() => undefined);
     bus.on("error", this.failed);
     bus.on("message", this.message);
-    this.ready = this.initialize(appId, shortcut).catch(this.failed);
+    this.ready = this.subscribe();
+    this.register();
+  }
+
+  private async subscribe() {
+    for (const rule of [
+      `type='signal',sender='${PORTAL}',path_namespace='${PATH}'`,
+      `type='signal',sender='org.freedesktop.DBus',interface='${DBUS}',member='NameOwnerChanged',arg0='${PORTAL}'`,
+    ])
+      await this.call({
+        destination: DBUS,
+        path: "/org/freedesktop/DBus",
+        interface: DBUS,
+        member: "AddMatch",
+        signature: "s",
+        body: [rule],
+      });
+  }
+
+  private register() {
+    const generation = this.generation;
+    // Drain the interrupted registration before starting another on this connection.
+    this.ready = this.ready
+      .then(async () => {
+        if (this.closed || generation !== this.generation) return;
+        this.stopped = new Promise((_, reject) => {
+          this.rejectStopped = reject;
+        });
+        void this.stopped.catch(() => undefined);
+        await this.initialize(this.appId, this.shortcut);
+        if (generation === this.generation) this.reconnecting = false;
+      })
+      .catch((error) => {
+        if (generation === this.generation) this.failed(error);
+      });
   }
 
   close = () => {
@@ -173,9 +213,10 @@ export class PortalCaptureShortcut {
   };
 
   private async wait<T>(promise: Promise<T>, timeoutMs = 5_000): Promise<T> {
+    const generation = this.generation;
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      return await Promise.race([
+      const result = await Promise.race([
         promise,
         this.stopped,
         new Promise<never>((_, reject) => {
@@ -185,6 +226,9 @@ export class PortalCaptureShortcut {
           );
         }),
       ]);
+      if (generation !== this.generation)
+        throw new Error("The desktop shortcut service restarted.");
+      return result;
     } finally {
       clearTimeout(timer);
     }
@@ -215,10 +259,35 @@ export class PortalCaptureShortcut {
       message.sender === "org.freedesktop.DBus" &&
       message.interface === DBUS &&
       message.member === "NameOwnerChanged" &&
+      message.signature === "sss" &&
       message.body[0] === PORTAL &&
-      message.body[1] === this.owner
+      message.body[1] === this.owner &&
+      (this.owner || this.reconnecting)
     ) {
-      this.failed(new Error("The desktop shortcut service restarted. Retry the shortcut request."));
+      if (
+        !this.reconnecting &&
+        !this.state.shortcutRegistered &&
+        !this.state.shortcutActionRegistered
+      ) {
+        this.failed(
+          new Error("The desktop shortcut service restarted. Retry the shortcut request."),
+        );
+        return;
+      }
+      this.generation++;
+      this.reconnecting = true;
+      this.rejectStopped(new Error("The desktop shortcut service restarted."));
+      this.owner = string(message.body[2]);
+      this.session = "";
+      this.pending = undefined;
+      this.responses.clear();
+      this.update({
+        shortcutRegistered: false,
+        shortcutPending: true,
+        shortcutCanRetry: false,
+        shortcutMessage: "Reconnecting to the desktop shortcut service…",
+      });
+      if (this.owner) this.register();
       return;
     }
     if (!this.owner || message.sender !== this.owner) return;
@@ -272,11 +341,22 @@ export class PortalCaptureShortcut {
   ) {
     const token = `t3_${NodeCrypto.randomUUID().replaceAll("-", "")}`;
     const expectedPath = this.namespace + token;
-    let resolve!: (body: unknown) => void;
-    const response = new Promise<unknown>((done) => {
-      resolve = done;
-    });
-    this.pending = { path: expectedPath, resolve };
+    const response = Promise.withResolvers<ReturnType<typeof decodeResponse>>();
+    void response.promise.catch(() => undefined);
+    const pending = {
+      path: expectedPath,
+      resolve: (body: unknown) => {
+        try {
+          const result = decodeResponse(body);
+          // A refusal must take effect before a queued owner-change signal can retry it.
+          if (member === "BindShortcuts" && result[0] !== 0) this.reconnecting = false;
+          response.resolve(result);
+        } catch (error) {
+          response.reject(error);
+        }
+      },
+    };
+    this.pending = pending;
     this.responses.clear();
     let completed = false;
     try {
@@ -290,10 +370,11 @@ export class PortalCaptureShortcut {
       });
       const handle = string(reply.body[0]);
       if (!handle.startsWith(this.namespace)) throw new Error("Invalid shortcut request handle.");
-      this.pending.path = handle;
-      if (this.responses.has(handle)) resolve(this.responses.get(handle));
-      const [status, results] = decodeResponse(
-        await this.wait(response, member === "BindShortcuts" ? 120_000 : 5_000),
+      pending.path = handle;
+      if (this.responses.has(handle)) pending.resolve(this.responses.get(handle));
+      const [status, results] = await this.wait(
+        response.promise,
+        member === "BindShortcuts" ? 120_000 : 5_000,
       );
       completed = true;
       if (status !== 0) {
@@ -312,7 +393,8 @@ export class PortalCaptureShortcut {
       }
       return results;
     } finally {
-      if (!completed && !this.closed && this.pending) this.closeObject(this.pending.path, REQUEST);
+      if (!completed && !this.closed && this.pending === pending)
+        this.closeObject(pending.path, REQUEST);
       this.pending = undefined;
       this.responses.clear();
     }
@@ -385,18 +467,6 @@ export class PortalCaptureShortcut {
       body: [SHORTCUTS, "version"],
     });
     this.version = decodeVersion(version.body[0]).value;
-    for (const rule of [
-      `type='signal',sender='${this.owner}',path_namespace='${PATH}'`,
-      `type='signal',sender='org.freedesktop.DBus',interface='${DBUS}',member='NameOwnerChanged',arg0='${PORTAL}'`,
-    ])
-      await this.call({
-        destination: DBUS,
-        path: "/org/freedesktop/DBus",
-        interface: DBUS,
-        member: "AddMatch",
-        signature: "s",
-        body: [rule],
-      });
     const created = await this.request("CreateSession", "", [], {
       session_handle_token: new Variant(
         "s",


### PR DESCRIPTION
A desktop portal restart leaves the SnapShot shortcut dead until T3 Code is restarted. Keep watching for the portal's return and register a fresh capture session automatically.

Recovery drains the old registration, ignores stale responses, and stops when capture is disabled or permission is refused.

Fixes #11494.

Validation: 141 focused tests, desktop typecheck, targeted lint and formatting. Verified two portal replacements and capture callbacks using a test portal on a private D-Bus session.

Model: GPT-6. Harness: Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop shortcut reliability when the portal service restarts.
  * Added recovery for portal owner replacement and prevented stale connections from interfering with newer ones.
  * Shortcut status now reflects portal recovery activity.
  * Improved handling when reconnection is refused or a shortcut is closed during recovery.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->