### PR TITLE
feat(swift-ios): customize thread swipe actions

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -74,7 +74,7 @@
     "effect": "catalog:",
     "expo": "~57.0.18",
     "expo-asset": "~57.0.15",
-    "expo-audio": "~57.0.4",
+    "expo-audio": "57.0.4",
     "expo-auth-session": "~57.0.10",
     "expo-blur": "~57.0.2",
     "expo-build-properties": "~57.0.15",

--- a/apps/swift-ios/Features/Settings/SettingsSwipeActionsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsSwipeActionsView.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+struct SettingsSwipeActionsView: View {
+    @Binding var settings: FeatureSwipeSettings
+    @State private var direction = SwipePreviewDirection.left
+
+    private var configuration: Binding<FeatureSwipeConfiguration> {
+        direction == .left ? $settings.left : $settings.right
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Swipe direction", selection: $direction) {
+                    Text("Swipe Left").tag(SwipePreviewDirection.left)
+                    Text("Swipe Right").tag(SwipePreviewDirection.right)
+                }
+                .pickerStyle(.segmented)
+                .accessibilityIdentifier("swipe-direction")
+                SwipeThreadPreview(direction: direction, configuration: configuration.wrappedValue)
+                    .id(direction)
+                    .listRowInsets(EdgeInsets(top: 12, leading: 0, bottom: 12, trailing: 0))
+            } footer: {
+                Text("Try swiping the example thread. Your threads won’t change.")
+            }
+            .listRowBackground(T3Colors.surface)
+
+            Section {
+                ForEach(FeatureSwipeAction.allCases, id: \.self) { action in
+                    Toggle(isOn: Binding(
+                        get: { configuration.wrappedValue.actions.contains(action) },
+                        set: { enabled in
+                            var updated = configuration.wrappedValue
+                            updated.setEnabled(action, enabled: enabled)
+                            configuration.wrappedValue = updated
+                        }
+                    )) {
+                        Label {
+                            Text(action.settingsTitle)
+                        } icon: {
+                            Image(systemName: action.example.systemImage)
+                                .foregroundStyle(action.color)
+                        }
+                    }
+                    .tint(T3Colors.accent)
+                    .accessibilityIdentifier("swipe-action-\(action.rawValue)")
+                }
+            } header: {
+                Text("Buttons when you swipe \(direction.rawValue)")
+            } footer: {
+                Text("Actions adapt to each thread. Unavailable actions are hidden.")
+            }
+            .listRowBackground(T3Colors.surface)
+
+            Section {
+                Picker("Full swipe", selection: Binding(
+                    get: { configuration.wrappedValue.enabledFullSwipe },
+                    set: { configuration.wrappedValue.fullSwipe = $0 }
+                )) {
+                    Text("None").tag(FeatureSwipeAction?.none)
+                    ForEach(configuration.wrappedValue.orderedActions, id: \.self) { action in
+                        Text(action.settingsTitle).tag(Optional(action))
+                    }
+                }
+                .accessibilityIdentifier("swipe-full-action")
+            } footer: {
+                Text(configuration.wrappedValue.fullSwipe == .delete
+                    ? "A full swipe asks you to confirm deletion."
+                    : "The full-swipe action appears at the outside edge. If it’s unavailable, a full swipe does nothing.")
+            }
+            .listRowBackground(T3Colors.surface)
+
+            Section {
+                Button("Reset Both Directions") { settings = .init() }
+                    .disabled(settings == FeatureSwipeSettings())
+                    .accessibilityIdentifier("swipe-reset")
+            }
+            .listRowBackground(T3Colors.surface)
+        }
+        .scrollContentBackground(.hidden)
+        .background(T3Colors.background)
+        .navigationTitle("Swipe Actions")
+        .navigationBarTitleDisplayMode(.inline)
+        .t3NavigationChrome()
+    }
+}
+
+private enum SwipePreviewDirection: String {
+    case left, right
+
+    var sign: CGFloat { self == .left ? -1 : 1 }
+}
+
+/// Uses the Home row itself, with a local gesture that demonstrates the saved
+/// choices without sending any thread commands.
+private struct SwipeThreadPreview: View {
+    @SwiftUI.Environment(\.layoutDirection) private var layoutDirection
+    @SwiftUI.Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ScaledMetric(relativeTo: .body) private var rowHeight = 120
+    let direction: SwipePreviewDirection
+    let configuration: FeatureSwipeConfiguration
+    @State private var distance: CGFloat? = 0
+    @State private var result: String?
+    @State private var dragOrigin: CGFloat?
+
+    private let exampleDate = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private var actions: [FeatureSwipeAction] { configuration.orderedActions }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Label("Try swiping \(direction.rawValue)", systemImage: direction == .left ? "arrow.left" : "arrow.right")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(T3Colors.textSecondary)
+            GeometryReader { geometry in
+                let width = geometry.size.width
+                let reveal = min(width * 0.7, CGFloat(actions.count) * 76)
+                let offset = min(configuration.enabledFullSwipe == nil ? reveal : width, max(0, distance ?? reveal))
+                let full = configuration.enabledFullSwipe != nil && offset > width * 0.8
+                ZStack(alignment: direction == .left ? .trailing : .leading) {
+                    HStack(spacing: 0) {
+                        ForEach(visibleActions(full: full), id: \.self) { action in
+                            VStack(spacing: 8) {
+                                Image(systemName: action.example.systemImage)
+                                    .font(.title3.weight(.semibold))
+                                Text(action.example.title)
+                                    .font(.caption.weight(.semibold))
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.75)
+                            }
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(action.color)
+                        }
+                    }
+                    .frame(width: full ? width : max(reveal, offset))
+
+                    FeatureThreadRow(
+                        thread: FeatureThread(
+                            id: "swipe-example", projectID: "example", title: "Polish the thread list",
+                            preview: "Ready for your review", createdAt: exampleDate,
+                            updatedAt: exampleDate, lastActivityAt: exampleDate
+                        ),
+                        context: .fallback,
+                        now: exampleDate
+                    )
+                    .environment(\.layoutDirection, layoutDirection)
+                    .padding(.horizontal, 16)
+                    .frame(width: width, height: geometry.size.height)
+                    .background(T3Colors.surface)
+                    .offset(x: direction.sign * offset)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(T3Colors.border))
+                .contentShape(Rectangle())
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 15)
+                        .onChanged { value in
+                            guard !actions.isEmpty, abs(value.translation.width) > abs(value.translation.height) else { return }
+                            result = nil
+                            if dragOrigin == nil { dragOrigin = distance ?? reveal }
+                            distance = (dragOrigin ?? 0) + value.translation.width * direction.sign
+                        }
+                        .onEnded { value in
+                            guard let origin = dragOrigin else { return }
+                            let finalDistance = max(0, origin + value.translation.width * direction.sign)
+                            let completesFullSwipe = configuration.enabledFullSwipe != nil && finalDistance > width * 0.8
+                            if completesFullSwipe, let action = configuration.enabledFullSwipe {
+                                result = fullSwipeResult(action)
+                            }
+                            dragOrigin = nil
+                            withAnimation(reduceMotion ? nil : .snappy(duration: 0.25)) {
+                                distance = completesFullSwipe || finalDistance < reveal * 0.4 ? 0 : nil
+                            }
+                        }
+                )
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Example thread, swipe \(direction.rawValue)")
+                .accessibilityValue(actions.isEmpty ? "No swipe actions" : actions.map { $0.example.title }.joined(separator: ", "))
+                .accessibilityAction(named: "Try full swipe") {
+                    result = configuration.enabledFullSwipe.map(fullSwipeResult) ?? "Full swipe is off"
+                }
+            }
+            .frame(height: rowHeight)
+            .environment(\.layoutDirection, .leftToRight)
+            .padding(.horizontal, 12)
+
+            Text(result ?? (actions.isEmpty ? "No buttons selected" : distance == 0 ? "Drag the thread to try it" : configuration.enabledFullSwipe == nil ? "Full swipe is off" : "Slide further to try a full swipe"))
+                .font(.footnote)
+                .foregroundStyle(T3Colors.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 12)
+                .accessibilityIdentifier("swipe-preview-result")
+
+            Button(distance == 0 ? "Show buttons" : "Reset example") {
+                result = nil
+                withAnimation(reduceMotion ? nil : .snappy(duration: 0.25)) {
+                    distance = distance == 0 ? nil : 0
+                }
+            }
+            .font(.footnote.weight(.semibold))
+            .disabled(actions.isEmpty)
+            .accessibilityIdentifier("swipe-preview-toggle")
+        }
+        .onChange(of: configuration) { _, _ in
+            distance = nil
+            result = nil
+        }
+    }
+
+    private func fullSwipeResult(_ action: FeatureSwipeAction) -> String {
+        action == .delete ? "Full swipe → Confirm delete" : "Full swipe → \(action.example.title)"
+    }
+
+    private func visibleActions(full: Bool) -> [FeatureSwipeAction] {
+        if full, let action = configuration.enabledFullSwipe { return [action] }
+        return direction == .left ? actions.reversed() : actions
+    }
+}
+
+private extension FeatureSwipeAction {
+    var settingsTitle: String {
+        switch self {
+        case .settle: "Settle / Reopen"
+        case .pin: "Pin / Unpin"
+        case .archive: "Archive / Restore"
+        case .delete: "Delete"
+        }
+    }
+
+    var example: HomeThreadSwipeAction {
+        switch self {
+        case .settle: .settle
+        case .pin: .pin
+        case .archive: .archive
+        case .delete: .delete
+        }
+    }
+
+    var color: Color { Color(uiColor: example.backgroundColor ?? .systemRed) }
+}

--- a/apps/swift-ios/Features/Settings/SettingsView.swift
+++ b/apps/swift-ios/Features/Settings/SettingsView.swift
@@ -131,6 +131,15 @@ public struct SettingsView: View {
                 .accessibilityIdentifier("settings-appearance")
                 settingsDivider
                 NavigationLink {
+                    SettingsSwipeActionsView(settings: preference(\.swipeActions))
+                } label: {
+                    SettingsNavigationRow(title: "Swipe Actions", systemImage: "hand.draw")
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Buttons and full-swipe actions for thread rows")
+                .accessibilityIdentifier("settings-swipe-actions")
+                settingsDivider
+                NavigationLink {
                     SettingsNotificationsView(
                         notificationsEnabled: preference(\.notificationsEnabled),
                         liveActivitiesEnabled: preference(\.liveActivitiesEnabled)

--- a/apps/swift-ios/Features/Shared/FeatureModels.swift
+++ b/apps/swift-ios/Features/Shared/FeatureModels.swift
@@ -1030,6 +1030,7 @@ public struct FeatureTextSizeAdjustment: Sendable, Equatable, Hashable, Codable 
 }
 
 public struct FeatureSettings: Sendable, Equatable, Codable {
+    public var swipeActions: FeatureSwipeSettings
     public var appearance: FeatureAppearance
     public var textSize: FeatureTextSizeAdjustment
     public var codeSize: FeatureTextSizeAdjustment
@@ -1040,6 +1041,7 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
 
     public init(
         appearance: FeatureAppearance = .system,
+        swipeActions: FeatureSwipeSettings = .init(),
         textSize: FeatureTextSizeAdjustment = .standard,
         codeSize: FeatureTextSizeAdjustment = .standard,
         hapticsEnabled: Bool = true,
@@ -1048,6 +1050,7 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
         defaultSelection: FeatureSelection? = nil
     ) {
         self.appearance = appearance
+        self.swipeActions = swipeActions
         self.textSize = textSize
         self.codeSize = codeSize
         self.hapticsEnabled = hapticsEnabled
@@ -1057,6 +1060,7 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case swipeActions
         case appearance
         case textSize
         case codeSize
@@ -1068,6 +1072,7 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        swipeActions = try container.decodeIfPresent(FeatureSwipeSettings.self, forKey: .swipeActions) ?? .init()
         appearance = try container.decodeIfPresent(
             FeatureAppearance.self,
             forKey: .appearance
@@ -1100,6 +1105,7 @@ public struct FeatureSettings: Sendable, Equatable, Codable {
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(swipeActions, forKey: .swipeActions)
         try container.encode(appearance, forKey: .appearance)
         try container.encode(textSize, forKey: .textSize)
         try container.encode(codeSize, forKey: .codeSize)

--- a/apps/swift-ios/Features/Shared/FeatureSwipeSettings.swift
+++ b/apps/swift-ios/Features/Shared/FeatureSwipeSettings.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+public enum FeatureSwipeAction: String, CaseIterable, Codable, Sendable {
+    case settle, pin, archive, delete
+}
+
+public struct FeatureSwipeConfiguration: Codable, Equatable, Sendable {
+    public var actions: [FeatureSwipeAction]
+    public var fullSwipe: FeatureSwipeAction?
+
+    public init(actions: [FeatureSwipeAction], fullSwipe: FeatureSwipeAction? = nil) {
+        self.actions = actions
+        self.fullSwipe = fullSwipe
+    }
+
+    public var enabledFullSwipe: FeatureSwipeAction? {
+        fullSwipe.flatMap { actions.contains($0) ? $0 : nil }
+    }
+
+    /// UIKit performs the outermost button on a full swipe. Keep the chosen
+    /// action there, and never substitute another action if it is unavailable.
+    public var orderedActions: [FeatureSwipeAction] {
+        var seen = Set<FeatureSwipeAction>()
+        let unique = actions.filter { seen.insert($0).inserted }
+        guard let fullSwipe = enabledFullSwipe else { return unique }
+        return [fullSwipe] + unique.filter { $0 != fullSwipe }
+    }
+
+    public mutating func setEnabled(_ action: FeatureSwipeAction, enabled: Bool) {
+        actions.removeAll { $0 == action }
+        if enabled {
+            actions.append(action)
+        } else if fullSwipe == action {
+            fullSwipe = nil
+        }
+    }
+}
+
+public struct FeatureSwipeSettings: Codable, Equatable, Sendable {
+    public var left: FeatureSwipeConfiguration
+    public var right: FeatureSwipeConfiguration
+
+    public init(
+        left: FeatureSwipeConfiguration = .init(actions: [.settle, .archive, .delete], fullSwipe: .settle),
+        right: FeatureSwipeConfiguration = .init(actions: [.pin], fullSwipe: .pin)
+    ) {
+        self.left = left
+        self.right = right
+    }
+
+    public func configuration(leading: Bool, isRightToLeft: Bool) -> FeatureSwipeConfiguration {
+        leading != isRightToLeft ? right : left
+    }
+}

--- a/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
+++ b/apps/swift-ios/Features/Workspace/HomeThreadCollectionView.swift
@@ -40,8 +40,11 @@ struct HomeThreadCollectionView: UIViewRepresentable {
         configuration.showsSeparators = false
         configuration.headerMode = .none
         configuration.footerMode = .none
+        configuration.leadingSwipeActionsConfigurationProvider = { [weak coordinator = context.coordinator] indexPath in
+            coordinator?.swipeActions(at: indexPath, leading: true)
+        }
         configuration.trailingSwipeActionsConfigurationProvider = { [weak coordinator = context.coordinator] indexPath in
-            coordinator?.trailingSwipeActions(at: indexPath)
+            coordinator?.swipeActions(at: indexPath, leading: false)
         }
 
         let collectionView = UICollectionView(
@@ -292,25 +295,26 @@ struct HomeThreadCollectionView: UIViewRepresentable {
             }
         }
 
-        func trailingSwipeActions(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        func swipeActions(
+            at indexPath: IndexPath,
+            leading: Bool
+        ) -> UISwipeActionsConfiguration? {
+            let isRightToLeft = collectionView?.effectiveUserInterfaceLayoutDirection == .rightToLeft
+            let preference = parent.settings.swipeActions.configuration(
+                leading: leading, isRightToLeft: isRightToLeft
+            )
             guard case let .thread(thread, _, _, isArchived, _, _) = item(at: indexPath) else {
                 return nil
             }
-
-            let actions = HomeThreadSwipeAction
-                .trailingActions(
-                    for: thread,
-                    isArchived: isArchived,
-                    at: .now
-                )
+            let actions = HomeThreadSwipeAction.actions(
+                for: thread, isArchived: isArchived, at: .now, configuration: preference
+            )
+            guard !actions.isEmpty else { return nil }
             let configuration = UISwipeActionsConfiguration(
                 actions: actions.map { contextualAction($0, for: thread) }
             )
-            // A full swipe runs the edge action, which is only ever settlement.
-            // Delete can never reach that slot, so the gesture cannot destroy a
-            // thread; rows with nothing to settle keep the full swipe disabled.
             configuration.performsFirstActionWithFullSwipe =
-                HomeThreadSwipeAction.performsFullSwipe(with: actions)
+                HomeThreadSwipeAction.performsFullSwipe(with: actions, configuration: preference)
             return configuration
         }
 
@@ -937,22 +941,11 @@ struct HomeThreadCollectionView: UIViewRepresentable {
     }
 }
 
-/// The trailing swipe actions a Home row offers, resolved as data so the row's
-/// gesture semantics stay deterministic and testable without hosting a
-/// collection view. Order is outermost-first, matching
-/// `UISwipeActionsConfiguration`, which lays trailing actions out from the
-/// trailing edge inward and runs the first action on a full swipe.
+/// Resolves saved choices against each row's capabilities and lifecycle state.
+/// Order is outermost-first, matching UIKit's full-swipe action.
 enum HomeThreadSwipeAction: Equatable {
-    case delete
-    case restore
-    case unpin
-    case settle
-    case reopen
-    case archive
+    case delete, restore, pin, unpin, settle, reopen, archive
 
-    /// The lifecycle mutation an action requests. Keeping it separate from the
-    /// action keeps the swipe wiring verifiable and forces every case through
-    /// the row's existing callbacks instead of a second settlement path.
     enum Intent: Equatable {
         case delete
         case setArchived(Bool)
@@ -960,45 +953,44 @@ enum HomeThreadSwipeAction: Equatable {
         case setSettled(Bool)
     }
 
-    /// Settlement owns the edge slot on every row that can settle, so a full
-    /// swipe clears the task in one motion and a partial swipe still reveals
-    /// every button. Delete is always last and therefore can never be the
-    /// full-swipe action. A pinned row keeps Unpin between the two: settling
-    /// already clears the pin, so the full swipe unpins and settles together.
-    /// Archived rows stay restore-only, and a row with nothing to settle keeps
-    /// its reversible action at the edge with the full swipe turned off.
-    static func trailingActions(
+    static func actions(
         for thread: FeatureThread,
         isArchived: Bool,
-        at now: Date
+        at now: Date,
+        configuration: FeatureSwipeConfiguration = FeatureSwipeSettings().left
     ) -> [HomeThreadSwipeAction] {
-        guard !isArchived else { return [.restore, .delete] }
-
-        let isSettled = thread.isEffectivelySettled()
-        let settlement: HomeThreadSwipeAction? = isSettled
-            ? .reopen
-            : (thread.canSettleNow(at: now) ? .settle : nil)
-        let isPinned = thread.pinnedAt != nil && thread.canTogglePin
-
-        var actions: [HomeThreadSwipeAction] = []
-        if let settlement {
-            actions.append(settlement)
-            if isPinned {
-                actions.append(.unpin)
+        configuration.orderedActions.compactMap { choice in
+            switch choice {
+            case .settle:
+                guard !isArchived else { return nil }
+                if thread.isEffectivelySettled() { return .reopen }
+                return thread.canSettleNow(at: now) ? .settle : nil
+            case .pin:
+                guard !isArchived, thread.canTogglePin else { return nil }
+                return thread.pinnedAt == nil ? .pin : .unpin
+            case .archive:
+                return isArchived ? .restore : .archive
+            case .delete:
+                return .delete
             }
-        } else if isPinned {
-            actions.append(.unpin)
-        } else {
-            actions.append(.archive)
         }
-        actions.append(.delete)
-        return actions
     }
 
-    /// The full swipe is armed only when the edge action settles or reopens.
-    /// Nothing else may run from the gesture alone.
-    static func performsFullSwipe(with actions: [HomeThreadSwipeAction]) -> Bool {
-        actions.first?.isSettlement ?? false
+    static func performsFullSwipe(
+        with actions: [HomeThreadSwipeAction],
+        configuration: FeatureSwipeConfiguration = FeatureSwipeSettings().left
+    ) -> Bool {
+        guard let selected = configuration.enabledFullSwipe else { return false }
+        return actions.first?.choice == selected
+    }
+
+    var choice: FeatureSwipeAction {
+        switch self {
+        case .settle, .reopen: .settle
+        case .pin, .unpin: .pin
+        case .archive, .restore: .archive
+        case .delete: .delete
+        }
     }
 
     var isSettlement: Bool {
@@ -1010,6 +1002,7 @@ enum HomeThreadSwipeAction: Equatable {
         case .delete: .delete
         case .restore: .setArchived(false)
         case .archive: .setArchived(true)
+        case .pin: .setPinned(true)
         case .unpin: .setPinned(false)
         case .settle: .setSettled(true)
         case .reopen: .setSettled(false)
@@ -1020,6 +1013,7 @@ enum HomeThreadSwipeAction: Equatable {
         switch self {
         case .delete: "Delete"
         case .restore: "Restore"
+        case .pin: "Pin"
         case .unpin: "Unpin"
         case .settle: "Settle"
         case .reopen: "Reopen"
@@ -1031,6 +1025,7 @@ enum HomeThreadSwipeAction: Equatable {
         switch self {
         case .delete: "trash"
         case .restore: "arrow.uturn.backward"
+        case .pin: "pin"
         case .unpin: "pin.slash"
         case .settle: "checkmark"
         case .reopen: "arrow.counterclockwise"
@@ -1039,14 +1034,16 @@ enum HomeThreadSwipeAction: Equatable {
     }
 
     var style: UIContextualAction.Style {
-        self == .delete ? .destructive : .normal
+        // Delete opens a confirmation. UIKit must not remove the row before
+        // the user confirms and the existing deletion path succeeds.
+        .normal
     }
 
-    /// Destructive actions keep UIKit's own tint.
     var backgroundColor: UIColor? {
         switch self {
-        case .delete: nil
-        case .restore, .unpin, .reopen: .systemBlue
+        case .delete: .systemRed
+        case .pin, .unpin: .systemOrange
+        case .restore, .reopen: .systemBlue
         case .settle: .systemGreen
         case .archive: .systemGray
         }

--- a/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/DailyUXSidebarTests.swift
@@ -207,7 +207,7 @@ struct DailyUXSidebarTests {
         #expect(queued.hasQueuedTurnStart(at: now))
         #expect(queued.isEffectivelySettled())
         #expect(!queued.canSettleNow(at: now))
-        #expect(HomeThreadSwipeAction.trailingActions(
+        #expect(HomeThreadSwipeAction.actions(
             for: queued,
             isArchived: false,
             at: now

--- a/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
+++ b/apps/swift-ios/Tests/FeatureTests/HomeThreadSwipeActionTests.swift
@@ -5,9 +5,19 @@ import UIKit
 @testable import T3Code
 
 @MainActor
-@Suite("Home row trailing swipe actions")
+@Suite("Home row swipe actions")
 struct HomeThreadSwipeActionTests {
     private let now = Date(timeIntervalSince1970: 20_000)
+
+    @Test
+    func physicalDirectionsRespectBothLayoutDirections() {
+        let settings = FeatureSwipeSettings()
+        #expect(settings.configuration(leading: true, isRightToLeft: false) == settings.right)
+        #expect(settings.configuration(leading: false, isRightToLeft: false) == settings.left)
+        #expect(settings.configuration(leading: true, isRightToLeft: true) == settings.left)
+        #expect(settings.configuration(leading: false, isRightToLeft: true) == settings.right)
+        #expect(FeatureSwipeConfiguration(actions: [.archive], fullSwipe: .delete).enabledFullSwipe == nil)
+    }
 
     @Test
     func backKeepsTheMostRecentlyOpenedThreadHighlighted() {
@@ -25,180 +35,123 @@ struct HomeThreadSwipeActionTests {
     }
 
     @Test
-    func settlementOwnsTheEdgeSlotSoAFullSwipeSettles() {
-        let active = thread(id: "active")
-        let actions = HomeThreadSwipeAction.trailingActions(
-            for: active,
-            isArchived: false,
-            at: now
+    func defaultsOfferSettlementOnTheLeftAndPinningOnTheRight() {
+        let candidate = thread(id: "active")
+        let left = HomeThreadSwipeAction.actions(for: candidate, isArchived: false, at: now)
+        #expect(left == [.settle, .archive, .delete])
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: left))
+        let rightPreference = FeatureSwipeSettings().right
+        let right = HomeThreadSwipeAction.actions(
+            for: candidate, isArchived: false, at: now, configuration: rightPreference
         )
-
-        #expect(actions == [.settle, .delete])
-        #expect(actions.first == .settle)
-        #expect(actions.first?.intent == .setSettled(true))
-        #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions))
-        #expect(actions.map(\.title) == ["Settle", "Delete"])
+        #expect(right == [.pin])
+        #expect(HomeThreadSwipeAction.performsFullSwipe(with: right, configuration: rightPreference))
     }
 
     @Test
-    func pinnedRowsSettleFromTheEdgeAndKeepUnpinBesideIt() {
-        let pinned = thread(id: "pinned", pinnedAt: now.addingTimeInterval(-30))
-        let actions = HomeThreadSwipeAction.trailingActions(
-            for: pinned,
-            isArchived: false,
-            at: now
+    func selectionsFollowLifecycleAndCapabilitiesWithoutReplacingTheFullSwipe() {
+        let preference = FeatureSwipeConfiguration(actions: [.pin, .archive, .settle, .delete], fullSwipe: .pin)
+        var candidate = thread(id: "row", pinnedAt: now)
+        candidate.settlementFacts = .init(settlementOverride: .settled)
+        #expect(HomeThreadSwipeAction.actions(
+            for: candidate, isArchived: false, at: now, configuration: preference
+        ) == [.unpin, .archive, .reopen, .delete])
+        candidate.supportsPinning = false
+        // Existing pins stay reversible even when new pinning is unavailable.
+        #expect(candidate.canTogglePin)
+        candidate.pinnedAt = nil
+        let unsupported = HomeThreadSwipeAction.actions(
+            for: candidate, isArchived: false, at: now, configuration: preference
         )
-
-        #expect(actions == [.settle, .unpin, .delete])
-        #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions))
-        #expect(actions.map(\.title) == ["Settle", "Unpin", "Delete"])
-        #expect(actions.map(\.systemImage) == ["checkmark", "pin.slash", "trash"])
-    }
-
-    /// The pinned shelf also holds settled threads, so the edge action has to be
-    /// able to reverse instead of settling a second time.
-    @Test
-    func settledRowsPutReopenAtTheEdge() {
-        var settled = thread(id: "settled")
-        settled.settlementFacts = .init(settlementOverride: .settled)
-        let settledActions = HomeThreadSwipeAction.trailingActions(
-            for: settled,
-            isArchived: false,
-            at: now
+        #expect(unsupported == [.archive, .reopen, .delete])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: unsupported, configuration: preference))
+        let archived = HomeThreadSwipeAction.actions(
+            for: candidate, isArchived: true, at: now, configuration: preference
         )
-        #expect(settledActions == [.reopen, .delete])
-        #expect(settledActions.first?.intent == .setSettled(false))
-        #expect(HomeThreadSwipeAction.performsFullSwipe(with: settledActions))
-
-        var pinnedSettled = thread(id: "pinned-settled", pinnedAt: now.addingTimeInterval(-30))
-        pinnedSettled.settlementFacts = .init(settlementOverride: .settled)
-        #expect(
-            HomeThreadSwipeAction.trailingActions(
-                for: pinnedSettled,
-                isArchived: false,
-                at: now
-            ) == [.reopen, .unpin, .delete]
-        )
-
-        // Age alone does not settle a row. The server decides when it moves.
-        var resting = thread(id: "resting")
-        resting.lastActivityAt = now.addingTimeInterval(-4 * 24 * 60 * 60)
-        #expect(
-            HomeThreadSwipeAction.trailingActions(
-                for: resting,
-                isArchived: false,
-                at: now
-            ) == [.settle, .delete]
-        )
+        #expect(archived == [.restore, .delete])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: archived, configuration: preference))
     }
 
     @Test
-    func rowsWithNothingToSettleKeepAReversibleEdgeActionAndNoFullSwipe() {
-        var unsupported = thread(id: "no-settlement")
-        unsupported.supportsSettlement = false
-        let unsupportedActions = HomeThreadSwipeAction.trailingActions(
-            for: unsupported,
-            isArchived: false,
-            at: now
-        )
-        #expect(unsupportedActions == [.archive, .delete])
-        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: unsupportedActions))
-
-        var pinnedUnsupported = thread(
-            id: "pinned-no-settlement",
-            pinnedAt: now.addingTimeInterval(-30)
-        )
-        pinnedUnsupported.supportsSettlement = false
-        let pinnedActions = HomeThreadSwipeAction.trailingActions(
-            for: pinnedUnsupported,
-            isArchived: false,
-            at: now
-        )
-        #expect(pinnedActions == [.unpin, .delete])
-        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: pinnedActions))
-
-        // Archived rows stay restore-only, and restoring is not a full swipe.
-        var archived = thread(id: "archived", pinnedAt: now.addingTimeInterval(-30))
-        archived.isArchived = true
-        archived.isSettled = true
-        let archivedActions = HomeThreadSwipeAction.trailingActions(
-            for: archived,
-            isArchived: true,
-            at: now
-        )
-        #expect(archivedActions == [.restore, .delete])
-        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: archivedActions))
-    }
-
-    @Test
-    func workingRowsNeverOfferSettlementOrAFullSwipe() {
-        for state in [
-            FeatureThreadState.queued,
-            .working,
-            .monitoring,
-            .waitingForApproval,
-            .waitingForInput,
-        ] {
-            var active = thread(id: "active-\(state.rawValue)")
-            active.state = state
-
-            let actions = HomeThreadSwipeAction.trailingActions(
-                for: active,
-                isArchived: false,
-                at: now
+    func choosingAFullSwipeMovesItToTheOuterEdge() {
+        for selected in FeatureSwipeAction.allCases {
+            let preference = FeatureSwipeConfiguration(actions: FeatureSwipeAction.allCases, fullSwipe: selected)
+            let actions = HomeThreadSwipeAction.actions(
+                for: thread(id: "row"), isArchived: false, at: now, configuration: preference
             )
+            #expect(actions.first?.choice == selected)
+            #expect(HomeThreadSwipeAction.performsFullSwipe(with: actions, configuration: preference))
+        }
+    }
 
+    @Test
+    func disablingAnActionClearsItsFullSwipeAndEmptyDirectionsStayEmpty() {
+        var preference = FeatureSwipeConfiguration(actions: [.pin], fullSwipe: .pin)
+        preference.setEnabled(.pin, enabled: false)
+        #expect(preference.fullSwipe == nil)
+        #expect(HomeThreadSwipeAction.actions(
+            for: thread(id: "row"), isArchived: false, at: now, configuration: preference
+        ).isEmpty)
+        preference.setEnabled(.archive, enabled: true)
+        #expect(preference.actions == [.archive])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: [.archive], configuration: preference))
+    }
+
+    @Test
+    func unavailableSettlementNeverTurnsAFullSwipeIntoAnotherAction() {
+        for state in [FeatureThreadState.queued, .working, .monitoring, .waitingForApproval, .waitingForInput] {
+            var candidate = thread(id: "active")
+            candidate.state = state
+            let actions = HomeThreadSwipeAction.actions(for: candidate, isArchived: false, at: now)
             #expect(actions == [.archive, .delete])
             #expect(!HomeThreadSwipeAction.performsFullSwipe(with: actions))
         }
     }
 
-    /// Delete must never reach the edge slot, because the edge slot is what a
-    /// full swipe runs. This sweeps every pinned/settled/capability/archived
-    /// combination rather than trusting the branch order.
     @Test
-    func deleteIsNeverTheEdgeActionAndOnlySettlementArmsTheFullSwipe() {
-        for isSettled in [false, true] {
-            for isPinned in [false, true] {
-                for supportsSettlement in [nil, true, false] as [Bool?] {
-                    for supportsPinning in [nil, true, false] as [Bool?] {
-                        for isArchived in [false, true] {
-                            var candidate = thread(
-                                id: "row",
-                                pinnedAt: isPinned ? now.addingTimeInterval(-30) : nil
-                            )
-                            candidate.isSettled = isSettled
-                            candidate.supportsSettlement = supportsSettlement
-                            candidate.supportsPinning = supportsPinning
-                            candidate.isArchived = isArchived
+    func settingsRoundTripAndOlderInstallsGetDefaults() throws {
+        let legacy = try JSONDecoder().decode(FeatureSettings.self, from: Data("{}".utf8))
+        #expect(legacy.swipeActions == FeatureSwipeSettings())
+        var settings = legacy
+        settings.swipeActions.left = .init(actions: [], fullSwipe: nil)
+        settings.swipeActions.right = .init(actions: [.archive, .delete], fullSwipe: .delete)
+        let saved = try JSONEncoder().encode(settings)
+        #expect(try JSONDecoder().decode(FeatureSettings.self, from: saved) == settings)
+    }
 
-                            let actions = HomeThreadSwipeAction.trailingActions(
-                                for: candidate,
-                                isArchived: isArchived,
-                                at: now
-                            )
-
-                            #expect(actions.last == .delete)
-                            #expect(actions.first != .delete)
-                            #expect(actions.count == Set(actions).count)
-                            #expect(actions.filter { $0.style == .destructive } == [.delete])
-                            #expect(actions.filter(\.isSettlement).count <= 1)
-
-                            let armsFullSwipe = HomeThreadSwipeAction.performsFullSwipe(with: actions)
-                            #expect(armsFullSwipe == (actions.first?.isSettlement ?? false))
-                            if armsFullSwipe {
-                                switch actions.first?.intent {
-                                case .setSettled:
-                                    break
-                                default:
-                                    Issue.record("A full swipe may only request settlement")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+    @Test
+    func swipePreferencesSurviveNativeClientRecreation() async throws {
+        let suite = "swipe-settings-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(suite)
+        defer {
+            defaults.removePersistentDomain(forName: suite)
+            try? FileManager.default.removeItem(at: directory)
         }
+        let runtime = EnvironmentRuntime(
+            environmentStore: EnvironmentStore(fileURL: directory.appendingPathComponent("environments.json")),
+            credentialStore: InMemoryCredentialStore()
+        )
+        let client = NativeFeatureClient(runtime: runtime, settingsStore: defaults)
+        var settings = FeatureSettings()
+        settings.swipeActions.left = .init(actions: [])
+        settings.swipeActions.right = .init(actions: [.archive, .delete], fullSwipe: .archive)
+        try await client.saveSettings(settings)
+        await client.disconnect()
+        let reopened = NativeFeatureClient(runtime: runtime, settingsStore: defaults)
+        let snapshot = try await reopened.initialSnapshot()
+        #expect(snapshot.settings == settings)
+        await reopened.disconnect()
+    }
+
+    @Test
+    func duplicateChoicesAndHiddenFullSwipeNeverCreateExtraActions() {
+        let preference = FeatureSwipeConfiguration(actions: [.archive, .archive], fullSwipe: .delete)
+        let actions = HomeThreadSwipeAction.actions(
+            for: thread(id: "row"), isArchived: false, at: now, configuration: preference
+        )
+        #expect(actions == [.archive])
+        #expect(!HomeThreadSwipeAction.performsFullSwipe(with: actions, configuration: preference))
     }
 
     @Test
@@ -221,8 +174,8 @@ struct HomeThreadSwipeActionTests {
         #expect(HomeThreadSwipeAction.settle.backgroundColor == .systemGreen)
         #expect(HomeThreadSwipeAction.reopen.backgroundColor == .systemBlue)
         #expect(HomeThreadSwipeAction.reopen.systemImage == "arrow.counterclockwise")
-        #expect(HomeThreadSwipeAction.delete.style == .destructive)
-        #expect(HomeThreadSwipeAction.delete.backgroundColor == nil)
+        #expect(HomeThreadSwipeAction.delete.style == .normal)
+        #expect(HomeThreadSwipeAction.delete.backgroundColor == .systemRed)
     }
 
     /// The full swipe carries no settlement logic of its own: its edge action is
@@ -250,7 +203,7 @@ struct HomeThreadSwipeActionTests {
 
         #expect(presentation(for: model).pinned.map(\.id) == ["pinned"])
 
-        let actions = HomeThreadSwipeAction.trailingActions(
+        let actions = HomeThreadSwipeAction.actions(
             for: pinned,
             isArchived: false,
             at: now
@@ -277,8 +230,8 @@ struct HomeThreadSwipeActionTests {
         #expect(shelves.pinned.isEmpty)
         #expect(shelves.settled.map(\.id) == ["pinned"])
         #expect(
-            HomeThreadSwipeAction.trailingActions(for: updated, isArchived: false, at: now)
-                == [.reopen, .delete]
+            HomeThreadSwipeAction.actions(for: updated, isArchived: false, at: now)
+                == [.reopen, .archive, .delete]
         )
     }
 

--- a/docs/user/swiftui-mobile.md
+++ b/docs/user/swiftui-mobile.md
@@ -12,6 +12,16 @@ selected computer. Other connected computers are not refreshed.
 Star a model to keep it in **Favorites**, including legacy models. Removing a star from a legacy
 model returns it to **Legacy models**.
 
+## Thread swipes
+
+Open **Settings > Swipe Actions** to choose the buttons shown when you swipe a thread left or
+right, and the action performed by a full swipe in each direction. Choose **None** to disable a
+full swipe. Try your choices on the example thread without changing your real threads.
+
+These settings stay on this device and apply across your connected computers. Actions adapt to
+the thread: Pin becomes Unpin, Settle becomes Reopen, and Archive becomes Restore. If the selected
+full-swipe action is unavailable, the gesture does nothing. Delete always asks for confirmation.
+
 ## Providers and skills
 
 Open **Settings > Providers**, or **Providers** in the model picker, to manage a provider on its

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,7 +317,7 @@ importers:
         specifier: ~57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2)
       expo-audio:
-        specifier: ~57.0.4
+        specifier: 57.0.4
         version: 57.0.4(patch_hash=fa9a3e0442ed395d4071bb406e08c3a471c9a84700bdfa0b9ad7ff144c96041a)(expo-asset@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@7.0.2))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-auth-session:
         specifier: ~57.0.10


### PR DESCRIPTION
## What Changed

Adds **Settings → Swipe Actions** to choose the buttons and full-swipe action independently for physical left and right swipes, including **None**. The interactive example uses the real Home thread row and lets users try a swipe without changing their threads.

Choices are Settle/Reopen, Pin/Unpin, Archive/Restore, and Delete. They adapt to each thread; an unavailable selected full-swipe action never falls through to another button. Delete asks for confirmation. Preferences persist on the device, with a reset for both directions.

## Why

Thread swipes previously had a fixed trailing action list. Users can now put frequent actions on either side. Defaults are Settle/Archive/Delete on the left, with full-swipe Settle, and Pin on the right, with full-swipe Pin.

The separate prerequisite commit backports the exact two-line dependency pin already merged in #11426. Release Smoke otherwise fails because fresh resolution selects an `expo-audio` version that does not match its patch. No SwiftUI source changed in that backport.

## UI Changes

Actual iPhone 16 Pro simulator recordings on iOS 26.5, dark appearance, with the same disposable local thread fixtures. Relative timestamps naturally advance between captures. GIFs preserve the gestures and settled results; idle automation waits are trimmed, with no speed-up.

**Before — fixed left-swipe buttons.**

![Before: a left swipe reveals Delete and Settle](https://github.com/user-attachments/assets/a7256927-b532-41fa-b08d-cad870550f0d)

**After — the default left-swipe buttons include Archive and can be customized.**

![After: a left swipe reveals Delete, Archive, and Settle](https://github.com/user-attachments/assets/be784744-57c7-4905-b173-1ce5fdaa2657)

**The Settings example demonstrates left and right partial and full swipes.**

![Settings: preview partial and full swipes in both directions](https://github.com/user-attachments/assets/beedfa84-d5d3-4b96-a329-6d862659c868)

[Watch the preview interaction video (MP4)](https://github.com/user-attachments/assets/6196179f-6864-4720-b9fc-fbfe39943eef)

<details>
<summary>Settings screenshots: before, after, and the thread example</summary>

**Before**

<img src="https://github.com/user-attachments/assets/541c7528-3a6c-4235-bf29-c0df928c2948" alt="Before: Settings has no swipe customization" width="402">

**After**

<img src="https://github.com/user-attachments/assets/bd8926b9-9fce-4dd7-8b02-d50ebfd57232" alt="After: Swipe Actions appears in Settings" width="402">

**Example thread before a swipe**

<img src="https://github.com/user-attachments/assets/0e166199-28be-4c70-8ab4-a9fdd0bbac8e" alt="Swipe Actions shows a readable example of the Home thread row" width="402">

</details>

<details>
<summary>Choosing actions, disabling full swipe, and cancelling Delete</summary>

Choosing Delete as the full-swipe action moves it to the outside edge. Turning Settle off updates the preview.

![Choose full-swipe Delete and disable the Settle button](https://github.com/user-attachments/assets/e4eb8b0f-5c23-4a88-9de6-b6c6151fd9ee)

After restarting the app, this fixture has left = Delete with full-swipe Delete, and right = Archive with full swipe set to None. A right full swipe only reveals Archive; a left full swipe asks for deletion confirmation. Cancel keeps the thread.

![A disabled full swipe does nothing; full-swipe Delete asks for confirmation and Cancel preserves the thread](https://github.com/user-attachments/assets/9af86b6e-f8e6-4f0f-a6e2-e32105f87ac8)

[Watch the confirmation and cancellation video (MP4)](https://github.com/user-attachments/assets/f8cb221a-f4c2-480b-8044-b55069f5fe0f)

</details>

<details>
<summary>Light appearance, larger text, and iPad layout</summary>

**iPhone, accessibility-medium text size:** the example and controls remain readable; the form scrolls to the full-swipe picker and reset.

<img src="https://github.com/user-attachments/assets/1ef48415-ee7a-4bb4-a5c2-00459558a8b8" alt="Light appearance with larger text in the swipe example" width="402">

<img src="https://github.com/user-attachments/assets/79ba102a-e59f-416e-b82e-520754ad2978" alt="Larger-text controls and full-swipe picker remain accessible by scrolling" width="402">

**iPad mini:** a full swipe completes in the regular-width Settings sheet and leaves its feedback visible.

<img src="https://github.com/user-attachments/assets/324ab60b-0336-4b5c-b132-d5168b3f73cc" alt="iPad Settings example after a full swipe" width="744">

</details>

## Validation

- XcodeBuildMCP 2.7.0 `simulator test`, scheme `T3Code`, selectors `-only-testing:T3CodeTests/HomeThreadSwipeActionTests` and `-only-testing:T3CodeTests/DailyUXSidebarTests`: **58 passed, 0 failed or skipped**. Signed simulator build passed.
- Integrated iPhone and iPad checks: partial/full previews, action selection, None, real Pin/Unpin, Delete confirmation/cancel, saved preferences after restart, and reset. Saved settings and real thread transitions were checked against their authoritative stores. Accessibility inspection exposes the preview’s named “Try full swipe” action.
- CI on `f61fe6a8e30e`: Release Smoke, Check, Test, Rust, server tests, and Contract fixtures/native tests passed.
- Fresh read-only Claude Fable 5 high review of the complete feature at `7b7c147c4b8c`: no actionable findings, process exit 0. Re-review of the exact upstream dependency backport was attempted but hit the session quota (exit 1).

Base media: `93ca26695eb1`. Native candidate media: `7b7c147c4b8c`. The final head `f61fe6a8e30e` differs only by the credited manifest/lockfile pin, so the native evidence still applies. Verification used disposable local environments and simulators.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Implementation: GPT-6 in the Codex harness. Independent feature review: Claude Fable 5 high through the direct Claude CLI.
